### PR TITLE
Fix for junit fuilure message

### DIFF
--- a/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -405,7 +405,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
               (throwableType, throwableText)
           }
         
-        <failure message = { { unparsedXml(failure.message.replaceAll("\n", "&#010;")) } }
+        <failure message = { { failure.message.replaceAll("\n", "&#010;") } }
                  type    = { throwableType   } >
           { throwableText }
         </failure>
@@ -483,7 +483,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
   //
   // Class to hold information about an execution of a test suite.
   //
-  private case class Testsuite(name: String, timeStamp: Long) {
+  private[scalatest] case class Testsuite(name: String, timeStamp: Long) {
     var errors   = 0
     var failures = 0
     var time     = 0L
@@ -493,7 +493,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
   //
   // Class to hold information about an execution of a testcase.
   //
-  private case class Testcase(name: String, className: Option[String],
+  private[scalatest] case class Testcase(name: String, className: Option[String],
                               timeStamp: Long) {
     var time = 0L
     var pending = false

--- a/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
+++ b/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
@@ -270,4 +270,29 @@ class JUnitXmlReporterSuite extends FunSuite {
     assert(!(tcPending \ "skipped").isEmpty)
     assert(!(tcCanceled \ "skipped").isEmpty)
   }
+
+  test("testcase failure message xmlified properly"){
+    //"" - not used parameters
+    val bigFail = TestFailed(new Ordinal(0),
+        "Unusually formed message: \n less:'<', amp:'&', double-quote:\"",
+        "",
+        "",
+        None,
+        "",
+        "",
+        null,
+        Some(new Exception("Unusually formed exception: \n less:'<', more:'>' amp:'&', double-quote:\"")))`
+
+    val testsuite = reporter.Testsuite("TestSuite", 10L)
+    testsuite.testcases += reporter.Testcase("TestCase", Some("someClass"), 1L)
+    testsuite.testcases.foreach(tc => tc.failure = Some(bigFail))
+
+    val rawXml:String = reporter.xmlify(testsuite)
+
+    //correct xml, no exceptions are thrown
+    val res= scala.xml.XML.loadString(rawXml)
+
+    val message = (res \\ "failure" \ "@message").toString
+    assert(message==="""Unusually formed message: &amp;#010; less:'&lt;', amp:'&amp;', double-quote:&quot;""","failure/@message is not as expected")
+  }
 }


### PR DESCRIPTION
Issue was mentioned here:
https://groups.google.com/forum/?hl=en&fromgroups=#!topic/scalatest-users/4rvEBV5PTsQ

Note:
- I didn't yet understand what is the better way to compile project. So I checked the fix in sandbox, and I assume some imports may be missed, hope not.
- @bvenners, I had to change case class access for testing purpose, but in general I'd like to make this reporter more public. I don't see reasons why is it private, with plenty private methods. Idea to make it more extensible.
