### PR TITLE
Improved isInstanceOf checks in tests for contain matchers.

### DIFF
--- a/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
@@ -11,7 +11,11 @@ class AllOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -30,7 +34,11 @@ class AllOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1
@@ -52,7 +60,11 @@ class AllOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapAppended: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1

--- a/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
@@ -11,7 +11,11 @@ class InOrderContainMatcherDeciderSpec extends Spec with Matchers with Explicitl
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -30,7 +34,11 @@ class InOrderContainMatcherDeciderSpec extends Spec with Matchers with Explicitl
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1

--- a/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
@@ -11,7 +11,11 @@ class NoneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -30,7 +34,11 @@ class NoneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1
@@ -52,7 +60,11 @@ class NoneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly
   val mapAppended: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1

--- a/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
@@ -11,7 +11,11 @@ class OneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -30,7 +34,11 @@ class OneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1
@@ -52,7 +60,11 @@ class OneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly 
   val mapAppended: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1

--- a/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
@@ -11,7 +11,11 @@ class OnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly w
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -30,7 +34,11 @@ class OnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly w
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1
@@ -52,7 +60,11 @@ class OnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly w
   val mapAppended: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1

--- a/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
@@ -10,7 +10,11 @@ class TheSameElementsAsContainMatcherDeciderSpec extends Spec with Matchers with
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {
 
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
 
       def normalized(s: (Int, String)): (Int, String) = (s._1, s._2.trim)
     }
@@ -29,7 +33,11 @@ class TheSameElementsAsContainMatcherDeciderSpec extends Spec with Matchers with
   val mapIncremented: Normalization[(Int, String)] = 
     new Normalization[(Int, String)] {
       var count = 0
-      def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)]
+      def isInstanceOfA(b: Any) = 
+        b match {
+          case (_: Int, _: String) => true
+          case _ => false
+        }
     
       def normalized(s: (Int, String)): (Int, String) = {
         count += 1


### PR DESCRIPTION
def isInstanceOfA(b: Any) = b.isInstanceOf[(Int, String)] 

changed to:-

def isInstanceOfA(b: Any) = 
        b match {
          case (_: Int, _: String) => true
          case _ => false
        }
