### PR TITLE
Minor Version Change in SBT Build

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -6,7 +6,7 @@ object ScalatestBuild extends Build {
 
   val scalaVersionToUse = "2.10.0"
     
-  val releaseVersion = "2.0.M6-SNAP13"
+  val releaseVersion = "2.0.M6-SNAP14"
   
   val includeTestPackageSet = Set("org.scalatest", 
                                   "org.scalatest.fixture", 
@@ -132,7 +132,7 @@ object ScalatestBuild extends Build {
    ).dependsOn(scalatest  % "test->test")
 
    def simpledependencies = Seq(
-     "org.scalatest" % "test-interface" % "1.0-SNAP1",  // TODO optional
+     "org.scalatest" % "test-interface" % "1.0-SNAP2",  // TODO optional
      "org.scalacheck" % ("scalacheck_" + scalaVersionToUse) % "1.10.0",   // TODO optional
      "org.easymock" % "easymockclassextension" % "3.1",   // TODO optional
      "org.jmock" % "jmock-legacy" % "2.5.1", // TODO optional


### PR DESCRIPTION
Updated project/scalatest.scala to use latest test-interface version, and updated release version to 2.0.M6-SNAP14 to match build.xml.
