### PR TITLE
Deprecate ShouldMatchers and MustMatchers in 2.0 trunk. 

### DIFF
--- a/project/GenMatchers.scala
+++ b/project/GenMatchers.scala
@@ -20,6 +20,8 @@ import java.io.{File, FileWriter, BufferedWriter}
 
 object GenMatchers {
 
+  val deprecationLine = "@deprecated(\"Please use Matchers instead.\")\n"
+
   def translateShouldToMust(shouldLine: String): String = {
     val temp1 = shouldLine.replaceAll("<code>must</code>", "<code>I_WAS_must_ORIGINALLY</code>")
     val temp2 = temp1.replaceAll("<!-- PRESERVE -->should", " I_MUST_STAY_SHOULD")
@@ -50,6 +52,9 @@ object GenMatchers {
       val lines = Source.fromFile(new File("src/main/scala/org/scalatest/Matchers.scala")).getLines.toList
       for (line <- lines) {
         val mustLine = translateShouldToMust(line)
+        if (mustLine.startsWith("trait MustMatchers extends ") ||
+            mustLine.startsWith("object MustMatchers extends "))
+          mustMatchersWriter.write(deprecationLine)
         mustMatchersWriter.write(mustLine)
         mustMatchersWriter.newLine()
       }

--- a/src/main/scala/org/scalatest/junit/ShouldMatchersForJUnit.scala
+++ b/src/main/scala/org/scalatest/junit/ShouldMatchersForJUnit.scala
@@ -94,6 +94,7 @@ import org.scalatest.words.Complainer
  *
  * @author Bill Venners
  */
+@deprecated("Please use MatchersForJUnit instead.")
 trait ShouldMatchersForJUnit extends ShouldMatchers with AssertionsForJUnit {
   private[scalatest] override val complainer: Complainer =
     new Complainer {
@@ -147,4 +148,5 @@ trait ShouldMatchersForJUnit extends ShouldMatchers with AssertionsForJUnit {
  *
  * @author Bill Venners
  */
+@deprecated("Please use MatchersForJUnit instead.")
 object ShouldMatchersForJUnit extends ShouldMatchersForJUnit

--- a/src/main/scala/org/scalatest/matchers/ShouldMatchers.scala
+++ b/src/main/scala/org/scalatest/matchers/ShouldMatchers.scala
@@ -17,6 +17,8 @@ package org.scalatest.matchers
 
 import org.scalatest.Matchers
 
+@deprecated("Please use Matchers instead.")
 trait ShouldMatchers extends Matchers
 
+@deprecated("Please use Matchers instead.")
 object ShouldMatchers extends ShouldMatchers


### PR DESCRIPTION
Deprecated ShouldMatchers, MustMatchers, ShouldMatchersForJUnit, and MustMatchersForJUnit.
