### PR TITLE
SharedHelpers as object

### DIFF
--- a/project/GenInspectors.scala
+++ b/project/GenInspectors.scala
@@ -576,11 +576,12 @@ object GenInspectors {
       new SingleClassFile(
         packageName = Some("org.scalatest.inspectors.nested"), 
         importList = List("org.scalatest._", 
+                          "SharedHelpers._", 
                           "collection.GenTraversable"), 
         classTemplate = new ClassTemplate {
           val name = "NestedInspectorsSpec"
           override val extendName = Some("Spec")
-          override val withList = List("Inspectors", "SharedHelpers")
+          override val withList = List("Inspectors")
           override val children = {
             
             val succeededAssertion = "assert(n % 2 == 0, n % 2 + \" was not equal to 0\")"
@@ -1201,6 +1202,7 @@ object GenInspectors {
         packageName = Some("org.scalatest.inspectors.all"), 
         importList = List(
                        "org.scalatest._", 
+                       "SharedHelpers._", 
                        "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                        "collection.GenTraversable", 
                        "collection.GenMap"
@@ -1208,7 +1210,7 @@ object GenInspectors {
         classTemplate = new ClassTemplate {
           val name = "InspectorShorthandsForAllSucceededSpec"
           override val extendName = Some("Spec")
-          override val withList = List("Matchers", "SharedHelpers")
+          override val withList = List("Matchers")
           override val children = succeedTests
         }
       )
@@ -1227,6 +1229,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.all"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1234,7 +1237,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -1257,6 +1260,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.atLeast"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1264,7 +1268,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = "InspectorShorthandsForAtLeastSucceededSpec"
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = succeedTests
           }
         )
@@ -1425,6 +1429,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.atLeast"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1432,7 +1437,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -1455,6 +1460,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.every"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1462,7 +1468,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = "InspectorShorthandsForEverySucceededSpec"
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = succeedTests
           }
         )
@@ -1624,6 +1630,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.every"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1631,7 +1638,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -1654,6 +1661,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.exactly"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1661,7 +1669,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = "InspectorShorthandsForExactlySucceededSpec"
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = succeedTests
           }
         )
@@ -1823,6 +1831,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.exactly"), 
           importList = List(
                          "org.scalatest._", 
+                         "SharedHelpers._", 
                          "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
                          "collection.GenTraversable", 
                          "collection.GenMap"
@@ -1830,7 +1839,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -1853,6 +1862,7 @@ object GenInspectors {
         packageName = Some("org.scalatest.inspectors.no"),
         importList = List(
           "org.scalatest._", 
+          "SharedHelpers._", 
           "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
           "collection.GenTraversable",
           "collection.GenMap"
@@ -1860,7 +1870,7 @@ object GenInspectors {
         classTemplate = new ClassTemplate {
           val name = "InspectorShorthandsForNoSucceededSpec"
           override val extendName = Some("Spec")
-          override val withList = List("Matchers", "SharedHelpers")
+          override val withList = List("Matchers")
           override val children = succeedTests
         }
       )
@@ -2020,6 +2030,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.no"),
           importList = List(
             "org.scalatest._", 
+            "SharedHelpers._", 
             "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
             "collection.GenTraversable",
             "collection.GenMap"
@@ -2027,7 +2038,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -2050,6 +2061,7 @@ object GenInspectors {
         packageName = Some("org.scalatest.inspectors.between"),
         importList = List(
           "org.scalatest._", 
+          "SharedHelpers._", 
           "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
           "collection.GenTraversable",
           "collection.GenMap"
@@ -2057,7 +2069,7 @@ object GenInspectors {
         classTemplate = new ClassTemplate {
           val name = "InspectorShorthandsForBetweenSucceededSpec"
           override val extendName = Some("Spec")
-          override val withList = List("Matchers", "SharedHelpers")
+          override val withList = List("Matchers")
           override val children = succeedTests
         }
       )
@@ -2220,6 +2232,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.between"),
           importList = List(
             "org.scalatest._", 
+            "SharedHelpers._", 
             "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
             "collection.GenTraversable",
             "collection.GenMap"
@@ -2227,7 +2240,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )
@@ -2250,6 +2263,7 @@ object GenInspectors {
         packageName = Some("org.scalatest.inspectors.atMost"),
         importList = List(
           "org.scalatest._", 
+          "SharedHelpers._", 
           "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
           "collection.GenTraversable",
           "collection.GenMap"
@@ -2257,7 +2271,7 @@ object GenInspectors {
         classTemplate = new ClassTemplate {
           val name = "InspectorShorthandsForAtMostSucceededSpec"
           override val extendName = Some("Spec")
-          override val withList = List("Matchers", "SharedHelpers")
+          override val withList = List("Matchers")
           override val children = succeedTests
         }
       )
@@ -2425,6 +2439,7 @@ object GenInspectors {
           packageName = Some("org.scalatest.inspectors.atMost"),
           importList = List(
             "org.scalatest._", 
+            "SharedHelpers._", 
             "org.scalatest.matchers.{BePropertyMatcher, BePropertyMatchResult, HavePropertyMatcher, HavePropertyMatchResult}", 
             "collection.GenTraversable",
             "collection.GenMap"
@@ -2432,7 +2447,7 @@ object GenInspectors {
           classTemplate = new ClassTemplate {
             val name = className
             override val extendName = Some("Spec")
-            override val withList = List("Matchers", "SharedHelpers")
+            override val withList = List("Matchers")
             override val children = new InspectorShorthandsHelpersTemplate :: failedTests
           }
         )

--- a/src/test/scala/org/scalatest/AMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/AMatcherSpec.scala
@@ -15,10 +15,10 @@
  */
 package org.scalatest
 
-import org.scalatest._
 import matchers._
+import SharedHelpers._
 
-class AMatcherSpec extends Spec with Matchers with SharedHelpers {
+class AMatcherSpec extends Spec with Matchers {
 
   object `AMatcher ` {
     

--- a/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class AllOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class AllOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class AllOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class AllOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/AllOfContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/AllOfContainMatcherSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import collection.GenTraversable
 import words.AllOfContainMatcher
+import SharedHelpers._
 
-class AllOfContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class AllOfContainMatcherSpec extends Spec with Matchers {
 
   object `allOf ` {
     

--- a/src/test/scala/org/scalatest/AnMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/AnMatcherSpec.scala
@@ -15,10 +15,10 @@
  */
 package org.scalatest
 
-import org.scalatest._
+import SharedHelpers._
 import matchers._
 
-class AnMatcherSpec extends Spec with Matchers with SharedHelpers {
+class AnMatcherSpec extends Spec with Matchers {
 
   object `AnMatcher ` {
     

--- a/src/test/scala/org/scalatest/ArgsSpec.scala
+++ b/src/test/scala/org/scalatest/ArgsSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import matchers.ShouldMatchers
 import prop.TableDrivenPropertyChecks
+import SharedHelpers._
 
-class ArgsSpec extends WordSpec with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers with SeveredStackTraces {
+class ArgsSpec extends WordSpec with TableDrivenPropertyChecks with ShouldMatchers with SeveredStackTraces {
   "The Args constructor" should {
     "throw NullPointerExcepion when passed a null" in {
 

--- a/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
+++ b/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
@@ -20,6 +20,7 @@ import org.scalatest.junit.JUnitSuite
 import org.junit.Test
 import org.testng.annotations.{Test => TestNG }
 import org.scalatest.testng.TestNGSuite
+import SharedHelpers._
 
 class BeforeAndAfterAllProp extends AllSuiteProp {
 

--- a/src/test/scala/org/scalatest/BigSuiteSuite.scala
+++ b/src/test/scala/org/scalatest/BigSuiteSuite.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class BigSuiteSuite extends FunSuite with SharedHelpers {
+import SharedHelpers._
+
+class BigSuiteSuite extends FunSuite {
   test("a BigSuite(Some(0)) has 100 tests") {
     val bs = new BigSuite(Some(0))
     assert(bs.expectedTestCount(Filter()) === 100)

--- a/src/test/scala/org/scalatest/CancelAfterFailureSpec.scala
+++ b/src/test/scala/org/scalatest/CancelAfterFailureSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class CancelAfterFailureSpec extends FlatSpec with SharedHelpers {
+import SharedHelpers._
+
+class CancelAfterFailureSpec extends FlatSpec {
 
   "CancelAfterFailure" should "not interfere if no tests fail" in {
     class MySuite extends FunSuite with CancelAfterFailure {

--- a/src/test/scala/org/scalatest/CatchReporterProp.scala
+++ b/src/test/scala/org/scalatest/CatchReporterProp.scala
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream
 import org.scalatest.tools.SuiteSortingReporter
 import org.scalatest.time._
 import org.scalatest.tools.TestSortingReporter
+import SharedHelpers._
 
 class CatchReporterProp extends AllSuiteProp {
 

--- a/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
+++ b/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class ConfigMapWrapperSuiteSpec extends FunSuite with SharedHelpers with SeveredStackTraces {
+import SharedHelpers._
+
+class ConfigMapWrapperSuiteSpec extends FunSuite with SeveredStackTraces {
 
   // Need a test that ensures the passed config map gets in there.
   test("configMap should get passed into the wrapped Suite") {

--- a/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
+import SharedHelpers._
 
-class ContainMatcherAndOrDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class ContainMatcherAndOrDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val equality = new Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/ContainMatcherAndOrEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/ContainMatcherAndOrEqualitySpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalautils.Equality
+import SharedHelpers._
 
-class ContainMatcherAndOrEqualitySpec extends Spec with Matchers with SharedHelpers {
+class ContainMatcherAndOrEqualitySpec extends Spec with Matchers {
   
   implicit val equality = new Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import org.scalautils.Equality
 import org.scalautils.Explicitly
+import SharedHelpers._
 
-class ContainMatcherAndOrExplicitEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class ContainMatcherAndOrExplicitEqualitySpec extends Spec with Matchers with Explicitly {
 
   val equality = new Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/ContainMatcherAndOrSpec.scala
+++ b/src/test/scala/org/scalatest/ContainMatcherAndOrSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class ContainMatcherAndOrSpec extends Spec with Matchers with SharedHelpers {
+import SharedHelpers._
+
+class ContainMatcherAndOrSpec extends Spec with Matchers {
 
   // TODO: Should reenable the all 'and/or contain' without paren flavor when we get MatcherGen2, MatcherGen3 working.
   

--- a/src/test/scala/org/scalatest/DeprecatedGivenWhenThenSpec.scala
+++ b/src/test/scala/org/scalatest/DeprecatedGivenWhenThenSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import events.InfoProvided
+import SharedHelpers._
 
-class DeprecatedGivenWhenThenSpec extends FunSpec with SharedHelpers {
+class DeprecatedGivenWhenThenSpec extends FunSpec {
   describe("The GivenWhenThen trait") {
 
     val theGiven = "an invalid zip code"

--- a/src/test/scala/org/scalatest/DeprecatedMethodFormSuiteSpec.scala
+++ b/src/test/scala/org/scalatest/DeprecatedMethodFormSuiteSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest
 
 import collection.immutable.TreeSet
+import SharedHelpers._
 import org.scalatest.events._
 
 /* Uncomment after remove type aliases in org.scalatest package object
@@ -23,7 +24,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestPendingException
 */
 
-class DeprecatedMethodFormSuiteSpec extends FunSpec with PrivateMethodTester with SharedHelpers {
+class DeprecatedMethodFormSuiteSpec extends FunSpec with PrivateMethodTester {
 
   describe("The simpleNameForTest method") {
     it("should return the correct test simple name with or without Informer") {

--- a/src/test/scala/org/scalatest/EngineSpec.scala
+++ b/src/test/scala/org/scalatest/EngineSpec.scala
@@ -15,13 +15,14 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import events.InfoProvided
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.events.LineInFile
 import org.scalatest.exceptions._
 import org.scalatest.OutcomeOf.outcomeOf
 
-class EngineSpec extends FlatSpec with SharedHelpers with ShouldMatchers {
+class EngineSpec extends FlatSpec with ShouldMatchers {
 
   "EngineSpec.getTestNamePrefix" should "return empty string for Trunk" in {
     val engine = new Engine("concurrentFunSuiteBundleMod", "FunSuite")

--- a/src/test/scala/org/scalatest/FeatureSpecSpec.scala
+++ b/src/test/scala/org/scalatest/FeatureSpecSpec.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.events.TestStarting
 import org.scalatest.events.InfoProvided
 import org.scalatest.events.MarkupProvided
@@ -24,7 +25,7 @@ import org.scalatest.exceptions.NotAllowedException
 import org.scalatest.exceptions.TestFailedException
 */
 
-class FeatureSpecSpec extends FunSpec with SharedHelpers {
+class FeatureSpecSpec extends FunSpec {
 
   describe("A FeatureSpec") {
 

--- a/src/test/scala/org/scalatest/FilterProp.scala
+++ b/src/test/scala/org/scalatest/FilterProp.scala
@@ -19,6 +19,7 @@ import org.scalatest.events.Ordinal
 import org.scalatest.junit.JUnit3Suite
 import org.scalatest.junit.JUnitSuite
 import org.scalatest.testng.TestNGSuite
+import SharedHelpers._
 
 class FilterProp extends SuiteProp {
   

--- a/src/test/scala/org/scalatest/FlatSpecSpec.scala
+++ b/src/test/scala/org/scalatest/FlatSpecSpec.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.events._
 /* Uncomment after remove type aliases in org.scalatest package object
@@ -22,7 +23,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 */
 
-class FlatSpecSpec extends FunSpec with SharedHelpers with GivenWhenThen with ShouldMatchers {
+class FlatSpecSpec extends FunSpec with GivenWhenThen with ShouldMatchers {
 
   describe("A FlatSpec") {
 

--- a/src/test/scala/org/scalatest/FreeSpecSpec.scala
+++ b/src/test/scala/org/scalatest/FreeSpecSpec.scala
@@ -16,13 +16,14 @@
 package org.scalatest
 
 // elements
+import SharedHelpers._
 import org.scalatest.events._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 */
 
-class FreeSpecSpec extends FunSpec with SharedHelpers with GivenWhenThen {
+class FreeSpecSpec extends FunSpec with GivenWhenThen {
 
   describe("A FreeSpec") {
 

--- a/src/test/scala/org/scalatest/FunSpecSpec.scala
+++ b/src/test/scala/org/scalatest/FunSpecSpec.scala
@@ -15,13 +15,14 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.events._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 */
 
-class FunSpecSpec extends FunSpec with SharedHelpers with GivenWhenThen {
+class FunSpecSpec extends FunSpec with GivenWhenThen {
 
   describe("A FunSpec") {
 

--- a/src/test/scala/org/scalatest/FunSpecSuite.scala
+++ b/src/test/scala/org/scalatest/FunSpecSuite.scala
@@ -15,10 +15,11 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.events._
 
-class FunSpecSuite extends FunSuite with SharedHelpers {
+class FunSpecSuite extends FunSuite {
 
   test("three plain-old specifiers should be invoked in order") {
     class MySpec extends FunSpec with ShouldMatchers {

--- a/src/test/scala/org/scalatest/FunSuiteSpec.scala
+++ b/src/test/scala/org/scalatest/FunSuiteSpec.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.events._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.DuplicateTestNameException
@@ -22,7 +23,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 */
 
-class FunSuiteSpec extends FunSpec with SharedHelpers {
+class FunSuiteSpec extends FunSpec {
 
   describe("A FunSuite") {
 

--- a/src/test/scala/org/scalatest/FunSuiteSuite.scala
+++ b/src/test/scala/org/scalatest/FunSuiteSuite.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import org.scalatest.events._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.TestRegistrationClosedException
@@ -27,7 +28,7 @@ package mytags {
   object WeakAsAKitten extends Tag("org.scalatest.WeakAsAKitten")
 }
 
-class FunSuiteSuite extends Suite with SharedHelpers {
+class FunSuiteSuite extends Suite {
 
   def testThatTestMethodsWithNoTagsDontShowUpInTagsMap() {
     

--- a/src/test/scala/org/scalatest/FunctionSuiteProp.scala
+++ b/src/test/scala/org/scalatest/FunctionSuiteProp.scala
@@ -18,6 +18,6 @@ package org.scalatest
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.ShouldMatchers
 
-trait FunctionSuiteProp extends FunSuite with FunctionSuiteExamples with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers {
+trait FunctionSuiteProp extends FunSuite with FunctionSuiteExamples with TableDrivenPropertyChecks with ShouldMatchers {
 
 }

--- a/src/test/scala/org/scalatest/GivenWhenThenSpec.scala
+++ b/src/test/scala/org/scalatest/GivenWhenThenSpec.scala
@@ -15,9 +15,10 @@
  */
 package org.scalatest
 
+import SharedHelpers._
 import events.InfoProvided
 
-class GivenWhenThenSpec extends FunSpec with SharedHelpers {
+class GivenWhenThenSpec extends FunSpec {
   describe("The GivenWhenThen trait") {
 
     val theGiven = "an invalid zip code"

--- a/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class InOrderContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class InOrderContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class InOrderContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class InOrderContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
   
   class CustomEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/InOrderContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/InOrderContainMatcherSpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import collection.GenTraversable
 import collection.mutable.LinkedHashMap
 import words.InOrderContainMatcher
+import SharedHelpers._
 
-class InOrderContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class InOrderContainMatcherSpec extends Spec with Matchers {
 
   object `inOrder ` {
     

--- a/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class InOrderOnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class InOrderOnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
   
   val incremented: Normalization[Int] = 
     new Normalization[Int] {

--- a/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class InOrderOnlyContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class InOrderOnlyContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/InOrderOnlyContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/InOrderOnlyContainMatcherSpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import collection.GenTraversable
 import collection.mutable.LinkedHashMap
 import words.InOrderOnlyContainMatcher
+import SharedHelpers._
 
-class InOrderOnlyContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class InOrderOnlyContainMatcherSpec extends Spec with Matchers {
 
   object `inOrderOnly ` {
     

--- a/src/test/scala/org/scalatest/InformerSpec.scala
+++ b/src/test/scala/org/scalatest/InformerSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class InformerSpec extends FlatSpec with SharedHelpers {
+import SharedHelpers._
+
+class InformerSpec extends FlatSpec {
   /*
   "An Informer" should "give back another Informer from its compose method" in {
     var lastS = "2"

--- a/src/test/scala/org/scalatest/InspectorShorthandsRegexWithGroupsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorShorthandsRegexWithGroupsSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class InspectorShorthandsRegexWithGroupsSpec extends Spec with Matchers with SharedHelpers {
+import SharedHelpers._
+
+class InspectorShorthandsRegexWithGroupsSpec extends Spec with Matchers {
   
   def errorMessage(index: Int, message: String, lineNumber: Int, left: Any): String = 
     "'all' inspection failed, because: \n" +

--- a/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
@@ -27,8 +27,9 @@ import matchers.HavePropertyMatchResult
 import matchers.BePropertyMatcher
 import matchers.BePropertyMatchResult
 import org.scalautils.Equality
+import SharedHelpers._
 
-class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropertyChecks with SharedHelpers {
+class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropertyChecks {
 
   def examples =
     Table[Set[Int] => GenTraversable[Int]](

--- a/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
@@ -23,8 +23,9 @@ import javax.xml.transform.TransformerFactoryConfigurationError
 import scala.collection.GenTraversable
 import scala.annotation.tailrec
 import collection._
+import SharedHelpers._
 
-class InspectorsForMapSpec extends Spec with Matchers with Inspectors with TableDrivenPropertyChecks with SharedHelpers {
+class InspectorsForMapSpec extends Spec with Matchers with Inspectors with TableDrivenPropertyChecks {
 
   def examples =
     Table[Map[Int, String] => collection.GenMap[Int, String]](

--- a/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -23,8 +23,9 @@ import javax.xml.transform.TransformerFactoryConfigurationError
 import scala.collection.GenTraversable
 import scala.annotation.tailrec
 import collection._
+import SharedHelpers._
 
-class InspectorsSpec extends Spec with Matchers with Inspectors with TableDrivenPropertyChecks with SharedHelpers {
+class InspectorsSpec extends Spec with Matchers with Inspectors with TableDrivenPropertyChecks {
   
   def examples =
     Table[Set[Int] => GenTraversable[Int]](

--- a/src/test/scala/org/scalatest/LoneElementSpec.scala
+++ b/src/test/scala/org/scalatest/LoneElementSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class LoneElementSpec extends Spec with SharedHelpers {
+import SharedHelpers._
+
+class LoneElementSpec extends Spec {
 
   object `when used with Matchers` extends Matchers {
     

--- a/src/test/scala/org/scalatest/MethodSuiteProp.scala
+++ b/src/test/scala/org/scalatest/MethodSuiteProp.scala
@@ -18,6 +18,6 @@ package org.scalatest
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.ShouldMatchers
 
-trait MethodSuiteProp extends FunSuite with MethodSuiteExamples with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers {
+trait MethodSuiteProp extends FunSuite with MethodSuiteExamples with TableDrivenPropertyChecks with ShouldMatchers {
 
 }

--- a/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class NoneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class NoneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class NoneOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class NoneOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/NoneOfContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/NoneOfContainMatcherSpec.scala
@@ -16,10 +16,10 @@
 package org.scalatest
 
 import collection.GenTraversable
-
 import org.scalatest.words.NoneOfContainMatcher
+import SharedHelpers._
 
-class NoneOfContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class NoneOfContainMatcherSpec extends Spec with Matchers {
 
   object `noneOf ` {
     

--- a/src/test/scala/org/scalatest/OneInstancePerTestSpec.scala
+++ b/src/test/scala/org/scalatest/OneInstancePerTestSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest
 
 import events._
+import SharedHelpers._
 
 class TopLevelSuite extends Suite with OneInstancePerTest {
   import TopLevelSuite.sideEffectWasNotSeen
@@ -37,7 +38,7 @@ object TopLevelSuite {
   var sideEffectWasNotSeen = true
 }
 
-class OneInstancePerTestSpec extends FunSpec with SharedHelpers {
+class OneInstancePerTestSpec extends FunSpec {
   describe("The OneInstancePerTest trait") {
     it("should isolate side effects from one test to the next in a top level Suite class that does not override newInstance") {
       var sideEffectWasNotSeen = true

--- a/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class OneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class OneOfContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class OneOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class OneOfContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/OneOfContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/OneOfContainMatcherSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import collection.GenTraversable
 import words.OneOfContainMatcher
+import SharedHelpers._
 
-class OneOfContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class OneOfContainMatcherSpec extends Spec with Matchers {
 
   object `oneOf ` {
     

--- a/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
@@ -20,8 +20,9 @@ import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
 import collection.GenTraversable
+import SharedHelpers._
 
-class OnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class OnlyContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
 
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import org.scalautils.Equality
 import org.scalautils.Explicitly
 import collection.GenTraversable
+import SharedHelpers._
 
-class OnlyContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class OnlyContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/OnlyContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/OnlyContainMatcherSpec.scala
@@ -16,10 +16,10 @@
 package org.scalatest
 
 import collection.GenTraversable
-
 import words.OnlyContainMatcher
+import SharedHelpers._
 
-class OnlyContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class OnlyContainMatcherSpec extends Spec with Matchers {
 
   object `only ` {
     

--- a/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
+++ b/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalautils.Equality
+import SharedHelpers._
 
-class OptionShouldContainOneOfSpec extends Spec with Matchers with SharedHelpers {
+class OptionShouldContainOneOfSpec extends Spec with Matchers {
 
   object `an Option` {
 

--- a/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
+++ b/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalautils.Equality
+import SharedHelpers._
 
-class OptionShouldContainSpec extends Spec with Matchers with SharedHelpers {
+class OptionShouldContainSpec extends Spec with Matchers {
 
   object `an Option` {
 

--- a/src/test/scala/org/scalatest/ParallelTestExecutionProp.scala
+++ b/src/test/scala/org/scalatest/ParallelTestExecutionProp.scala
@@ -37,9 +37,11 @@ import org.scalatest.tools.TestSortingReporter
 import org.scalatest.concurrent.Eventually
 import org.scalatest.tools.DistributedTestRunnerSuite
 import org.scalatest.tools.Runner
+import SharedHelpers._
 
 class ParallelTestExecutionProp extends FunSuite 
-  with TableDrivenPropertyChecks with SharedHelpers with Eventually
+  with TableDrivenPropertyChecks 
+  with Eventually
   with ParallelTestExecutionOrderExamples 
   with ParallelTestExecutionInfoExamples 
   with ParallelTestExecutionTestTimeoutExamples

--- a/src/test/scala/org/scalatest/PropSpecSpec.scala
+++ b/src/test/scala/org/scalatest/PropSpecSpec.scala
@@ -16,12 +16,13 @@
 package org.scalatest
 
 import org.scalatest.events._
+import SharedHelpers._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
 */
 
-class PropSpecSpec extends FunSpec with SharedHelpers {
+class PropSpecSpec extends FunSpec {
 
   describe("A PropSpec") {
 

--- a/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
+++ b/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class SequentialNestedSuiteExecutionSpec extends Spec with SharedHelpers {
+import SharedHelpers._
+
+class SequentialNestedSuiteExecutionSpec extends Spec {
   object `the SequentialNestedSuiteExecution trait` {
     object `when mixed into a Suite` {
       def `should override runNestedSuites such that it calls super.runNestedSuites with the distributor set to None` {

--- a/src/test/scala/org/scalatest/SharedHelpers.scala
+++ b/src/test/scala/org/scalatest/SharedHelpers.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
 import scala.collection.GenTraversable
 import scala.collection.GenMap
 
-trait SharedHelpers extends Assertions {
+object SharedHelpers extends Assertions {
 
   object SilentReporter extends Reporter {
     def apply(event: Event) = ()  
@@ -1115,7 +1115,4 @@ trait SharedHelpers extends Assertions {
     ois.readObject.asInstanceOf[A]
   }
 }
-
-// Selfless trait pattern
-object SharedHelpers extends SharedHelpers
 

--- a/src/test/scala/org/scalatest/ShouldBeAMatcherAndOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeAMatcherAndOrSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import matchers.AMatcher
 import matchers.AnMatcher
+import SharedHelpers._
 
-class ShouldBeAMatcherAndOrSpec extends Spec with Matchers with SharedHelpers {
+class ShouldBeAMatcherAndOrSpec extends Spec with Matchers {
 
   object `AMatcher ` {
     

--- a/src/test/scala/org/scalatest/ShouldBeASymbolSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeASymbolSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldBeASymbolSpec extends Spec with Matchers with FileMocks with SharedHelpers {
+class ShouldBeASymbolSpec extends Spec with Matchers with FileMocks {
 
   object `The be a ('symbol) syntax` {
 

--- a/src/test/scala/org/scalatest/ShouldBeAnMatcherAndOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeAnMatcherAndOrSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import matchers.AMatcher
 import matchers.AnMatcher
+import SharedHelpers._
 
-class ShouldBeAnMatcherAndOrSpec extends Spec with Matchers with SharedHelpers {
+class ShouldBeAnMatcherAndOrSpec extends Spec with Matchers {
 
   object `AnMatcher ` {
     

--- a/src/test/scala/org/scalatest/ShouldBeAnSymbolSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeAnSymbolSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldBeAnSymbolSpec extends Spec with Matchers with FruitMocks with SharedHelpers {
+class ShouldBeAnSymbolSpec extends Spec with Matchers with FruitMocks {
 
   object `The be an ('symbol) syntax` {
 

--- a/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import matchers.{BeMatcher, MatchResult, BePropertyMatcher, BePropertyMatchResult}
+import SharedHelpers._
 
-class ShouldBeShorthandForAllSpec extends Spec with Matchers with SharedHelpers with EmptyMocks with BookPropertyMatchers {
+class ShouldBeShorthandForAllSpec extends Spec with Matchers with EmptyMocks with BookPropertyMatchers {
   
   def errorMessage(index: Int, message: String, lineNumber: Int, left: Any): String = 
     "'all' inspection failed, because: \n" +

--- a/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import matchers.{BeMatcher, MatchResult, BePropertyMatcher, BePropertyMatchResult}
+import SharedHelpers._
 
-class ShouldBeShorthandSpec extends Spec with Matchers with SharedHelpers with EmptyMocks with BookPropertyMatchers {
+class ShouldBeShorthandSpec extends Spec with Matchers with EmptyMocks with BookPropertyMatchers {
 
   object `The shouldBe syntax` {
 

--- a/src/test/scala/org/scalatest/ShouldBeSymbolSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSymbolSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldBeSymbolSpec extends Spec with Matchers with EmptyMocks with SharedHelpers {
+class ShouldBeSymbolSpec extends Spec with Matchers with EmptyMocks {
 
   object `The be ('symbol) syntax` {
 

--- a/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsSpec.scala
@@ -24,8 +24,9 @@ import scala.collection.GenTraversableOnce
 import org.scalautils.TripleEquals
 import org.scalautils.TypeCheckedTripleEquals
 import org.scalautils.ConversionCheckedTripleEquals
+import SharedHelpers._
 
-class ShouldCollectedTripleEqualsSpec extends Spec with NonImplicitAssertions with Matchers with SharedHelpers {
+class ShouldCollectedTripleEqualsSpec extends Spec with NonImplicitAssertions with Matchers {
 
   case class Super(size: Int)
   class Sub(sz: Int) extends Super(sz)

--- a/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsToleranceSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsToleranceSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalautils._
+import SharedHelpers._
 
-class ShouldCollectedTripleEqualsToleranceSpec extends Spec /* with NonImplicitAssertions */ with Matchers with TripleEquals with Tolerance with SharedHelpers {
+class ShouldCollectedTripleEqualsToleranceSpec extends Spec /* with NonImplicitAssertions */ with Matchers with TripleEquals with Tolerance {
 
   val sevenDotOh = 7.0
   val minusSevenDotOh = -7.0

--- a/src/test/scala/org/scalatest/ShouldContainAMatcherAndOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldContainAMatcherAndOrSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import matchers.AMatcher
 import matchers.AnMatcher
+import SharedHelpers._
 
-class ShouldContainAMatcherAndOrSpec extends Spec with Matchers with SharedHelpers {
+class ShouldContainAMatcherAndOrSpec extends Spec with Matchers {
 
   object `AMatcher ` {
     

--- a/src/test/scala/org/scalatest/ShouldContainAnMatcherAndOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldContainAnMatcherAndOrSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import matchers.AnMatcher
 import matchers.AMatcher
+import SharedHelpers._
 
-class ShouldContainAnMatcherAndOrSpec extends Spec with Matchers with SharedHelpers {
+class ShouldContainAnMatcherAndOrSpec extends Spec with Matchers {
 
   object `AMatcher ` {
     

--- a/src/test/scala/org/scalatest/ShouldEndWithRegexSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldEndWithRegexSpec.scala
@@ -20,8 +20,9 @@ import org.scalacheck._
 import Arbitrary._
 import Prop._
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldEndWithRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion with SharedHelpers {
+class ShouldEndWithRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion {
 
 /*
 s should include substring t

--- a/src/test/scala/org/scalatest/ShouldFullyMatchSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldFullyMatchSpec.scala
@@ -20,8 +20,9 @@ import org.scalacheck._
 import Arbitrary._
 import Prop._
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldFullyMatchSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion with SharedHelpers {
+class ShouldFullyMatchSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion {
 
 /*
 s should include substring t

--- a/src/test/scala/org/scalatest/ShouldIncludeRegexSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldIncludeRegexSpec.scala
@@ -20,8 +20,9 @@ import org.scalacheck._
 import Arbitrary._
 import Prop._
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldIncludeRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion with SharedHelpers {
+class ShouldIncludeRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion {
 
 /*
 s should include substring t

--- a/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import matchers.{BeMatcher, MatchResult, BePropertyMatcher, BePropertyMatchResult}
+import SharedHelpers._
 
-class ShouldNotShorthandForAllSpec extends Spec with Matchers with SharedHelpers with EmptyMocks with BookPropertyMatchers {
+class ShouldNotShorthandForAllSpec extends Spec with Matchers with EmptyMocks with BookPropertyMatchers {
   
   def errorMessage(index: Int, message: String, lineNumber: Int, left: Any): String = 
     "'all' inspection failed, because: \n" +

--- a/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import matchers.{BeMatcher, MatchResult, BePropertyMatcher, BePropertyMatchResult}
+import SharedHelpers._
 
-class ShouldNotShorthandSpec extends Spec with Matchers with SharedHelpers with EmptyMocks with BookPropertyMatchers {
+class ShouldNotShorthandSpec extends Spec with Matchers with EmptyMocks with BookPropertyMatchers {
 
   object `The shouldNot syntax` {
 

--- a/src/test/scala/org/scalatest/ShouldStartWithRegexSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldStartWithRegexSpec.scala
@@ -20,8 +20,9 @@ import org.scalacheck._
 import Arbitrary._
 import Prop._
 import org.scalatest.exceptions.TestFailedException
+import SharedHelpers._
 
-class ShouldStartWithRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion with SharedHelpers {
+class ShouldStartWithRegexSpec extends Spec with Matchers with Checkers with ReturnsNormallyThrowsAssertion {
 
 /*
 s should include substring t

--- a/src/test/scala/org/scalatest/SpecSpec.scala
+++ b/src/test/scala/org/scalatest/SpecSpec.scala
@@ -18,8 +18,9 @@ package org.scalatest
 import scala.reflect.NameTransformer.encode
 import org.scalatest.events._
 import collection.immutable.TreeSet
+import SharedHelpers._
 
-class SpecSpec extends FunSpec with PrivateMethodTester with SharedHelpers {
+class SpecSpec extends FunSpec with PrivateMethodTester {
 
   describe("A Spec") {
     /*

--- a/src/test/scala/org/scalatest/StatusProp.scala
+++ b/src/test/scala/org/scalatest/StatusProp.scala
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.testng.annotations.{Test => TestNG }
 import scala.collection.mutable.ListBuffer
 import org.scalatest.tools.SuiteRunner
+import SharedHelpers._
 
 class StatusProp extends AllSuiteProp {
   

--- a/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
+++ b/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class StepwiseNestedSuiteExecutionSpec extends Spec with SharedHelpers {
+import SharedHelpers._
+
+class StepwiseNestedSuiteExecutionSpec extends Spec {
   object `the StepwiseNestedSuiteExecution trait` {
     object `when mixed into a Suite` {
       def `should override runNestedSuites such that it calls run on nested suites in stepwise order, but with the distributor passed as is` {

--- a/src/test/scala/org/scalatest/StopOnFailureProp.scala
+++ b/src/test/scala/org/scalatest/StopOnFailureProp.scala
@@ -19,6 +19,7 @@ import org.scalatest.junit.JUnitSuite
 import org.junit.Test
 import org.testng.annotations.{Test => TestNG }
 import org.scalatest.testng.TestNGSuite
+import SharedHelpers._
 
 class StopOnFailureProp extends AllSuiteProp {
 

--- a/src/test/scala/org/scalatest/StopOnFailureSpec.scala
+++ b/src/test/scala/org/scalatest/StopOnFailureSpec.scala
@@ -15,7 +15,9 @@
  */
 package org.scalatest
 
-class StopOnFailureSpec extends FlatSpec with SharedHelpers {
+import SharedHelpers._
+
+class StopOnFailureSpec extends FlatSpec {
 
   "StopOnFailure" should "not invoke stop on the stopper if a test succeeds" in {
     class MySuite extends FunSuite with StopOnFailure {

--- a/src/test/scala/org/scalatest/SuiteProp.scala
+++ b/src/test/scala/org/scalatest/SuiteProp.scala
@@ -18,4 +18,4 @@ package org.scalatest
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.ShouldMatchers
 
-trait SuiteProp extends FunSuite with SuiteExamples with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers
+trait SuiteProp extends FunSuite with SuiteExamples with TableDrivenPropertyChecks with ShouldMatchers

--- a/src/test/scala/org/scalatest/SuiteSpec.scala
+++ b/src/test/scala/org/scalatest/SuiteSpec.scala
@@ -18,6 +18,7 @@ package org.scalatest
 import collection.immutable.TreeSet
 import org.scalatest.events._
 import scala.reflect.NameTransformer.encode
+import SharedHelpers._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestPendingException
@@ -86,7 +87,7 @@ class MandarinOrangeSpecs(suites: Suite*) extends Specs(suites: _*)
 class MandarinOrangeSequential(suites: Suite*) extends Sequential(suites: _*)
 class MandarinOrangeStepwise(suites: Suite*) extends Stepwise(suites: _*)
 
-class SuiteSpec extends FunSpec with PrivateMethodTester with SharedHelpers {
+class SuiteSpec extends FunSpec with PrivateMethodTester {
 
   describe("the toString method on Suites and SuiteLike traits other than TestNGSuiteLike") {
     describe("when the suite contains no nested suites") {

--- a/src/test/scala/org/scalatest/SuiteSuite.scala
+++ b/src/test/scala/org/scalatest/SuiteSuite.scala
@@ -22,13 +22,14 @@ import java.nio.charset.CoderMalfunctionError
 import javax.xml.parsers.FactoryConfigurationError
 import javax.xml.transform.TransformerFactoryConfigurationError
 import java.awt.AWTError
+import SharedHelpers._
 
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.NotAllowedException
 import org.scalatest.exceptions.TestFailedException
 */
 
-class SuiteSuite extends Suite with PrivateMethodTester with SharedHelpers with SeveredStackTraces {
+class SuiteSuite extends Suite with PrivateMethodTester with SeveredStackTraces {
 
   def `test: Suite should discover method names and tags using deprecated Informer form` {
 

--- a/src/test/scala/org/scalatest/SuitesSpec.scala
+++ b/src/test/scala/org/scalatest/SuitesSpec.scala
@@ -15,11 +15,13 @@
  */
 package org.scalatest
 
+import SharedHelpers._
+
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.NotAllowedException
 */
 
-class SuitesSpec extends FunSpec with SharedHelpers {
+class SuitesSpec extends FunSpec {
 
   val a = new Suite {}
   val b = new FunSuite {}

--- a/src/test/scala/org/scalatest/TestColonEscapeProp.scala
+++ b/src/test/scala/org/scalatest/TestColonEscapeProp.scala
@@ -26,6 +26,7 @@ import org.scalatest.events.IndentedText
 import org.junit.Test
 import org.testng.annotations.{Test => TestNGTest}
 import org.scalatest.events.Formatter
+import SharedHelpers._
 
 trait TestColonEscapeExamples extends Tables {
   def suite: Suite
@@ -83,7 +84,7 @@ trait NonTestColonEscapeExamples extends Tables {
     (testngSuite, Some("- test: A Succeeded Test"), Some("- test: A Failed Test"), Some("- test: An Ignored Test"), None, None))
 }
 
-class TestColonEscapeProp extends FunSuite with TestColonEscapeExamples with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers {
+class TestColonEscapeProp extends FunSuite with TestColonEscapeExamples with TableDrivenPropertyChecks with ShouldMatchers {
 
   def assertFormattedText(formatter: Option[Formatter], expected: String) {
     formatter match {
@@ -187,7 +188,7 @@ class TestColonEscapeExamplePathFunSpec extends path.FunSpec {
   }
 }
 
-class NonTestColonEscapeProp extends FunSuite with NonTestColonEscapeExamples with TableDrivenPropertyChecks with ShouldMatchers with SharedHelpers {
+class NonTestColonEscapeProp extends FunSuite with NonTestColonEscapeExamples with TableDrivenPropertyChecks with ShouldMatchers {
   
   def assertFormattedText(formatter: Option[Formatter], expected: Option[String]) {
     expected match {

--- a/src/test/scala/org/scalatest/TestDataProp.scala
+++ b/src/test/scala/org/scalatest/TestDataProp.scala
@@ -19,6 +19,7 @@ import org.scalatest.junit.JUnitSuite
 import org.junit.Test
 import org.testng.annotations.{Test => TestNG }
 import org.scalatest.testng.TestNGSuite
+import SharedHelpers._
 
 class TestDataProp extends AllSuiteProp {
 

--- a/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
@@ -19,8 +19,9 @@ import org.scalautils.Equality
 import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
+import SharedHelpers._
 
-class TheSameElementsAsContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class TheSameElementsAsContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
   
   val mapTrimmed: Normalization[(Int, String)] =
     new Normalization[(Int, String)] {

--- a/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import org.scalautils.Equality
 import org.scalautils.Explicitly
+import SharedHelpers._
 
-class TheSameElementsAsContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class TheSameElementsAsContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherSpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import collection.mutable.LinkedHashMap
 import words.TheSameElementsAsContainMatcher
+import SharedHelpers._
 
-class TheSameElementsAsContainMatcherSpec extends Spec with Matchers with SharedHelpers {
+class TheSameElementsAsContainMatcherSpec extends Spec with Matchers {
   
   object `theSameElementsAs ` {
     

--- a/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherDeciderSpec.scala
+++ b/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherDeciderSpec.scala
@@ -19,8 +19,9 @@ import org.scalautils.Equality
 import org.scalautils.Explicitly
 import org.scalautils.StringNormalizations
 import org.scalautils.Normalization
+import SharedHelpers._
 
-class TheSameIteratedElementsAsContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations with SharedHelpers {
+class TheSameIteratedElementsAsContainMatcherDeciderSpec extends Spec with Matchers with Explicitly with StringNormalizations {
   
   val incremented: Normalization[Int] = 
     new Normalization[Int] {

--- a/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherEqualitySpec.scala
+++ b/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherEqualitySpec.scala
@@ -17,8 +17,9 @@ package org.scalatest
 
 import org.scalautils.Equality
 import org.scalautils.Explicitly
+import SharedHelpers._
 
-class TheSameIteratedElementsAsContainMatcherEqualitySpec extends Spec with Matchers with Explicitly with SharedHelpers {
+class TheSameIteratedElementsAsContainMatcherEqualitySpec extends Spec with Matchers with Explicitly {
 
   class TrimEquality extends Equality[String] {
     def areEqual(left: String, right: Any) = 

--- a/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherSpec.scala
+++ b/src/test/scala/org/scalatest/TheSameIteratedElementsAsContainMatcherSpec.scala
@@ -16,10 +16,10 @@
 package org.scalatest
 
 import collection.mutable.LinkedHashMap
-
 import words.TheSameIteratedElementsAsContainMatcher
+import SharedHelpers._
 
-class TheSameIteratedElementsAsContainMatcherSpec extends Spec with Matchers with SharedHelpers  {
+class TheSameIteratedElementsAsContainMatcherSpec extends Spec with Matchers  {
 
   object `theSameIteratedElementsAs ` {
     

--- a/src/test/scala/org/scalatest/TimesOnIntSpec.scala
+++ b/src/test/scala/org/scalatest/TimesOnIntSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest
 
 import org.scalatest.events._
+import SharedHelpers._
 
-class TimesOnIntSpec extends FunSpec with SharedHelpers with TimesOnInt {
+class TimesOnIntSpec extends FunSpec with TimesOnInt {
 
   describe("The TimesOnInt trait") {
 

--- a/src/test/scala/org/scalatest/WordSpecSpec.scala
+++ b/src/test/scala/org/scalatest/WordSpecSpec.scala
@@ -17,13 +17,14 @@ package org.scalatest
 
 // elements
 import org.scalatest.events._
+import SharedHelpers._
 /* Uncomment after remove type aliases in org.scalatest package object
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.exceptions.TestFailedException
 */
 
-class WordSpecSpec extends FunSpec with SharedHelpers with GivenWhenThen {
+class WordSpecSpec extends FunSpec with GivenWhenThen {
 
   describe("A WordSpec") {
 

--- a/src/test/scala/org/scalatest/concurrent/AsyncAssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/concurrent/AsyncAssertionsSpec.scala
@@ -16,13 +16,14 @@
 package org.scalatest.concurrent
 
 import org.scalatest._
+import SharedHelpers._
 import matchers.ShouldMatchers
 import SharedHelpers.thisLineNumber
 import time.{Span, Millis}
 import org.scalatest.exceptions.NotAllowedException
 import org.scalatest.exceptions.TestFailedException
 
-class AsyncAssertionsSpec extends fixture.FunSpec with ShouldMatchers with SharedHelpers with ConductorFixture with
+class AsyncAssertionsSpec extends fixture.FunSpec with ShouldMatchers with ConductorFixture with
     OptionValues with AsyncAssertions {
 /*
   def withCause(cause: Throwable)(fun: => Unit) {

--- a/src/test/scala/org/scalatest/concurrent/ConductorDeprecatedSuite.scala
+++ b/src/test/scala/org/scalatest/concurrent/ConductorDeprecatedSuite.scala
@@ -16,14 +16,15 @@
 package org.scalatest.concurrent
 
 import org.scalatest._
+import SharedHelpers._
 import matchers.ShouldMatchers
 import Thread.State._
 import java.util.concurrent.atomic.AtomicBoolean
 import org.scalatest.exceptions.NotAllowedException
 
-class ConductorDeprecatedSuite extends FunSuite with ShouldMatchers with SharedHelpers with SeveredStackTraces {
+class ConductorDeprecatedSuite extends FunSuite with ShouldMatchers with SeveredStackTraces {
 
-  val baseLineNumber = 26
+  val baseLineNumber = thisLineNumber
 
   test("if conduct is called twice, the second time it throws an NotAllowedException") {
     val conductor = new Conductor

--- a/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
+++ b/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
@@ -16,6 +16,7 @@
 package org.scalatest.concurrent
 
 import org.scalatest._
+import SharedHelpers._
 import matchers.ShouldMatchers
 import Thread.State._
 import java.util.concurrent.atomic.AtomicBoolean
@@ -23,7 +24,7 @@ import org.scalatest.exceptions.NotAllowedException
 import org.scalatest.SharedHelpers.thisLineNumber
 import time.{Millis, Span}
 
-class ConductorSuite extends FunSuite with ShouldMatchers with Conductors with SharedHelpers with SeveredStackTraces {
+class ConductorSuite extends FunSuite with ShouldMatchers with Conductors with SeveredStackTraces {
 
   test("if conduct is called twice, the second time it throws an NotAllowedException") {
     val conductor = new Conductor

--- a/src/test/scala/org/scalatest/concurrent/TimeLimitedTestsSpec.scala
+++ b/src/test/scala/org/scalatest/concurrent/TimeLimitedTestsSpec.scala
@@ -18,9 +18,10 @@ package org.scalatest.concurrent
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.time.{Span, Millis}
 import org.scalatest._
+import SharedHelpers._
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 
-class TimeLimitedTestsSpec extends FunSpec with ShouldMatchers with SharedHelpers with SeveredStackTraces {
+class TimeLimitedTestsSpec extends FunSpec with ShouldMatchers with SeveredStackTraces {
   describe("A time-limited test") {
     describe("when it does not timeout") {
       describe("when it succeeds") {

--- a/src/test/scala/org/scalatest/events/LocationFunctionSuiteProp.scala
+++ b/src/test/scala/org/scalatest/events/LocationFunctionSuiteProp.scala
@@ -2,6 +2,7 @@ package org.scalatest.events
 
 import org.scalatest.SharedHelpers.thisLineNumber
 import org.scalatest._
+import SharedHelpers._
 
 class LocationFunctionSuiteProp extends FunctionSuiteProp {
   

--- a/src/test/scala/org/scalatest/events/LocationMethodSuiteProp.scala
+++ b/src/test/scala/org/scalatest/events/LocationMethodSuiteProp.scala
@@ -1,6 +1,7 @@
 package org.scalatest.events
 
 import org.scalatest._
+import SharedHelpers._
 
 class LocationMethodSuiteProp extends MethodSuiteProp {
   

--- a/src/test/scala/org/scalatest/events/LocationSuiteProp.scala
+++ b/src/test/scala/org/scalatest/events/LocationSuiteProp.scala
@@ -1,6 +1,7 @@
 package org.scalatest.events
 import org.scalatest.junit.JUnit3Suite
 import org.scalatest._
+import SharedHelpers._
 
 class LocationSuiteProp extends SuiteProp
 {

--- a/src/test/scala/org/scalatest/events/ScopePendingProp.scala
+++ b/src/test/scala/org/scalatest/events/ScopePendingProp.scala
@@ -2,6 +2,7 @@ package org.scalatest.events
 
 import org.scalatest.AllSuiteProp
 import org.scalatest._
+import SharedHelpers._
 
 class ScopePendingProp extends AllSuiteProp {
 

--- a/src/test/scala/org/scalatest/exceptions/PayloadSpec.scala
+++ b/src/test/scala/org/scalatest/exceptions/PayloadSpec.scala
@@ -18,6 +18,7 @@ package exceptions
 
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.SharedHelpers._
 import time.{Span, Second}
 import junit.JUnitTestFailedError
 
@@ -25,7 +26,7 @@ import junit.JUnitTestFailedError
 import org.scalatest.exceptions.TestFailedException
 */
 
-class PayloadSpec extends FlatSpec with SharedHelpers with ShouldMatchers with TableDrivenPropertyChecks with Payloads with SeveredStackTraces {
+class PayloadSpec extends FlatSpec with ShouldMatchers with TableDrivenPropertyChecks with Payloads with SeveredStackTraces {
 
   def examples =  // TODO, also support payloads in JUnit errors
     Table(

--- a/src/test/scala/org/scalatest/fixture/ConfigMapFixtureSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/ConfigMapFixtureSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 
-class ConfigMapFixtureSpec extends org.scalatest.FunSpec with SharedHelpers {
+class ConfigMapFixtureSpec extends org.scalatest.FunSpec {
   describe("A ConfigMapFixture") {
     it("should pass the config map to each test") {
       val myConfigMap = ConfigMap("hello" -> "world", "salt" -> "pepper")

--- a/src/test/scala/org/scalatest/fixture/FeatureSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/FeatureSpecSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.NotAllowedException
@@ -23,7 +24,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.events.InfoProvided
 
-class FeatureSpecSpec extends org.scalatest.FunSpec with SharedHelpers {
+class FeatureSpecSpec extends org.scalatest.FunSpec {
 
   describe("A fixture.FeatureSpec") {
     it("should return the test names in order of registration from testNames") {

--- a/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import org.scalatest.events.{TestStarting, TestFailed}
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
@@ -24,7 +25,7 @@ import org.scalatest.events.InfoProvided
 
 object SlowTest extends Tag("SlowTest")
 
-class FlatSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class FlatSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.FlatSpec ") {
     it("A fixture.Spec should return the test names in order of registration from testNames") {

--- a/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala
@@ -16,13 +16,14 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.events.InfoProvided
 
-class FreeSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class FreeSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.FreeSpec") {
 

--- a/src/test/scala/org/scalatest/fixture/FunSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/FunSpecSpec.scala
@@ -16,13 +16,14 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.events.InfoProvided
 
-class FunSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class FunSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.FunSpec") {
 

--- a/src/test/scala/org/scalatest/fixture/FunSuiteSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/FunSuiteSpec.scala
@@ -16,12 +16,13 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 
-class FunSuiteSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class FunSuiteSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.FunSuite") {
     it("should return the test names in order of registration from testNames") {

--- a/src/test/scala/org/scalatest/fixture/NoArgSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/NoArgSpec.scala
@@ -16,9 +16,10 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import NoArgSpec.invokedCount
 
-class NoArgSpec extends org.scalatest.Spec with SharedHelpers {
+class NoArgSpec extends org.scalatest.Spec {
   object `A NoArg` {
     def `should use the init function as the implementation of its apply method` {
       invokedCount = 0

--- a/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala
@@ -16,12 +16,13 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestRegistrationClosedException
 
-class PropSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class PropSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.PropSpec") {
     it("should return the test names in order of registration from testNames") {

--- a/src/test/scala/org/scalatest/fixture/SpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/SpecSpec.scala
@@ -20,12 +20,13 @@ import org.scalatest.events._
 import org.scalatest.exceptions._
 import collection.immutable.TreeSet
 import org.scalatest.Suite._
-import org.scalatest.{ PrivateMethodTester, SharedHelpers, ShouldMatchers, BeforeAndAfterEach, BeforeAndAfterAll, 
+import org.scalatest.{ PrivateMethodTester, ShouldMatchers, BeforeAndAfterEach, BeforeAndAfterAll, 
                         Filter, Args, Stopper, Tracker, Ignore, SlowAsMolasses, FastAsLight, WeakAsAKitten, Specs, 
                         Reporter, Distributor, OptionValues, NotAllowedException, Resources, DoNotDiscover, WrapWith, 
                         ConfigMapWrapperSuite, StringFixture, Status, SucceededStatus, ConfigMap, Outcome }
+import org.scalatest.SharedHelpers._
 
-class SpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class SpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.Spec") {
     /*

--- a/src/test/scala/org/scalatest/fixture/SuiteSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/SuiteSpec.scala
@@ -22,8 +22,9 @@ import events.TestSucceeded
 import mock.MockitoSugar
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.events.InfoProvided
+import SharedHelpers._
 
-class SuiteSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class SuiteSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("The private testMethodTakesInformer method") {
     val testMethodTakesAFixtureAndInformer = PrivateMethod[Boolean]('testMethodTakesAFixtureAndInformer)

--- a/src/test/scala/org/scalatest/fixture/TestDataFixtureSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/TestDataFixtureSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 
-class TestDataFixtureSpec extends org.scalatest.FunSpec with SharedHelpers {
+class TestDataFixtureSpec extends org.scalatest.FunSpec {
   describe("A TestDataFixture") {
     it("should pass the test data to each test") {
       val myConfigMap = ConfigMap("hello" -> "world", "salt" -> "pepper")

--- a/src/test/scala/org/scalatest/fixture/UnitFixtureSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/UnitFixtureSpec.scala
@@ -16,8 +16,9 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 
-class UnitFixtureSpec extends org.scalatest.Spec with SharedHelpers {
+class UnitFixtureSpec extends org.scalatest.Spec {
   object `A UnitFixture` {
     def `should pass the unit value to each test` {
       class MySuite extends fixture.FunSuite with UnitFixture {

--- a/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala
+++ b/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.fixture
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestFailed
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestRegistrationClosedException
@@ -23,7 +24,7 @@ import org.scalatest.events.InfoProvided
 import org.scalatest.events.MotionToSuppress
 import org.scalatest.events.IndentedText
 
-class WordSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester with SharedHelpers {
+class WordSpecSpec extends org.scalatest.FunSpec with PrivateMethodTester {
 
   describe("A fixture.WordSpec") {
 

--- a/src/test/scala/org/scalatest/junit/JUnit3SuiteSpec.scala
+++ b/src/test/scala/org/scalatest/junit/JUnit3SuiteSpec.scala
@@ -16,11 +16,12 @@
 package org.scalatest.junit
 
 import org.scalatest._
+import SharedHelpers._
 import collection.immutable.TreeSet
 import helpers._
 import org.scalatest.events._
 
-class JUnit3SuiteSpec extends FunSpec with SharedHelpers {
+class JUnit3SuiteSpec extends FunSpec {
 
   describe("A JUnit3Suite") {
     it("should return the test names in alphabetical order from testNames") {

--- a/src/test/scala/org/scalatest/junit/JUnitSuiteSpec.scala
+++ b/src/test/scala/org/scalatest/junit/JUnitSuiteSpec.scala
@@ -16,12 +16,13 @@
 package org.scalatest.junit
 
 import org.scalatest._
+import SharedHelpers._
 import scala.collection.immutable.TreeSet
 import org.scalatest.junit.junit4helpers._
 import org.junit.Test
 import org.junit.Ignore
 
-class JUnitSuiteSpec extends FunSpec with SharedHelpers {
+class JUnitSuiteSpec extends FunSpec {
 
   describe("A JUnitSuite") {
     it("should return the test names in alphabetical order from testNames") {

--- a/src/test/scala/org/scalatest/mock/EasyMockSugarSpec.scala
+++ b/src/test/scala/org/scalatest/mock/EasyMockSugarSpec.scala
@@ -16,9 +16,10 @@
 package org.scalatest.mock
 
 import org.scalatest._
+import SharedHelpers._
 import matchers.ShouldMatchers
 
-class EasyMockSugarSpec extends FlatSpec with ShouldMatchers with SharedHelpers {
+class EasyMockSugarSpec extends FlatSpec with ShouldMatchers {
   "The EasyMockSugar trait's whenExecuting method" should
           "work with multiple mocks passed in" in {
     val a = new Suite with EasyMockSugar {

--- a/src/test/scala/org/scalatest/mock/JMockCycleSpec.scala
+++ b/src/test/scala/org/scalatest/mock/JMockCycleSpec.scala
@@ -16,11 +16,12 @@
 package org.scalatest.mock
 
 import org.scalatest._
+import SharedHelpers._
 import org.scalatest.fixture
 import matchers.ShouldMatchers
 import org.jmock.Expectations.{equal => thatEquals}
 
-class JMockCycleSpec extends FlatSpec with ShouldMatchers with SharedHelpers {
+class JMockCycleSpec extends FlatSpec with ShouldMatchers {
 
   "The JMockCycle trait" should "work with multiple mocks" in {
 

--- a/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
+++ b/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.path
 
 import org.scalatest._
+import SharedHelpers._
 
 import org.scalatest.path.{ FreeSpec => PathFreeSpec }
 // elements
@@ -24,7 +25,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestRegistrationClosedException
 
-class FreeSpecSpec extends org.scalatest.FunSpec with SharedHelpers with GivenWhenThen {
+class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
 
   describe("A FreeSpec") {
 

--- a/src/test/scala/org/scalatest/path/FunSpecSpec.scala
+++ b/src/test/scala/org/scalatest/path/FunSpecSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.path
 
 import org.scalatest._
+import SharedHelpers._
 
 import org.scalatest.path.{ FunSpec => PathFunSpec }
 import org.scalatest.events._
@@ -23,7 +24,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.DuplicateTestNameException
 import org.scalatest.exceptions.TestRegistrationClosedException
 
-class FunSpecSpec extends org.scalatest.FreeSpec with SharedHelpers with GivenWhenThen {
+class FunSpecSpec extends org.scalatest.FreeSpec with GivenWhenThen {
 
   "A path.FunSpec" - {
 

--- a/src/test/scala/org/scalatest/suiteprop/PathSuiteMatrix.scala
+++ b/src/test/scala/org/scalatest/suiteprop/PathSuiteMatrix.scala
@@ -1,10 +1,11 @@
 package org.scalatest.suiteprop
 
 import org.scalatest._
+import SharedHelpers._
 import prop.TableDrivenPropertyChecks
 import matchers.ShouldMatchers
 
-class PathSuiteMatrix extends PropSpec with ShouldMatchers with TableDrivenPropertyChecks with SharedHelpers {
+class PathSuiteMatrix extends PropSpec with ShouldMatchers with TableDrivenPropertyChecks {
   
   property("A path trait should execute the first test, and only the first test, on initial instance creation") {
 

--- a/src/test/scala/org/scalatest/suiteprop/SuiteMatrix.scala
+++ b/src/test/scala/org/scalatest/suiteprop/SuiteMatrix.scala
@@ -16,10 +16,11 @@
 package org.scalatest.suiteprop
 
 import org.scalatest._
+import SharedHelpers._
 import prop.TableDrivenPropertyChecks
 import matchers.ShouldMatchers
 
-class SuiteMatrix extends PropSpec with ShouldMatchers with TableDrivenPropertyChecks with SharedHelpers {
+class SuiteMatrix extends PropSpec with ShouldMatchers with TableDrivenPropertyChecks {
 
   property("When info appears in the code of a successful test, it should be reported in the TestSucceeded.") {
     new InfoInsideTestFiredAfterTestExamples {

--- a/src/test/scala/org/scalatest/tools/DashboardReporterSpec.scala
+++ b/src/test/scala/org/scalatest/tools/DashboardReporterSpec.scala
@@ -1,9 +1,10 @@
 package org.scalatest.tools
 
 import org.scalatest._
+import SharedHelpers._
 import events._
 
-class DashboardReporterSpec extends Spec with SharedHelpers {
+class DashboardReporterSpec extends Spec {
 
   object `DashboardReporter ` {
     

--- a/src/test/scala/org/scalatest/tools/HtmlReporterSpec.scala
+++ b/src/test/scala/org/scalatest/tools/HtmlReporterSpec.scala
@@ -1,9 +1,10 @@
 package org.scalatest.tools
 
 import org.scalatest._
+import SharedHelpers._
 import org.scalatest.events.{SuiteCompleted, SuiteAborted, Ordinal, TestStarting}
 
-class HtmlReporterSpec extends Spec with SharedHelpers {
+class HtmlReporterSpec extends Spec {
 
   object `HtmlReporter ` {
     

--- a/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
+++ b/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
@@ -29,8 +29,9 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.time.Span
 import org.scalatest.time.Seconds
 import org.scalatest._
+import SharedHelpers._
 
-class XmlSocketReporterSpec extends FunSpec with SharedHelpers with Eventually {
+class XmlSocketReporterSpec extends FunSpec with Eventually {
   
   class SocketEventRecorder(socket: ServerSocket) extends Runnable {
     @volatile

--- a/src/test/scala/org/scalatest/words/CanVerbSuite.scala
+++ b/src/test/scala/org/scalatest/words/CanVerbSuite.scala
@@ -16,9 +16,10 @@
 package org.scalatest.words
 
 import org.scalatest._
+import SharedHelpers._
 import events.TestSucceeded
 
-class CanVerbSuite extends FunSuite with SharedHelpers {
+class CanVerbSuite extends FunSuite {
   test("can use can in WordSpec (which might be very convenient at times)") {
     class MySpec extends WordSpec {
       "A thingy" can {


### PR DESCRIPTION
Changed SharedHelpers as object, and use it by importing instead of mixing it in.
