### PR TITLE
Minor adjustment for test-interface

### DIFF
--- a/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/src/main/scala/org/scalatest/tools/Framework.scala
@@ -850,7 +850,7 @@ class Framework extends SbtFramework {
             eventHandler.handle(ScalaTestSbtEvent(fullyQualifiedName, fingerprint, getTestSelector(t.suiteId, t.testName), SbtStatus.Success, new OptionalThrowable, t.duration.getOrElse(0)))
           case t: TestIgnored => 
             summaryCounter.incrementTestsIgnoredCount()
-            eventHandler.handle(ScalaTestSbtEvent(fullyQualifiedName, fingerprint, getTestSelector(t.suiteId, t.testName), SbtStatus.Ignored, new OptionalThrowable, 0))
+            eventHandler.handle(ScalaTestSbtEvent(fullyQualifiedName, fingerprint, getTestSelector(t.suiteId, t.testName), SbtStatus.Ignored, new OptionalThrowable, -1))
           case t: TestCanceled =>
             summaryCounter.incrementTestsCanceledCount()
             eventHandler.handle(ScalaTestSbtEvent(fullyQualifiedName, fingerprint, getTestSelector(t.suiteId, t.testName), SbtStatus.Canceled, new OptionalThrowable, t.duration.getOrElse(0)))

--- a/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -234,7 +234,7 @@ class FrameworkSuite extends FunSuite {
     assert(Status.Ignored === event.status)
     assert(suiteClassName === event.fullyQualifiedName)
     assert(fingerprint === event.fingerprint)
-    assert(event.duration === 0)
+    assert(event.duration === -1)
     assert(!event.throwable.isDefined)
     val selector = event.selector
     selector match {
@@ -295,7 +295,7 @@ class FrameworkSuite extends FunSuite {
     assert(Status.Ignored === event.status)
     assert(suiteClassName === event.fullyQualifiedName)
     assert(fingerprint === event.fingerprint)
-    assert(event.duration === 0)
+    assert(event.duration === -1)
     assert(!event.throwable.isDefined)
     val selector = event.selector
     selector match {


### PR DESCRIPTION
Changed Event fired by TestIgnored to have duration of -1, which is the correct behavior specified by test-interface javadoc.
