### PR TITLE
Array & Java List tests for Sorted Matchers, and WrappedArray Cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -203,6 +203,7 @@
         	<include name="GenFactories.scala" />
         	<include name="GenTheyWord.scala" />
         	<include name="GenContain.scala" />
+        	<include name="GenSorted.scala" />
         	<include name="GenLoneElement.scala" />
         </scalac>
     </target>
@@ -281,6 +282,15 @@
 		<arg value="${build.generated.tests.src}" />
 		<arg value="${scala.version}" />
       </java>
+	</target>
+	
+	<target name="gensorted" depends="init, compile-codegenerators"
+	        unless="gensorted.uptodate">
+	  <java classname="GenSorted"
+	        classpathref="run.generators.class.path" fork="false">
+	    <arg value="${build.generated.tests.src}" />
+	    <arg value="${scala.version}" />
+	  </java>
 	</target>
 	
 	<target name="genloneelement" depends="init, compile-codegenerators"
@@ -387,7 +397,7 @@
 	  <delete dir="${build.generated.tests.bin}" />
 	</target>
 	
-    <target name="compile-gentests" depends="compile-tests, geninspectors, gencontain, genloneelement">
+    <target name="compile-gentests" depends="compile-tests, geninspectors, gencontain, gensorted, genloneelement">
       <scalac srcdir="${build.generated.tests.src}" destdir="${build.generated.tests.bin}" target="jvm-1.5" classpathref="build.test.class.path" deprecation="yes" addparams="-no-specialization" fork="true" jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
 		<include name="org/scalatest/junit/*.scala"/>
 		<include name="org/scalatest/matchers/*.scala"/>
@@ -398,7 +408,7 @@
 		<include name="org/scalatest/inspectors/atLeast/*.scala"/>
 		<include name="org/scalatest/inspectors/atMost/*.scala"/>
       </scalac>
-	  <scalac srcdir="${build.generated.tests.src}" destdir="${build.generated.tests.bin}" target="jvm-1.5" classpathref="build.test.class.path" deprecation="yes" addparams="-no-specialization" fork="true" jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
+      <scalac srcdir="${build.generated.tests.src}" destdir="${build.generated.tests.bin}" target="jvm-1.5" classpathref="build.test.class.path" deprecation="yes" addparams="-no-specialization" fork="true" jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
         <include name="org/scalatest/inspectors/between/*.scala"/>
         <include name="org/scalatest/inspectors/every/*.scala"/>
         <include name="org/scalatest/inspectors/exactly/*.scala"/>
@@ -412,6 +422,9 @@
       </scalac>
       <scalac srcdir="${build.generated.tests.src}" destdir="${build.generated.tests.bin}" target="jvm-1.5" classpathref="build.test.class.path" deprecation="yes" addparams="-no-specialization" fork="true" jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
         <include name="org/scalatest/lone/*.scala"/>
+      </scalac>
+      <scalac srcdir="${build.generated.tests.src}" destdir="${build.generated.tests.bin}" target="jvm-1.5" classpathref="build.test.class.path" deprecation="yes" addparams="-no-specialization" fork="true" jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
+        <include name="org/scalatest/sorted/*.scala"/>
       </scalac>
 <!--
  <echo message="Compiling ArrayShouldContainAllOfLogicalAndSpec.scala"/>

--- a/project/GenInspectors.scala
+++ b/project/GenInspectors.scala
@@ -113,8 +113,8 @@ object GenInspectors {
     val xsName: String = "xs"
     val maxSucceed = max + 1
     def extractXsName =
-      if (xsName.startsWith("\"WrappedArray(")) {
-        val elements = xsName.substring(1, xsName.length - 2).substring(13)
+      if (xsName.startsWith("\"Array(")) {
+        val elements = xsName.substring(1, xsName.length - 2).substring(6)
         if (colType == "String")
           "Array(" + elements.split(", ").map(e => if (e != "null") "\"" + e + "\"" else e).mkString(", ") + ")"
         else
@@ -421,7 +421,7 @@ object GenInspectors {
       "val empty = new EmptyBePropertyMatcher()\n" + 
       "def plength(expectedValue: Int) = new StringLengthMatcher(expectedValue)\n" + 
       "val theInstance = \"2\"\n" + 
-      "def arrayToString(xs: GenTraversable[_]): String = xs.toString\n" +  // pass in array so that it is implicit converted
+      "def arrayToString(xs: GenTraversable[_]): String = FailureMessages.decorateToStringValue(xs)\n" + 
       "def checkErrorAndCause(e: exceptions.TestFailedException, assertLineNumber: Int, fileName: String, errorMessage: String, causeErrorMessage: String) {\n" +
       "  assert(e.failedCodeFileName == Some(fileName), e.failedCodeFileName + \" did not equal \" + Some(fileName))\n" + 
       "  assert(e.failedCodeLineNumber == Some(assertLineNumber), e.failedCodeLineNumber + \" did not equal \" + Some(assertLineNumber))\n" +
@@ -1042,7 +1042,7 @@ object GenInspectors {
     !(colText.startsWith("Array") && condition == "'traversable should not be symbol' failed")
   
   def genInspectorShorthandsForAllSpecFile(targetDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
               
     val succeedTests = 
     int123Col map { case (colText, xsText) =>
@@ -1058,7 +1058,7 @@ object GenInspectors {
         ("more than one element failed", " should be < 2", "getFirstLessThan", "getFirstMoreThanEqual", "2", (errorFun: String, errorValue: String) => new WasNotLessThanMessageTemplate(intDynaFirst(errorFun, errorValue), 2))
       ) ++ stdInt123Types(intDynaFirst, 2, "getFirst")
               
-      val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+      val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
             
       def stringDynaFirst(errorFun: String, errorValue: String) = 
         new DynamicFirstElementTemplate("String", errorFun, errorValue)
@@ -1068,17 +1068,17 @@ object GenInspectors {
             
       val nullStringTypes = stdNullStringTypes(stringDynaFirst, "getFirst")
               
-      val propertyCheckCol = genCol("\"\", \"boom!\", \"\"", "\"WrappedArray(, boom!, )\"")
+      val propertyCheckCol = genCol("\"\", \"boom!\", \"\"", "\"Array(, boom!, )\"")
             
       val propertyCheckTypes = stdPropertyCheckTypes(0, stringDynaFirst, stringDynaFirst, stringDynaFirstLength, "getFirst")
       
       val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, stringDynaFirst, stringDynaFirstLength, "getFirst")
               
-      val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+      val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
             
       val instanceCheckTypes = stdInstanceCheckTypes(stringDynaFirst, "2", "getFirst")
             
-      val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+      val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
               
       val stringCheckTypes = stdStringCheckTypes(stringDynaFirst, "getFirst")
             
@@ -1094,13 +1094,13 @@ object GenInspectors {
       def trvStringDynaFirstSize(colType: String, errorFun: String, errorValue: String) = 
         new DynamicFirstElementSizeTemplate(colType, errorFun, errorValue)
               
-      val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+      val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
             
       val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvStringDynaFirst, "getFirst").filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
         condition != "'traversable should be symbol' failed"
       }
               
-      val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+      val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
             
       val traversableCheckTypes = stdTraversableCheckTypes(trvStringDynaFirst, trvStringDynaFirstSize, 0, 1, "hi", "getFirst")
               
@@ -1249,7 +1249,7 @@ object GenInspectors {
   }
   
   def genInspectorShorthandsForAtLeastSpecFile(targetDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
               
     val succeedTests = 
     (int123Col map { case (colText, xsText) =>
@@ -1282,25 +1282,25 @@ object GenInspectors {
         ("at least one element failed", " should equal (2)", "indexElementEqual[Int]", "indexElementNotEqual[Int]", "2", (errorFun: String, errorValue: String) => new DidNotEqualMessageTemplate("{1}", 2, false))
       ) ++ stdInt123Types(simpleMessageFun, 2, "indexElement", false)
     
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false)
     
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"WrappedArray(, boom!, hi)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"Array(, boom!, hi)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(0, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement")
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
     
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement")
     
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
     
-    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
     
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 0, 1, "hi", "indexElement", true)
     
     val maps = genMap(Array("\"1\" -> \"one\", \"2\" -> \"two\", \"3\" -> \"three\"", 
@@ -1449,7 +1449,7 @@ object GenInspectors {
   }
   
   def genInspectorShorthandsForEverySpecFile(targetMatchersDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
               
     val succeedTests = 
     int123Col map { case (colText, xsText) =>
@@ -1483,25 +1483,25 @@ object GenInspectors {
         ("more than one element failed", " should be < 2", "indexElementLessThan", "indexElementMoreThanEqual", "2", (errorFun: String, errorValue: String) => new WasNotLessThanMessageTemplate("{1}", 2, false))
       ) ++ stdInt123Types(simpleMessageFun, 2, "indexElement", false)
       
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false)
     
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"WrappedArray(, boom!, hi)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"Array(, boom!, hi)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(0, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement")
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
     
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement")
     
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
     
-    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
     
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 0, 1, "hi", "indexElement", true)
     
     val maps = genMap(Array("\"1\" -> \"one\", \"2\" -> \"two\", \"3\" -> \"three\"", 
@@ -1650,7 +1650,7 @@ object GenInspectors {
   }
   
   def genInspectorShorthandsForExactlySpecFile(targetMatchersDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
               
     val succeedTests = 
     (int123Col map { case (colText, xsText) =>
@@ -1683,25 +1683,25 @@ object GenInspectors {
         ("less one element passed", " should equal (2)", "Equal[Int]", "indexElementNotEqual[Int]", "2", (errorFun: String, errorValue: String) => new DidNotEqualMessageTemplate("{1}", 2, false))
       ) ++ stdInt123Types(simpleMessageFun, 2, "indexElement", false)
     
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false)
     
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"WrappedArray(, boom!, hi)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"Array(, boom!, hi)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(0, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement")
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
       
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement")
     
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
     
-    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
     
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 0, 1, "hi", "indexElement", true)
     
     val maps = genMap(Array("\"1\" -> \"one\", \"2\" -> \"two\", \"3\" -> \"three\"", 
@@ -1851,7 +1851,7 @@ object GenInspectors {
   }
 
   def genInspectorShorthandsForNoSpecFile(targetMatchersDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
 
     val succeedTests =
       int123Col map { case (colText, xsText) =>
@@ -1884,25 +1884,25 @@ object GenInspectors {
         ("at least one element failed", " should equal (2)", "Equal[Int]", "indexElementNotEqual[Int]", "2", (errorFun: String, errorValue: String) => new DidNotEqualMessageTemplate("{1}", 2, false))
       ) ++ stdInt123Types(simpleMessageFun, 2, "indexElement", false)
 
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false)
 
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"WrappedArray(, boom!, hi)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"Array(, boom!, hi)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(0, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement")
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
 
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement")
 
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
 
-    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
 
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 1, 2, "hi", "indexElement", true)
 
     val maps = genMap(Array("\"1\" -> \"one\", \"2\" -> \"two\", \"3\" -> \"three\"",
@@ -2050,7 +2050,7 @@ object GenInspectors {
   }
 
   def genInspectorShorthandsForBetweenSpecFile(targetMatchersDir: File) {
-    val int123Col = genCol("1, 2, 3", "\"WrappedArray(1, 2, 3)\"")
+    val int123Col = genCol("1, 2, 3", "\"Array(1, 2, 3)\"")
 
     val succeedTests =
       int123Col map { case (colText, xsText) =>
@@ -2083,25 +2083,25 @@ object GenInspectors {
         ("less one element passed", " should equal (2)", "Equal[Int]", "indexElementNotEqual[Int]", "2", (errorFun: String, errorValue: String) => new DidNotEqualMessageTemplate("{1}", 2, false))
       ) ++ stdInt123Types(simpleMessageFun, 2, "indexElement", false)
 
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false)
 
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"WrappedArray(, boom!, hi)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\"", "\"Array(, boom!, hi)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(0, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement")
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(0, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
 
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"WrappedArray(1, 2, 3)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\"", "\"Array(1, 2, 3)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement")
 
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"WrappedArray(hello A!, hi B, hello C!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\"", "\"Array(hello A!, hi B, hello C!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
 
-    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", ""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array())\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
 
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     // XXX
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 0, 1, "hi", "indexElement", true)
 
@@ -2252,7 +2252,7 @@ object GenInspectors {
   }
 
   def genInspectorShorthandsForAtMostSpecFile(targetMatchersDir: File) {
-    val int123Col = genCol("1, 2, 3, 4, 5", "\"WrappedArray(1, 2, 3, 4, 5)\"")
+    val int123Col = genCol("1, 2, 3, 4, 5", "\"Array(1, 2, 3, 4, 5)\"")
 
     val succeedTests =
       (int123Col map { case (colText, xsText) =>
@@ -2290,12 +2290,12 @@ object GenInspectors {
         condition != "'should be ===' failed"// no way to get this two to fail with atMost(1).
       })
 
-    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"WrappedArray(1, null, 3)\"")
+    val nullStringCol = genNullableCol("\"1\", null, \"3\"", "\"Array(1, null, 3)\"")
     val nullStringTypes = stdNullStringTypes(quotedSimpleMessageFun, "indexElement", false).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'should be null' failed"
     }
 
-    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\", \"cool!\", \"great!\"", "\"WrappedArray(, boom!, hi, cool!, great!)\"")
+    val propertyCheckCol = genCol("\"\", \"boom!\", \"hi\", \"cool!\", \"great!\"", "\"Array(, boom!, hi, cool!, great!)\"")
     val propertyCheckTypes = stdPropertyCheckTypes(5, quotedSimpleMessageFun, quotedSimpleMessageFun2, simpleMessageFun, "indexElement").filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'should be symbol' failed" &&
       condition != "'should be property' failed" &&
@@ -2307,20 +2307,20 @@ object GenInspectors {
     }
     val lengthSizeCheckTypes = stdLengthSizeCheckTypes(5, quotedSimpleMessageFun, lengthSimpleMessageFun, "indexElement")
 
-    val instanceCheckCol = genCol("\"1\", theInstance, \"3\", \"4\", \"5\"", "\"WrappedArray(1, 2, 3, 4, 5)\"")
+    val instanceCheckCol = genCol("\"1\", theInstance, \"3\", \"4\", \"5\"", "\"Array(1, 2, 3, 4, 5)\"")
     val instanceCheckTypes = stdInstanceCheckTypes(quotedSimpleMessageFun, "2", "indexElement").filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'should be theSameInstanceAs' failed"
     }
 
-    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\", \"hi D\", \"hello E!\"", "\"WrappedArray(hello A!, hi B, hello C!, hi D, hello E!)\"")
+    val stringCheckCol = genCol("\"hello A!\", \"hi B\", \"hello C!\", \"hi D\", \"hello E!\"", "\"Array(hello A!, hi B, hello C!, hi D, hello E!)\"")
     val stringCheckTypes = stdStringCheckTypes(quotedSimpleMessageFun, "indexElement", true)
 
-    val traversablePropertyCheckCol = genColCol("String", Array("\"\", \"boom!\", \"great!\"", "", "\"hi\", \"cool!\""), "\"WrappedArray(Array(), Array(\\\"boom!\\\"), Array(\\\"hi\\\"), Array(\\\"cool!\\\"), Array(\\\"great!\\\"))\"")
+    val traversablePropertyCheckCol = genColCol("String", Array("\"\", \"boom!\", \"great!\"", "", "\"hi\", \"cool!\""), "\"Array(Array(), Array(\\\"boom!\\\"), Array(\\\"hi\\\"), Array(\\\"cool!\\\"), Array(\\\"great!\\\"))\"")
     val traversablePropertyCheckTypes = stdTraversablePropertyCheckTypes(trvSimpleMessageFun, "indexElement", true).filter { case (condition, assertText, okFun, errorFun, errorValue, messageFun) =>
       condition != "'traversable should be symbol' failed"
     }
 
-    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\"", "\"boom!\", \"hi\""), "\"WrappedArray(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
+    val traversableCheckCol = genColCol("String", Array("\"hi\"", "\"boom!\"", "\"hello\"", "\"boom!\", \"hi\""), "\"Array(Array(\\\"hi\\\"), Array(\\\"boom!\\\"), Array(\\\"hello\\\"))\"")
     val traversableCheckTypes = stdTraversableCheckTypes(trvSimpleMessageFun, trvSizeSimpleMessageFun, 1, 2, "hi", "indexElement", true)
 
     val maps = genMap(Array("\"1\" -> \"one\", \"2\" -> \"two\", \"3\" -> \"three\"",

--- a/project/GenSorted.scala
+++ b/project/GenSorted.scala
@@ -1,0 +1,98 @@
+/*
+* Copyright 2001-2013 Artima, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import scala.annotation.tailrec
+import io.Source
+import java.io.{File, FileWriter, BufferedWriter}
+
+object GenSorted {
+  
+  def translateLine(line: String, mapping: (String, String)*): String = {
+    @tailrec
+    def translate(current: String, itr: Iterator[(String, String)]): String = 
+      if (itr.hasNext) {
+        val next = itr.next
+        translate(current.replaceAll(next._1, next._2), itr)
+      }
+      else
+        current
+    translate(line, mapping.toIterator)
+  }
+  
+  def genTest(targetBaseDir: File, scalaVersion: String) {
+    
+    val sourceBaseDir = new File("src/test/scala/org/scalatest")
+    val sortedDir = new File(targetBaseDir, "sorted")
+    sortedDir.mkdirs()
+    
+    def generateFile(sourceFileName: String, generatedFileName: String, mapping: (String, String)*) {
+      val generatedFile = new File(sortedDir, generatedFileName)
+      val writer = new BufferedWriter(new FileWriter(generatedFile))
+      try {
+        val lines = Source.fromFile(new File(sourceBaseDir, sourceFileName)).getLines().toList // for 2.8
+        for (line <- lines) {
+          val generatedLine = translateLine(line, mapping.toList: _*)
+          writer.write(generatedLine.toString)
+          writer.newLine() // add for 2.8
+        }
+      }
+      finally {
+        writer.close()
+        println("Generated " + generatedFile.getAbsolutePath)
+      }
+    }
+    
+    val arrayMapping = 
+      List(
+        "List\\[String\\]" -> "Array[String]", 
+        "List\\[Int\\]" -> "Array[Int]", 
+        "List" -> "Array", 
+        "Nil" -> "Array()", 
+        "ShouldBeSortedSpec" -> "ShouldBeSortedForArraySpec", 
+        "ShouldBeSortedLogicalAndSpec" -> "ShouldBeSortedLogicalAndForArraySpec", 
+        "ShouldBeSortedLogicalOrSpec" -> "ShouldBeSortedLogicalOrForArraySpec"
+      )
+      
+    val javaListMapping = 
+      List(
+        "//ADDITIONAL//" -> "import SharedHelpers.javaList", 
+        "List\\[String\\]" -> "java.util.List[String]", 
+        "List\\[Int\\]" -> "java.util.List[Int]", 
+        "List.empty\\[Int\\]" -> "javaList[Int]()", 
+        "List.empty\\[Student\\]" -> "javaList[Student]()", 
+        "List\\(1, 2, 3\\)" -> "javaList(1, 2, 3)", 
+        "List\\(3, 2, 1\\)" -> "javaList(3, 2, 1)", 
+        "List\\(Student" -> "javaList(Student", 
+        "ShouldBeSortedSpec" -> "ShouldBeSortedForJavaColSpec", 
+        "ShouldBeSortedLogicalAndSpec" -> "ShouldBeSortedLogicalAndForJavaColSpec",
+        "ShouldBeSortedLogicalOrSpec" -> "ShouldBeSortedLogicalOrForJavaColSpec"
+      )
+    
+    generateFile("ShouldBeSortedSpec.scala", "ShouldBeSortedForArraySpec.scala", arrayMapping: _*)
+    generateFile("ShouldBeSortedLogicalAndSpec.scala", "ShouldBeSortedLogicalAndForArraySpec.scala", arrayMapping: _*)
+    generateFile("ShouldBeSortedLogicalOrSpec.scala", "ShouldBeSortedLogicalOrForArraySpec.scala", arrayMapping: _*)
+    
+    generateFile("ShouldBeSortedSpec.scala", "ShouldBeSortedForJavaColSpec.scala", javaListMapping: _*)
+    generateFile("ShouldBeSortedLogicalAndSpec.scala", "ShouldBeSortedLogicalAndForJavaColSpec.scala", javaListMapping: _*)
+    generateFile("ShouldBeSortedLogicalOrSpec.scala", "ShouldBeSortedLogicalOrForJavaColSpec.scala", javaListMapping: _*)
+  }
+  
+  def main(args: Array[String]) {
+    val targetDir = args(0)
+    val scalaVersion = args(1)
+    genTest(new File(targetDir + "/org/scalatest/"), scalaVersion)
+  }
+}

--- a/src/main/scala/org/scalatest/FailureMessages.scala
+++ b/src/main/scala/org/scalatest/FailureMessages.scala
@@ -17,6 +17,7 @@ package org.scalatest
 
 import java.util.ResourceBundle
 import java.text.MessageFormat
+import scala.collection.mutable.WrappedArray
 
 /**
  * Grab a resource intended for use in a failure message. For each argument passed,
@@ -34,6 +35,7 @@ private[scalatest] object FailureMessages {
       case aString: String => "\"" + aString + "\""
       case aChar: Char =>  "\'" + aChar + "\'"
       case anArray: Array[_] =>  prettifyArrays(anArray)
+      case aWrappedArray: WrappedArray[_] => prettifyArrays(aWrappedArray)
       case anythingElse => anythingElse.toString
     }
 
@@ -44,6 +46,7 @@ private[scalatest] object FailureMessages {
   def prettifyArrays(o: Any): String = {
     o match {
       case arr: Array[_] => "Array(" + (arr map (a => prettifyArrays(a))).mkString(", ") + ")"
+      case wrappedArr: WrappedArray[_] => "Array(" + (wrappedArr map (a => prettifyArrays(a))).mkString(", ") + ")"
       case _ => if (o != null) o.toString else "null"
     }
   }

--- a/src/main/scala/org/scalatest/Inspectors.scala
+++ b/src/main/scala/org/scalatest/Inspectors.scala
@@ -5,6 +5,7 @@ import scala.annotation.tailrec
 import org.scalatest.exceptions.StackDepthExceptionHelper.getStackDepthFun
 import scala.collection.GenSeq
 import Suite.indentLines
+import FailureMessages.decorateToStringValue
 
 /**
  * Provides nestable <em>inspector methods</em> (or just <em>inspectors</em>) that enable assertions to be made about collections.
@@ -287,7 +288,7 @@ private[scalatest] object InspectorsHelper {
       runFor(xs.toIterator, resourceNamePrefix, 0, new ForResult[T], fun, _.failedElements.length > 0)
     if (result.failedElements.length > 0) 
       throw new exceptions.TestFailedException(
-        sde => Some(Resources(resourceName, indentErrorMessages(result.messageAcc).mkString(", \n"), xs.toString)),
+        sde => Some(Resources(resourceName, indentErrorMessages(result.messageAcc).mkString(", \n"), decorateToStringValue(xs))),
         Some(result.failedElements(0)._3),
         getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment)
       )
@@ -330,9 +331,9 @@ private[scalatest] object InspectorsHelper {
         sde => 
           Some(
             if (passedCount > 0)
-              Resources(resourceName, min.toString, elementLabel(passedCount), indentErrorMessages(messageAcc).mkString(", \n"), xs.toString)
+              Resources(resourceName, min.toString, elementLabel(passedCount), indentErrorMessages(messageAcc).mkString(", \n"), decorateToStringValue(xs))
             else
-              Resources(resourceName + "NoElement", min.toString, indentErrorMessages(messageAcc).mkString(", \n"), xs.toString)
+              Resources(resourceName + "NoElement", min.toString, indentErrorMessages(messageAcc).mkString(", \n"), decorateToStringValue(xs))
           ),
         None,
         getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment)
@@ -367,7 +368,7 @@ private[scalatest] object InspectorsHelper {
     val messageList = runAndCollectErrorMessage(xs.toIterator, IndexedSeq.empty, 0)(fun)
     if (messageList.size > 0)
       throw new exceptions.TestFailedException(
-          sde => Some(Resources(resourceName, indentErrorMessages(messageList).mkString(", \n"), xs)),
+          sde => Some(Resources(resourceName, indentErrorMessages(messageList).mkString(", \n"), decorateToStringValue(xs))),
           None,
           getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment)
         )
@@ -385,12 +386,12 @@ private[scalatest] object InspectorsHelper {
         sde => 
           Some(
             if (result.passedCount == 0)
-              Resources(resourceName + "NoElement", succeededCount.toString, indentErrorMessages(result.messageAcc).mkString(", \n"), xs.toString)
+              Resources(resourceName + "NoElement", succeededCount.toString, indentErrorMessages(result.messageAcc).mkString(", \n"), decorateToStringValue(xs))
             else {
               if (result.passedCount < succeededCount)
-                Resources(resourceName + "Less", succeededCount.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), indentErrorMessages(result.messageAcc).mkString(", \n"), xs.toString)
+                Resources(resourceName + "Less", succeededCount.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), indentErrorMessages(result.messageAcc).mkString(", \n"), decorateToStringValue(xs))
               else
-                Resources(resourceName + "More", succeededCount.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), xs.toString)
+                Resources(resourceName + "More", succeededCount.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), decorateToStringValue(xs))
             }
           ),
         None,
@@ -404,7 +405,7 @@ private[scalatest] object InspectorsHelper {
       runFor(xs.toIterator, resourceNamePrefix, 0, new ForResult[T], fun, _.passedCount != 0)
     if (result.passedCount != 0)
       throw new exceptions.TestFailedException(
-        sde => Some(Resources(resourceName, keyOrIndexLabel(xs, result.passedElements), xs)),
+        sde => Some(Resources(resourceName, keyOrIndexLabel(xs, result.passedElements), decorateToStringValue(xs))),
         None,
         getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment)
       )
@@ -426,12 +427,12 @@ private[scalatest] object InspectorsHelper {
         sde =>
           Some(
             if (result.passedCount == 0)
-              Resources(resourceName + "NoElement", from.toString, upTo.toString, indentErrorMessages(result.messageAcc).mkString(", \n"), xs)
+              Resources(resourceName + "NoElement", from.toString, upTo.toString, indentErrorMessages(result.messageAcc).mkString(", \n"), decorateToStringValue(xs))
             else {
               if (result.passedCount < from)
-                Resources(resourceName + "Less", from.toString, upTo.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), indentErrorMessages(result.messageAcc).mkString(", \n"), xs)
+                Resources(resourceName + "Less", from.toString, upTo.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), indentErrorMessages(result.messageAcc).mkString(", \n"), decorateToStringValue(xs))
               else
-                Resources(resourceName + "More", from.toString, upTo.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), xs)
+                Resources(resourceName + "More", from.toString, upTo.toString, elementLabel(result.passedCount), keyOrIndexLabel(xs, result.passedElements), decorateToStringValue(xs))
             }
           ),
         None,
@@ -448,7 +449,7 @@ private[scalatest] object InspectorsHelper {
       runFor(xs.toIterator, resourceNamePrefix, 0, new ForResult[T], fun, _.passedCount > max)
     if (result.passedCount > max)
       throw new exceptions.TestFailedException(
-        sde => Some(Resources(resourceName, max.toString, result.passedCount.toString, keyOrIndexLabel(xs, result.passedElements), xs.toString)),
+        sde => Some(Resources(resourceName, max.toString, result.passedCount.toString, keyOrIndexLabel(xs, result.passedElements), decorateToStringValue(xs))),
         None,
         getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment)
       )

--- a/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
@@ -166,7 +166,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
         e.message should be (Some("'all' inspection failed, because: \n" +
                                    "  at index " + getIndex(col, 2) + ", 2 equaled 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 5) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -190,7 +190,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ >= 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not less than 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -213,7 +213,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not equal 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -236,7 +236,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not equal 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -270,7 +270,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, i => i >= 1 && i <= 3)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not equal 2 plus or minus 1 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -292,7 +292,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
       val firstViolation = getFirstNot[String](col, _ == null)
       e2.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not equal null (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
       e2.getCause match {
         case tfe: exceptions.TestFailedException =>
           tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -336,7 +336,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ != 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " equaled 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -359,7 +359,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -382,7 +382,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -405,7 +405,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ < 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not less than 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -428,7 +428,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ < 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was less than 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -451,7 +451,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ <= 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not less than or equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -474,7 +474,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ <= 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was less than or equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -497,7 +497,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ > 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not greater than 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -520,7 +520,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ > 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was greater than 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -543,7 +543,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ >= 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not greater than or equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -566,7 +566,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ >= 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was greater than or equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -589,7 +589,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -612,7 +612,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[Int](col, _ == 2)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was equal to 2 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -635,7 +635,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = col.head
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not null (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -669,7 +669,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
             val firstViolation = getFirst[String](col, _ == null)
             e2.message should be (Some("'all' inspection failed, because: \n" +
                                        "  at index " + getIndex(col, firstViolation) + ", The reference was null (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                       "in " + col))
+                                       "in " + decorateToStringValue(col)))
             e2.getCause match {
               case tfe: exceptions.TestFailedException =>
                 tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -700,7 +700,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -723,7 +723,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -746,7 +746,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -774,7 +774,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -797,7 +797,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -820,7 +820,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not a empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -843,7 +843,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not a empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -866,7 +866,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was a empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -889,7 +889,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not a empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -912,7 +912,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was a empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -935,7 +935,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not an empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -958,7 +958,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not an empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -981,7 +981,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was an empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1004,7 +1004,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not an empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1027,7 +1027,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was an empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1051,7 +1051,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _ eq theInstance)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was not the same instance as \"" + theInstance + "\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1075,7 +1075,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _ eq theInstance)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" was the same instance as \"" + theInstance + "\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1105,7 +1105,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", The length property had value " + firstViolation.length + ", instead of its expected value 0, on object \"" + firstViolation + "\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1129,7 +1129,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", The length property had its expected value 5, on object \"" + firstViolation + "\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1152,7 +1152,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + FailureMessages("hadLengthInsteadOfExpectedLength", firstViolation, 5, 0) + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1175,7 +1175,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" had length 0 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1198,7 +1198,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + FailureMessages("hadSizeInsteadOfExpectedSize", firstViolation, 5, 0) + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1221,7 +1221,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" had size 0 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1244,7 +1244,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.startsWith("hello"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not start with substring \"hello\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1267,7 +1267,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.startsWith("hello"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" started with substring \"hello\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1290,7 +1290,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.endsWith("folks"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not end with substring \"folks\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1313,7 +1313,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.endsWith("folks"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" ended with substring \"folks\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1336,7 +1336,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.indexOf("folks") >= 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not include substring \"folks\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1359,7 +1359,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.indexOf("folks") >= 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" included substring \"folks\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1382,7 +1382,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.startsWith("hello"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not start with a substring that matched the regular expression hel*o (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1405,7 +1405,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.startsWith("hello"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" started with a substring that matched the regular expression hel*o (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1428,7 +1428,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.endsWith("folks!"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not end with a substring that matched the regular expression folks! (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1451,7 +1451,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.endsWith("folks!"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" ended with a substring that matched the regular expression folks! (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1474,7 +1474,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.indexOf("folks") >= 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" did not include substring that matched regex folks (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1497,7 +1497,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.indexOf("folks") >= 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + "\" included substring that matched regex folks (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1520,7 +1520,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[String](col, _.matches("""(-)?(\d+)(\.\d*)?"""))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + """" did not fully match the regular expression (-)?(\d+)(\.\d*)? (InspectorShorthandsSpec.scala:""" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1543,7 +1543,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[String](col, _.matches("""(-)?(\d+)(\.\d*)?"""))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", \"" + firstViolation + """" fully matched the regular expression (-)?(\d+)(\.\d*)? (InspectorShorthandsSpec.scala:""" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1566,7 +1566,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenTraversable[String]](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1589,7 +1589,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenTraversable[String]](col, _.isEmpty)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was empty (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1612,7 +1612,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenSeq[String]](col, _.length == 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + FailureMessages("hadLengthInsteadOfExpectedLength", firstViolation, 1, 0) + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1635,7 +1635,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenSeq[String]](col, _.length == 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " had length 0 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1658,7 +1658,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenTraversable[String]](col, _.size == 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + FailureMessages("hadSizeInsteadOfExpectedSize", firstViolation, 1, 0) + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1681,7 +1681,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenTraversable[String]](col, _.size == 0)
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " had size 0 (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1704,7 +1704,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenTraversable[String]](col, _.exists(_ == "2"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain element \"2\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1727,7 +1727,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenTraversable[String]](col, _.exists(_ == "2"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained element \"2\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1750,7 +1750,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenMap[String, String]](col, _.exists(_._1 == "2"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain key \"2\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1773,7 +1773,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenMap[String, String]](col, _.exists(_._1 == "2"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained key \"2\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1796,7 +1796,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirstNot[GenMap[String, String]](col, _.exists(_._2 == "two"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain value \"two\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1819,7 +1819,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = getFirst[GenMap[String, String]](col, _.exists(_._2 == "two"))
         e2.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained value \"two\" (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1866,7 +1866,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1894,7 +1894,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1924,7 +1924,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1955,7 +1955,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenMap[String, String]](col, map => map.size == 3 && map.exists(e => e._1 == "1" && e._2 == "one") && map.exists(e => e._1 == "2" && e._2 == "two") && map.exists(e => e._1 == "8" && e._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -1986,7 +1986,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2014,7 +2014,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2044,7 +2044,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2075,7 +2075,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.size == 3 && map.exists(e => e._1 == "1" && e._2 == "one") && map.exists(e => e._1 == "2" && e._2 == "two") && map.exists(e => e._1 == "8" && e._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained the same elements as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2109,7 +2109,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2137,7 +2137,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2167,7 +2167,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2198,7 +2198,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2226,7 +2226,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2256,7 +2256,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained the same elements in the same (iterated) order as " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2290,7 +2290,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2318,7 +2318,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2348,7 +2348,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2379,7 +2379,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenMap[String, String]](col, map => map.size == 3 && map.exists(e => e._1 == "1" && e._2 == "one") && map.exists(e => e._1 == "2" && e._2 == "two") && map.exists(e => e._1 == "8" && e._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2410,7 +2410,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2438,7 +2438,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2468,7 +2468,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained all of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2499,7 +2499,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.size == 3 && map.toList(0)._1 == "1" && map.toList(0)._2 == "one" && map.toList(1)._1 == "2" && map.toList(1)._2 == "two" && map.toList(2)._1 == "8" && map.toList(2)._2 == "eight" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained all of (" + right.mkString(", ") + ") (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2533,7 +2533,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2561,7 +2561,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2591,7 +2591,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2622,7 +2622,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2650,7 +2650,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2680,7 +2680,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained all of " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2714,7 +2714,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.exists(_ == "3") || e.exists(_ == "5") || e.exists(_ == "7") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2742,7 +2742,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2772,7 +2772,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.exists(_ == "3") || e.exists(_ == "5") || e.exists(_ == "9") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2803,7 +2803,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenMap[String, String]](col, map => map.exists(e => e._1 == "3" && e._2 == "three") || map.exists(e => e._1 == "5" && e._2 == "five") || map.exists(e => e._1 == "7" && e._2 == "seven") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2834,7 +2834,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.exists(_ == "6") || e.exists(_ == "7") || e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2862,7 +2862,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2892,7 +2892,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.exists(_ == "6") || e.exists(_ == "7") || e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained at least one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2923,7 +2923,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.exists(t => t._1 == "6" && t._2 == "six") || map.exists(t => t._1 == "7" && t._2 == "seven") || map.exists(t => t._1 == "8" && t._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained at least one of (" + right.mkString(", ") + ") (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2957,7 +2957,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -2985,7 +2985,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3015,7 +3015,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3046,7 +3046,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenMap[String, String]](col, map => map.size == 3 && map.exists(e => e._1 == "1" && e._2 == "one") && map.exists(e => e._1 == "2" && e._2 == "two") && map.exists(e => e._1 == "8" && e._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3077,7 +3077,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3105,7 +3105,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3135,7 +3135,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e.exists(_ == "1") && e.exists(_ == "2") && e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained only " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3166,7 +3166,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.size == 3 && map.exists(t => t._1 == "1" && t._2 == "one") && map.exists(t => t._1 == "2" && t._2 == "two") && map.exists(t => t._1 == "8" && t._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained only (" + right.mkString(", ") + ") (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3200,7 +3200,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3228,7 +3228,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3258,7 +3258,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirstNot[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3289,7 +3289,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.size == 3 && e.toList(0) == "1" && e.toList(1) == "2" && e.toList(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3317,7 +3317,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3347,7 +3347,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.size == 3 && e(0) == "1" && e(1) == "2" && e(2) == "8" )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained only " + right + " in order (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3381,7 +3381,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.exists(_ == "1") || e.exists(_ == "2") || e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3409,7 +3409,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " contained one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3439,7 +3439,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.exists(_ == "1") || e.exists(_ == "2") || e.exists(_ == "8") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3470,7 +3470,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.exists(e => e._1 == "1" && e._2 == "one") || map.exists(e => e._1 == "2" && e._2 == "two") || map.exists(e => e._1 == "8" && e._2 == "eight") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " contained one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3501,7 +3501,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenTraversable[String]](col, e => e.exists(_ != "6") && e.exists(_ != "7") && e.exists(_ != "9") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3529,7 +3529,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
         val firstViolation = decorateToStringValue(firstViolationArray)
         e.message should be (Some("'all' inspection failed, because: \n" +
                                   "  at index " + getIndex(col, firstViolationArray) + ", " + firstViolation + " did not contain one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3559,7 +3559,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenSeq[String]](col, e => e.exists(_ != "6") && e.exists(_ != "7") && e.exists(_ != "9") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain one of " + right + " (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))
@@ -3590,7 +3590,7 @@ class InspectorShorthandsSpec extends Spec with Matchers with TableDrivenPropert
           val firstViolation = getFirst[GenMap[String, String]](col, map => map.exists(t => t._1 != "6" && t._2 != "six") && map.exists(t => t._1 != "7" && t._2 != "seven") && map.exists(t => t._1 != "9" && t._2 != "nine") )
           e.message should be (Some("'all' inspection failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " did not contain one of (" + right.mkString(", ") + ") (InspectorShorthandsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
           e.getCause match {
             case tfe: exceptions.TestFailedException =>
               tfe.failedCodeFileName should be (Some("InspectorShorthandsSpec.scala"))

--- a/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -24,6 +24,7 @@ import scala.collection.GenTraversable
 import scala.annotation.tailrec
 import collection._
 import SharedHelpers._
+import FailureMessages.decorateToStringValue
 
 class InspectorsSpec extends Spec with Matchers with Inspectors with TableDrivenPropertyChecks {
   
@@ -71,7 +72,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.failedCodeLineNumber should be (Some(thisLineNumber - 5))
         e.message should be (Some("forAll failed, because: \n" +
                                    "  at index " + getIndex(col, 2) + ", 2 equaled 2 (InspectorsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorsSpec.scala"))
@@ -96,7 +97,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val firstViolation = getFirst[Int](col, _ >= 2)
         e2.message should be (Some("forAll failed, because: \n" +
                                     "  at index " + getIndex(col, firstViolation) + ", " + firstViolation + " was not less than 2 (InspectorsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                    "in " + col))
+                                    "in " + decorateToStringValue(col)))
         e2.getCause match {
           case tfe: exceptions.TestFailedException =>
             tfe.failedCodeFileName should be (Some("InspectorsSpec.scala"))
@@ -237,7 +238,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forAtLeast(2) failed, because only 1 element satisfied the assertion block: \n" +
                                    "  at index " + firstIndex + ", " + first + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                    "  at index " + secondIndex + ", " + second + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -260,7 +261,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
                                    "  at index 0, " + first + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 10) + "), \n" +
                                    "  at index 1, " + second + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                    "  at index 2, " + third + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -283,7 +284,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forAtLeast(2) failed, because only 1 element satisfied the assertion block: \n" +
                                    "  at index " + firstIndex + ", " + first + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                    "  at index " + secondIndex + ", " + second + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -301,7 +302,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val index = getIndex(col, 3)
         e.message should be (Some("forAtLeast(3) failed, because only 2 elements satisfied the assertion block: \n" +
                                    "  at index " + index + ", 3 was not less than 3 (InspectorsSpec.scala:" + (thisLineNumber - 7) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -331,7 +332,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
                                    "  at index 0, " + first + " was not greater than 5 (InspectorsSpec.scala:" + (thisLineNumber - 10) + "), \n" +
                                    "  at index 1, " + second + " was not greater than 5 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                    "  at index 2, " + third + " was not greater than 5 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                   "in " + col))
+                                   "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -478,7 +479,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val secondIndex = getIndex(col, second)
         val third = getNext[Int](itr, _ < 4)
         val thirdIndex = getIndex(col, third)
-        e.message should be (Some("forAtMost(2) failed, because 3 elements satisfied the assertion block at index " + firstIndex + ", " + secondIndex + " and " + thirdIndex + " in " + col))
+        e.message should be (Some("forAtMost(2) failed, because 3 elements satisfied the assertion block at index " + firstIndex + ", " + secondIndex + " and " + thirdIndex + " in " + decorateToStringValue(col)))
       }
     }
     
@@ -618,7 +619,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
                                   "  at index 0, " + first + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 10) + "), \n" +
                                   "  at index 1, " + second + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                   "  at index 2, " + third + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -642,7 +643,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forExactly(2) failed, because only 1 element satisfied the assertion block at index " + succeededIndex + ": \n" +
                                   "  at index " + firstIndex + ", " + first + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 12) + "), \n" +
                                   "  at index " + secondIndex + ", " + second + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 13) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -657,7 +658,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         }
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 5))
-        e.message should be (Some("forExactly(2) failed, because 3 elements satisfied the assertion block at index 0, 1 and 2 in " + col))
+        e.message should be (Some("forExactly(2) failed, because 3 elements satisfied the assertion block at index 0, 1 and 2 in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -680,7 +681,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val failedIndex = getIndex(col, 3)
         e.message should be (Some("forExactly(3) failed, because only 2 elements satisfied the assertion block at index " + passedFirstIndex + " and " + passedSecondIndex + ": \n" +
                                   "  at index " + failedIndex + ", 3 was not less than 3 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -700,7 +701,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val firstIndex = getIndex(col, first)
         val second = getNext[Int](itr, _ < 3)
         val secondIndex = getIndex(col, second)
-        e.message should be (Some("forExactly(1) failed, because 2 elements satisfied the assertion block at index " + firstIndex + " and " + secondIndex + " in " + col))
+        e.message should be (Some("forExactly(1) failed, because 2 elements satisfied the assertion block at index " + firstIndex + " and " + secondIndex + " in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -724,7 +725,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forExactly(2) failed, because only 1 element satisfied the assertion block at index " + index + ": \n" +
                                   "  at index " + firstIndex + ", " + first + " did not equal 2 (InspectorsSpec.scala:" + (thisLineNumber - 12) + "), \n" +
                                   "  at index " + secondIndex + ", " + second + " did not equal 2 (InspectorsSpec.scala:" + (thisLineNumber - 13) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
       }
     }
     
@@ -736,7 +737,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         }
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
-        e.message should be (Some("forExactly(2) failed, because 3 elements satisfied the assertion block at index 0, 1 and 2 in " + col))
+        e.message should be (Some("forExactly(2) failed, because 3 elements satisfied the assertion block at index 0, 1 and 2 in " + decorateToStringValue(col)))
       }
     }
     
@@ -840,7 +841,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
         val index = getIndex(col, 2)
-        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index " + index + " in " + col))
+        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index " + index + " in " + decorateToStringValue(col)))
       }
     }
     
@@ -853,7 +854,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
         val first = col.toIterator.next
-        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index 0 in " + col))
+        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index 0 in " + decorateToStringValue(col)))
       }
     }
     
@@ -865,7 +866,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         }
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
-        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index 0 in " + col))
+        e.message should be (Some("forNo failed, because 1 element satisfied the assertion block at index 0 in " + decorateToStringValue(col)))
       }
     }
     
@@ -1049,7 +1050,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
                                   "  at index 0, " + first + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 10) + "), \n" +
                                   "  at index 1, " + second + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 11) + "), \n" +
                                   "  at index 2, " + third + " was not equal to 5 (InspectorsSpec.scala:" + (thisLineNumber - 12) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -1073,7 +1074,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forBetween(2, 3) failed, because only 1 element satisfied the assertion block at index " + passedIndex + ": \n" +
                                   "  at index " + firstIndex + ", " + first + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 12) + "), \n" +
                                   "  at index " + secondIndex + ", " + second + " was not equal to 2 (InspectorsSpec.scala:" + (thisLineNumber - 13) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -1094,7 +1095,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val failedIndex = getIndex(col, 3)
         e.message should be (Some("forBetween(3, 4) failed, because only 2 elements satisfied the assertion block at index " + firstIndex + " and " + secondIndex + ": \n" +
                                   "  at index " + failedIndex + ", 3 was not less than 3 (InspectorsSpec.scala:" + (thisLineNumber - 10) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -1114,7 +1115,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val secondIndex = getIndex(col, getNext[Int](itr, _ > 1))
         val thirdIndex = getIndex(col, getNext[Int](itr, _ > 1))
         val forthIndex = getIndex(col, getNext[Int](itr, _ > 1))
-        e.message should be (Some("forBetween(2, 3) failed, because 4 elements satisfied the assertion block at index " + firstIndex + ", " + secondIndex + ", " + thirdIndex + " and " + forthIndex + " in " + col))
+        e.message should be (Some("forBetween(2, 3) failed, because 4 elements satisfied the assertion block at index " + firstIndex + ", " + secondIndex + ", " + thirdIndex + " and " + forthIndex + " in " + decorateToStringValue(col)))
         e.getCause should be (null)
       }
     }
@@ -1144,7 +1145,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
                                   "  at index " + secondIndex + ", " + second  + " was not greater than 4 (InspectorsSpec.scala:" + (thisLineNumber - 17) + "), \n" +
                                   "  at index " + thirdIndex + ", " + third  + " was not greater than 4 (InspectorsSpec.scala:" + (thisLineNumber - 18) + "), \n" +
                                   "  at index " + forthIndex + ", " + forth  + " was not greater than 4 (InspectorsSpec.scala:" + (thisLineNumber - 19) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
       }
     }
     
@@ -1156,7 +1157,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         }
         e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
-        e.message should be (Some("forBetween(2, 4) failed, because 5 elements satisfied the assertion block at index 0, 1, 2, 3 and 4 in " + col))
+        e.message should be (Some("forBetween(2, 4) failed, because 5 elements satisfied the assertion block at index 0, 1, 2, 3 and 4 in " + decorateToStringValue(col)))
       }
     }
     
@@ -1262,7 +1263,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         val index = getIndex(col, 2)
         e.message should be (Some("forEvery failed, because: \n" +
                                   "  at index " + index + ", 2 equaled 2 (InspectorsSpec.scala:" + (thisLineNumber - 6) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
       }
     }
     
@@ -1282,7 +1283,7 @@ class InspectorsSpec extends Spec with Matchers with Inspectors with TableDriven
         e.message should be (Some("forEvery failed, because: \n" +
                                   "  at index " + firstIndex + ", " + first + " was not less than 2 (InspectorsSpec.scala:" + (thisLineNumber - 10) + "), \n" +
                                   "  at index " + secondIndex + ", " + second + " was not less than 2 (InspectorsSpec.scala:" + (thisLineNumber - 11) + ") \n" +
-                                  "in " + col))
+                                  "in " + decorateToStringValue(col)))
       }
     }
     

--- a/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
@@ -17,31 +17,34 @@ package org.scalatest
 
 import SharedHelpers.thisLineNumber
 import org.scalatest.enablers.Sortable
+import FailureMessages.decorateToStringValue
 
 class ShouldBeSortedLogicalAndSpec extends Spec with Matchers {
   
+  //ADDITIONAL//
+  
   def wasEqualTo(left: Any, right: Any): String = 
-    left + " was equal to " + right
+    decorateToStringValue(left) + " was equal to " + decorateToStringValue(right)
     
   def wasNotEqualTo(left: Any, right: Any): String = 
-    left + " was not equal to " + right
+    decorateToStringValue(left) + " was not equal to " + decorateToStringValue(right)
     
   def equaled(left: Any, right: Any): String = 
-    left + " equaled " + right
+    decorateToStringValue(left) + " equaled " + decorateToStringValue(right)
     
   def didNotEqual(left: Any, right: Any): String = 
-    left + " did not equal " + right
+    decorateToStringValue(left) + " did not equal " + decorateToStringValue(right)
   
   def wasNotSorted(left: Any): String = 
-    left + " was not sorted"
+    decorateToStringValue(left) + " was not sorted"
     
   def wasSorted(left: Any): String = 
-    left + " was sorted"
+    decorateToStringValue(left) + " was sorted"
     
   def allInspectionFailed(idx: Int, message: String, lineNumber:Int, left: Any) = 
     "'all' inspection failed, because: \n" + 
     "  at index " + idx + ", " + message + " (ShouldBeSortedLogicalAndSpec.scala:" + lineNumber + ") \n" + 
-    "in " + left
+    "in " + decorateToStringValue(left)
     
   case class Student(name: String, scores: Int)
   implicit val studentOrdering = new Ordering[Student] {

--- a/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
@@ -17,31 +17,34 @@ package org.scalatest
 
 import SharedHelpers.thisLineNumber
 import org.scalatest.enablers.Sortable
+import FailureMessages.decorateToStringValue
 
 class ShouldBeSortedLogicalOrSpec extends Spec with Matchers {
   
+  //ADDITIONAL//
+  
   def wasEqualTo(left: Any, right: Any): String = 
-    left + " was equal to " + right
+    decorateToStringValue(left) + " was equal to " + decorateToStringValue(right)
     
   def wasNotEqualTo(left: Any, right: Any): String = 
-    left + " was not equal to " + right
+    decorateToStringValue(left) + " was not equal to " + decorateToStringValue(right)
     
   def equaled(left: Any, right: Any): String = 
-    left + " equaled " + right
+    decorateToStringValue(left) + " equaled " + decorateToStringValue(right)
     
   def didNotEqual(left: Any, right: Any): String = 
-    left + " did not equal " + right
+    decorateToStringValue(left) + " did not equal " + decorateToStringValue(right)
   
   def wasNotSorted(left: Any): String = 
-    left + " was not sorted"
+    decorateToStringValue(left) + " was not sorted"
     
   def wasSorted(left: Any): String = 
-    left + " was sorted"
+    decorateToStringValue(left) + " was sorted"
     
   def allInspectionFailed(idx: Int, message: String, lineNumber:Int, left: Any) = 
     "'all' inspection failed, because: \n" + 
     "  at index " + idx + ", " + message + " (ShouldBeSortedLogicalOrSpec.scala:" + lineNumber + ") \n" + 
-    "in " + left
+    "in " + decorateToStringValue(left)
     
   case class Student(name: String, scores: Int)
   implicit val studentOrdering = new Ordering[Student] {

--- a/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
@@ -17,19 +17,22 @@ package org.scalatest
 
 import SharedHelpers.thisLineNumber
 import enablers.Sortable
+import FailureMessages.decorateToStringValue
 
 class ShouldBeSortedSpec extends Spec with Matchers {
   
+  //ADDITIONAL//
+  
   def wasNotSorted(left: Any): String = 
-    left + " was not sorted"
+    decorateToStringValue(left) + " was not sorted"
     
   def wasSorted(left: Any): String = 
-    left + " was sorted"
+    decorateToStringValue(left) + " was sorted"
     
   def allInspectionFailed(idx: Int, message: String, lineNumber:Int, left: Any) = 
     "'all' inspection failed, because: \n" + 
     "  at index " + idx + ", " + message + " (ShouldBeSortedSpec.scala:" + lineNumber + ") \n" + 
-    "in " + left
+    "in " + decorateToStringValue(left)
     
   case class Student(name: String, scores: Int)
   implicit val studentOrdering = new Ordering[Student] {


### PR DESCRIPTION
Added generated Array and Java List tests for sorted matchers, and eliminate 'WrappedArray' in error messages, especially in inspectors.
