### PR TITLE
Build Adjustments

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1174,7 +1174,7 @@
             <reporter type="dashboard" directory="target/dash" numfiles="3" />
             <reporter type="junitxml" directory="target"/>
             <reporter type="stdout" config="DI"/>
-        	<reporter type="html" directory="target/html" config="D" />
+            <reporter type="html" directory="target/html" config="D" />
             <membersonly package="org.scalatest" />
             <membersonly package="org.scalautils" />
             <membersonly package="org.scalatest.fixture" />
@@ -1187,8 +1187,11 @@
             <membersonly package="org.scalatest.matchers" />
             <membersonly package="org.scalatest.suiteprop" />
             <membersonly package="org.scalatest.mock" />
-        	<membersonly package="org.scalatest.path" />
-        	<membersonly package="org.scalatest.selenium" />
+            <membersonly package="org.scalatest.path" />
+            <membersonly package="org.scalatest.selenium" />
+            <membersonly package="org.scalatest.exceptions" />
+            <!--<membersonly package="org.scalatest.time" />--> <!-- Enable this will hang the run, why? -->
+            <!--<membersonly package="org.scalatest.words" />--> <!-- Enable this will hang the run, why? -->
             <config name="dbname" value="testdb" />
         </scalatest>
     </target>

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -22,7 +22,11 @@ object ScalatestBuild extends Build {
                                   "org.scalatest.suiteprop", 
                                   "org.scalatest.mock", 
                                   "org.scalatest.path", 
-                                  "org.scalatest.selenium")
+                                  "org.scalatest.selenium", 
+                                  "org.scalatest.exceptions", 
+                                  "org.scalatest.time", 
+                                  "org.scalatest.words", 
+                                  "org.scalautils")
                                                      
   def isIncludedPackage(className: String) = {
     try {

--- a/src/test/scala/org/scalatest/exceptions/TestCanceledExceptionSpec.scala
+++ b/src/test/scala/org/scalatest/exceptions/TestCanceledExceptionSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.FunSpec
 
 class TestCanceledExceptionSpec extends FunSpec with ShouldMatchers {
 
-  val baseLineNumber = 22
+  val baseLineNumber = 23
 
   describe("The TestCanceledException") {
 


### PR DESCRIPTION
Added missing membersonly to build.xml and scalatest.scala, and fixed failing tests in TestCanceledException.

The commented membersonly in build.xml will hang the run when enabled, but it does not hang sbt run, so suspected there's a bug in Runner's discovery that needs to investigate further.
