### PR TITLE
Fix for Deadlock

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1190,8 +1190,8 @@
             <membersonly package="org.scalatest.path" />
             <membersonly package="org.scalatest.selenium" />
             <membersonly package="org.scalatest.exceptions" />
-            <!--<membersonly package="org.scalatest.time" />--> <!-- Enable this will hang the run, why? -->
-            <!--<membersonly package="org.scalatest.words" />--> <!-- Enable this will hang the run, why? -->
+            <membersonly package="org.scalatest.time" />
+            <membersonly package="org.scalatest.words" />
             <config name="dbname" value="testdb" />
         </scalatest>
     </target>

--- a/src/main/scala/org/scalatest/tools/SuiteRunner.scala
+++ b/src/main/scala/org/scalatest/tools/SuiteRunner.scala
@@ -59,14 +59,16 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
 
         val duration = System.currentTimeMillis - suiteStartTime
 
-        // Must call succeeds before dispatching SuiteCompleted, because if parallel test execution is mixed in,
+        // Must wait until runStatus completed before dispatching SuiteCompleted, because if parallel test execution is mixed in,
         // the main thread will return before the tests are done. And the HTMLReporter uses SuiteCompleted to
         // determine when to write the page for that suite.
-        if (!runStatus.succeeds())
-          status.setFailed()
-
-        if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-          dispatch(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(duration), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+        runStatus.whenCompleted { succeed =>
+          if (!succeed)
+            status.setFailed()
+          if (!suite.isInstanceOf[DistributedTestRunnerSuite])
+            dispatch(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(duration), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+          status.setCompleted()
+        }
       }
       catch {
         case e: NotAllowedException =>
@@ -75,6 +77,7 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
           // dispatch(SuiteAborted(tracker.nextOrdinal(), e.getMessage, suite.suiteName, Some(suite.getClass.getName), None, None, formatter, rerunnable))
           dispatch(SuiteAborted(tracker.nextOrdinal(), e.getMessage, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), suite.rerunner))
           status.setFailed()
+          status.setCompleted()
         case e: RuntimeException => { // Do fire SuiteAborted even if a DistributedTestRunnerSuite 
           val eMessage = e.getMessage
           val rawString3 = 
@@ -87,13 +90,12 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
           val duration = System.currentTimeMillis - suiteStartTime
           dispatch(SuiteAborted(tracker.nextOrdinal(), rawString3, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(e), Some(duration), formatter3, Some(SeeStackDepthException), suite.rerunner))
           status.setFailed()
+          status.setCompleted()
         }
         case e: Throwable => 
           status.setFailed()
+          status.setCompleted()
           throw e
-      }
-      finally {
-        status.setCompleted()
       }
     }
   }


### PR DESCRIPTION
Fixed deadlock problem when nested suites run in parallel by changing the blocking runStatus.succeeds() to use non-blocking runStatus.whenCompleted call.
