### PR TITLE
add nested testsfile elements to ScalaTestAntTask

### DIFF
--- a/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
+++ b/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
@@ -213,14 +213,23 @@ import org.apache.tools.ant.taskdefs.Java
  * </pre>
  *
  * <p>
- * Use attribute <code>testsfile="[file name]"</code> to specify
- * a file containing a list of tests to be run.  This is used to
- * rerun failed/canceled tests listed in a file written by the
- * memory reporter.  E.g.:
+ * Use attribute <code>testsfile="[file name]"</code> or nested
+ * <testsfile> elements to specify files containing a list of
+ * tests to be run.  This is used to rerun failed/canceled tests
+ * listed in files written by the memory reporter.  E.g.:
  * </p>
  *
  * <pre>
  *   &lt;scalatest testsfile="target/memory.out"&gt;
+ * </pre>
+ *
+ * <p>
+ * or
+ * </p>
+ *
+ * <pre>
+ *   &lt;scalatest&gt;
+ *     &lt;testsfile filename="target/memory.out"/&gt;
  * </pre>
  *
  * <p>
@@ -271,7 +280,6 @@ class ScalaTestAntTask extends Task {
   private var excludes:  String = ""
   private var maxMemory: String = null
   private var suffixes:  String = null
-  private var testsfile: String = null
 
   private var parallel      = false
   private var sortSuites    = false
@@ -289,6 +297,7 @@ class ScalaTestAntTask extends Task {
   private val wildcards    = new ListBuffer[String]
   private val testNGSuites = new ListBuffer[String]
   private val chosenStyles = new ListBuffer[String]
+  private val testsfiles   = new ListBuffer[String]
 
   private val reporters  = new ListBuffer[ReporterElement]
   private val properties = new ListBuffer[NameValuePair]
@@ -319,7 +328,7 @@ class ScalaTestAntTask extends Task {
     addTestNGSuiteArgs(args)
     addParallelArg(args)
     addSuffixesArg(args)
-    addTestsfileArg(args)
+    addTestsfileArgs(args)
     addChosenStyles(args)
     addSpanScaleFactorArg(args)
 
@@ -409,8 +418,8 @@ class ScalaTestAntTask extends Task {
   // Adds '-A' arg to args list if 'testsfile' attribute was
   // specified for task.
   //
-  private def addTestsfileArg(args: ListBuffer[String]) {
-    if (testsfile != null) {
+  private def addTestsfileArgs(args: ListBuffer[String]) {
+    for (testsfile <- testsfiles) {
       args += "-A"
       args += testsfile
     }
@@ -734,7 +743,7 @@ class ScalaTestAntTask extends Task {
    * Sets value of the <code>testsfile</code> attribute.
    */
   def setTestsfile(testsfile: String) {
-    this.testsfile = testsfile
+    this.testsfiles += testsfile
   }
   
   /**
@@ -917,6 +926,13 @@ class ScalaTestAntTask extends Task {
   }
 
   /**
+   * Sets value from nested element <code>testsfile</code>.
+   */
+  def addConfiguredTestsfile(testsfile: TestsfileElement) {
+    this.testsfiles += testsfile.getFilename
+  }
+
+  /**
    * Sets value from nested element <code>includes</code>.
    * <b>The <code>includes</code> attribute has been deprecated and will be removed in a future version of ScalaTest.
    * Please use the <code>tagsToInclude</code> attribute instead.</b>
@@ -981,6 +997,19 @@ class ScalaTestAntTask extends Task {
     }
     
     def getName = name
+  }
+
+  //
+  // Class to hold data from <testsfile> elements.
+  //
+  private class TestsfileElement {
+    private var filename: String = null
+    
+    def setFilename(filename: String) {
+      this.filename = filename
+    }
+    
+    def getFilename = filename
   }
 
   //

--- a/src/test/scala/org/scalatest/tools/ScalaTestAntTaskSpec.scala
+++ b/src/test/scala/org/scalatest/tools/ScalaTestAntTaskSpec.scala
@@ -58,6 +58,23 @@ class ScalaTestAntTaskSpec extends Spec {
     assert(argsList containsSlice List("-A", "target/testsfile.dat"))
   }
 
+  def `command line args should get generated for testsfile elements` {
+    val task = new ScalaTestAntTask
+
+    val elem = new TestsfileElement
+    elem.setFilename("target/testsfile.dat")
+    task.addConfiguredTestsfile(elem)
+
+    val elem2 = new TestsfileElement
+    elem2.setFilename("target/testsfile2.dat")
+    task.addConfiguredTestsfile(elem2)
+
+    val argsList = task.buildArgsList
+
+    assert(argsList containsSlice List("-A", "target/testsfile.dat"))
+    assert(argsList containsSlice List("-A", "target/testsfile2.dat"))
+  }
+
   def `command line arg should get generated for memory reporter` {
     val task = new ScalaTestAntTask
 


### PR DESCRIPTION
This somehow got left out of my jira-179 branch.  It allows a user to specify multiple files containing lists of tests to be run instead of just the one permitted by use of the testsfile attribute.
