### PR TITLE
Add trait WebBrowserDriver which extends WebBrowser and allows access to the webDriver

### DIFF
--- a/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -967,7 +967,6 @@ import org.scalatest.Resources
  * @author Bill Venners
  */
 trait WebBrowser { 
-
   /**
    * A point containing an XY screen location.
    */
@@ -3705,8 +3704,12 @@ trait WebBrowser {
  */
 object WebBrowser extends WebBrowser
 
+trait WebBrowserDriver extends WebBrowser {
+	val webDriver: WebDriver
+}
+
 /**
- * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for HTMLUnit (an <code>org.openqa.selenium.htmlunit.HtmlUnitDriver</code>), with JavaScript
+ * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for HTMLUnit (an <code>org.openqa.selenium.htmlunit.HtmlUnitDriver</code>), with JavaScript
  * enabled by default.
  *
  * <p>
@@ -3717,10 +3720,10 @@ object WebBrowser extends WebBrowser
  * webDriver.setJavascriptEnabled(false)
  * </pre>
  */
-trait HtmlUnit extends WebBrowser with ScreenshotCapturer {
+trait HtmlUnit extends WebBrowserDriver with ScreenshotCapturer {
 
   /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for HTMLUnit (an <code>org.openqa.selenium.htmlunit.HtmlUnitDriver</code>), with JavaScript
+   * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for HTMLUnit (an <code>org.openqa.selenium.htmlunit.HtmlUnitDriver</code>), with JavaScript
    * enabled by default.
    *
    * <p>
@@ -3751,14 +3754,14 @@ trait HtmlUnit extends WebBrowser with ScreenshotCapturer {
 object HtmlUnit extends HtmlUnit
 
 /**
- * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>).
+ * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>).
  *
  * <p>
  * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
  * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
  * </p>
  */
-trait Firefox extends WebBrowser with ScreenshotCapturer {
+trait Firefox extends WebBrowserDriver with ScreenshotCapturer {
 
   /**
    * The <code>FirefoxProfile</code> passed to the constructor of the <code>FirefoxDriver</code> returned by <code>webDriver</code>.
@@ -3771,7 +3774,7 @@ trait Firefox extends WebBrowser with ScreenshotCapturer {
   val firefoxProfile = new FirefoxProfile()
 
   /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>), with a default
+   * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>), with a default
    * Firefox profile.
    *
    * <p>
@@ -3797,11 +3800,11 @@ trait Firefox extends WebBrowser with ScreenshotCapturer {
 object Firefox extends Firefox
 
 /**
- * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Safari (an <code>org.openqa.selenium.safari.SafariDriver</code>).
+ * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Safari (an <code>org.openqa.selenium.safari.SafariDriver</code>).
  */
-trait Safari extends WebBrowser with ScreenshotCapturer {
+trait Safari extends WebBrowserDriver with ScreenshotCapturer {
   /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Safari (an <code>org.openqa.selenium.safari.SafariDriver</code>).
+   * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Safari (an <code>org.openqa.selenium.safari.SafariDriver</code>).
    */
   implicit val webDriver = new SafariDriver()
 
@@ -3821,11 +3824,11 @@ trait Safari extends WebBrowser with ScreenshotCapturer {
 object Safari extends Safari
 
 /**
- * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Chrome (an <code>org.openqa.selenium.chrome.ChromeDriver</code>).
+ * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Chrome (an <code>org.openqa.selenium.chrome.ChromeDriver</code>).
  */
-trait Chrome extends WebBrowser with ScreenshotCapturer {
+trait Chrome extends WebBrowserDriver with ScreenshotCapturer {
   /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Chrome (an <code>org.openqa.selenium.chrome.ChromeDriver</code>).
+   * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Chrome (an <code>org.openqa.selenium.chrome.ChromeDriver</code>).
    */
   implicit val webDriver = new ChromeDriver()
 
@@ -3845,11 +3848,11 @@ trait Chrome extends WebBrowser with ScreenshotCapturer {
 object Chrome extends Chrome
 
 /**
- * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Internet Explorer (an <code>org.openqa.selenium.ie.InternetExplorerDriver</code>).
+ * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Internet Explorer (an <code>org.openqa.selenium.ie.InternetExplorerDriver</code>).
  */
-trait InternetExplorer extends WebBrowser with ScreenshotCapturer {
+trait InternetExplorer extends WebBrowserDriver with ScreenshotCapturer {
   /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Internet Explorer (an <code>org.openqa.selenium.ie.InternetExplorerDriver</code>).
+   * <code>WebBrowserDriver</code> subtrait that defines an implicit <code>WebDriver</code> for Internet Explorer (an <code>org.openqa.selenium.ie.InternetExplorerDriver</code>).
    */
   implicit val webDriver = new InternetExplorerDriver()
 
@@ -3872,8 +3875,8 @@ object InternetExplorer extends InternetExplorer
  * <p>
  * If you mix in <a href="../ScreenshotOnFailure.html"><code>ScreenshotOnFailure</code></a>, ScalaTest will capture a screenshot and store it to either the system temp directory
  * or a directory you choose, and send the filename to the report, associated with the failed test. The <code>ScreenshotOnFailure</code> trait requires that it be
- * mixed into a <a href="../ScreenshotCapturer.html"><code>ScreenshotCapturer</code></a>, which trait <code>WebBrowser</code> does not extend. To satisfy this
- * requirement, you can extend one of <code>WebBrowser</code>'s subtraits, such as:
+ * mixed into a <a href="../ScreenshotCapturer.html"><code>ScreenshotCapturer</code></a>, which trait <code>WebBrowserDriver</code> does not extend. To satisfy this
+ * requirement, you can extend one of <code>WebBrowserDriver</code>'s subtraits, such as:
  * </p>
  * 
  * <pre class="stHighlight">


### PR DESCRIPTION
This allows use cases such as:

trait FooSpec extends WebBrowserDriver {
   // tests, some of which use webDriver
   // for instance webDriver.setSize()
}

class ChromeFooSpec extends FooSpec with Chrome
class InternetExplorerFooSpec extends FooSpec with InternetExplorer
