### PR TITLE
Removal of legacyEqual.

### DIFF
--- a/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -2243,8 +2243,8 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      *                                ^
      * </pre>
      */
-    def equal(any: Any): Matcher[T] =
-      outerInstance.or(MatcherWords.not.apply(MatcherWords.legacyEqual(any)))
+    def equal(any: Any): MatcherFactory1[T, Equality] =
+      outerInstance.or(MatcherWords.not.apply(MatcherWords.equal(any)))
 
     /**
      * This method enables the following syntax for the "primitive" numeric types:

--- a/src/main/scala/org/scalatest/words/MatcherWords.scala
+++ b/src/main/scala/org/scalatest/words/MatcherWords.scala
@@ -275,21 +275,6 @@ trait MatcherWords {
       }
       override def toString: String = "equal (" + Prettifier.default(right) + ")"
     }
-
-  def legacyEqual(right: Any): Matcher[Any] =
-    new Matcher[Any] {
-      def apply(left: Any): MatchResult = {
-        val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, right)
-        MatchResult(
-          areEqualComparingArraysStructurally(left, right),
-          Resources("didNotEqual"),
-          Resources("equaled"), 
-          Vector(leftee, rightee), 
-          Vector(left, right)
-        )
-      }
-      override def toString: String = "legacyEqual (" + Prettifier.default(right) + ")"
-    }
 }
 
 object MatcherWords extends MatcherWords

--- a/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
@@ -193,49 +193,49 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain allOf (..))` {
+    object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain allOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain allOf ("happy", "birthday", "to", "you"))
+          fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
+          fumList should (be (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain allOf ())
+          fumList should (be (fumList) and contain allOf ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -244,7 +244,7 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -252,49 +252,49 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain allOf (..) and legacyEqual (..))` {
+    object `when used with (contain allOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") and legacyEqual (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fum") and legacyEqual (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fum") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("happy", "birthday", "to", "you") and legacyEqual (fumList))
+          fumList should (contain allOf ("happy", "birthday", "to", "you") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and legacyEqual (toList))
+          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf () and legacyEqual (fumList))
+          fumList should (contain allOf () and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -303,7 +303,7 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
@@ -181,43 +181,43 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain allOf (..))` {
+    object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (toList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be (toList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain allOf ("fie", "fee", "fam", "foe"))
+          fumList should (be (toList) or contain allOf ("fie", "fee", "fam", "foe"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain allOf ())
+          fumList should (be (fumList) or contain allOf ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -226,7 +226,7 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -234,43 +234,43 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain allOf (..) and legacyEqual (..))` {
+    object `when used with (contain allOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain allOf ("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or legacyEqual (toList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain allOf ("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fam") or legacyEqual (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fam") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))
+          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf () or legacyEqual (fumList))
+          fumList should (contain allOf () or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -279,7 +279,7 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -174,49 +174,49 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain oneOf (..))` {
+    object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = invertedStringEquality
-        fumList should (legacyEqual (fumList) and contain atLeastOneOf ("have", "a", "nice", "day"))
+        fumList should (be (fumList) and contain atLeastOneOf ("have", "a", "nice", "day"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain atLeastOneOf ("fum"))
+          fumList should (be (toList) and contain atLeastOneOf ("fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain atLeastOneOf ("fum")))
+          fumList should (be (fumList) and (contain atLeastOneOf ("fum")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))) (decided by invertedStringEquality)
+          (fumList should (be (toList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))) (decided by invertedStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain atLeastOneOf())
+          fumList should (be (fumList) and contain atLeastOneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -225,7 +225,7 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -233,49 +233,49 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain oneOf (..) and legacyEqual (..))` {
+    object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and legacyEqual (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and legacyEqual (toList))
+          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and legacyEqual (fumList))
+          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = invertedStringEquality
-        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") and legacyEqual (fumList))
+        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum") and legacyEqual (toList))
+          fumList should (contain atLeastOneOf ("fum") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum") and (legacyEqual (fumList)))
+          fumList should (contain atLeastOneOf ("fum") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") and legacyEqual (fumList))) (decided by invertedStringEquality)
+        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") and be (fumList))) (decided by invertedStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum") and legacyEqual (fumList))) (decided by invertedStringEquality)
+          (fumList should (contain atLeastOneOf ("fum") and be (fumList))) (decided by invertedStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and legacyEqual (toList))) (decided by invertedStringEquality)
+          (fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be (toList))) (decided by invertedStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf() and legacyEqual (fumList))
+          fumList should (contain atLeastOneOf() and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -284,7 +284,7 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -162,43 +162,43 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec with Matchers 
       }
     }
     
-    "when used with (legacyEqual (...) and contain oneOf (...)) syntax" - {
+    "when used with (be (...) and contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (legacyEqual (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = invertedStringEquality
-        fumList should (legacyEqual (fumList) or contain atLeastOneOf ("have", "a", "nice", "day"))
-        fumList should (legacyEqual (toList) or contain atLeastOneOf ("have", "a", "nice", "day"))
-        fumList should (legacyEqual (fumList) or contain atLeastOneOf ("fum"))
+        fumList should (be (fumList) or contain atLeastOneOf ("have", "a", "nice", "day"))
+        fumList should (be (toList) or contain atLeastOneOf ("have", "a", "nice", "day"))
+        fumList should (be (fumList) or contain atLeastOneOf ("fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain atLeastOneOf ("fum")))
+          fumList should (be (toList) or (contain atLeastOneOf ("fum")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (legacyEqual (fumList) or contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
-        (fumList should (legacyEqual (toList) or contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
-        (fumList should (legacyEqual (fumList) or contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
+        (fumList should (be (toList) or contain atLeastOneOf ("have", "a", "nice", "day"))) (decided by invertedStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
+          (fumList should (be (toList) or contain atLeastOneOf ("fum"))) (decided by invertedStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS is empty" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain atLeastOneOf())
+          fumList should (be (fumList) or contain atLeastOneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -207,7 +207,7 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec with Matchers 
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -215,43 +215,43 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec with Matchers 
       }
     }
 
-    "when used with (contain oneOf (...) and legacyEqual (...)) syntax" - {
+    "when used with (contain oneOf (...) and be (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or legacyEqual (toList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fam") or legacyEqual (toList))
+          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fam") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = invertedStringEquality
-        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or legacyEqual (fumList))
-        fumList should (contain atLeastOneOf ("fum") or legacyEqual (fumList))
-        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or legacyEqual (toList))
+        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or be (fumList))
+        fumList should (contain atLeastOneOf ("fum") or be (fumList))
+        fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum") or legacyEqual (toList))
+          fumList should (contain atLeastOneOf ("fum") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or legacyEqual (fumList))) (decided by invertedStringEquality)
-        (fumList should (contain atLeastOneOf ("fum") or legacyEqual (fumList))) (decided by invertedStringEquality)
-        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or legacyEqual (toList))) (decided by invertedStringEquality)
+        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or be (fumList))) (decided by invertedStringEquality)
+        (fumList should (contain atLeastOneOf ("fum") or be (fumList))) (decided by invertedStringEquality)
+        (fumList should (contain atLeastOneOf ("have", "a", "nice", "day") or be (toList))) (decided by invertedStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum") or legacyEqual (toList))) (decided by invertedStringEquality)
+          (fumList should (contain atLeastOneOf ("fum") or be (toList))) (decided by invertedStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS is empty" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf() or legacyEqual (fumList))
+          fumList should (contain atLeastOneOf() or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -260,7 +260,7 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec with Matchers 
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -188,49 +188,49 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain atMostOneOf (..))` {
+    object `when used with (be (..) and contain atMostOneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+        fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+          fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain atMostOneOf())
+          fumList should (be (fumList) and contain atMostOneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -239,7 +239,7 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -247,49 +247,49 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain atMostOneOf (..) and legacyEqual (..))` {
+    object `when used with (contain atMostOneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and legacyEqual (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and legacyEqual (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and legacyEqual (fumList))
+        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (legacyEqual (toList)))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (be (toList)))
         }
-        checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf() and legacyEqual (fumList))
+          fumList should (contain atMostOneOf() and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -298,7 +298,7 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -176,43 +176,43 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec with Matchers {
       }
     }
     
-    "when used with (legacyEqual (...) and contain theMostOneOf (...)) syntax" - {
+    "when used with (be (...) and contain theMostOneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (legacyEqual (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (legacyEqual (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (legacyEqual (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (legacyEqual (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (legacyEqual (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (be (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (legacyEqual (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS is empty" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain atMostOneOf())
+          fumList should (be (fumList) or contain atMostOneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -221,7 +221,7 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec with Matchers {
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -229,43 +229,43 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec with Matchers {
       }
     }
 
-    "when used with (contain oneOf (...) and legacyEqual (...)) syntax" - {
+    "when used with (contain oneOf (...) and be (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or legacyEqual (toList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or legacyEqual (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (toList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS is empty" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf() or legacyEqual (fumList))
+          fumList should (contain atMostOneOf() or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -274,7 +274,7 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec with Matchers {
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
@@ -193,49 +193,49 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual xx and contain inOrder xx)` {
+    object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (be (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain inOrder ())
+          fumList should (be (fumList) and contain inOrder ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -244,7 +244,7 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -252,49 +252,49 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain inOrder xx and legacyEqual xx)` {
+    object `when used with (contain inOrder xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and legacyEqual (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and legacyEqual (toList))
+          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and legacyEqual (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder () and legacyEqual (fumList))
+          fumList should (contain inOrder () and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -303,7 +303,7 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
@@ -181,43 +181,43 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual xx and contain inOrder xx)` {
+    object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (be (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain inOrder ())
+          fumList should (be (fumList) or contain inOrder ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -226,7 +226,7 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -234,43 +234,43 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain inOrder xx and legacyEqual xx)` {
+    object `when used with (contain inOrder xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or legacyEqual (fumList))
-        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or legacyEqual (fumList))
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or legacyEqual (toList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (fumList))
+        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or legacyEqual (toList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))
-        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))
+        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder () or legacyEqual (fumList))
+          fumList should (contain inOrder () or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -279,7 +279,7 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -193,49 +193,49 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual xx and contain inOrderOnly xx)` {
+    object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (be (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain inOrderOnly ())
+          fumList should (be (fumList) and contain inOrderOnly ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -244,7 +244,7 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -252,49 +252,49 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain inOrderOnly xx and legacyEqual xx)` {
+    object `when used with (contain inOrderOnly xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and legacyEqual (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and legacyEqual (toList))
+          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and legacyEqual (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly () and legacyEqual (fumList))
+          fumList should (contain inOrderOnly () and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -303,7 +303,7 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -181,43 +181,43 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual xx and contain inOrderOnly xx)` {
+    object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (be (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain inOrderOnly ())
+          fumList should (be (fumList) or contain inOrderOnly ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -226,7 +226,7 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -234,43 +234,43 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain inOrderOnly xx and legacyEqual xx)` {
+    object `when used with (contain inOrderOnly xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or legacyEqual (fumList))
-        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or legacyEqual (fumList))
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or legacyEqual (toList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (fumList))
+        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or legacyEqual (toList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))
-        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))
+        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly () or legacyEqual (fumList))
+          fumList should (contain inOrderOnly () or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -279,7 +279,7 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -199,49 +199,49 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain noneOf (..))` {
+    object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain noneOf())
+          fumList should (be (fumList) and contain noneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -250,7 +250,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -258,49 +258,49 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain noneOf (..) and legacyEqual (..))` {
+    object `when used with (contain noneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") and legacyEqual (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and legacyEqual (toList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (legacyEqual (fumList)))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf() and legacyEqual (fumList))
+          fumList should (contain noneOf() and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -309,7 +309,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -187,43 +187,43 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain noneOf (..))` {
+    object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (legacyEqual (toList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (legacyEqual (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (toList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (legacyEqual (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (legacyEqual (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain noneOf())
+          fumList should (be (fumList) or contain noneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -232,7 +232,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -240,43 +240,43 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain noneOf (..) and legacyEqual (..))` {
+    object `when used with (contain noneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain noneOf("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or legacyEqual (toList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain noneOf("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or legacyEqual (toList))
+          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or legacyEqual (fumList))
-        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or legacyEqual (toList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))
+        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf() or legacyEqual (fumList))
+          fumList should (contain noneOf() or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -285,7 +285,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -199,49 +199,49 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain oneOf (..))` {
+    object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
+          fumList should (be (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
+          fumList should (be (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain oneOf())
+          fumList should (be (fumList) and contain oneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -250,7 +250,7 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -258,49 +258,49 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain oneOf (..) and legacyEqual (..))` {
+    object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") and legacyEqual (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and legacyEqual (toList))
+          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and legacyEqual (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (legacyEqual (fumList)))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf() and legacyEqual (fumList))
+          fumList should (contain oneOf() and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -309,7 +309,7 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -187,43 +187,43 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain oneOf (..))` {
+    object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (toList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (toList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (legacyEqual (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (legacyEqual (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
+          fumList should (be (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain oneOf())
+          fumList should (be (fumList) or contain oneOf())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -232,7 +232,7 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -240,43 +240,43 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain oneOf (..) and legacyEqual (..))` {
+    object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or legacyEqual (toList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or legacyEqual (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf() or legacyEqual (fumList))
+          fumList should (contain oneOf() or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -285,7 +285,7 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -193,49 +193,49 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain only (..))` {
+    object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain only ("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain only ("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain only ("happy", "birthday", "to", "you"))
+          fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain only ("happy", "birthday", "to", "you")))
+          fumList should (be (fumList) and (contain only ("happy", "birthday", "to", "you")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain only ())
+          fumList should (be (fumList) and contain only ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -244,7 +244,7 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -252,49 +252,49 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain only (..) and legacyEqual (..))` {
+    object `when used with (contain only (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") and legacyEqual (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fum") and legacyEqual (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fum") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("happy", "birthday", "to", "you") and legacyEqual (fumList))
+          fumList should (contain only ("happy", "birthday", "to", "you") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and legacyEqual (toList))
+          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () and legacyEqual (fumList))
+          fumList should (contain only () and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -303,7 +303,7 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and legacyEqual (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -181,43 +181,43 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec with Matchers {
       }
     }
     
-    object `when used with (legacyEqual (..) and contain only (..))` {
+    object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (toList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (fumList) or contain only ("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be (toList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain only ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain only ("fie", "fee", "fam", "foe"))
+          fumList should (be (toList) or contain only ("fie", "fee", "fam", "foe"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain only ())
+          fumList should (be (fumList) or contain only ())
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -226,7 +226,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (legacyEqual (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -234,43 +234,43 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec with Matchers {
       }
     }
 
-    object `when used with (contain only (..) and legacyEqual (..))` {
+    object `when used with (contain only (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain only ("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain only ("fie", "fee", "fum", "foe") or legacyEqual (toList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain only ("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fam") or legacyEqual (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fam") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))
-        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))
+        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))
+          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS is empty` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () or legacyEqual (fumList))
+          fumList should (contain only () or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -279,7 +279,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or legacyEqual (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or be (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -143,85 +143,85 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec with Matcher
       }
     }
     
-    object `when used with (legacyEqual (..) and contain theSameElementsAs (..))` {
+    object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
+          fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
+          fumList should (be (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
-    object `when used with (contain theSameElementsAs (..) and legacyEqual (..))` {
+    object `when used with (contain theSameElementsAs (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and legacyEqual (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and legacyEqual (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))) + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and legacyEqual (fumList))
+          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and legacyEqual (toList))
+          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
     }
     

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -131,73 +131,73 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec with Matchers
       }
     }
     
-    object `when used with (legacyEqual (..) and contain theSameElementsAs (..))` {
+    object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+          fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
-    object `when used with (contain theSameElementsAs (..) and legacyEqual (..))` {
+    object `when used with (contain theSameElementsAs (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or legacyEqual (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or legacyEqual (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or legacyEqual (toList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or be (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or legacyEqual (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fam"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fam"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))
+          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
     }
     

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -144,85 +144,85 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec with 
       }
     }
     
-    object `when used with (legacyEqual xx and contain theSameElementsInOrderAs xx)` {
+    object `when used with (be xx and contain theSameElementsInOrderAs xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (legacyEqual (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e2, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("equaled", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
-    object `when used with (contain theSameElementsInOrderAs xx and legacyEqual xx)` {
+    object `when used with (contain theSameElementsInOrderAs xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and legacyEqual (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and legacyEqual (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (toList))
         }
-        checkMessageStackDepth(e1, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))) + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and legacyEqual (fumList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and be (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and legacyEqual (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (legacyEqual (fumList)))
+          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and legacyEqual (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e2, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e2, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
       }
     }
     

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -132,73 +132,73 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec wi
       }
     }
     
-    "when used with (legacyEqual xx and contain theSameElementsInOrderAs xx)" - {
+    "when used with (be xx and contain theSameElementsInOrderAs xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (legacyEqual (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (legacyEqual (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (legacyEqual (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
-    "when used with (contain theSameElementsInOrderAs xx and legacyEqual xx)" - {
+    "when used with (contain theSameElementsInOrderAs xx and be xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or legacyEqual (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or legacyEqual (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or legacyEqual (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or legacyEqual (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or legacyEqual (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or legacyEqual (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
         }
-        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("didNotEqual", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or legacyEqual (fumList))) (after being lowerCased and trimmed)
+        checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
       }
     }
     

--- a/src/test/scala/org/scalatest/words/MatcherWordsSpec.scala
+++ b/src/test/scala/org/scalatest/words/MatcherWordsSpec.scala
@@ -73,57 +73,6 @@ class MatcherWordsSpec extends Spec with MatcherWords {
       }
       
     }
-    
-    object `legacyEqual(Any) method returns Matcher` {
-      
-      val mt = legacyEqual ("tommy")
-      
-      def `should have pretty toString` {
-        mt.toString should be ("legacyEqual (\"tommy\")")
-      }
-      
-      val mr = mt("tomy")
-      
-      def `should have correct MatcherResult` {
-        mr should have (
-          'matches (false),
-          'failureMessage ("\"tom[]y\" did not equal \"tom[m]y\""),
-          'negatedFailureMessage ("\"tomy\" equaled \"tommy\""),
-          'midSentenceFailureMessage ("\"tom[]y\" did not equal \"tom[m]y\""),
-          'midSentenceNegatedFailureMessage ("\"tomy\" equaled \"tommy\""),
-          'rawFailureMessage ("{0} did not equal {1}"),
-          'rawNegatedFailureMessage ("{0} equaled {1}"),
-          'rawMidSentenceFailureMessage ("{0} did not equal {1}"),
-          'rawMidSentenceNegatedFailureMessage ("{0} equaled {1}"),
-          'failureMessageArgs(Vector("tom[]y", "tom[m]y")),
-          'negatedFailureMessageArgs(Vector("tomy", "tommy")),
-          'midSentenceFailureMessageArgs(Vector("tom[]y", "tom[m]y")),
-          'midSentenceNegatedFailureMessageArgs(Vector("tomy", "tommy"))    
-        )
-      }
-      
-      val nmr = mr.negated
-      
-      def `should have correct negated MatcherResult` {
-        nmr should have (
-          'matches (true),
-          'failureMessage ("\"tomy\" equaled \"tommy\""),
-          'negatedFailureMessage ("\"tom[]y\" did not equal \"tom[m]y\""),
-          'midSentenceFailureMessage ("\"tomy\" equaled \"tommy\""),
-          'midSentenceNegatedFailureMessage ("\"tom[]y\" did not equal \"tom[m]y\""),
-          'rawFailureMessage ("{0} equaled {1}"),
-          'rawNegatedFailureMessage ("{0} did not equal {1}"),
-          'rawMidSentenceFailureMessage ("{0} equaled {1}"),
-          'rawMidSentenceNegatedFailureMessage ("{0} did not equal {1}"),
-          'failureMessageArgs(Vector("tomy", "tommy")),
-          'negatedFailureMessageArgs(Vector("tom[]y", "tom[m]y")),
-          'midSentenceFailureMessageArgs(Vector("tomy", "tommy")),
-          'midSentenceNegatedFailureMessageArgs(Vector("tom[]y", "tom[m]y"))    
-        )
-      }
-      
-    }
-    
   }
   
 }


### PR DESCRIPTION
Removed legacyEqual in MatcherWords.scala which is no longer needed.
