### PR TITLE
Respecting -Dsbt.log.noformat=true in Framework/ScalaTestFramework

### DIFF
--- a/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/src/main/scala/org/scalatest/tools/Framework.scala
@@ -873,12 +873,7 @@ class Framework extends SbtFramework {
         Runner.parseReporterArgsIntoConfigurations("-K" :: remoteArgs(0) :: remoteArgs(1) :: Nil)
       }
 
-    val sbtNoFormatValue = System.getProperty("sbt.log.noformat")
-    val sbtNoFormat =
-      if (sbtNoFormatValue == null)
-        false
-      else
-        sbtNoFormatValue.toLowerCase == "true"
+    val sbtNoFormat = java.lang.Boolean.getBoolean("sbt.log.noformat")
 
     val (
       useStdout,

--- a/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -199,12 +199,7 @@ class ScalaTestFramework extends SbtFramework {
           Runner.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
           
           val fullReporterConfigurations = Runner.parseReporterArgsIntoConfigurations(reporterArgs)
-          val sbtNoFormatValue = System.getProperty("sbt.log.noformat")
-          val sbtNoFormat =
-            if (sbtNoFormatValue == null)
-              false
-            else
-              sbtNoFormatValue.toLowerCase == "true"
+          val sbtNoFormat = java.lang.Boolean.getBoolean("sbt.log.noformat")
           
           fullReporterConfigurations.standardOutReporterConfiguration match {
             case Some(stdoutConfig) =>


### PR DESCRIPTION
Make Framework and ScalaTestFramework to respect -Dsbt.log.noformat=true which turns off color in console output.
