### PR TITLE
private[scalatest] 'contain AMatcher/AnMatcher'

### DIFF
--- a/src/main/scala/org/scalatest/words/ContainWord.scala
+++ b/src/main/scala/org/scalatest/words/ContainWord.scala
@@ -163,7 +163,7 @@ final class ContainWord {
    *                                ^
    * </pre>
    */
-  def a[T](aMatcher: AMatcher[T]): Matcher[GenTraversable[T]] = 
+  private[scalatest] def a[T](aMatcher: AMatcher[T]): Matcher[GenTraversable[T]] =
     new Matcher[GenTraversable[T]] {
       def apply(left: GenTraversable[T]): MatchResult = {
         val matched = left.find(aMatcher(_).matches)
@@ -186,7 +186,7 @@ final class ContainWord {
    *                                ^
    * </pre>
    */
-  def an[T](anMatcher: AnMatcher[T]): Matcher[GenTraversable[T]] = 
+  private[scalatest] def an[T](anMatcher: AnMatcher[T]): Matcher[GenTraversable[T]] =
     new Matcher[GenTraversable[T]] {
       def apply(left: GenTraversable[T]): MatchResult = {
         val matched = left.find(anMatcher(_).matches)

--- a/src/main/scala/org/scalatest/words/NotWord.scala
+++ b/src/main/scala/org/scalatest/words/NotWord.scala
@@ -1374,7 +1374,7 @@ final class NotWord {
    *                    ^
    * </pre>
    */
-  def contain[T](resultOfAWordApplication: ResultOfAWordToAMatcherApplication[T]): Matcher[GenTraversable[T]] = {
+  private[scalatest] def contain[T](resultOfAWordApplication: ResultOfAWordToAMatcherApplication[T]): Matcher[GenTraversable[T]] = {
     new Matcher[GenTraversable[T]] {
       def apply(left: GenTraversable[T]): MatchResult = {
         val aMatcher = resultOfAWordApplication.aMatcher
@@ -1399,7 +1399,7 @@ final class NotWord {
    *                    ^
    * </pre>
    */
-  def contain[T](resultOfAnWordApplication: ResultOfAnWordToAnMatcherApplication[T]): Matcher[GenTraversable[T]] = {
+  private[scalatest] def contain[T](resultOfAnWordApplication: ResultOfAnWordToAnMatcherApplication[T]): Matcher[GenTraversable[T]] = {
     new Matcher[GenTraversable[T]] {
       def apply(left: GenTraversable[T]): MatchResult = {
         val anMatcher = resultOfAnWordApplication.anMatcher


### PR DESCRIPTION
Mark methods that enable 'contain AMatcher/AnMatcher' as private[scalatest], should re-enable them back when it is completed like others contain xxx using type classes.
