### PR TITLE
LegacyTripleEquals Deprecations

### DIFF
--- a/src/main/scala/org/scalautils/ConversionCheckedLegacyTripleEquals.scala
+++ b/src/main/scala/org/scalautils/ConversionCheckedLegacyTripleEquals.scala
@@ -164,6 +164,7 @@ import TripleEqualsSupport._
  * 
  * @author Bill Venners
  */
+@deprecated("org.scalautils.ConversionCheckedLegacyTripleEquals has been deprecated and will be removed in a future version of ScalaTest. If you need this, please copy the source code into your own trait instead.")
 trait ConversionCheckedLegacyTripleEquals extends LowPriorityConversionCheckedConstraint {
 
   override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)

--- a/src/main/scala/org/scalautils/TypeCheckedLegacyTripleEquals.scala
+++ b/src/main/scala/org/scalautils/TypeCheckedLegacyTripleEquals.scala
@@ -163,6 +163,7 @@ import TripleEqualsSupport._
  * 
  * @author Bill Venners
  */
+@deprecated("org.scalautils.TypeCheckedLegacyTripleEquals has been deprecated and will be removed in a future version of ScalaTest. If you need this, please copy the source code into your own trait instead.")
 trait TypeCheckedLegacyTripleEquals extends LowPriorityTypeCheckedConstraint {
 
   override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)


### PR DESCRIPTION
Deprecated ConversionCheckedLegacyTripleEquals and TypeCheckedLegacyTripleEquals.
