### PR TITLE
Enable Postfix in SpanSugar

### DIFF
--- a/src/main/scala/org/scalatest/time/SpanSugar.scala
+++ b/src/main/scala/org/scalatest/time/SpanSugar.scala
@@ -316,6 +316,8 @@ package org.scalatest.time
  */
 trait SpanSugar {
 
+  implicit val postfixOps = language.postfixOps
+
   /**
    * Class containing methods that return a <code>Span</code> time value calculated from the
    * <code>Long</code> value passed to the <code>GrainOfTime</code> constructor.


### PR DESCRIPTION
Added implicit val postfixOps = language.postfixOps to SpanSugar to avoid compiler warning in user code.
