### PR TITLE
Yet another adjustment in WebBrowser scaladoc

### DIFF
--- a/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -59,7 +59,8 @@ import org.scalatest.Resources
  * <pre class="stHighlight">
  * import org.scalatest._
  * import selenium._
- * import org.openqa.selenium.htmlunit.HtmlUnitDriver
+ * import org.openqa.selenium._
+ * import htmlunit._
  *
  * class BlogSpec extends FlatSpec with Matchers with WebBrowser {
  *


### PR DESCRIPTION
Adjusted scaladoc in WebBrowser so that its examples works in REPL.
