### PR TITLE
Fix for TestFailedDueToTimeoutException serialization problem

### DIFF
--- a/src/main/scala/org/scalatest/concurrent/Eventually.scala
+++ b/src/main/scala/org/scalatest/concurrent/Eventually.scala
@@ -417,13 +417,14 @@ trait Eventually extends PatienceConfiguration {
           }
           else {
             val durationSpan = Span(1, Nanosecond) scaledBy duration // Use scaledBy to get pretty units
-            def msg =
-              if (e.getMessage == null)
-                Resources("didNotEventuallySucceed", attempt.toString, durationSpan.prettyString)
-              else
-                Resources("didNotEventuallySucceedBecause", attempt.toString, durationSpan.prettyString, e.getMessage)
             throw new TestFailedDueToTimeoutException(
-              sde => Some(msg),
+              sde =>
+                Some(
+                  if (e.getMessage == null)
+                    Resources("didNotEventuallySucceed", attempt.toString, durationSpan.prettyString)
+                  else
+                    Resources("didNotEventuallySucceedBecause", attempt.toString, durationSpan.prettyString, e.getMessage)
+                ),
               Some(e),
               getStackDepthFun("Eventually.scala", "eventually"),
               None,

--- a/src/main/scala/org/scalatest/time/Span.scala
+++ b/src/main/scala/org/scalatest/time/Span.scala
@@ -18,6 +18,7 @@ package org.scalatest.time
 import Span.totalNanosForLongLength
 import Span.totalNanosForDoubleLength
 import org.scalatest.Resources
+import java.io.Serializable
 
 /**
  * A time span.
@@ -333,7 +334,7 @@ import org.scalatest.Resources
  *
  * @author Bill Venners
  */
-final class Span private (totNanos: Long, lengthString: String, unitsResource: String, unitsName: String) {
+final class Span private (totNanos: Long, lengthString: String, unitsResource: String, unitsName: String) extends Serializable {
 
   private[time] def this(length: Long, units: Units) {
     this(

--- a/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
+++ b/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
@@ -23,6 +23,7 @@ import time.{Millisecond, Span, Millis}
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestPendingException
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
+import SharedHelpers.serializeRoundtrip
 
 class EventuallySpec extends FunSpec with ShouldMatchers with OptionValues with SeveredStackTraces {
 
@@ -219,6 +220,15 @@ class EventuallySpec extends FunSpec with ShouldMatchers with OptionValues with 
         }
       } should produce [TestFailedException]
       count should be > (1)
+    }
+
+    it ("should blow up with a TFE that is serializable") {
+      val e = intercept[TestFailedException] {
+        eventually {
+          1 should equal (2)
+        }
+      }
+      serializeRoundtrip(e)
     }
   }
 }


### PR DESCRIPTION
Fixed serialization problem of TestFailedDueToTimeoutException thrown from Eventually.
