### PR TITLE
Stricter Macro

### DIFF
--- a/src/main/scala/org/scalatest/AssertionsMacro.scala
+++ b/src/main/scala/org/scalatest/AssertionsMacro.scala
@@ -213,30 +213,46 @@ private[scalatest] class AssertionsMacro[C <: Context](val context: C) {
       )
     )
 
+  private val supportedOperations = Set("==", "!=", "===", "!==")
+
+  def isSupported(operator: String) = supportedOperations.contains(operator)
+
   def assert(booleanExpr: Expr[Boolean]): Expr[Unit] = {
     val booleanTree = booleanExpr.tree
     booleanTree match {
       case apply: Apply =>
         apply.fun match {
           case select: Select if apply.args.size == 1 => // For simple assert(a == b)
-            val sExpr: Apply = simpleSubstitute(select)
             val operator: String = select.name.decoded
-            val assertExpr: Apply = assertMacro(operator)
-            genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assertExpr)
+            if (isSupported(operator)) {
+              val sExpr: Apply = simpleSubstitute(select)
+              val assertExpr: Apply = assertMacro(operator)
+              genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assertExpr)
+            }
+            else
+              simpleAssertMacro(booleanTree)
           case funApply: Apply =>
             funApply.fun match {
               case select: Select if funApply.args.size == 1 => // For === that takes Equality
-                val sExpr: Apply = nestedSubstitute(select, apply)
                 val operator: String = select.name.decoded
-                val assertExpr: Apply = assertMacro(operator)
-                genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                if (isSupported(operator)) {
+                  val sExpr: Apply = nestedSubstitute(select, apply)
+                  val assertExpr: Apply = assertMacro(operator)
+                  genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                }
+                else
+                  simpleAssertMacro(booleanTree)
               case typeApply: TypeApply =>
                 typeApply.fun match {
                   case select: Select if funApply.args.size == 1 => // For TypeCheckedTripleEquals
-                    val sExpr: Apply = nestedSubstitute(select, apply)
                     val operator: String = select.name.decoded
-                    val assertExpr: Apply = assertMacro(operator)
-                    genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                    if (isSupported(operator)) {
+                      val sExpr: Apply = nestedSubstitute(select, apply)
+                      val assertExpr: Apply = assertMacro(operator)
+                      genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                    }
+                    else
+                      simpleAssertMacro(booleanTree)
                   case _ => simpleAssertMacro(booleanTree)
                 }
               case _ => simpleAssertMacro(booleanTree)
@@ -254,24 +270,36 @@ private[scalatest] class AssertionsMacro[C <: Context](val context: C) {
       case apply: Apply =>
         apply.fun match {
           case select: Select if apply.args.size == 1 => // For simple assert(a == b)
-            val sExpr: Apply = simpleSubstitute(select)
             val operator: String = select.name.decoded
-            val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
-            genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assertExpr)
+            if (isSupported(operator)) {
+              val sExpr: Apply = simpleSubstitute(select)
+              val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
+              genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assertExpr)
+            }
+            else
+              simpleAssertMacroWithClue(booleanTree, clueTree)
           case funApply: Apply =>
             funApply.fun match {
               case select: Select if funApply.args.size == 1 => // For === that takes Equality
-                val sExpr: Apply = nestedSubstitute(select, apply)
                 val operator: String = select.name.decoded
-                val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
-                genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                if (isSupported(operator)) {
+                  val sExpr: Apply = nestedSubstitute(select, apply)
+                  val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
+                  genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                }
+                else
+                  simpleAssertMacroWithClue(booleanTree, clueTree)
               case typeApply: TypeApply =>
                 typeApply.fun match {
                   case select: Select if funApply.args.size == 1 => // For TypeCheckedTripleEquals
-                    val sExpr: Apply = nestedSubstitute(select, apply)
                     val operator: String = select.name.decoded
-                    val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
-                    genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                    if (isSupported(operator)) {
+                      val sExpr: Apply = nestedSubstitute(select, apply)
+                      val assertExpr: Apply = assertMacroWithClue(operator, clueTree)
+                      genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assertExpr)
+                    }
+                    else
+                      simpleAssertMacroWithClue(booleanTree, clueTree)
                   case _ => simpleAssertMacro(booleanTree)
                 }
               case _ => simpleAssertMacroWithClue(booleanTree, clueTree)
@@ -288,24 +316,36 @@ private[scalatest] class AssertionsMacro[C <: Context](val context: C) {
       case apply: Apply =>
         apply.fun match {
           case select: Select if apply.args.size == 1 => // For simple assert(a == b)
-            val sExpr: Apply = simpleSubstitute(select)
             val operator: String = select.name.decoded
-            val assumeExpr: Apply = assumeMacro(operator)
-            genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assumeExpr)
+            if (isSupported(operator)) {
+              val sExpr: Apply = simpleSubstitute(select)
+              val assumeExpr: Apply = assumeMacro(operator)
+              genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assumeExpr)
+            }
+            else
+              simpleAssumeMacro(booleanTree)
           case funApply: Apply =>
             funApply.fun match {
               case select: Select if funApply.args.size == 1 => // For === that takes Equality
-                val sExpr: Apply = nestedSubstitute(select, apply)
                 val operator: String = select.name.decoded
-                val assumeExpr: Apply = assumeMacro(operator)
-                genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                if (isSupported(operator)) {
+                  val sExpr: Apply = nestedSubstitute(select, apply)
+                  val assumeExpr: Apply = assumeMacro(operator)
+                  genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                }
+                else
+                  simpleAssumeMacro(booleanTree)
               case typeApply: TypeApply =>
                 typeApply.fun match {
                   case select: Select if funApply.args.size == 1 => // For TypeCheckedTripleEquals
-                    val sExpr: Apply = nestedSubstitute(select, apply)
                     val operator: String = select.name.decoded
-                    val assumeExpr: Apply = assumeMacro(operator)
-                    genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                    if (isSupported(operator)) {
+                      val sExpr: Apply = nestedSubstitute(select, apply)
+                      val assumeExpr: Apply = assumeMacro(operator)
+                      genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                    }
+                    else
+                      simpleAssumeMacro(booleanTree)
                   case _ => simpleAssumeMacro(booleanTree)
                 }
               case _ => simpleAssumeMacro(booleanTree)
@@ -323,25 +363,37 @@ private[scalatest] class AssertionsMacro[C <: Context](val context: C) {
       case apply: Apply =>
         apply.fun match {
           case select: Select if apply.args.size == 1 => // For simple assert(a == b)
-            val sExpr: Apply = simpleSubstitute(select)
             val operator: String = select.name.decoded
-            val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
-            genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assumeExpr)
+            if (isSupported(operator)) {
+              val sExpr: Apply = simpleSubstitute(select)
+              val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
+              genExpression(select.qualifier.duplicate, operator, apply.args(0).duplicate, sExpr, assumeExpr)
+            }
+            else
+              simpleAssumeMacroWithClue(booleanTree, clueTree)
           case funApply: Apply =>
             funApply.fun match {
               case select: Select if funApply.args.size == 1 => // For === that takes Equality
-                val sExpr: Apply = nestedSubstitute(select, apply)
                 val operator: String = select.name.decoded
-                val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
-                genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                if (isSupported(operator)) {
+                  val sExpr: Apply = nestedSubstitute(select, apply)
+                  val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
+                  genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                }
+                else
+                  simpleAssumeMacroWithClue(booleanTree, clueTree)
               case typeApply: TypeApply =>
                 typeApply.fun match {
                   case select: Select if funApply.args.size == 1 => // For TypeCheckedTripleEquals
-                    val sExpr: Apply = nestedSubstitute(select, apply)
                     val operator: String = select.name.decoded
-                    val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
-                    genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
-                  case _ => simpleAssumeMacro(booleanTree)
+                    if (isSupported(operator)) {
+                      val sExpr: Apply = nestedSubstitute(select, apply)
+                      val assumeExpr: Apply = assumeMacroWithClue(operator, clueTree)
+                      genExpression(select.qualifier.duplicate, operator, funApply.args(0).duplicate, sExpr, assumeExpr)
+                    }
+                    else
+                      simpleAssumeMacroWithClue(booleanTree, clueTree)
+                  case _ => simpleAssumeMacroWithClue(booleanTree, clueTree)
                 }
               case _ => simpleAssumeMacroWithClue(booleanTree, clueTree)
             }

--- a/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -191,6 +191,10 @@ class AssertionsSpec extends FunSpec with OptionValues {
 
   def wasLessThanOrEqualTo(left: Any, right: Any): String =
     FailureMessages("wasLessThanOrEqualTo", left, right)
+
+  private def neverRuns1(f: => Unit): Boolean = true
+  private def neverRuns2(f: => Unit)(a: Int): Boolean = true
+  private def neverRuns3[T](f: => Unit)(a: T): Boolean = true
   
   describe("The assert(boolean) method") {
     val a = 3
@@ -523,6 +527,18 @@ class AssertionsSpec extends FunSpec with OptionValues {
       assert(e.message === Some(equaled(3, 3)))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should preserve side effects when Apply with single argument is passed in") {
+      assert(neverRuns1(sys.error("Sad times 1")))
+    }
+
+    it("should preserve side effects when Apply with 2 argument list is passed in") {
+      assert(neverRuns2(sys.error("Sad times 2"))(0))
+    }
+
+    it("should preserve side effects when typed Apply with 2 argument list is passed in") {
+      assert(neverRuns3(sys.error("Sad times 3"))(0))
     }
   }
 
@@ -858,6 +874,18 @@ class AssertionsSpec extends FunSpec with OptionValues {
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
+
+    it("should preserve side effects when Apply with single argument is passed in") {
+      assert(neverRuns1(sys.error("Sad times 1")), "should not fail!")
+    }
+
+    it("should preserve side effects when Apply with 2 argument list is passed in") {
+      assert(neverRuns2(sys.error("Sad times 2"))(0), "should not fail!")
+    }
+
+    it("should preserve side effects when typed Apply with 2 argument list is passed in") {
+      assert(neverRuns3(sys.error("Sad times 3"))(0), "should not fail!")
+    }
   }
 
   describe("The assume(boolean) method") {
@@ -1192,6 +1220,18 @@ class AssertionsSpec extends FunSpec with OptionValues {
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
+
+    it("should preserve side effects when Apply with single argument is passed in") {
+      assume(neverRuns1(sys.error("Sad times 1")))
+    }
+
+    it("should preserve side effects when Apply with 2 argument list is passed in") {
+      assume(neverRuns2(sys.error("Sad times 2"))(0))
+    }
+
+    it("should preserve side effects when typed Apply with 2 argument list is passed in") {
+      assume(neverRuns3(sys.error("Sad times 3"))(0))
+    }
   }
 
   describe("The assume(boolean, clue) method") {
@@ -1525,6 +1565,18 @@ class AssertionsSpec extends FunSpec with OptionValues {
       assert(e.message === Some(equaled(3, 3) + "; dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should preserve side effects when Apply with single argument is passed in") {
+      assume(neverRuns1(sys.error("Sad times 1")), "should not fail!")
+    }
+
+    it("should preserve side effects when Apply with 2 argument list is passed in") {
+      assume(neverRuns2(sys.error("Sad times 2"))(0), "should not fail!")
+    }
+
+    it("should preserve side effects when typed Apply with 2 argument list is passed in") {
+      assume(neverRuns3(sys.error("Sad times 3"))(0), "should not fail!")
     }
   }
 


### PR DESCRIPTION
Make assert/assume macro to only perform expansion when the operator is one of ==, !=, ===, !==.
