### PR TITLE
Runner: Allow several pairs of tagging arguments

### DIFF
--- a/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/src/main/scala/org/scalatest/tools/Runner.scala
@@ -2095,20 +2095,21 @@ object Runner {
     if (args.length == 0) {
       List()
     }
-    else if (args.length == 2) {
-      val dashArg = args(0)
-      val runpathArg = args(1)
+    else if (args.length % 2 == 0) {
+      def parsePair(dashArg: String, runpathArg:String) = {
+        if (dashArg != expectedDashArg)
+          throw new IllegalArgumentException("First arg must be " + expectedDashArg + ", but was: " + dashArg)
 
-      if (dashArg != expectedDashArg)
-        throw new IllegalArgumentException("First arg must be " + expectedDashArg + ", but was: " + dashArg)
+        if (runpathArg.trim.isEmpty)
+          throw new IllegalArgumentException("The runpath string must actually include some non-whitespace characters.")
 
-      if (runpathArg.trim.isEmpty)
-        throw new IllegalArgumentException("The runpath string must actually include some non-whitespace characters.")
+        splitPath(runpathArg)
+      }
+      args.grouped(2).flatMap(p => parsePair(p(0),p(1))).toList
 
-      splitPath(runpathArg)
     }
     else {
-      throw new IllegalArgumentException("Runpath must be either zero or two args: " + args)
+      throw new IllegalArgumentException("Runpath must be either zero or have even number of args: " + args)
     }
   }
   

--- a/src/test/scala/org/scalatest/tools/RunnerSpec.scala
+++ b/src/test/scala/org/scalatest/tools/RunnerSpec.scala
@@ -1000,9 +1000,39 @@ class RunnerSpec extends Spec with PrivateMethodTester {
     )
   }
 
-  def `parseCompoundArgIntoSet should work correctly` {
-    assertResult(Set("Cat", "Dog")) {
-      Runner.parseCompoundArgIntoSet(List("-n", "Cat Dog"), "-n")
+  object `parseCompoundArgIntoSet should` {
+    def `work correctly` {
+      assertResult(Set("Cat", "Dog")) {
+        Runner.parseCompoundArgIntoSet(List("-n", "Cat Dog"), "-n")
+      }
+    }
+    def `merge overlapping values` {
+      assertResult(Set("tag", "tag2", "tag3")) {
+        Runner.parseCompoundArgIntoSet(List("-l", "tag tag2", "-l", "tag2 tag3"),"-l")
+      }
+    }
+  }
+
+  object `parseCompoundArgIntoList should parse` {
+    def `single` {
+      assertResult(List("tag")) {
+        Runner.parseCompoundArgIntoList(List("-l", "tag"),"-l")
+      }
+    }
+    def `multi` {
+      assertResult(List("tag","tag2")) {
+        Runner.parseCompoundArgIntoList(List("-l", "tag tag2"),"-l")
+      }
+    }
+    def `different pairs` {
+      assertResult(List("tag", "tag2", "tag3", "tag4")) {
+        Runner.parseCompoundArgIntoList(List("-l", "tag tag2", "-l", "tag3 tag4"),"-l")
+      }
+    }
+    def `overlapping pairs` {
+      assertResult(List("tag", "tag2", "tag2", "tag3")) {
+        Runner.parseCompoundArgIntoList(List("-l", "tag tag2", "-l", "tag2 tag3"),"-l")
+      }
     }
   }
 


### PR DESCRIPTION
Using sbt:

``` scala
lazy val IntegrationFast = config("it-fast") extend (IntegrationTest)

val testSettings = inConfig(IntegrationFast)(Defaults.testTasks) ++
    Seq(Test, IntegrationTest, IntegrationFast).flatMap {
      scope => Seq(
        testOptions in scope <++= (loadedTestFrameworks in scope, target in scope) map {
          case (fw, t) =>
            fw.get(TestFrameworks.ScalaTest).map {
              _ =>
                val args:Seq[String] = if (scope != IntegrationFast) Seq(
                  "-l", "my.test.utils.tags.FaultyTest"
                )
                else Seq(
                  "-l", "my.test.utils.tags.SlowTest my.test.utils.tags.FaultyTest"
                )
                Tests.Argument(TestFrameworks.ScalaTest, args: _*)
            }.toSeq
        },
        scalacOptions in scope ++= Seq(
          "-language:reflectiveCalls"
        )
      )
    }

```

due to extend relationship "IntegrationFast extend (IntegrationTest)"
I got on it-fast:test
"Runpath must be either zero or two args: List(-l, my.test.utils.tags.SlowTest my.test.utils.tags.FaultyTest, -l, my.test.utils.tags.FaultyTest)"
And it is pretty hard to do a workaround for this.

This pull request should allow using several -l and -n pairs.
In case of `List(-l, my.test.utils.tags.SlowTest my.test.utils.tags.FaultyTest, -l, my.test.utils.tags.FaultyTest)"` 
Will parse to `List(my.test.utils.tags.SlowTest, my.test.utils.tags.FaultyTest)`

This also allows: `-l SlowTests -l PerfTests` and `-n UnitTests -n FastTests` mentioned in example column [Guide](http://www.scalatest.org/user_guide/using_the_runner) and [ScalaDoc](http://doc.scalatest.org/2.0/index.html#org.scalatest.tools.Runner$)
