### PR TITLE
[WiP] Travis CI with publishing and gentests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: scala
+scala:
+  - 2.10.3
+  - 2.11.0-M8
+jdk:
+  - oraclejdk7
+  - openjdk6
+env:
+  #see https://github.com/scalatest/scalatest/pull/245
+  #global values should be replaced using http://docs.travis-ci.com/user/encryption-keys/ with valid values
+  global:
+    - SCALATEST_NEXUS_LOGIN=tbd
+    - SCALATEST_NEXUS_PASSWORD=tbd
+    - SCALATEST_GPG_FILE=tbd
+    - SCALATEST_GPG_PASSPHASE=tbd
+
+  matrix:
+    - MODE=Main
+    - MODE=Gentests
+
+before_script: ./travis_build.sh Compile
+script: ./travis_build.sh $MODE
+
+after_success:
+  # only 'scalatest/scalatest' 'master' branch is published from the first node
+  - |
+      echo "Succeded on: ${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}"
+      if [ "${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}" = "scalatest/scalatest/master" ]; then
+        # temporary for convinience taken outside, todo: grab in repo, also some of steps may be hidden in inside of travis_build
+        curl -o travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
+        python travis_after_all.py
+        export $(cat .to_export_back)
+        if [ "$BUILD_LEADER" = "YES" ]; then
+          if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+            ./travis_build.sh Publish
+          fi
+        fi
+      fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ScalaTest
 =========
 
+[![Build Status](https://travis-ci.org/scalatest/scalatest.png?branch=master)](https://travis-ci.org/scalatest/scalatest)
+
 ScalaTest is a free, open-source testing toolkit for Scala and
 Java programmers.
 

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+export JVM_OPTS="-server -Xms2G -Xmx2G -Xss8M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=1024M -XX:-UseGCOverheadLimit"
+export MODE=$1
+
+if [[ $MODE = 'Compile' ]] ; then
+  #this echo is required to keep travis alive, because some compilation parts are silent for more than 10 minutes
+  while true; do echo "..."; sleep 60; done &
+  sbt ++$TRAVIS_SCALA_VERSION compile test:compile #gentests has .dependsOn(scalatest  % "test->test"), so it is common
+  rc=$?
+  kill %1
+  exit $rc
+fi
+
+if [[ $MODE = 'Main' ]] ; then
+  echo "Doing 'sbt test'"
+
+  sbt ++$TRAVIS_SCALA_VERSION testQuick
+  rc=$?
+  echo first try, exitcode $rc      
+  if [[ $rc != 0 ]] ; then
+    sbt ++$TRAVIS_SCALA_VERSION testQuick
+    rc=$?
+    echo second try, exitcode $rc
+  fi
+  echo final, exitcode $rc
+  exit $rc
+
+fi
+
+if [[ $MODE = 'Gentests' ]] ; then
+  echo "Doing 'sbt gentests/test'"
+  export JVM_OPTS="-server -Xms5G -Xmx6G -Xss8M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=1024M -XX:-UseGCOverheadLimit"
+  
+  while true; do echo "..."; sleep 60; done &
+  sbt ++$TRAVIS_SCALA_VERSION gentests/test:compile #try to reduce presure on sbt, for OOM
+  sbt ++$TRAVIS_SCALA_VERSION gentests/test
+  rc=$?
+  kill %1  
+  exit $rc
+fi
+
+if [[ $MODE = 'Gentests' ]] ; then
+  sbt ++$TRAVIS_SCALA_VERSION publishSigned
+  sbt ++$TRAVIS_SCALA_VERSION scalautils/publishSigned
+fi


### PR DESCRIPTION
Continues: #235
Assumes: #245

Known issues/todo: 
- [ ] gentests are not succeeded, due to extreme memory needs
- [ ] publishSigned still requires some local file
- [ ] replace `curl` with local file
- [ ] scala 2.11 seems out of scope yet see [here](https://travis-ci.org/dmakhno/scalatest/builds/19105806)
- [ ] not clear if different jdks make sense

Future:
- Separate publishing for different scala's, due to byte code difference.

Note: Just in Case `WiP == Work In Progress`
