### PR TITLE
Travis & README Adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
   - 2.10.3
-  - 2.11.0-M8
+#  - 2.11.0-M8
 jdk:
   - oraclejdk7
   - openjdk6
@@ -16,7 +16,7 @@ env:
 
   matrix:
     - MODE=Main
-    - MODE=Gentests
+#    - MODE=Gentests
 
 before_script: ./travis_build.sh Compile
 script: ./travis_build.sh $MODE

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The followings are needed for building ScalaTest:
 
 and use the following options in your SBT launch file:
 
-    SBT_OPTS="-server -Xms512M -Xmx2048M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M"
+    SBT_OPTS="-server -Xms512M -Xmx2200M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M"
 
 ### Building and Running Tests
 
@@ -42,7 +42,7 @@ This command will build and run the regular tests:
 
 To run generated tests, you'll need to increase maximum heap size to -Xmx5120M, and use this command instead:
 
-  `$ sbt "project gentests" "test"`
+  `$ sbt gentests/test`
 
 What it does is simply switch to gentests project and run test.
 

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export JVM_OPTS="-server -Xms2G -Xmx2G -Xss8M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=1024M -XX:-UseGCOverheadLimit"
+export JVM_OPTS="-server -Xms2G -Xmx2200M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 export MODE=$1
 
 if [[ $MODE = 'Compile' ]] ; then
@@ -30,17 +30,17 @@ fi
 
 if [[ $MODE = 'Gentests' ]] ; then
   echo "Doing 'sbt gentests/test'"
-  export JVM_OPTS="-server -Xms5G -Xmx6G -Xss8M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=1024M -XX:-UseGCOverheadLimit"
+  export JVM_OPTS="-server -Xms5G -Xmx5G -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
   
   while true; do echo "..."; sleep 60; done &
-  sbt ++$TRAVIS_SCALA_VERSION gentests/test:compile #try to reduce presure on sbt, for OOM
+  sbt ++$TRAVIS_SCALA_VERSION test:compile #try to reduce presure on sbt, for OOM
   sbt ++$TRAVIS_SCALA_VERSION gentests/test
   rc=$?
   kill %1  
   exit $rc
 fi
 
-if [[ $MODE = 'Gentests' ]] ; then
+if [[ $MODE = 'Publish' ]] ; then
   sbt ++$TRAVIS_SCALA_VERSION publishSigned
   sbt ++$TRAVIS_SCALA_VERSION scalautils/publishSigned
 fi


### PR DESCRIPTION
-Adjusted memory to use in travis script and README.md.
-Temporary disable 2.11.0-M8 build, as current master does not build with it yet, there's another branch that's compatible though.
-Temporary disable Gentests build, since it is not working currently due to OOM.
