### PR TITLE
prettify xml NodeSeq and NodeBuffer

### DIFF
--- a/src/main/scala/org/scalautils/Prettifier.scala
+++ b/src/main/scala/org/scalautils/Prettifier.scala
@@ -18,6 +18,7 @@ package org.scalautils
 import scala.collection._
 import mutable.WrappedArray
 import scala.util.Success
+import scala.xml
 
 /**
  * A function that given any object will produce a &ldquo;pretty&rdquo; string representation of that object,
@@ -188,7 +189,10 @@ object Prettifier {
               (aGenMap.toIterator.map { case (key, value) => // toIterator is needed for consistent ordering
                 apply(key) + " -> " + apply(value)
               }).mkString(", ") + ")"
-            case anXMLNode: scala.xml.Node => anXMLNode.toString // Must handle this specially, else get infinite recursion and StackOverflowError
+            case anXMLNode: xml.Node => anXMLNode.toString // Must handle this specially, else get infinite recursion and StackOverflowError
+            case anXMLNodeSeq: xml.NodeSeq => anXMLNodeSeq.toString 
+            case anXMLNodeBuffer: xml.NodeBuffer =>
+              xml.NodeSeq.fromSeq(anXMLNodeBuffer).toString
             case aGenTraversable: GenTraversable[_] =>
               val defaultToString = aGenTraversable.toString
               val typeName = defaultToString.takeWhile(_ != '(')

--- a/src/test/scala/org/scalautils/PrettifierSpec.scala
+++ b/src/test/scala/org/scalautils/PrettifierSpec.scala
@@ -19,6 +19,7 @@ import org.scalatest._
 import scala.collection.mutable.WrappedArray
 import scala.util.Success
 import SharedHelpers.{javaList, javaSortedMap}
+import scala.xml.NodeSeq
 
 class PrettifierSpec extends Spec with Matchers {
   object `A Prettifier` {
@@ -314,8 +315,18 @@ class PrettifierSpec extends Spec with Matchers {
     def `should pretty print nested string Java Map` {
       Prettifier.default(javaSortedMap(Entry("akey", javaSortedMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))))) should be ("{\"akey\"={1=\"one\", 2=\"two\", 3=\"three\"}}")
     }
-    def `should pretty print xml` {
-      Prettifier.default(<a></a>) should be ("<a></a>")
+    def `should pretty print xml <a/>` {
+      Prettifier.default(<a/>) should be ("<a/>")
+    }
+    def `should pretty print xml <a><b/></a>` {
+      Prettifier.default(<a><b/></a>) should be ("<a><b/></a>")
+    }
+    def `should pretty print xml <a/><b/>` {
+      Prettifier.default(<a/><b/>) should be ("<a/><b/>")
+    }
+    def `should pretty print xml.NodeSeq <a/><b/>` {
+      val ab: NodeSeq = <a/><b/>;
+      Prettifier.default(ab) should be ("<a/><b/>")
     }
     def `should handle runaway recursion gracefully, if not necessarily quickly` {
       /*


### PR DESCRIPTION
Before:

```
  scala> val ab = <a/><b/>
  ab: scala.xml.NodeBuffer = ArrayBuffer(<a/>, <b/>)

  scala> Prettifier.default(ab) 
  res0: String = ArrayBuffer(<a/>, <b/>)

  scala> val ab: NodeSeq = <a/><b/>
  ab: scala.xml.NodeSeq = NodeSeq(<a/>, <b/>)

  scala> Prettifier.default(ab) 
  res1: String = <a/><b/>(<a/>, <b/>)

```

After:

```
  scala> val ab = <a/><b/>
  ab: scala.xml.NodeBuffer = ArrayBuffer(<a/>, <b/>)

  scala> Prettifier.default(ab) 
  res0: String = <a/><b/>

  scala> val ab: NodeSeq = <a/><b/>
  ab: scala.xml.NodeSeq = NodeSeq(<a/>, <b/>)

  scala> Prettifier.default(ab) 
  res1: String = <a/><b/>
```
