### PR TITLE
Scalautils SBT Project Adjustments

### DIFF
--- a/project/GenScalaUtils.scala
+++ b/project/GenScalaUtils.scala
@@ -59,6 +59,12 @@ object GenScalaUtils {
   }
 
   def genTest(targetDir: File, scalaVersion: String) {
+    val scalatestDir = new File(targetDir, "org/scalatest")
+    scalatestDir.mkdirs()
+    val sharedHelpersSourceFile = new File("src/test/scala/org/scalatest/SharedHelpers.scala")
+    val sharedHelpersTargetFile = new File(scalatestDir, sharedHelpersSourceFile.getName)
+    copyFile(sharedHelpersSourceFile, sharedHelpersTargetFile)
+
     val packageDir = new File(targetDir, "org/scalautils")
     packageDir.mkdirs()
     val sourceDir = new File("src/test/scala/org/scalautils")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -204,7 +204,7 @@ object ScalatestBuild extends Build {
         "Bundle-DocURL" -> "http://www.scalautils.org/",
         "Bundle-Vendor" -> "Artima, Inc."
       )
-    ).dependsOn(scalatest  % "test->test")
+    ).dependsOn(scalatest)
 
   def gentestsSharedSettings: Seq[Setting[_]] = Seq(
     scalacOptions ++= Seq("-no-specialization", "-feature"),


### PR DESCRIPTION
Make scalautils project in sbt build to depends on just scalatest main, not scalatest test.
