### PR TITLE
WebBrowser#Query.findElement workaround for PhantomJS

### DIFF
--- a/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -2848,6 +2848,12 @@ trait WebBrowser {
       }
       catch {
         case e: org.openqa.selenium.NoSuchElementException => None
+        case e: org.openqa.selenium.WebDriverException =>
+          if (e.getMessage.contains("Unable to find element") && e.getMessage.contains(by.queryString)) {
+            None
+          } else {
+            throw e
+        }
       }
 
     /**

--- a/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -2849,7 +2849,7 @@ trait WebBrowser {
       catch {
         case e: org.openqa.selenium.NoSuchElementException => None
         case e: org.openqa.selenium.WebDriverException =>
-          if (e.getMessage.contains("Unable to find element") && e.getMessage.contains(by.queryString)) {
+          if (e.getMessage.contains("Unable to find element") && e.getMessage.contains(queryString)) {
             None
           } else {
             throw e


### PR DESCRIPTION
For PhantomJS driver (and PhantomJS 1.9.7) in case when element not found driver throw org.openqa.selenium.WebDriverException instead expected org.openqa.selenium.NoSuchElementException. As result - find method fire exception instead None.
