### PR TITLE
2.11 Failing Test

### DIFF
--- a/src/test/scala/org/scalautils/OrSpec.scala
+++ b/src/test/scala/org/scalautils/OrSpec.scala
@@ -289,8 +289,8 @@ class OrSpec extends UnitSpec with Accumulation with TypeCheckedTripleEquals {
       case _ => fail()
     }
     divByZero should be a 'bad
-    intercept[NotImplementedError] {
-      attempt { ??? }
+    intercept[VirtualMachineError] {
+      attempt { throw new VirtualMachineError {} }
     }
   }
   it can "be created from a Try via the from factory method" in {


### PR DESCRIPTION
Fixed a failing test in the old OrSpec.scala as NotImplementedError is no longer fatal in Scala 2.11.
