### PR TITLE
Travis Script Tweak

### DIFF
--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export JVM_OPTS="-server -Xms2000M -Xmx3000M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
+export JVM_OPTS="-server -Xms2G -Xmx4G -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 export MODE=$1
 
 if [[ $MODE = 'Compile' ]] ; then


### PR DESCRIPTION
Tweaked travis build to run sbt compile first, hopefully to solve cannot allocate memory problem in travis build.
