### PR TITLE
Path Style Trait Fix in Master

### DIFF
--- a/src/main/scala/org/scalatest/path/FreeSpecLike.scala
+++ b/src/main/scala/org/scalatest/path/FreeSpecLike.scala
@@ -48,7 +48,7 @@ trait FreeSpecLike extends org.scalatest.Suite with OneInstancePerTest with Info
   private final val engine = PathEngine.getEngine()
   import engine._
 
-  override def newInstance: FreeSpec = this.getClass.newInstance.asInstanceOf[FreeSpec]
+  override def newInstance: FreeSpecLike = this.getClass.newInstance.asInstanceOf[FreeSpecLike]
 
   /**
    * Returns an <code>Informer</code> that during test execution will forward strings (and other objects) passed to its

--- a/src/main/scala/org/scalatest/path/FunSpecLike.scala
+++ b/src/main/scala/org/scalatest/path/FunSpecLike.scala
@@ -49,7 +49,7 @@ trait FunSpecLike extends org.scalatest.Suite with OneInstancePerTest with Infor
   private final val engine = PathEngine.getEngine()
   import engine._
 
-  override def newInstance: FunSpec = this.getClass.newInstance.asInstanceOf[FunSpec]
+  override def newInstance: FunSpecLike = this.getClass.newInstance.asInstanceOf[FunSpecLike]
 
   /**
    * Returns an <code>Informer</code> that during test execution will forward strings (and other objects) passed to its

--- a/src/test/scala/org/scalatest/path/ExampleLikeSpecs.scala
+++ b/src/test/scala/org/scalatest/path/ExampleLikeSpecs.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.path
+
+import org.scalatest.DoNotDiscover
+
+class ExampleBaseClass
+
+@DoNotDiscover
+class ExampleFreeSpecLike extends ExampleBaseClass with FreeSpecLike
+
+@DoNotDiscover
+class ExampleFunSpecLike extends ExampleBaseClass with FunSpecLike

--- a/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
+++ b/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
@@ -223,6 +223,11 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       }
     }
 
+    it("should create new instance as FreeSpecLike") {
+      val spec = new ExampleFreeSpecLike
+      assert(spec.newInstance.isInstanceOf[FreeSpecLike])
+    }
+
     describe("(with info calls)") {
       class InfoInsideTestSpec extends PathFreeSpec {
         val msg = "hi there, dude"

--- a/src/test/scala/org/scalatest/path/FunSpecSpec.scala
+++ b/src/test/scala/org/scalatest/path/FunSpecSpec.scala
@@ -121,6 +121,11 @@ class FunSpecSpec extends org.scalatest.FreeSpec with GivenWhenThen {
       }
     }
 
+    "should create new instance as FunSpecLike" in {
+      val spec = new ExampleFunSpecLike
+      assert(spec.newInstance.isInstanceOf[FunSpecLike])
+    }
+
     "(with info calls)" - {
       class InfoInsideTestSpec extends PathFunSpec {
         val msg = "hi there, dude"


### PR DESCRIPTION
Fixed path.FreeSpecLike's newInstance method wrong type, as well as the same problem in FreeSpecLike, just make sure we didn't forget to cherry pick this fix from 2.1.x branch.
