### PR TITLE
Bump up scala-xml version to 1.0.2, because 1.0.1 depends on Scala 2.11....

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -122,7 +122,7 @@ object ScalatestBuild extends Build {
       // if scala 2.11+ is used, add dependency on scala-xml module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
-          "org.scala-lang.modules" %% "scala-xml" % "1.0.1",
+          "org.scala-lang.modules" %% "scala-xml" % "1.0.2",
           "org.scalacheck" %% "scalacheck" % "1.11.3" % "optional"
         )
       case _ =>


### PR DESCRIPTION
Bump up scala-xml version to 1.0.2, because 1.0.1 depends on Scala 2.11.0 not 2.11.1 which will cause multiple scala version warning.

This fix should be cheery-pick into master as well.
