### PR TITLE
be_== Part 1

### DIFF
--- a/project/GenFactories.scala
+++ b/project/GenFactories.scala
@@ -823,11 +823,22 @@ $endif$
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
      *
      * <pre class="stHighlight">
+     * aMatcherFactory and not be_== (3 - 1)
+     *                         ^
+     * </pre>
+     */
+     def be_==(any: Any): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
+       thisMatcherFactory.and(MatcherWords.not.apply(MatcherWords.be_==(any)))
+
+    /**
+     * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
+     *
+     * <pre class="stHighlight">
      * aMatcherFactory and not be (3 - 1)
      *                         ^
      * </pre>
      */
-    def be(any: Any): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
+    def be[R](any: R): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, EvidenceThat[R]#CanEqual] =
       thisMatcherFactory.and(MatcherWords.not.apply(MatcherWords.be(any)))
 
     /**
@@ -1971,11 +1982,22 @@ $endif$
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
      *
      * <pre class="stHighlight">
+     * aMatcherFactory or not be_== (2)
+     *                        ^
+     * </pre>
+     */
+     def be_==(any: Any): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
+       thisMatcherFactory.or(MatcherWords.not.apply(MatcherWords.be_==(any)))
+
+    /**
+     * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
+     *
+     * <pre class="stHighlight">
      * aMatcherFactory or not be (2)
      *                        ^
      * </pre>
      */
-    def be(any: Any): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
+    def be[R](any: R): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, EvidenceThat[R]#CanEqual] =
       thisMatcherFactory.or(MatcherWords.not.apply(MatcherWords.be(any)))
 
     /**

--- a/src/main/scala/org/scalatest/Matchers.scala
+++ b/src/main/scala/org/scalatest/Matchers.scala
@@ -3208,13 +3208,36 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * This method enables the following syntax:
      *
      * <pre class="stHighlight">
+     * all(xs) should not be_== (7)
+     *                    ^
+     * </pre>
+     */
+    def be_==(right: Any) {
+      doCollected(collected, xs, original, "be", 1) { e =>
+        if ((e == right) != shouldBeTrue)
+          throw newTestFailedException(
+            FailureMessages(
+              if (shouldBeTrue) "wasNotEqualTo" else "wasEqualTo",
+              e,
+              right
+            ),
+            None,
+            6
+          )
+      }
+    }
+
+    /**
+     * This method enables the following syntax:
+     *
+     * <pre class="stHighlight">
      * all(xs) should not be (7)
      *                    ^
      * </pre>
      */
-    def be(right: Any) {
+    def be[R](right: R)(implicit evidence: EvidenceThat[R]#CanEqual[T]) {
       doCollected(collected, xs, original, "be", 1) { e =>
-        if ((e == right) != shouldBeTrue)
+        if ((evidence.areEqual(e, right)) != shouldBeTrue)
           throw newTestFailedException(
             FailureMessages(
               if (shouldBeTrue) "wasNotEqualTo" else "wasEqualTo",

--- a/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -1214,11 +1214,22 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * This method enables the following syntax:
      *
      * <pre class="stHighlight">
+     * aMatcher and not be_== (3 - 1)
+     *                  ^
+     * </pre>
+     */
+    def be_==(any: Any): Matcher[T] =
+      outerInstance.and(MatcherWords.not.apply(MatcherWords.be_==(any)))
+
+    /**
+     * This method enables the following syntax:
+     *
+     * <pre class="stHighlight">
      * aMatcher and not be (3 - 1)
      *                  ^
      * </pre>
      */
-    def be(any: Any): Matcher[T] =
+    def be[R](any: R): MatcherFactory1[T, EvidenceThat[R]#CanEqual] =
       outerInstance.and(MatcherWords.not.apply(MatcherWords.be(any)))
 
     /**
@@ -2360,11 +2371,22 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * This method enables the following syntax:
      *
      * <pre class="stHighlight">
+     * aMatcher or not be_== (2)
+     *                 ^
+     * </pre>
+     */
+    def be_==(any: Any): Matcher[T] =
+      outerInstance.or(MatcherWords.not.apply(MatcherWords.be_==(any)))
+
+    /**
+     * This method enables the following syntax:
+     *
+     * <pre class="stHighlight">
      * aMatcher or not be (2)
      *                 ^
      * </pre>
      */
-    def be(any: Any): Matcher[T] =
+    def be[R](any: R): MatcherFactory1[T, EvidenceThat[R]#CanEqual] =
       outerInstance.or(MatcherWords.not.apply(MatcherWords.be(any)))
 
     /**

--- a/src/main/scala/org/scalatest/words/BeEqualEqualWord.scala
+++ b/src/main/scala/org/scalatest/words/BeEqualEqualWord.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.words
+
+import org.scalatest.{Suite, Resources}
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.Assertions.areEqualComparingArraysStructurally
+
+/**
+ * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="Matchers.html"><code>Matchers</code></a> for an overview of
+ * the matchers DSL.
+ *
+ * @author Bill Venners
+ */
+
+final class BeEqualEqualWord {
+
+  /**
+   * This method enables the following syntax:
+   *
+   * <pre class="stHighlight">
+   * "hi" should not have length (3)
+   *                             ^
+   * </pre>
+   */
+
+  /**
+   * This method enables <code>be_==</code> to be used for equality comparison (using Scala default ==):
+   *
+   * <pre class="stHighlight">
+   * sum should be_== (19)
+   *            ^
+   * </pre>
+   */
+  def apply(right: Any): Matcher[Any] =
+    new Matcher[Any] {
+      def apply(left: Any): MatchResult = {
+        val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, right) // TODO: To move this to reporter
+        MatchResult(
+          areEqualComparingArraysStructurally(left, right),
+          Resources("wasNotEqualTo"),
+          Resources("wasEqualTo"),
+          Vector(leftee, rightee),
+          Vector(left, right)
+        )
+      }
+    }
+
+
+  /**
+   * Overrides toString to return "length"
+   */
+  override def toString: String = "be_=="
+}

--- a/src/main/scala/org/scalatest/words/MatcherWords.scala
+++ b/src/main/scala/org/scalatest/words/MatcherWords.scala
@@ -114,6 +114,16 @@ trait MatcherWords {
    * This field enables syntax such as the following:
    *
    * <pre class="stHighlight">
+   * obj should (be_== (string) and be_== (string))
+   *             ^
+   * </pre>
+   */
+  val be_== = new BeEqualEqualWord
+
+  /**
+   * This field enables syntax such as the following:
+   *
+   * <pre class="stHighlight">
    * list should (contain ('a') and have length (7))
    *              ^
    * </pre>

--- a/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
@@ -20,6 +20,7 @@ import org.scalactic.StringNormalizations._
 import SharedHelpers._
 import FailureMessages.decorateToStringValue
 import Matchers._
+import org.scalatest.matchers.{MatchResult, BeMatcher}
 
 class EveryShouldContainAllOfLogicalAndSpec extends Spec {
 
@@ -171,46 +172,46 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain allOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -221,46 +222,46 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (contain allOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain allOf ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -378,38 +379,38 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) and not contain allOf ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain allOf ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain allOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
+          fumList should (not be_== (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain allOf ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (not be_== (toList) and (not contain allOf ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -417,7 +418,7 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -511,28 +512,28 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
-        atLeast (2, lists) should (be (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
-        atMost (2, lists) should (be (Many(3, 2, 1, 0)) and contain allOf (2, 3, 1))
-        no (lists) should (be (Many(3, 6, 9)) and contain allOf (3, 4, 5))
+        all (list1s) should (be_== (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+        atLeast (2, lists) should (be_== (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+        atMost (2, lists) should (be_== (Many(3, 2, 1, 0)) and contain allOf (2, 3, 1))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain allOf (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+          all (lists) should (be_== (Many(3, 2, 1, 0)) and contain allOf (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(8, 4, 3, 2)) + " was not equal to " + decorateToStringValue(Many(3, 2, 1, 0)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1, 0)) and contain allOf (2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1, 0)) and contain allOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(Many(3, 2, 1, 0)) + ", but " + decorateToStringValue(Many(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (Many("howdy", "hi", "hello")) and contain allOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1, 0)) and contain allOf (2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1, 0)) and contain allOf (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(Many(3, 2, 1, 0)) + ", but " + decorateToStringValue(Many(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -540,35 +541,35 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))
+          all (hiLists) should (be_== (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1, 0)) and contain allOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(3, 2, 1, 0)) and contain allOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -654,28 +655,28 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain allOf (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain allOf (8, 3, 4))
-        atMost (2, lists) should (not be (Many(4, 3, 2)) and not contain allOf (3, 4, 2))
-        no (list1s) should (not be (Many(3, 2, 1)) and not contain allOf (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) and not contain allOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain allOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (Many(4, 3, 2)) and not contain allOf (3, 4, 2))
+        no (list1s) should (not be_== (Many(3, 2, 1)) and not contain allOf (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(8, 4, 3, 2)) and not contain allOf (8, 3, 4))
+          all (lists) should (not be_== (Many(8, 4, 3, 2)) and not contain allOf (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(8, 4, 3, 2)) + " was equal to " + decorateToStringValue(Many(8, 4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain allOf (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain allOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(Many(8, 4, 3, 2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(Many(8, 4, 3, 2)) + " contained all of " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (Many("howdy", "hi", "hello")) and not contain allOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain allOf ("hello", "hi"))
+          all (hiLists) should (not be_== (One("ho")) and not contain allOf ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -683,35 +684,35 @@ class EveryShouldContainAllOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))
+        all (hiLists) should (not be_== (One("ho")) and not contain allOf ("HO", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))
+          all (hiLists) should (not be_== (One("ho")) and not contain allOf ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain allOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) and not contain allOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
@@ -20,6 +20,7 @@ import org.scalactic.StringNormalizations._
 import SharedHelpers._
 import FailureMessages.decorateToStringValue
 import Matchers._
+import org.scalatest.matchers.{MatchResult, BeMatcher}
 
 class EveryShouldContainAllOfLogicalOrSpec extends Spec {
 
@@ -159,40 +160,40 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain allOf ("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain allOf ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -203,40 +204,40 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (contain allOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain allOf ("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain allOf ("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -342,32 +343,32 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain allOf ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain allOf ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain allOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain allOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain allOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain allOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -375,7 +376,7 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -458,12 +459,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1, 0)) or contain allOf (1, 2, 3))
-        all (list1s) should (be (Many(2, 3, 4)) or contain allOf (1, 2, 3))
-        all (list1s) should (be (Many(3, 2, 1, 0)) or contain allOf (2, 3, 4))
+        all (list1s) should (be_== (Many(3, 2, 1, 0)) or contain allOf (1, 2, 3))
+        all (list1s) should (be_== (Many(2, 3, 4)) or contain allOf (1, 2, 3))
+        all (list1s) should (be_== (Many(3, 2, 1, 0)) or contain allOf (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3, 4)) or contain allOf (2, 3, 4))
+          all (list1s) should (be_== (Many(2, 3, 4)) or contain allOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1, 0)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(Many(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -471,30 +472,30 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))
-        all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))
+        all (hiLists) should (be_== (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(3, 2, 1, 0)) or contain allOf (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(3, 2, 1, 0)) or contain allOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -559,12 +560,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain allOf (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain allOf (8, 3, 4))
-        all (list1s) should (not be (Many(3, 2, 1, 0)) or not contain allOf (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain allOf (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) or not contain allOf (8, 3, 4))
+        all (list1s) should (not be_== (Many(3, 2, 1, 0)) or not contain allOf (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain allOf (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(3, 2, 1, 0)) or not contain allOf (2, 3, 1))
+          all (list1s) should (not be_== (Many(3, 2, 1, 0)) or not contain allOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(Many(3, 2, 1, 0)) + ", and " + decorateToStringValue(Many(3, 2, 1, 0)) + " contained all of " + "(2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -572,30 +573,30 @@ class EveryShouldContainAllOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain allOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) or not contain allOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -21,6 +21,7 @@ import org.scalactic.StringNormalizations._
 import SharedHelpers._
 import FailureMessages.decorateToStringValue
 import Matchers._
+import org.scalatest.matchers.{MatchResult, BeMatcher}
 
 class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
 
@@ -162,96 +163,96 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain atLeastOneOf ("fum", "foe")))
+          fumList should (be_== (fumList) and (contain atLeastOneOf ("fum", "foe")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources("atLeastOneOfDuplicate")))
+        e1.message should be_== (Some(Resources("atLeastOneOfDuplicate")))
       }
     }
 
     object `when used with (contain oneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+        fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") and be (toList))
+          fumList should (contain atLeastOneOf ("fum", "foe") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") and (be (fumList)))
+          fumList should (contain atLeastOneOf ("fum", "foe") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -371,36 +372,36 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
         fumList should (not be (toList) and not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (toList) and not contain atLeastOneOf ("fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))
+          fumList should (not be_== (fumList) and not contain atLeastOneOf ("fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (toList) and (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -408,7 +409,7 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -508,28 +509,28 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (One(1)) and contain atLeastOneOf (1, 3, 4))
-        atLeast (2, lists) should (be (One(1)) and contain atLeastOneOf (1, 3, 4))
-        atMost (2, lists) should (be (One(1)) and contain atLeastOneOf (2, 3, 4))
-        no (lists) should (be (One(8)) and contain atLeastOneOf (3, 4, 5))
+        all (list1s) should (be_== (One(1)) and contain atLeastOneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (One(1)) and contain atLeastOneOf (1, 3, 4))
+        atMost (2, lists) should (be_== (One(1)) and contain atLeastOneOf (2, 3, 4))
+        no (lists) should (be_== (One(8)) and contain atLeastOneOf (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (One(1)) and contain atLeastOneOf (1, 3, 4))
+          all (lists) should (be_== (One(1)) and contain atLeastOneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (One(1)) and contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + decorateToStringValue(One(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (One("hi")) and contain atLeastOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + decorateToStringValue(One("hi")) + " did not contain at least one of (\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (One(1)) and contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + decorateToStringValue(One(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -537,35 +538,35 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("hi")) and contain atLeastOneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (One("ho")) and contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("hi")) and contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + decorateToStringValue(One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + decorateToStringValue(One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) and contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (One(1)) and contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -651,28 +652,28 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain atLeastOneOf (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain atLeastOneOf (8, 3, 4))
-        atMost (2, lists) should (not be (One(3)) and contain atLeastOneOf (5, 3, 4))
-        no (list1s) should (not be (One(1)) and not contain atLeastOneOf (2, 1, 5))
+        all (list1s) should (not be_== (One(2)) and not contain atLeastOneOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain atLeastOneOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (One(3)) and contain atLeastOneOf (5, 3, 4))
+        no (list1s) should (not be_== (One(1)) and not contain atLeastOneOf (2, 1, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (One(2)) and not contain atLeastOneOf (2, 3, 4))
+          all (lists) should (not be_== (One(2)) and not contain atLeastOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was equal to " + decorateToStringValue(One(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain atLeastOneOf (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain atLeastOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(One(2)) + " contained at least one of (2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (One("hi")) and not contain atLeastOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (One("ho")) and not contain atLeastOneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(One("hi")) + " contained at least one of (\"hi\", \"hello\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -680,35 +681,35 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("ho")) and not contain atLeastOneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (not be_== (One("hi")) and not contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("ho")) and not contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) and not contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -20,6 +20,7 @@ import org.scalactic.StringNormalizations._
 import SharedHelpers._
 import FailureMessages.decorateToStringValue
 import Matchers._
+import org.scalatest.matchers.{MatchResult, BeMatcher}
 
 class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
 
@@ -149,40 +150,40 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain atLeastOneOf ("fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain atLeastOneOf ("fum", "foe")))
+          fumList should (be_== (toList) or (contain atLeastOneOf ("fum", "foe")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -193,9 +194,9 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (contain oneOf (...) and be (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
           fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fam") or be (toList))
         }
@@ -204,29 +205,29 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain atLeastOneOf ("fum", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))
+          fumList should (contain atLeastOneOf ("fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -332,32 +333,32 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))
-        fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))
-        fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (fumList) or not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -365,7 +366,7 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -448,12 +449,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (One(1)) or contain atLeastOneOf (1, 3, 4))
-        all (list1s) should (be (One(2)) or contain atLeastOneOf (1, 3, 4))
-        all (list1s) should (be (One(1)) or contain atLeastOneOf (2, 3, 4))
+        all (list1s) should (be_== (One(1)) or contain atLeastOneOf (1, 3, 4))
+        all (list1s) should (be_== (One(2)) or contain atLeastOneOf (1, 3, 4))
+        all (list1s) should (be_== (One(1)) or contain atLeastOneOf (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (One(2)) or contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (One(2)) or contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was not equal to " + decorateToStringValue(One(2)) + ", and " + decorateToStringValue(One(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -461,30 +462,30 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))
-        all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))
-        all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (be_== (One("hi")) or contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("ho")) or contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("hi")) or contain atLeastOneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("ho")) or contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + decorateToStringValue(One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + decorateToStringValue(One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) or contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (One(1)) or contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -549,12 +550,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...))" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (One(2)) or not contain atLeastOneOf (8, 3, 4))
-        all (list1s) should (not be (One(1)) or not contain atLeastOneOf (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain atLeastOneOf (8, 3, 1))
+        all (list1s) should (not be_== (One(2)) or not contain atLeastOneOf (8, 3, 4))
+        all (list1s) should (not be_== (One(1)) or not contain atLeastOneOf (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain atLeastOneOf (8, 3, 1))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (One(1)) or not contain atLeastOneOf (2, 3, 1))
+          all (list1s) should (not be_== (One(1)) or not contain atLeastOneOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", and " + decorateToStringValue(One(1)) + " contained at least one of (2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -562,30 +563,30 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))
-        all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))
-        all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("ho")) or not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("hi")) or not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("ho")) or not contain atLeastOneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("hi")) or not contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + decorateToStringValue(One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + decorateToStringValue(One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) or not contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -166,46 +166,46 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain atMostOneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be_== (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+        fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+          fumList should (be_== (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -216,46 +216,46 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (contain atMostOneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and be (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and be (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))
+        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (be (toList)))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (be_== (toList)))
         }
         checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -373,38 +373,38 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain atMostOneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (toList) and not contain atMostOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atMostOneOf ("fie", "fee", "fum", "foe"))
+          fumList should (not be_== (fumList) and not contain atMostOneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain atMostOneOf ("fie", "fee", "fam", "foe"))
+          fumList should (not be_== (toList) and not contain atMostOneOf ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+          fumList should (not be_== (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (not be_== (toList) and (not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -412,7 +412,7 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -512,28 +512,28 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain atMostOneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(1, 2)) and contain atMostOneOf (1, 3, 4))
-        atLeast (2, lists) should (be (Many(1, 2)) and contain atMostOneOf (2, 3, 4))
-        atMost (2, lists) should (be (Many(1, 2)) and contain atMostOneOf (2, 3, 4))
-        no (lists) should (be (One(8)) and contain atMostOneOf (3, 2, 1))
+        all (list1s) should (be_== (Many(1, 2)) and contain atMostOneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (Many(1, 2)) and contain atMostOneOf (2, 3, 4))
+        atMost (2, lists) should (be_== (Many(1, 2)) and contain atMostOneOf (2, 3, 4))
+        no (lists) should (be_== (One(8)) and contain atMostOneOf (3, 2, 1))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(1, 2)) and contain atMostOneOf (1, 3, 4))
+          all (lists) should (be_== (Many(1, 2)) and contain atMostOneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(Many(1, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2)) and contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (Many(1, 2)) and contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(1, 2)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("hi", "he"))
+          all (hiLists) should (be_== (Many("hi", "he")) and contain atMostOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2)) and contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (Many(1, 2)) and contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(1, 2)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -541,35 +541,35 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))
+        all (hiLists) should (be_== (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))
+          all (hiLists) should (be_== (One("ho")) and contain atMostOneOf ("HO", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(1, 2)) and contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(1, 2)) and contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -655,28 +655,28 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain atMostOneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
-        atLeast (2, lists) should (not be (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
-        atMost (2, lists) should (not be (Many(2, 3)) and contain atMostOneOf (1, 2, 3))
-        no (list1s) should (not be (Many(1, 2)) and not contain atMostOneOf (3, 6, 8))
+        all (list1s) should (not be_== (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
+        atLeast (2, lists) should (not be_== (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
+        atMost (2, lists) should (not be_== (Many(2, 3)) and contain atMostOneOf (1, 2, 3))
+        no (list1s) should (not be_== (Many(1, 2)) and not contain atMostOneOf (3, 6, 8))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
+          all (lists) should (not be_== (Many(2, 3)) and not contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(Many(2, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(2, 3, 4)) and not contain atMostOneOf (1, 2, 8))
+          all (lists) should (not be_== (Many(2, 3, 4)) and not contain atMostOneOf (1, 2, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", but " + decorateToStringValue(lists(2)) + " contained at most one of (1, 2, 8)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (Many("hi", "he")) and not contain atMostOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (Many("hi", "ho")) and not contain atMostOneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"hi\", \"hello\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -684,35 +684,35 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("hi", "he"))
+          all (hiLists) should (not be_== (Many("hi", "he")) and not contain atMostOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))
+          all (hiLists) should (not be_== (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (Many(2, 3)) and not contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (Many(2, 3)) and not contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -155,84 +155,84 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain theMostOneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be_== (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (be_== (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources("atMostOneOfDuplicate")))
+        e1.message should be_== (Some(Resources("atMostOneOfDuplicate")))
       }
     }
 
     "when used with (contain oneOf (...) and be (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (toList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -338,32 +338,32 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
-        fumList should (not be (fumList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
-        fumList should (not be (toList) or not contain atMostOneOf("fee", "fie", "foe", "fuu"))
+        fumList should (not be_== (toList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (fumList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (toList) or not contain atMostOneOf("fee", "fie", "foe", "fuu"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain atMostOneOf ("fee", "fie", "foe", "fuu"))
+          fumList should (not be_== (fumList) or not contain atMostOneOf ("fee", "fie", "foe", "fuu"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fuu\""), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU")))
+          fumList should (not be_== (fumList) or (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
         (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -371,7 +371,7 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -454,12 +454,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (Many(1, 2)) or contain atMostOneOf (1, 6, 8))
-        all (list1s) should (be (Many(2, 3)) or contain atMostOneOf (1, 6, 8))
-        all (list1s) should (be (Many(1, 2)) or contain atMostOneOf (1, 2, 3))
+        all (list1s) should (be_== (Many(1, 2)) or contain atMostOneOf (1, 6, 8))
+        all (list1s) should (be_== (Many(2, 3)) or contain atMostOneOf (1, 6, 8))
+        all (list1s) should (be_== (Many(1, 2)) or contain atMostOneOf (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3)) or contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (Many(2, 3)) or contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was not equal to " + decorateToStringValue(Many(2, 3)) + ", and " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -467,30 +467,30 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))
-        all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))
-        all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))
+        all (hiLists) should (be_== (One("HO")) or contain atMostOneOf ("HI", "HO"))
+        all (hiLists) should (be_== (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (One("HO")) or contain atMostOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("HO")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("HO")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(1, 2)) or contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(1, 2)) or contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -555,12 +555,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain atMostOneOf (...))" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (Many(2, 3)) or not contain atMostOneOf (1, 2, 3))
-        all (list1s) should (not be (Many(1, 2)) or not contain atMostOneOf (1, 2, 3))
-        all (list1s) should (not be (Many(2, 3)) or not contain atMostOneOf (2, 3, 4))
+        all (list1s) should (not be_== (Many(2, 3)) or not contain atMostOneOf (1, 2, 3))
+        all (list1s) should (not be_== (Many(1, 2)) or not contain atMostOneOf (1, 2, 3))
+        all (list1s) should (not be_== (Many(2, 3)) or not contain atMostOneOf (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(1, 2)) or not contain atMostOneOf (2, 3, 4))
+          all (list1s) should (not be_== (Many(1, 2)) or not contain atMostOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(1, 2)) + ", and " + decorateToStringValue(list1s(0)) + " contained at most one of (2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -568,30 +568,30 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))
-        all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))
-        all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("ho")) or not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))
+        all (hiLists) should (not be_== (One("ho")) or not contain atMostOneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))
+          all (hiLists) should (not be_== (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")) + ", and " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "he")) + ", and " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (Many(2, 3)) or not contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (Many(2, 3)) or not contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
@@ -171,46 +171,46 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -221,46 +221,46 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (contain inOrder xx and be xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -376,38 +376,38 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain inOrder ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (toList) and not contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (toList) and (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -415,7 +415,7 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -508,28 +508,28 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 3))
-        atLeast (2, lists) should (be (Many(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
-        atMost (2, lists) should (be (Many(3, 2, 1)) and contain inOrder (1, 2, 3))
-        no (lists) should (be (Many(3, 6, 9)) and contain inOrder (3, 4, 5))
+        all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 3))
+        atLeast (2, lists) should (be_== (Many(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
+        atMost (2, lists) should (be_== (Many(3, 2, 1)) and contain inOrder (1, 2, 3))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain inOrder (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
+          all (lists) should (be_== (Many(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(Many(0, 1, 2, 3, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
+          all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(0, 1, 2, 2, 3)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("hello", "hi"))
+          all (hiLists) should (be_== (Many("he", "hi", "hello")) and contain inOrder ("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"hello\", \"hi\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
+          all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(0, 1, 2, 2, 3)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -537,35 +537,35 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -651,28 +651,28 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain inOrder (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain inOrder (8, 3, 4))
-        atMost (2, lists) should (not be (Many(8, 2, 3, 4)) and not contain inOrder (2, 3, 4))
-        no (list1s) should (not be (Many(0, 1, 2, 2, 3)) and not contain inOrder (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) and not contain inOrder (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain inOrder (8, 3, 4))
+        atMost (2, lists) should (not be_== (Many(8, 2, 3, 4)) and not contain inOrder (2, 3, 4))
+        no (list1s) should (not be_== (Many(0, 1, 2, 2, 3)) and not contain inOrder (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(8, 2, 3, 4)) and not contain inOrder (8, 3, 4))
+          all (lists) should (not be_== (Many(8, 2, 3, 4)) and not contain inOrder (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(Many(8, 2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain inOrder (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain inOrder (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(lists(2)) + " contained all of " + "(2, 3, 4)" + " in order", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (Many("he", "hi", "hello")) and not contain inOrder ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain inOrder ("hi", "hello"))
+          all (hiLists) should (not be_== (One("ho")) and not contain inOrder ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -680,35 +680,35 @@ class EveryShouldContainInOrderLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))
+        all (hiLists) should (not be_== (One("ho")) and not contain inOrder ("HO", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (not be_== (One("ho")) and not contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain inOrder (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) and not contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
@@ -159,40 +159,40 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -203,40 +203,40 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (contain inOrder xx and be xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -340,32 +340,32 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain inOrder ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain inOrder ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (not be_== (toList) or not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain inOrder ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (fumList) or not contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (not be_== (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (fumList) or (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -373,7 +373,7 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -455,12 +455,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 3))
-        all (list1s) should (be (Many(8, 2, 3, 4)) or contain inOrder (1, 2, 3))
-        all (list1s) should (be (Many(0, 1, 2, 2, 3)) or contain inOrder (2, 3, 4))
+        all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 3))
+        all (list1s) should (be_== (Many(8, 2, 3, 4)) or contain inOrder (1, 2, 3))
+        all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) or contain inOrder (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(8, 2, 3, 4)) or contain inOrder (2, 3, 4))
+          all (list1s) should (be_== (Many(8, 2, 3, 4)) or contain inOrder (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was not equal to " + decorateToStringValue(Many(8, 2, 3, 4)) + ", and " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 4)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -468,30 +468,30 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))
-        all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -556,12 +556,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain inOrder (8, 3, 4))
-        all (list1s) should (not be (Many(0, 1, 2, 2, 3)) or not contain inOrder (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain inOrder (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) or not contain inOrder (8, 3, 4))
+        all (list1s) should (not be_== (Many(0, 1, 2, 2, 3)) or not contain inOrder (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain inOrder (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(0, 1, 2, 2, 3)) or not contain inOrder (1, 2, 3))
+          all (list1s) should (not be_== (Many(0, 1, 2, 2, 3)) or not contain inOrder (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(Many(0, 1, 2, 2, 3)) + ", and " + decorateToStringValue(list1s(0)) + " contained all of " + "(1, 2, 3)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -569,30 +569,30 @@ class EveryShouldContainInOrderLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (not be_== (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("he", "hi", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain inOrder (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) or not contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -171,96 +171,96 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources("inOrderOnlyDuplicate")))
+        e1.message should be_== (Some(Resources("inOrderOnlyDuplicate")))
       }
     }
 
     object `when used with (contain inOrderOnly xx and be xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -376,38 +376,38 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (toList) and not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (toList) and (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -415,7 +415,7 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -508,28 +508,28 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 3))
-        atLeast (2, lists) should (be (Many(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
-        atMost (2, lists) should (be (Many(3, 2, 1)) and contain inOrderOnly (1, 2, 3))
-        no (lists) should (be (Many(3, 6, 9)) and contain inOrderOnly (3, 4, 5))
+        all (list1s) should (be_== (Many(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 3))
+        atLeast (2, lists) should (be_== (Many(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
+        atMost (2, lists) should (be_== (Many(3, 2, 1)) and contain inOrderOnly (1, 2, 3))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain inOrderOnly (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
+          all (lists) should (be_== (Many(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(2, 3, 4)) + " was not equal to " + decorateToStringValue(Many(1, 2, 3, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
+          all (list1s) should (be_== (Many(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 2, 3)) + ", but " + decorateToStringValue(Many(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("hello", "hi"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain inOrderOnly ("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"hello\", \"hi\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
+          all (list1s) should (be_== (Many(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 2, 3)) + ", but " + decorateToStringValue(Many(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -537,35 +537,35 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -651,28 +651,28 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain inOrderOnly (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain inOrderOnly (8, 3, 4))
-        atMost (2, lists) should (not be (Many(2, 3, 4)) and not contain inOrderOnly (2, 3, 4))
-        no (list1s) should (not be (Many(1, 2, 2, 3)) and not contain inOrderOnly (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) and not contain inOrderOnly (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain inOrderOnly (8, 3, 4))
+        atMost (2, lists) should (not be_== (Many(2, 3, 4)) and not contain inOrderOnly (2, 3, 4))
+        no (list1s) should (not be_== (Many(1, 2, 2, 3)) and not contain inOrderOnly (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(2, 3, 4)) and not contain inOrderOnly (8, 3, 4))
+          all (lists) should (not be_== (Many(2, 3, 4)) and not contain inOrderOnly (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(2, 3, 4)) + " was equal to " + decorateToStringValue(Many(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain inOrderOnly (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain inOrderOnly (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(Many(2, 3, 4)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(Many(2, 3, 4)) + " contained only " + "(2, 3, 4)" + " in order", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain inOrderOnly ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("hi", "hello"))
+          all (hiLists) should (not be_== (One("ho")) and not contain inOrderOnly ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -680,35 +680,35 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))
+        all (hiLists) should (not be_== (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (not be_== (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) and not contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -159,40 +159,40 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -203,40 +203,40 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
     object `when used with (contain inOrderOnly xx and be xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -340,32 +340,32 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (fumList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (fumList) or (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -373,7 +373,7 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -455,12 +455,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 3))
-        all (list1s) should (be (Many(2, 3, 4)) or contain inOrderOnly (1, 2, 3))
-        all (list1s) should (be (Many(1, 2, 2, 3)) or contain inOrderOnly (2, 3, 4))
+        all (list1s) should (be_== (Many(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 3))
+        all (list1s) should (be_== (Many(2, 3, 4)) or contain inOrderOnly (1, 2, 3))
+        all (list1s) should (be_== (Many(1, 2, 2, 3)) or contain inOrderOnly (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3, 4)) or contain inOrderOnly (2, 3, 4))
+          all (list1s) should (be_== (Many(2, 3, 4)) or contain inOrderOnly (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(1, 2, 2, 3)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(Many(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 4)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -468,30 +468,30 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))
-        all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -556,12 +556,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain inOrderOnly (8, 3, 4))
-        all (list1s) should (not be (Many(1, 2, 2, 3)) or not contain inOrderOnly (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain inOrderOnly (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) or not contain inOrderOnly (8, 3, 4))
+        all (list1s) should (not be_== (Many(1, 2, 2, 3)) or not contain inOrderOnly (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain inOrderOnly (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(1, 2, 2, 3)) or not contain inOrderOnly (1, 2, 3))
+          all (list1s) should (not be_== (Many(1, 2, 2, 3)) or not contain inOrderOnly (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 2, 3)) + ", and " + decorateToStringValue(Many(1, 2, 2, 3)) + " contained only " + "(1, 2, 3)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -569,30 +569,30 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) or not contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
@@ -177,46 +177,46 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -227,46 +227,46 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (contain noneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") and be (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and be (toList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (be (fumList)))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -385,38 +385,38 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain noneOf ("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (toList) and (not contain noneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -424,7 +424,7 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -524,28 +524,28 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (One(1)) and contain noneOf (2, 3, 4))
-        atLeast (2, lists) should (be (One(1)) and contain noneOf (2, 3, 4))
-        atMost (2, lists) should (be (One(1)) and contain noneOf (2, 3, 4))
-        no (lists) should (be (One(8)) and contain noneOf (1, 2, 3))
+        all (list1s) should (be_== (One(1)) and contain noneOf (2, 3, 4))
+        atLeast (2, lists) should (be_== (One(1)) and contain noneOf (2, 3, 4))
+        atMost (2, lists) should (be_== (One(1)) and contain noneOf (2, 3, 4))
+        no (lists) should (be_== (One(8)) and contain noneOf (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (One(1)) and contain noneOf (3, 6, 9))
+          all (lists) should (be_== (One(1)) and contain noneOf (3, 6, 9))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (One(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "hey", "howdy"))
+          all (hiLists) should (be_== (One("hi")) and contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (One(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -553,35 +553,35 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (One("hi")) and contain noneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("ho")) and contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))
+          all (hiLists) should (be_== (One("hi")) and contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) and contain noneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (One(1)) and contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -667,28 +667,28 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain noneOf (1, 2, 3))
-        atLeast (2, lists) should (not be (One(3)) and not contain noneOf (1, 6, 8))
-        atMost (2, lists) should (not be (One(3)) and contain noneOf (1, 6, 8))
-        no (list1s) should (not be (One(1)) and not contain noneOf (3, 6, 9))
+        all (list1s) should (not be_== (One(2)) and not contain noneOf (1, 2, 3))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain noneOf (1, 6, 8))
+        atMost (2, lists) should (not be_== (One(3)) and contain noneOf (1, 6, 8))
+        no (list1s) should (not be_== (One(1)) and not contain noneOf (3, 6, 9))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (One(2)) and not contain noneOf (1, 2, 3))
+          all (lists) should (not be_== (One(2)) and not contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was equal to " + decorateToStringValue(One(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain noneOf (1, 6, 8))
+          all (lists) should (not be_== (One(3)) and not contain noneOf (1, 6, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + FailureMessages("didNotContainAtLeastOneOf", lists(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain noneOf ("hi", "hey", "howdy"))
+          all (hiLists) should (not be_== (One("hi")) and not contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain noneOf ("ho", "hello"))
+          all (hiLists) should (not be_== (One("ho")) and not contain noneOf ("ho", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"ho\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -696,35 +696,35 @@ class EveryShouldContainNoneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("ho")) and not contain noneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("hi")) and not contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))
+          all (hiLists) should (not be_== (One("ho")) and not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain noneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) and not contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
@@ -165,40 +165,40 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (toList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (toList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be_== (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -209,40 +209,40 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (contain noneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain noneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (toList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain noneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or be (toList))
+          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -347,32 +347,32 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain noneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain noneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain noneOf ("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) or (not contain noneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -380,7 +380,7 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -463,12 +463,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (One(1)) or contain noneOf (2, 6, 8))
-        all (list1s) should (be (One(2)) or contain noneOf (2, 6, 8))
-        all (list1s) should (be (One(1)) or contain noneOf (1, 2, 3))
+        all (list1s) should (be_== (One(1)) or contain noneOf (2, 6, 8))
+        all (list1s) should (be_== (One(2)) or contain noneOf (2, 6, 8))
+        all (list1s) should (be_== (One(1)) or contain noneOf (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (One(2)) or contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (One(2)) or contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was not equal to " + decorateToStringValue(One(2)) + ", and " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -476,30 +476,30 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))
-        all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))
-        all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("hi")) or contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (One("ho")) or contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (One("hi")) or contain noneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))
+          all (hiLists) should (be_== (One("ho")) or contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) or contain noneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (One(1)) or contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -564,12 +564,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain noneOf (1, 6, 8))
-        all (list1s) should (not be (One(1)) or not contain noneOf (1, 6, 8))
-        all (list1s) should (not be (One(2)) or not contain noneOf (2, 6, 8))
+        all (list1s) should (not be_== (One(2)) or not contain noneOf (1, 6, 8))
+        all (list1s) should (not be_== (One(1)) or not contain noneOf (1, 6, 8))
+        all (list1s) should (not be_== (One(2)) or not contain noneOf (2, 6, 8))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (One(1)) or not contain noneOf (2, 6, 8))
+          all (list1s) should (not be_== (One(1)) or not contain noneOf (2, 6, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", and " + FailureMessages("didNotContainAtLeastOneOf", list1s(0), UnquotedString("2, 6, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -577,30 +577,30 @@ class EveryShouldContainNoneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))
-        all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))
-        all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("ho")) or not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("hi")) or not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("ho")) or not contain noneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))
+          all (hiLists) should (not be_== (One("hi")) or not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain noneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) or not contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
@@ -177,46 +177,46 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
+          fumList should (be_== (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -227,46 +227,46 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (contain oneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (be (fumList)))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -384,38 +384,38 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (toList) and (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -423,7 +423,7 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -523,28 +523,28 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (One(1)) and contain oneOf (1, 3, 4))
-        atLeast (2, lists) should (be (One(1)) and contain oneOf (1, 3, 4))
-        atMost (2, lists) should (be (One(1)) and contain oneOf (2, 3, 4))
-        no (lists) should (be (One(8)) and contain oneOf (3, 4, 5))
+        all (list1s) should (be_== (One(1)) and contain oneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (One(1)) and contain oneOf (1, 3, 4))
+        atMost (2, lists) should (be_== (One(1)) and contain oneOf (2, 3, 4))
+        no (lists) should (be_== (One(8)) and contain oneOf (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (One(1)) and contain oneOf (1, 3, 4))
+          all (lists) should (be_== (One(1)) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (One(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + FailureMessages("didNotContainOneOfElements", list1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain oneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (One("hi")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (One(1)) and contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (One(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", but " + FailureMessages("didNotContainOneOfElements", list1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -552,35 +552,35 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("hi")) and contain oneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("ho")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("hi")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) and contain oneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (One(1)) and contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -666,28 +666,28 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain oneOf (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain oneOf (8, 3, 4))
-        atMost (2, lists) should (not be (One(3)) and contain oneOf (5, 3, 4))
-        no (list1s) should (not be (One(1)) and not contain oneOf (2, 1, 5))
+        all (list1s) should (not be_== (One(2)) and not contain oneOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain oneOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (One(3)) and contain oneOf (5, 3, 4))
+        no (list1s) should (not be_== (One(1)) and not contain oneOf (2, 1, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (One(2)) and not contain oneOf (2, 3, 4))
+          all (lists) should (not be_== (One(2)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(One(2)) + " was equal to " + decorateToStringValue(One(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain oneOf (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(One(2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + FailureMessages("containedOneOfElements", lists(2), UnquotedString("2, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain oneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (One("hi")) and not contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (One("ho")) and not contain oneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -695,35 +695,35 @@ class EveryShouldContainOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("ho")) and not contain oneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("hi")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("ho")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain oneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) and not contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
@@ -165,40 +165,40 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
+          fumList should (be_== (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -209,40 +209,40 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (contain oneOf (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -348,32 +348,32 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain oneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain oneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -381,7 +381,7 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -464,12 +464,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (One(1)) or contain oneOf (1, 3, 4))
-        all (list1s) should (be (One(2)) or contain oneOf (1, 3, 4))
-        all (list1s) should (be (One(1)) or contain oneOf (2, 3, 4))
+        all (list1s) should (be_== (One(1)) or contain oneOf (1, 3, 4))
+        all (list1s) should (be_== (One(2)) or contain oneOf (1, 3, 4))
+        all (list1s) should (be_== (One(1)) or contain oneOf (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (One(2)) or contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (One(2)) or contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was not equal to " + decorateToStringValue(One(2)) + ", and " + FailureMessages("didNotContainOneOfElements", list1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -477,30 +477,30 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))
-        all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))
-        all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))
+        all (hiLists) should (be_== (One("hi")) or contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("ho")) or contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (One("hi")) or contain oneOf ("hi", "he"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (One("ho")) or contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (One("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (One("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was not equal to " + decorateToStringValue(One("ho")) + ", and " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (One(1)) or contain oneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (One(1)) or contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -565,12 +565,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain oneOf (8, 3, 4))
-        all (list1s) should (not be (One(1)) or not contain oneOf (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain oneOf (8, 3, 1))
+        all (list1s) should (not be_== (One(2)) or not contain oneOf (8, 3, 4))
+        all (list1s) should (not be_== (One(1)) or not contain oneOf (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain oneOf (8, 3, 1))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (One(1)) or not contain oneOf (2, 3, 1))
+          all (list1s) should (not be_== (One(1)) or not contain oneOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(1)) + " was equal to " + decorateToStringValue(One(1)) + ", and " + FailureMessages("containedOneOfElements", list1s(0), UnquotedString("2, 3, 1")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -578,30 +578,30 @@ class EveryShouldContainOneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))
-        all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))
-        all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (One("ho")) or not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("hi")) or not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (One("ho")) or not contain oneOf ("HI", "HE"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (One("hi")) or not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One("hi")) + " was equal to " + decorateToStringValue(One("hi")) + ", and " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain oneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) or not contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
@@ -189,46 +189,46 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain only ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain only ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain only ("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain only ("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -237,7 +237,7 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain only Many("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain only Many("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Many("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
@@ -246,46 +246,46 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (contain only (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain only ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -294,7 +294,7 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only Many("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain only Many("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Many("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
@@ -428,38 +428,38 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) and not contain only ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain only ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain only ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain only ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
+          fumList should (not be_== (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain only ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (not be_== (toList) and (not contain only ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -467,7 +467,7 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -476,7 +476,7 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          One(Many("fee", "fie", "foe", "fum")) should (not be (toList) and not contain only (Many("fee", "fie", "foe", "fum")))
+          One(Many("fee", "fie", "foe", "fum")) should (not be_== (toList) and not contain only (Many("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(One(Many("fee", "fie", "foe", "fum"))), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElementsWithFriendlyReminder", decorateToStringValue(One(Many("fee", "fie", "foe", "fum"))), decorateToStringValue(Many("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
@@ -585,28 +585,28 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1)) and contain only (1, 3, 2))
-        atLeast (2, lists) should (be (Many(3, 2, 1)) and contain only (1, 3, 2))
-        atMost (2, lists) should (be (Many(3, 2, 1)) and contain only (2, 3, 1))
-        no (lists) should (be (Many(3, 6, 9)) and contain only (3, 4, 5))
+        all (list1s) should (be_== (Many(3, 2, 1)) and contain only (1, 3, 2))
+        atLeast (2, lists) should (be_== (Many(3, 2, 1)) and contain only (1, 3, 2))
+        atMost (2, lists) should (be_== (Many(3, 2, 1)) and contain only (2, 3, 1))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain only (3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(3, 2, 1)) and contain only (1, 3, 2))
+          all (lists) should (be_== (Many(3, 2, 1)) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was not equal to " + decorateToStringValue(Many(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain only (2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", but " + decorateToStringValue(Many(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain only ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain only (2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", but " + decorateToStringValue(Many(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -614,35 +614,35 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) and contain only ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain only ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain only (3, 2, 2, 1))
+          all (list1s) should (be_== (Many(3, 2, 1)) and contain only (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -651,17 +651,17 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (One(One(Many(3, 2, 1)))) should (be (One(Many(3, 2, 1))) and contain only Many(2, 3, 8))
+          all (One(One(Many(3, 2, 1)))) should (be_== (One(Many(3, 2, 1))) and contain only Many(2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(Many(3, 2, 1))) + " was equal to " + decorateToStringValue(One(Many(3, 2, 1))) + ", but " + decorateToStringValue(One(Many(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Many(2, 3, 8)) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many(3, 2, 1)))), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (One(One(Many("hi", "hello")))) should (be (One(Many("hi", "hello"))) and contain only Many("ho", "hey", "howdy"))
+          all (One(One(Many("hi", "hello")))) should (be_== (One(Many("hi", "hello"))) and contain only Many("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One(Many("hi", "hello"))) + " was equal to " + decorateToStringValue(One(Many("hi", "hello"))) + ", but " + decorateToStringValue(One(Many("hi", "hello"))) + " did not contain only (" + decorateToStringValue(Many("ho", "hey", "howdy")) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many("hi", "hello")))), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (One(One(Many(3, 2, 1)))) should (be (One(Many(3, 2, 1))) and contain only Many(2, 3, 8))
+          all (One(One(Many(3, 2, 1)))) should (be_== (One(Many(3, 2, 1))) and contain only Many(2, 3, 8))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(One(Many(3, 2, 1))) + " was equal to " + decorateToStringValue(One(Many(3, 2, 1))) + ", but " + decorateToStringValue(One(Many(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Many(2, 3, 8)) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many(3, 2, 1)))), fileName, thisLineNumber - 2)
       }
@@ -767,28 +767,28 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain only (8, 3, 4))
-        atLeast (2, lists) should (not be (One(3)) and not contain only (8, 3, 4))
-        atMost (2, lists) should (not be (Many(4, 3, 2)) and not contain only (3, 4, 2))
-        no (list1s) should (not be (Many(3, 2, 1)) and not contain only (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) and not contain only (8, 3, 4))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain only (8, 3, 4))
+        atMost (2, lists) should (not be_== (Many(4, 3, 2)) and not contain only (3, 4, 2))
+        no (list1s) should (not be_== (Many(3, 2, 1)) and not contain only (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(4, 3, 2)) and not contain only (8, 3, 4))
+          all (lists) should (not be_== (Many(4, 3, 2)) and not contain only (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was equal to " + decorateToStringValue(Many(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain only (2, 3, 4))
+          all (lists) should (not be_== (One(3)) and not contain only (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(Many(4, 3, 2)) + " contained only " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain only ("hello", "hi"))
+          all (hiLists) should (not be_== (One("ho")) and not contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -796,35 +796,35 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))
+        all (hiLists) should (not be_== (One("ho")) and not contain only ("HO", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))
+          all (hiLists) should (not be_== (One("ho")) and not contain only ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) and not contain only (3, 2, 2, 1))
+          all (list1s) should (not be_== (One(2)) and not contain only (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -833,12 +833,12 @@ class EveryShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (One(One(Many(3, 2, 1)))) should (not be (One(3)) and not contain only (Many(3, 2, 1)))
+          all (One(One(Many(3, 2, 1)))) should (not be_== (One(3)) and not contain only (Many(3, 2, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(Many(3, 2, 1))) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(One(Many(3, 2, 1))) + " contained only (" + decorateToStringValue(Many(3, 2, 1)) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many(3, 2, 1)))), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (One(One(Many("hi", "hello")))) should (not be (One("ho")) and not contain only (Many("hi", "hello")))
+          all (One(One(Many("hi", "hello")))) should (not be_== (One("ho")) and not contain only (Many("hi", "hello")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(One(Many("hi", "hello"))) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(One(Many("hi", "hello"))) + " contained only (" + decorateToStringValue(Many("hi", "hello")) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many("hi", "hello")))), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
@@ -173,40 +173,40 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain only ("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain only ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain only ("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain only ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -215,7 +215,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain only Many("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain only Many("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Many("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
       }
@@ -224,40 +224,40 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (contain only (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain only ("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain only ("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain only ("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -266,7 +266,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only Many("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain only Many("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Many("fee", "fie", "foe", "fam"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
@@ -384,32 +384,32 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain only ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain only ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain only ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain only ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain only ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain only ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain only ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -417,7 +417,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -426,7 +426,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          One(Many("fee", "fie", "foe", "fum")) should (not be (One(Many("fee", "fie", "foe", "fum"))) or not contain only (Many("fee", "fie", "foe", "fum")))
+          One(Many("fee", "fie", "foe", "fum")) should (not be_== (One(Many("fee", "fie", "foe", "fum"))) or not contain only (Many("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(One(Many("fee", "fie", "foe", "fum"))), decorateToStringValue(One(Many("fee", "fie", "foe", "fum")))) + ", and " + Resources("containedOnlyElementsWithFriendlyReminder", decorateToStringValue(One(Many("fee", "fie", "foe", "fum"))), decorateToStringValue(Many("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
@@ -514,12 +514,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1)) or contain only (1, 2, 3))
-        all (list1s) should (be (Many(2, 3, 4)) or contain only (1, 2, 3))
-        all (list1s) should (be (Many(3, 2, 1)) or contain only (2, 3, 4))
+        all (list1s) should (be_== (Many(3, 2, 1)) or contain only (1, 2, 3))
+        all (list1s) should (be_== (Many(2, 3, 4)) or contain only (1, 2, 3))
+        all (list1s) should (be_== (Many(3, 2, 1)) or contain only (2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3, 4)) or contain only (2, 3, 4))
+          all (list1s) should (be_== (Many(2, 3, 4)) or contain only (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(Many(3, 2, 1)) + " did not contain only " + "(2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -527,30 +527,30 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))
-        all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain only ("HELLO", "HO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain only ("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(3, 2, 1)) or contain only (1, 2, 2, 3))
+          all (list1s) should (be_== (Many(3, 2, 1)) or contain only (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -559,7 +559,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (One(One(Many(3, 2, 1)))) should (be (Many(2, 3, 4)) or contain only Many(2, 3, 4))
+          all (One(One(Many(3, 2, 1)))) should (be_== (Many(2, 3, 4)) or contain only Many(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(Many(3, 2, 1))) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(One(Many(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Many(2, 3, 4)) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many(3, 2, 1)))), fileName, thisLineNumber - 2)
       }
@@ -629,12 +629,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain only (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain only (8, 3, 4))
-        all (list1s) should (not be (Many(3, 2, 1)) or not contain only (8, 3, 4))
-        all (list1s) should (not be (One(2)) or not contain only (1, 2, 3))
+        all (list1s) should (not be_== (One(2)) or not contain only (8, 3, 4))
+        all (list1s) should (not be_== (Many(3, 2, 1)) or not contain only (8, 3, 4))
+        all (list1s) should (not be_== (One(2)) or not contain only (1, 2, 3))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(3, 2, 1)) or not contain only (2, 3, 1))
+          all (list1s) should (not be_== (Many(3, 2, 1)) or not contain only (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", and " + decorateToStringValue(Many(3, 2, 1)) + " contained only " + "(2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -642,30 +642,30 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain only ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hello", "hi")) or not contain only ("HELLO", "HO"))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain only ("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))
+          all (hiLists) should (not be_== (Many("hi", "hello")) or not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (One(2)) or not contain only (1, 2, 2, 3))
+          all (list1s) should (not be_== (One(2)) or not contain only (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -681,7 +681,7 @@ class EveryShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (One(One(Many(3, 2, 1)))) should (not be (One(Many(3, 2, 1))) or not contain only (Many(3, 2, 1)))
+          all (One(One(Many(3, 2, 1)))) should (not be_== (One(Many(3, 2, 1))) or not contain only (Many(3, 2, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(One(Many(3, 2, 1))) + " was equal to " + decorateToStringValue(One(Many(3, 2, 1))) + ", and " + decorateToStringValue(One(Many(3, 2, 1))) + " contained only (" + decorateToStringValue(Many(3, 2, 1)) + "), did you forget to say : _*", thisLineNumber - 2, One(One(Many(3, 2, 1)))), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -147,82 +147,82 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsAs (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
 
@@ -311,38 +311,38 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsAs (Set("happy", "birthday", "to", "you")))
+          fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (toList) and not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
+        fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
+          fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE"))))
+          fumList should (not be_== (toList) and (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE"))))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -419,28 +419,28 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
-        atLeast (2, lists) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
-        atMost (2, lists) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 1))
-        no (lists) should (be (Many(3, 6, 9)) and contain theSameElementsAs Set(3, 4, 5))
+        all (list1s) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+        atLeast (2, lists) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+        atMost (2, lists) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 1))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain theSameElementsAs Set(3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+          all (lists) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was not equal to " + decorateToStringValue(Many(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", but " + decorateToStringValue(Many(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsAs Set("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("ho", "hey", "howdy")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
+          all (list1s) should (be_== (Many(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", but " + decorateToStringValue(Many(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -448,28 +448,28 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -537,28 +537,28 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain theSameElementsAs (Set(8, 3, 4)))
-        atLeast (2, lists) should (not be (One(3)) and not contain theSameElementsAs (Set(8, 3, 4)))
-        atMost (2, lists) should (not be (Many(4, 3, 2)) and not contain theSameElementsAs (Set(3, 4, 2)))
-        no (list1s) should (not be (Many(3, 2, 1)) and not contain theSameElementsAs (Set(1, 2, 3)))
+        all (list1s) should (not be_== (One(2)) and not contain theSameElementsAs (Set(8, 3, 4)))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain theSameElementsAs (Set(8, 3, 4)))
+        atMost (2, lists) should (not be_== (Many(4, 3, 2)) and not contain theSameElementsAs (Set(3, 4, 2)))
+        no (list1s) should (not be_== (Many(3, 2, 1)) and not contain theSameElementsAs (Set(1, 2, 3)))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(4, 3, 2)) and not contain theSameElementsAs (Set(8, 3, 4)))
+          all (lists) should (not be_== (Many(4, 3, 2)) and not contain theSameElementsAs (Set(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was equal to " + decorateToStringValue(Many(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain theSameElementsAs (Set(2, 3, 4)))
+          all (lists) should (not be_== (One(3)) and not contain theSameElementsAs (Set(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(Many(4, 3, 2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(Many(4, 3, 2)) + " contained the same elements as " + decorateToStringValue(Set(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("hello", "hi")))
+          all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsAs (Set("hello", "hi")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -566,28 +566,28 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))
+        all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))
+          all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -134,70 +134,70 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsAs (..) and be (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fam"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
 
@@ -274,32 +274,32 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
-        fumList should (not be (fumList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
-        fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
+        fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM"))))
+          fumList should (not be_== (fumList) or (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM"))))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -365,12 +365,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(3, 2, 1)) or contain theSameElementsAs Set(1, 2, 3))
-        all (list1s) should (be (Many(2, 3, 4)) or contain theSameElementsAs Set(1, 2, 3))
-        all (list1s) should (be (Many(3, 2, 1)) or contain theSameElementsAs Set(2, 3, 4))
+        all (list1s) should (be_== (Many(3, 2, 1)) or contain theSameElementsAs Set(1, 2, 3))
+        all (list1s) should (be_== (Many(2, 3, 4)) or contain theSameElementsAs Set(1, 2, 3))
+        all (list1s) should (be_== (Many(3, 2, 1)) or contain theSameElementsAs Set(2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3, 4)) or contain theSameElementsAs Set(2, 3, 4))
+          all (list1s) should (be_== (Many(2, 3, 4)) or contain theSameElementsAs Set(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(Many(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 4)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -378,23 +378,23 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
-        all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -441,12 +441,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain theSameElementsAs (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) or not contain theSameElementsAs (Set(8, 3, 4)))
-        all (list1s) should (not be (Many(3, 2, 1)) or not contain theSameElementsAs (Set(8, 3, 4)))
-        all (list1s) should (not be (One(2)) or not contain theSameElementsAs (Set(1, 2, 3)))
+        all (list1s) should (not be_== (One(2)) or not contain theSameElementsAs (Set(8, 3, 4)))
+        all (list1s) should (not be_== (Many(3, 2, 1)) or not contain theSameElementsAs (Set(8, 3, 4)))
+        all (list1s) should (not be_== (One(2)) or not contain theSameElementsAs (Set(1, 2, 3)))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(3, 2, 1)) or not contain theSameElementsAs (Set(2, 3, 1)))
+          all (list1s) should (not be_== (Many(3, 2, 1)) or not contain theSameElementsAs (Set(2, 3, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(3, 2, 1)) + " was equal to " + decorateToStringValue(Many(3, 2, 1)) + ", and " + decorateToStringValue(Many(3, 2, 1)) + " contained the same elements as " + decorateToStringValue(Set(2, 3, 1)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -454,23 +454,23 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))
-        all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))
+        all (hiLists) should (not be_== (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -147,82 +147,82 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (be xx and contain theSameElementsInOrderAs xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsInOrderAs xx and be xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
 
@@ -309,38 +309,38 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain theSameElementsInOrderAs xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+          fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
+          fumList should (not be_== (toList) and (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsInOrderAs (LinkedList(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (LinkedList(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -417,28 +417,28 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (be xx and contain theSameElementsInOrderAs xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        atLeast (2, lists) should (be (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        atMost (2, lists) should (be (Many(3, 2, 1)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        no (lists) should (be (Many(3, 6, 9)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
+        all (list1s) should (be_== (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        atLeast (2, lists) should (be_== (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        atMost (2, lists) should (be_== (Many(3, 2, 1)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        no (lists) should (be_== (Many(3, 6, 9)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+          all (lists) should (be_== (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(Many(2, 3, 4)) + " was not equal to " + decorateToStringValue(Many(1, 2, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
+          all (list1s) should (be_== (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many(1, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 3)) + ", but " + decorateToStringValue(Many(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("hello", "hi"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e5 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
+          all (list1s) should (be_== (Many(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
         }
         checkMessageStackDepth(e5, allErrMsg(0, decorateToStringValue(Many(1, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 3)) + ", but " + decorateToStringValue(Many(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -446,28 +446,28 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+          all (hiLists) should (be_== (Many("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -535,28 +535,28 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain theSameElementsInOrderAs xx)` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (One(2)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        atLeast (2, lists) should (not be (One(3)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        atMost (2, lists) should (not be (Many(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
-        no (list1s) should (not be (Many(1, 2, 3)) and not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+        all (list1s) should (not be_== (One(2)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        atLeast (2, lists) should (not be_== (One(3)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        atMost (2, lists) should (not be_== (Many(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
+        no (list1s) should (not be_== (Many(1, 2, 3)) and not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
 
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (Many(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+          all (lists) should (not be_== (Many(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(Many(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (One(3)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
+          all (lists) should (not be_== (One(3)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(One(3)) + ", but " + decorateToStringValue(Many(2, 3, 4)) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("ho", "hey", "howdy")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("hi", "hello")))
+          all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("hi", "hello")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -564,28 +564,28 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))
+        all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+          all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (One("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(One("ho")) + ", but " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -135,70 +135,70 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (be xx and contain theSameElementsInOrderAs xx)" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
     "when used with (contain theSameElementsInOrderAs xx and be xx)" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
 
@@ -273,32 +273,32 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (not be xx and not contain theSameElementsInOrderAs xx)" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
-        fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+          fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))), fileName, thisLineNumber - 2)
       }
 
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
-        fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
+          fumList should (not be_== (fumList) or (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -364,12 +364,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (be xx and contain theSameElementsInOrderAs xx)" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (Many(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        all (list1s) should (be (Many(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        all (list1s) should (be (Many(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
+        all (list1s) should (be_== (Many(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        all (list1s) should (be_== (Many(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        all (list1s) should (be_== (Many(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (Many(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
+          all (list1s) should (be_== (Many(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(1, 2, 3)) + " was not equal to " + decorateToStringValue(Many(2, 3, 4)) + ", and " + decorateToStringValue(Many(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 4)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -377,23 +377,23 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
-        all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
-        all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+          all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (Many("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (Many("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was not equal to " + decorateToStringValue(Many("ho", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -440,12 +440,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (not be xx and not contain theSameElementsInOrderAs xx)" - {
 
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (One(2)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        all (list1s) should (not be (Many(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        all (list1s) should (not be (One(2)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+        all (list1s) should (not be_== (One(2)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        all (list1s) should (not be_== (Many(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        all (list1s) should (not be_== (One(2)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
 
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (Many(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+          all (list1s) should (not be_== (Many(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many(1, 2, 3)) + " was equal to " + decorateToStringValue(Many(1, 2, 3)) + ", and " + decorateToStringValue(Many(1, 2, 3)) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(1, 2, 3)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -453,23 +453,23 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
 
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
-        all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
-        all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
+        all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
+        all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
 
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+          all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (Many("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (Many("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Many("hi", "hello")) + " was equal to " + decorateToStringValue(Many("hi", "hello")) + ", and " + decorateToStringValue(Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
@@ -172,46 +172,46 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain allOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain allOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain allOf ("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -222,46 +222,46 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (contain allOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain allOf ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -379,38 +379,38 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) and not contain allOf ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain allOf ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain allOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
+          fumList should (not be_== (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain allOf ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (not be_== (toList) and (not contain allOf ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -418,7 +418,7 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -514,40 +514,40 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
-        atLeast (2, lists) should (be (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
-        atMost (2, lists) should (be (List(3, 2, 1, 0)) and contain allOf (2, 3, 1))
-        no (lists) should (be (List(3, 6, 9)) and contain allOf (3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain allOf (1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain allOf (3, 4, 5))
+        all (list1s) should (be_== (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+        atLeast (2, lists) should (be_== (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+        atMost (2, lists) should (be_== (List(3, 2, 1, 0)) and contain allOf (2, 3, 1))
+        no (lists) should (be_== (List(3, 6, 9)) and contain allOf (3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain allOf (1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain allOf (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+          all (lists) should (be_== (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(8, 4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3, 2, 1, 0)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1, 0)) and contain allOf (2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1, 0)) and contain allOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(List(3, 2, 1, 0)) + ", but " + decorateToStringValue(List(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain allOf ("hello", "hi"))
+          all (nils) should (be_== (List("hey")) and contain allOf ("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (List("howdy", "hi", "hello")) and contain allOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " did not contain all of " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
+          all (listsNil) should (be_== (List(3, 2, 1, 0)) and contain allOf (1, 3, 2))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List(3, 2, 1, 0)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1, 0)) and contain allOf (2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1, 0)) and contain allOf (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(List(3, 2, 1, 0)) + ", but " + decorateToStringValue(List(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -555,35 +555,35 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))
+          all (hiLists) should (be_== (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1, 0)) and contain allOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(3, 2, 1, 0)) and contain allOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -669,28 +669,28 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain allOf (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain allOf (8, 3, 4))
-        atMost (2, lists) should (not be (List(4, 3, 2)) and not contain allOf (3, 4, 2))
-        no (list1s) should (not be (List(3, 2, 1)) and not contain allOf (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) and not contain allOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain allOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(4, 3, 2)) and not contain allOf (3, 4, 2))
+        no (list1s) should (not be_== (List(3, 2, 1)) and not contain allOf (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(8, 4, 3, 2)) and not contain allOf (8, 3, 4))
+          all (lists) should (not be_== (List(8, 4, 3, 2)) and not contain allOf (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(8, 4, 3, 2)) + " was equal to " + decorateToStringValue(List(8, 4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain allOf (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain allOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(8, 4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(8, 4, 3, 2)) + " contained all of " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("howdy", "hi", "hello")) and not contain allOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain allOf ("hello", "hi"))
+          all (hiLists) should (not be_== (List("ho")) and not contain allOf ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,35 +698,35 @@ class ListShouldContainAllOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))
+        all (hiLists) should (not be_== (List("ho")) and not contain allOf ("HO", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("ho")) and not contain allOf ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain allOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) and not contain allOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
@@ -160,40 +160,40 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain allOf ("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain allOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain allOf ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain allOf ("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain allOf ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain allOf ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -204,40 +204,40 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (contain allOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain allOf ("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain allOf ("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain allOf ("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain allOf ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -343,32 +343,32 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain allOf ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain allOf ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain allOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain allOf ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain allOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain allOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain allOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain allOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain allOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -376,7 +376,7 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain allOf ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain allOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -461,12 +461,12 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain allOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1, 0)) or contain allOf (1, 2, 3))
-        all (list1s) should (be (List(2, 3, 4)) or contain allOf (1, 2, 3))
-        all (list1s) should (be (List(3, 2, 1, 0)) or contain allOf (2, 3, 4))
+        all (list1s) should (be_== (List(3, 2, 1, 0)) or contain allOf (1, 2, 3))
+        all (list1s) should (be_== (List(2, 3, 4)) or contain allOf (1, 2, 3))
+        all (list1s) should (be_== (List(3, 2, 1, 0)) or contain allOf (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3, 4)) or contain allOf (2, 3, 4))
+          all (list1s) should (be_== (List(2, 3, 4)) or contain allOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1, 0)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(List(3, 2, 1, 0)) + " did not contain all of " + "(2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -474,30 +474,30 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))
-        all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))
-        all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))
+        all (hiLists) should (be_== (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain allOf ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain allOf ("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1, 0)) or contain allOf (1, 2, 2, 3))
+          all (list1s) should (be_== (List(3, 2, 1, 0)) or contain allOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -562,12 +562,12 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain allOf (...))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain allOf (8, 3, 4))
-        all (list1s) should (not be (List(3, 2, 1, 0)) or not contain allOf (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain allOf (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) or not contain allOf (8, 3, 4))
+        all (list1s) should (not be_== (List(3, 2, 1, 0)) or not contain allOf (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain allOf (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(3, 2, 1, 0)) or not contain allOf (2, 3, 1))
+          all (list1s) should (not be_== (List(3, 2, 1, 0)) or not contain allOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1, 0)) + " was equal to " + decorateToStringValue(List(3, 2, 1, 0)) + ", and " + decorateToStringValue(List(3, 2, 1, 0)) + " contained all of " + "(2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -575,30 +575,30 @@ class ListShouldContainAllOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))
-        all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain allOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) or not contain allOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -162,96 +162,96 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain atLeastOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain atLeastOneOf ("fum", "foe")))
+          fumList should (be_== (fumList) and (contain atLeastOneOf ("fum", "foe")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources("atLeastOneOfDuplicate")))
+        e1.message should be_== (Some(Resources("atLeastOneOfDuplicate")))
       }
     }
 
     object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain atLeastOneOf ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+        fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") and be (toList))
+          fumList should (contain atLeastOneOf ("fum", "foe") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") and (be (fumList)))
+          fumList should (contain atLeastOneOf ("fum", "foe") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -369,38 +369,38 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) and not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (toList) and not contain atLeastOneOf ("fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))
+          fumList should (not be_== (fumList) and not contain atLeastOneOf ("fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (toList) and (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -408,7 +408,7 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -522,40 +522,40 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1)) and contain atLeastOneOf (1, 3, 4))
-        atLeast (2, lists) should (be (List(1)) and contain atLeastOneOf (1, 3, 4))
-        atMost (2, lists) should (be (List(1)) and contain atLeastOneOf (2, 3, 4))
-        no (lists) should (be (List(8)) and contain atLeastOneOf (3, 4, 5))
-        no (nils) should (be (List(8)) and contain atLeastOneOf (1, 3, 4))
-        no (listsNil) should (be (List(8)) and contain atLeastOneOf (3, 4, 5))
+        all (list1s) should (be_== (List(1)) and contain atLeastOneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (List(1)) and contain atLeastOneOf (1, 3, 4))
+        atMost (2, lists) should (be_== (List(1)) and contain atLeastOneOf (2, 3, 4))
+        no (lists) should (be_== (List(8)) and contain atLeastOneOf (3, 4, 5))
+        no (nils) should (be_== (List(8)) and contain atLeastOneOf (1, 3, 4))
+        no (listsNil) should (be_== (List(8)) and contain atLeastOneOf (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1)) and contain atLeastOneOf (1, 3, 4))
+          all (lists) should (be_== (List(1)) and contain atLeastOneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (List(1)) and contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + decorateToStringValue(List(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain atLeastOneOf ("ho", "hey", "howdy"))
+          all (nils) should (be_== (List("hey")) and contain atLeastOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (List("hi")) and contain atLeastOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + decorateToStringValue(List("hi")) + " did not contain at least one of (\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(1)) and contain atLeastOneOf (1, 3, Nil))
+          all (listsNil) should (be_== (List(1)) and contain atLeastOneOf (1, 3, Nil))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List(1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (List(1)) and contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + decorateToStringValue(List(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -563,35 +563,35 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi")) and contain atLeastOneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (List("ho")) and contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("hi")) and contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + decorateToStringValue(List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + decorateToStringValue(List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) and contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(1)) and contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -677,28 +677,28 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain atLeastOneOf (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain atLeastOneOf (8, 3, 4))
-        atMost (2, lists) should (not be (List(3)) and contain atLeastOneOf (5, 3, 4))
-        no (list1s) should (not be (List(1)) and not contain atLeastOneOf (2, 1, 5))
+        all (list1s) should (not be_== (List(2)) and not contain atLeastOneOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain atLeastOneOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(3)) and contain atLeastOneOf (5, 3, 4))
+        no (list1s) should (not be_== (List(1)) and not contain atLeastOneOf (2, 1, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2)) and not contain atLeastOneOf (2, 3, 4))
+          all (lists) should (not be_== (List(2)) and not contain atLeastOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was equal to " + decorateToStringValue(List(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain atLeastOneOf (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain atLeastOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(2)) + " contained at least one of (2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi")) and not contain atLeastOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (List("ho")) and not contain atLeastOneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi")) + " contained at least one of (\"hi\", \"hello\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -706,35 +706,35 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("ho")) and not contain atLeastOneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (not be_== (List("hi")) and not contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("ho")) and not contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) and not contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -150,40 +150,40 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain atLeastOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (toList) or contain atLeastOneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))
+        fumList should (be_== (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain atLeastOneOf ("fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain atLeastOneOf ("fum", "foe")))
+          fumList should (be_== (toList) or (contain atLeastOneOf ("fum", "foe")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -194,40 +194,40 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (contain oneOf (...) and be (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain atLeastOneOf ("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))
-        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain atLeastOneOf ("fum", "foe") or be_== (fumList))
+        fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))
+          fumList should (contain atLeastOneOf ("fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain atLeastOneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -333,32 +333,32 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain atLeastOneOf("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain atLeastOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))
-        fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))
-        fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (fumList) or not contain atLeastOneOf ("fum", "foe"))
+        fumList should (not be_== (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -366,7 +366,7 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain atLeastOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -451,12 +451,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (List(1)) or contain atLeastOneOf (1, 3, 4))
-        all (list1s) should (be (List(2)) or contain atLeastOneOf (1, 3, 4))
-        all (list1s) should (be (List(1)) or contain atLeastOneOf (2, 3, 4))
+        all (list1s) should (be_== (List(1)) or contain atLeastOneOf (1, 3, 4))
+        all (list1s) should (be_== (List(2)) or contain atLeastOneOf (1, 3, 4))
+        all (list1s) should (be_== (List(1)) or contain atLeastOneOf (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2)) or contain atLeastOneOf (2, 3, 8))
+          all (list1s) should (be_== (List(2)) or contain atLeastOneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was not equal to " + decorateToStringValue(List(2)) + ", and " + decorateToStringValue(List(1)) + " did not contain at least one of (2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -464,30 +464,30 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))
-        all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))
-        all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (be_== (List("hi")) or contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("ho")) or contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi")) or contain atLeastOneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("ho")) or contain atLeastOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + decorateToStringValue(List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + decorateToStringValue(List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) or contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(1)) or contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -552,12 +552,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...))" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (List(2)) or not contain atLeastOneOf (8, 3, 4))
-        all (list1s) should (not be (List(1)) or not contain atLeastOneOf (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain atLeastOneOf (8, 3, 1))
+        all (list1s) should (not be_== (List(2)) or not contain atLeastOneOf (8, 3, 4))
+        all (list1s) should (not be_== (List(1)) or not contain atLeastOneOf (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain atLeastOneOf (8, 3, 1))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1)) or not contain atLeastOneOf (2, 3, 1))
+          all (list1s) should (not be_== (List(1)) or not contain atLeastOneOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", and " + decorateToStringValue(List(1)) + " contained at least one of (2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -565,30 +565,30 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))
-        all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))
-        all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("ho")) or not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("hi")) or not contain atLeastOneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("ho")) or not contain atLeastOneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("hi")) or not contain atLeastOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + decorateToStringValue(List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + decorateToStringValue(List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain atLeastOneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) or not contain atLeastOneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -167,46 +167,46 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain atMostOneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) and contain atMostOneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be_== (toList) and contain atMostOneOf ("fee", "fie", "foe", "fam"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain atMostOneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+        fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
+          fumList should (be_== (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -217,46 +217,46 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (contain atMostOneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and be (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and be (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fam") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))
+        fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (be (toList)))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and (be_== (toList)))
         }
         checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -374,38 +374,38 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain atMostOneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (toList) and not contain atMostOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atMostOneOf ("fie", "fee", "fum", "foe"))
+          fumList should (not be_== (fumList) and not contain atMostOneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain atMostOneOf ("fie", "fee", "fam", "foe"))
+          fumList should (not be_== (toList) and not contain atMostOneOf ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+          fumList should (not be_== (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (not be_== (toList) and (not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -413,7 +413,7 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -515,28 +515,28 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain atMostOneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1, 2)) and contain atMostOneOf (1, 3, 4))
-        atLeast (2, lists) should (be (List(1, 2)) and contain atMostOneOf (2, 3, 4))
-        atMost (2, lists) should (be (List(1, 2)) and contain atMostOneOf (2, 3, 4))
-        no (lists) should (be (List(8)) and contain atMostOneOf (3, 2, 1))
+        all (list1s) should (be_== (List(1, 2)) and contain atMostOneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (List(1, 2)) and contain atMostOneOf (2, 3, 4))
+        atMost (2, lists) should (be_== (List(1, 2)) and contain atMostOneOf (2, 3, 4))
+        no (lists) should (be_== (List(8)) and contain atMostOneOf (3, 2, 1))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1, 2)) and contain atMostOneOf (1, 3, 4))
+          all (lists) should (be_== (List(1, 2)) and contain atMostOneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(List(1, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2)) and contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (List(1, 2)) and contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(1, 2)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("hi", "he")) and contain atMostOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2)) and contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (List(1, 2)) and contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(1, 2)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -544,35 +544,35 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))
+        all (hiLists) should (be_== (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))
+          all (hiLists) should (be_== (List("ho")) and contain atMostOneOf ("HO", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1, 2)) and contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1, 2)) and contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -658,28 +658,28 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain atMostOneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
-        atLeast (2, lists) should (not be (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
-        atMost (2, lists) should (not be (List(2, 3)) and contain atMostOneOf (1, 2, 3))
-        no (list1s) should (not be (List(1, 2)) and not contain atMostOneOf (3, 6, 8))
+        all (list1s) should (not be_== (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
+        atLeast (2, lists) should (not be_== (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
+        atMost (2, lists) should (not be_== (List(2, 3)) and contain atMostOneOf (1, 2, 3))
+        no (list1s) should (not be_== (List(1, 2)) and not contain atMostOneOf (3, 6, 8))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
+          all (lists) should (not be_== (List(2, 3)) and not contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(List(2, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2, 3, 4)) and not contain atMostOneOf (1, 2, 8))
+          all (lists) should (not be_== (List(2, 3, 4)) and not contain atMostOneOf (1, 2, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", but " + decorateToStringValue(lists(2)) + " contained at most one of (1, 2, 8)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi", "he")) and not contain atMostOneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (List("hi", "ho")) and not contain atMostOneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"hi\", \"hello\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -687,35 +687,35 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("hi", "he"))
+          all (hiLists) should (not be_== (List("hi", "he")) and not contain atMostOneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))
+          all (hiLists) should (not be_== (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("hi", "ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
 
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2, 3)) and not contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2, 3)) and not contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -155,40 +155,40 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain theMostOneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (toList) or contain atMostOneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain atMostOneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be_== (toList) or contain atMostOneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
-        fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (be_== (toList) or (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -199,40 +199,40 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (contain oneOf (...) and be (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be (toList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain atMostOneOf("fie", "fee", "fam", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain atMostOneOf ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain atMostOneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -338,32 +338,32 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
-        fumList should (not be (fumList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
-        fumList should (not be (toList) or not contain atMostOneOf("fee", "fie", "foe", "fuu"))
+        fumList should (not be_== (toList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (fumList) or not contain atMostOneOf("fie", "fee", "fum", "foe"))
+        fumList should (not be_== (toList) or not contain atMostOneOf("fee", "fie", "foe", "fuu"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain atMostOneOf ("fee", "fie", "foe", "fuu"))
+          fumList should (not be_== (fumList) or not contain atMostOneOf ("fee", "fie", "foe", "fuu"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fuu\""), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU")))
+          fumList should (not be_== (fumList) or (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAtMostOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
         (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -371,7 +371,7 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain atMostOneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -456,12 +456,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (be (...) and contain oneOf (...)) syntax" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (List(1, 2)) or contain atMostOneOf (1, 6, 8))
-        all (list1s) should (be (List(2, 3)) or contain atMostOneOf (1, 6, 8))
-        all (list1s) should (be (List(1, 2)) or contain atMostOneOf (1, 2, 3))
+        all (list1s) should (be_== (List(1, 2)) or contain atMostOneOf (1, 6, 8))
+        all (list1s) should (be_== (List(2, 3)) or contain atMostOneOf (1, 6, 8))
+        all (list1s) should (be_== (List(1, 2)) or contain atMostOneOf (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3)) or contain atMostOneOf (1, 2, 3))
+          all (list1s) should (be_== (List(2, 3)) or contain atMostOneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was not equal to " + decorateToStringValue(List(2, 3)) + ", and " + decorateToStringValue(list1s(0)) + " did not contain at most one of (1, 2, 3)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -469,30 +469,30 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))
-        all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))
-        all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))
+        all (hiLists) should (be_== (List("HO")) or contain atMostOneOf ("HI", "HO"))
+        all (hiLists) should (be_== (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))
+          all (hiLists) should (be_== (List("HO")) or contain atMostOneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("HO")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("HO")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1, 2)) or contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1, 2)) or contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -557,12 +557,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
     "when used with (not be (...) and not contain atMostOneOf (...))" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (List(2, 3)) or not contain atMostOneOf (1, 2, 3))
-        all (list1s) should (not be (List(1, 2)) or not contain atMostOneOf (1, 2, 3))
-        all (list1s) should (not be (List(2, 3)) or not contain atMostOneOf (2, 3, 4))
+        all (list1s) should (not be_== (List(2, 3)) or not contain atMostOneOf (1, 2, 3))
+        all (list1s) should (not be_== (List(1, 2)) or not contain atMostOneOf (1, 2, 3))
+        all (list1s) should (not be_== (List(2, 3)) or not contain atMostOneOf (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1, 2)) or not contain atMostOneOf (2, 3, 4))
+          all (list1s) should (not be_== (List(1, 2)) or not contain atMostOneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(1, 2)) + ", and " + decorateToStringValue(list1s(0)) + " contained at most one of (2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -570,30 +570,30 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))
-        all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))
-        all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("ho")) or not contain atMostOneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))
+        all (hiLists) should (not be_== (List("ho")) or not contain atMostOneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))
+          all (hiLists) should (not be_== (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")) + ", and " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "he")) + ", and " + decorateToStringValue(hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2, 3)) or not contain atMostOneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2, 3)) or not contain atMostOneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
@@ -172,46 +172,46 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain inOrder ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -222,46 +222,46 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (contain inOrder xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain inOrder ("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -377,38 +377,38 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain inOrder ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (toList) and not contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (toList) and (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -416,7 +416,7 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -518,40 +518,40 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 3))
-        atLeast (2, lists) should (be (List(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
-        atMost (2, lists) should (be (List(3, 2, 1)) and contain inOrder (1, 2, 3))
-        no (lists) should (be (List(3, 6, 9)) and contain inOrder (3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain inOrder (1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain inOrder (3, 4, 5))
+        all (list1s) should (be_== (List(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 3))
+        atLeast (2, lists) should (be_== (List(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
+        atMost (2, lists) should (be_== (List(3, 2, 1)) and contain inOrder (1, 2, 3))
+        no (lists) should (be_== (List(3, 6, 9)) and contain inOrder (3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain inOrder (1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain inOrder (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
+          all (lists) should (be_== (List(0, 1, 2, 3, 3)) and contain inOrder (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(List(0, 1, 2, 3, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
+          all (list1s) should (be_== (List(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(0, 1, 2, 2, 3)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain inOrder ("hi", "hello"))
+          all (nils) should (be_== (List("hey")) and contain inOrder ("hi", "hello"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(nils(0)) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("hello", "hi"))
+          all (hiLists) should (be_== (List("he", "hi", "hello")) and contain inOrder ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"hello\", \"hi\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(0, 1, 2, 3)) and contain inOrder (1, 2, 3))
+          all (listsNil) should (be_== (List(0, 1, 2, 3)) and contain inOrder (1, 2, 3))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(listsNil(2)) + " was not equal to " + decorateToStringValue(List(0, 1, 2, 3)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
+          all (list1s) should (be_== (List(0, 1, 2, 2, 3)) and contain inOrder (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(0, 1, 2, 2, 3)) + ", but " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -559,35 +559,35 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")) + ", but " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 2, 3))
+          all (list1s) should (be_== (List(0, 1, 2, 2, 3)) and contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -673,28 +673,28 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain inOrder (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain inOrder (8, 3, 4))
-        atMost (2, lists) should (not be (List(8, 2, 3, 4)) and not contain inOrder (2, 3, 4))
-        no (list1s) should (not be (List(0, 1, 2, 2, 3)) and not contain inOrder (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) and not contain inOrder (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain inOrder (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(8, 2, 3, 4)) and not contain inOrder (2, 3, 4))
+        no (list1s) should (not be_== (List(0, 1, 2, 2, 3)) and not contain inOrder (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(8, 2, 3, 4)) and not contain inOrder (8, 3, 4))
+          all (lists) should (not be_== (List(8, 2, 3, 4)) and not contain inOrder (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(List(8, 2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain inOrder (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain inOrder (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(lists(2)) + " contained all of " + "(2, 3, 4)" + " in order", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("he", "hi", "hello")) and not contain inOrder ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain inOrder ("hi", "hello"))
+          all (hiLists) should (not be_== (List("ho")) and not contain inOrder ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -702,35 +702,35 @@ class ListShouldContainInOrderLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))
+        all (hiLists) should (not be_== (List("ho")) and not contain inOrder ("HO", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("ho")) and not contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain inOrder (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) and not contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
@@ -160,40 +160,40 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain inOrder ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain inOrder ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain inOrder ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -204,40 +204,40 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (contain inOrder xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain inOrder ("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainAllOfElementsInOrder", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain inOrder ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -341,32 +341,32 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain inOrder ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain inOrder ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain inOrder ("fum", "foe", "fie", "fee"))
+        fumList should (not be_== (toList) or not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain inOrder ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain inOrder ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain inOrder ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (fumList) or not contain inOrder ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (not be_== (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (fumList) or (not contain inOrder ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedAllOfElementsInOrder", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -374,7 +374,7 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain inOrder ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -458,12 +458,12 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (be xx and contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 3))
-        all (list1s) should (be (List(8, 2, 3, 4)) or contain inOrder (1, 2, 3))
-        all (list1s) should (be (List(0, 1, 2, 2, 3)) or contain inOrder (2, 3, 4))
+        all (list1s) should (be_== (List(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 3))
+        all (list1s) should (be_== (List(8, 2, 3, 4)) or contain inOrder (1, 2, 3))
+        all (list1s) should (be_== (List(0, 1, 2, 2, 3)) or contain inOrder (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(8, 2, 3, 4)) or contain inOrder (2, 3, 4))
+          all (list1s) should (be_== (List(8, 2, 3, 4)) or contain inOrder (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was not equal to " + decorateToStringValue(List(8, 2, 3, 4)) + ", and " + decorateToStringValue(list1s(0)) + " did not contain all of " + "(2, 3, 4)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -471,30 +471,30 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))
-        all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))
-        all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 2, 3))
+          all (list1s) should (be_== (List(0, 1, 2, 2, 3)) or contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -559,12 +559,12 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
     object `when used with (not be xx and not contain inOrder xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain inOrder (8, 3, 4))
-        all (list1s) should (not be (List(0, 1, 2, 2, 3)) or not contain inOrder (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain inOrder (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) or not contain inOrder (8, 3, 4))
+        all (list1s) should (not be_== (List(0, 1, 2, 2, 3)) or not contain inOrder (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain inOrder (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(0, 1, 2, 2, 3)) or not contain inOrder (1, 2, 3))
+          all (list1s) should (not be_== (List(0, 1, 2, 2, 3)) or not contain inOrder (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(list1s(0)) + " was equal to " + decorateToStringValue(List(0, 1, 2, 2, 3)) + ", and " + decorateToStringValue(list1s(0)) + " contained all of " + "(1, 2, 3)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -572,30 +572,30 @@ class ListShouldContainInOrderLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))
-        all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("he", "hi", "hello")) + ", and " + decorateToStringValue(hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain inOrder (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) or not contain inOrder (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -172,46 +172,46 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -222,46 +222,46 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (contain inOrderOnly xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -377,38 +377,38 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (toList) and not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (toList) and (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -416,7 +416,7 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -518,40 +518,40 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 3))
-        atLeast (2, lists) should (be (List(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
-        atMost (2, lists) should (be (List(3, 2, 1)) and contain inOrderOnly (1, 2, 3))
-        no (lists) should (be (List(3, 6, 9)) and contain inOrderOnly (3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain inOrderOnly (1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain inOrderOnly (3, 4, 5))
+        all (list1s) should (be_== (List(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 3))
+        atLeast (2, lists) should (be_== (List(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
+        atMost (2, lists) should (be_== (List(3, 2, 1)) and contain inOrderOnly (1, 2, 3))
+        no (lists) should (be_== (List(3, 6, 9)) and contain inOrderOnly (3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain inOrderOnly (1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain inOrderOnly (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
+          all (lists) should (be_== (List(1, 2, 3, 3)) and contain inOrderOnly (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2, 3, 4)) + " was not equal to " + decorateToStringValue(List(1, 2, 3, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
+          all (list1s) should (be_== (List(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 2, 3)) + ", but " + decorateToStringValue(List(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain inOrderOnly ("hi", "hello"))
+          all (nils) should (be_== (List("hey")) and contain inOrderOnly ("hi", "hello"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(nils(0)) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("hello", "hi"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain inOrderOnly ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"hello\", \"hi\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(1, 2, 3)) and contain inOrderOnly (1, 2, 3))
+          all (listsNil) should (be_== (List(1, 2, 3)) and contain inOrderOnly (1, 2, 3))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(listsNil(2)) + " was not equal to " + decorateToStringValue(List(1, 2, 3)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
+          all (list1s) should (be_== (List(1, 2, 2, 3)) and contain inOrderOnly (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 2, 3)) + ", but " + decorateToStringValue(List(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 8)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -559,35 +559,35 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1, 2, 2, 3)) and contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -673,28 +673,28 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain inOrderOnly (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain inOrderOnly (8, 3, 4))
-        atMost (2, lists) should (not be (List(2, 3, 4)) and not contain inOrderOnly (2, 3, 4))
-        no (list1s) should (not be (List(1, 2, 2, 3)) and not contain inOrderOnly (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) and not contain inOrderOnly (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain inOrderOnly (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(2, 3, 4)) and not contain inOrderOnly (2, 3, 4))
+        no (list1s) should (not be_== (List(1, 2, 2, 3)) and not contain inOrderOnly (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2, 3, 4)) and not contain inOrderOnly (8, 3, 4))
+          all (lists) should (not be_== (List(2, 3, 4)) and not contain inOrderOnly (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2, 3, 4)) + " was equal to " + decorateToStringValue(List(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain inOrderOnly (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain inOrderOnly (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(2, 3, 4)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(2, 3, 4)) + " contained only " + "(2, 3, 4)" + " in order", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain inOrderOnly ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("hi", "hello"))
+          all (hiLists) should (not be_== (List("ho")) and not contain inOrderOnly ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -702,35 +702,35 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))
+        all (hiLists) should (not be_== (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) and not contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -159,40 +159,40 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
     object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain inOrderOnly ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -203,40 +203,40 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
     object `when used with (contain inOrderOnly xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain inOrderOnly ("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainInOrderOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain inOrderOnly ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -340,32 +340,32 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain inOrderOnly ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
+          fumList should (not be_== (fumList) or not contain inOrderOnly ("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"fum\", \"foe\", \"fie\", \"fee\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
+          fumList should (not be_== (fumList) or (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedInOrderOnlyElements", decorateToStringValue(fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -373,7 +373,7 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain inOrderOnly ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -457,12 +457,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
     object `when used with (be xx and contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 3))
-        all (list1s) should (be (List(2, 3, 4)) or contain inOrderOnly (1, 2, 3))
-        all (list1s) should (be (List(1, 2, 2, 3)) or contain inOrderOnly (2, 3, 4))
+        all (list1s) should (be_== (List(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 3))
+        all (list1s) should (be_== (List(2, 3, 4)) or contain inOrderOnly (1, 2, 3))
+        all (list1s) should (be_== (List(1, 2, 2, 3)) or contain inOrderOnly (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3, 4)) or contain inOrderOnly (2, 3, 4))
+          all (list1s) should (be_== (List(2, 3, 4)) or contain inOrderOnly (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1, 2, 2, 3)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(List(1, 2, 2, 3)) + " did not contain only " + "(2, 3, 4)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -470,30 +470,30 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))
-        all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))
-        all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1, 2, 2, 3)) or contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -558,12 +558,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
     object `when used with (not be xx and not contain inOrderOnly xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain inOrderOnly (8, 3, 4))
-        all (list1s) should (not be (List(1, 2, 2, 3)) or not contain inOrderOnly (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain inOrderOnly (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) or not contain inOrderOnly (8, 3, 4))
+        all (list1s) should (not be_== (List(1, 2, 2, 3)) or not contain inOrderOnly (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain inOrderOnly (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1, 2, 2, 3)) or not contain inOrderOnly (1, 2, 3))
+          all (list1s) should (not be_== (List(1, 2, 2, 3)) or not contain inOrderOnly (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1, 2, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 2, 3)) + ", and " + decorateToStringValue(List(1, 2, 2, 3)) + " contained only " + "(1, 2, 3)" + " in order", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -571,30 +571,30 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends Spec with Matchers {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain inOrderOnly (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) or not contain inOrderOnly (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -178,46 +178,46 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
+          fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fam"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -228,46 +228,46 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (contain noneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") and be (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and be (toList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fam") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (be (fumList)))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -386,38 +386,38 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain noneOf ("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (toList) and (not contain noneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -425,7 +425,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -527,28 +527,28 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1)) and contain noneOf (2, 3, 4))
-        atLeast (2, lists) should (be (List(1)) and contain noneOf (2, 3, 4))
-        atMost (2, lists) should (be (List(1)) and contain noneOf (2, 3, 4))
-        no (lists) should (be (List(8)) and contain noneOf (1, 2, 3))
+        all (list1s) should (be_== (List(1)) and contain noneOf (2, 3, 4))
+        atLeast (2, lists) should (be_== (List(1)) and contain noneOf (2, 3, 4))
+        atMost (2, lists) should (be_== (List(1)) and contain noneOf (2, 3, 4))
+        no (lists) should (be_== (List(8)) and contain noneOf (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1)) and contain noneOf (3, 6, 9))
+          all (lists) should (be_== (List(1)) and contain noneOf (3, 6, 9))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (List(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "hey", "howdy"))
+          all (hiLists) should (be_== (List("hi")) and contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (List(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -556,35 +556,35 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (List("hi")) and contain noneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("ho")) and contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))
+          all (hiLists) should (be_== (List("hi")) and contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) and contain noneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1)) and contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -670,28 +670,28 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain noneOf (1, 2, 3))
-        atLeast (2, lists) should (not be (List(3)) and not contain noneOf (1, 6, 8))
-        atMost (2, lists) should (not be (List(3)) and contain noneOf (1, 6, 8))
-        no (list1s) should (not be (List(1)) and not contain noneOf (3, 6, 9))
+        all (list1s) should (not be_== (List(2)) and not contain noneOf (1, 2, 3))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain noneOf (1, 6, 8))
+        atMost (2, lists) should (not be_== (List(3)) and contain noneOf (1, 6, 8))
+        no (list1s) should (not be_== (List(1)) and not contain noneOf (3, 6, 9))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2)) and not contain noneOf (1, 2, 3))
+          all (lists) should (not be_== (List(2)) and not contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was equal to " + decorateToStringValue(List(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain noneOf (1, 6, 8))
+          all (lists) should (not be_== (List(3)) and not contain noneOf (1, 6, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + FailureMessages("didNotContainAtLeastOneOf", lists(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain noneOf ("hi", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi")) and not contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain noneOf ("ho", "hello"))
+          all (hiLists) should (not be_== (List("ho")) and not contain noneOf ("ho", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"ho\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -699,35 +699,35 @@ class ListShouldContainNoneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("ho")) and not contain noneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("hi")) and not contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))
+          all (hiLists) should (not be_== (List("ho")) and not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain noneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) and not contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -166,40 +166,40 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (toList) or contain noneOf("fie", "fee", "fam", "foe"))
-        fumList should (be (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (toList) or contain noneOf("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain noneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
+          fumList should (be_== (toList) or contain noneOf ("fie", "fee", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
-        fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (toList) or contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain noneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -210,40 +210,40 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (contain noneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain noneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (toList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain noneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain noneOf("fie", "fee", "fam", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or be (toList))
+          fumList should (contain noneOf ("fie", "fee", "fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("containedAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -348,32 +348,32 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain noneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain noneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain noneOf ("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) or (not contain noneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("didNotContainAtLeastOneOf", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -381,7 +381,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -466,12 +466,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1)) or contain noneOf (2, 6, 8))
-        all (list1s) should (be (List(2)) or contain noneOf (2, 6, 8))
-        all (list1s) should (be (List(1)) or contain noneOf (1, 2, 3))
+        all (list1s) should (be_== (List(1)) or contain noneOf (2, 6, 8))
+        all (list1s) should (be_== (List(2)) or contain noneOf (2, 6, 8))
+        all (list1s) should (be_== (List(1)) or contain noneOf (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2)) or contain noneOf (1, 2, 3))
+          all (list1s) should (be_== (List(2)) or contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was not equal to " + decorateToStringValue(List(2)) + ", and " + FailureMessages("containedAtLeastOneOf", list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -479,30 +479,30 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))
-        all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))
-        all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi")) or contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (List("ho")) or contain noneOf ("hi", "he"))
+        all (hiLists) should (be_== (List("hi")) or contain noneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))
+          all (hiLists) should (be_== (List("ho")) or contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + FailureMessages("containedAtLeastOneOf", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) or contain noneOf (1, 2, 2, 3))
+          all (list1s) should (be_== (List(1)) or contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -567,12 +567,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain noneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain noneOf (1, 6, 8))
-        all (list1s) should (not be (List(1)) or not contain noneOf (1, 6, 8))
-        all (list1s) should (not be (List(2)) or not contain noneOf (2, 6, 8))
+        all (list1s) should (not be_== (List(2)) or not contain noneOf (1, 6, 8))
+        all (list1s) should (not be_== (List(1)) or not contain noneOf (1, 6, 8))
+        all (list1s) should (not be_== (List(2)) or not contain noneOf (2, 6, 8))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1)) or not contain noneOf (2, 6, 8))
+          all (list1s) should (not be_== (List(1)) or not contain noneOf (2, 6, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", and " + FailureMessages("didNotContainAtLeastOneOf", list1s(0), UnquotedString("2, 6, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -580,30 +580,30 @@ class ListShouldContainNoneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))
-        all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))
-        all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("ho")) or not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("hi")) or not contain noneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("ho")) or not contain noneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))
+          all (hiLists) should (not be_== (List("hi")) or not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + FailureMessages("didNotContainAtLeastOneOf", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain noneOf (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) or not contain noneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -178,46 +178,46 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
+          fumList should (be_== (fumList) and (contain oneOf ("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -228,46 +228,46 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain oneOf ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (be (fumList)))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -385,38 +385,38 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (not be_== (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (toList) and (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -424,7 +424,7 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -538,40 +538,40 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1)) and contain oneOf (1, 3, 4))
-        atLeast (2, lists) should (be (List(1)) and contain oneOf (1, 3, 4))
-        atMost (2, lists) should (be (List(1)) and contain oneOf (2, 3, 4))
-        no (lists) should (be (List(8)) and contain oneOf (3, 4, 5))
-        no (nils) should (be (List(8)) and contain oneOf (1, 3, 4))
-        no (listsNil) should (be (List(8)) and contain oneOf (3, 4, 5))
+        all (list1s) should (be_== (List(1)) and contain oneOf (1, 3, 4))
+        atLeast (2, lists) should (be_== (List(1)) and contain oneOf (1, 3, 4))
+        atMost (2, lists) should (be_== (List(1)) and contain oneOf (2, 3, 4))
+        no (lists) should (be_== (List(8)) and contain oneOf (3, 4, 5))
+        no (nils) should (be_== (List(8)) and contain oneOf (1, 3, 4))
+        no (listsNil) should (be_== (List(8)) and contain oneOf (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1)) and contain oneOf (1, 3, 4))
+          all (lists) should (be_== (List(1)) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (List(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + FailureMessages("didNotContainOneOfElements", List(1), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain oneOf ("ho", "hey", "howdy"))
+          all (nils) should (be_== (List("hey")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List()) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain oneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (List("hi")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", List("hi"), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(1)) and contain oneOf (1, 3, Nil))
+          all (listsNil) should (be_== (List(1)) and contain oneOf (1, 3, Nil))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(List()) + " was not equal to " + decorateToStringValue(List(1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1)) and contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (List(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", but " + FailureMessages("didNotContainOneOfElements", List(1), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -579,35 +579,35 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi")) and contain oneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("ho")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("hi")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", but " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) and contain oneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(1)) and contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -693,28 +693,28 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain oneOf (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain oneOf (8, 3, 4))
-        atMost (2, lists) should (not be (List(3)) and contain oneOf (5, 3, 4))
-        no (list1s) should (not be (List(1)) and not contain oneOf (2, 1, 5))
+        all (list1s) should (not be_== (List(2)) and not contain oneOf (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain oneOf (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(3)) and contain oneOf (5, 3, 4))
+        no (list1s) should (not be_== (List(1)) and not contain oneOf (2, 1, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2)) and not contain oneOf (2, 3, 4))
+          all (lists) should (not be_== (List(2)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2)) + " was equal to " + decorateToStringValue(List(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain oneOf (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + FailureMessages("containedOneOfElements", lists(2), UnquotedString("2, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain oneOf ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi")) and not contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "hello"))
+          all (hiLists) should (not be_== (List("ho")) and not contain oneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -722,35 +722,35 @@ class ListShouldContainOneOfLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("ho")) and not contain oneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("hi")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("ho")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " +  FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain oneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) and not contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -166,40 +166,40 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain oneOf("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain oneOf("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
-        fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
+          fumList should (be_== (toList) or (contain oneOf ("fie", "fee", "fum", "foe")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -210,40 +210,40 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (contain oneOf (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain oneOf("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))
+          fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOneOfElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -349,32 +349,32 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
-        fumList should (not be (toList) or not contain oneOf("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain oneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))
-        fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
-        fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -382,7 +382,7 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -467,12 +467,12 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1)) or contain oneOf (1, 3, 4))
-        all (list1s) should (be (List(2)) or contain oneOf (1, 3, 4))
-        all (list1s) should (be (List(1)) or contain oneOf (2, 3, 4))
+        all (list1s) should (be_== (List(1)) or contain oneOf (1, 3, 4))
+        all (list1s) should (be_== (List(2)) or contain oneOf (1, 3, 4))
+        all (list1s) should (be_== (List(1)) or contain oneOf (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2)) or contain oneOf (2, 3, 8))
+          all (list1s) should (be_== (List(2)) or contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was not equal to " + decorateToStringValue(List(2)) + ", and " + FailureMessages("didNotContainOneOfElements", list1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -480,30 +480,30 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))
-        all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))
-        all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))
+        all (hiLists) should (be_== (List("hi")) or contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("ho")) or contain oneOf ("HI", "HE"))
+        all (hiLists) should (be_== (List("hi")) or contain oneOf ("hi", "he"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))
+          all (hiLists) should (be_== (List("ho")) or contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was not equal to " + decorateToStringValue(List("ho")) + ", and " + FailureMessages("didNotContainOneOfElements", hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(1)) or contain oneOf (3, 2, 2, 1))
+          all (list1s) should (be_== (List(1)) or contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -568,12 +568,12 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain oneOf (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain oneOf (8, 3, 4))
-        all (list1s) should (not be (List(1)) or not contain oneOf (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain oneOf (8, 3, 1))
+        all (list1s) should (not be_== (List(2)) or not contain oneOf (8, 3, 4))
+        all (list1s) should (not be_== (List(1)) or not contain oneOf (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain oneOf (8, 3, 1))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1)) or not contain oneOf (2, 3, 1))
+          all (list1s) should (not be_== (List(1)) or not contain oneOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1)) + " was equal to " + decorateToStringValue(List(1)) + ", and " + FailureMessages("containedOneOfElements", list1s(0), UnquotedString("2, 3, 1")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -581,30 +581,30 @@ class ListShouldContainOneOfLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))
-        all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))
-        all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))
+        all (hiLists) should (not be_== (List("ho")) or not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("hi")) or not contain oneOf ("hi", "he"))
+        all (hiLists) should (not be_== (List("ho")) or not contain oneOf ("HI", "HE"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))
+          all (hiLists) should (not be_== (List("hi")) or not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi")) + " was equal to " + decorateToStringValue(List("hi")) + ", and " + FailureMessages("containedOneOfElements", hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain oneOf (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) or not contain oneOf (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -190,46 +190,46 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain only ("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain only ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain only ("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain only ("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -238,7 +238,7 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain only Vector("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain only Vector("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Vector("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
@@ -247,46 +247,46 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (contain only (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain only ("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -295,7 +295,7 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only Vector("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain only Vector("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Vector("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
@@ -429,46 +429,46 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) and not contain only ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain only ("happy", "birthday", "to", "you"))
+          fumList should (not be_== (fumList) and not contain only ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain only ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (toList) and not contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
+          fumList should (not be_== (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain only ("FIE", "FEE", "FUM", "FOE")))
+          fumList should (not be_== (toList) and (not contain only ("FIE", "FEE", "FUM", "FOE")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -477,7 +477,7 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          Vector(Vector("fee", "fie", "foe", "fum")) should (not be (toList) and not contain only (Vector("fee", "fie", "foe", "fum")))
+          Vector(Vector("fee", "fie", "foe", "fum")) should (not be_== (toList) and not contain only (Vector("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(toList)) + ", but " + Resources("containedOnlyElementsWithFriendlyReminder", decorateToStringValue(Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(Vector("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
@@ -588,40 +588,40 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
-        atLeast (2, lists) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
-        atMost (2, lists) should (be (List(3, 2, 1)) and contain only (2, 3, 1))
-        no (lists) should (be (List(3, 6, 9)) and contain only (3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain only (1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain only (3, 4, 5))
+        all (list1s) should (be_== (List(3, 2, 1)) and contain only (1, 3, 2))
+        atLeast (2, lists) should (be_== (List(3, 2, 1)) and contain only (1, 3, 2))
+        atMost (2, lists) should (be_== (List(3, 2, 1)) and contain only (2, 3, 1))
+        no (lists) should (be_== (List(3, 6, 9)) and contain only (3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain only (1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain only (3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
+          all (lists) should (be_== (List(3, 2, 1)) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain only (2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", but " + decorateToStringValue(List(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain only ("hello", "hi"))
+          all (nils) should (be_== (List("hey")) and contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain only ("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
+          all (listsNil) should (be_== (List(3, 2, 1)) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List(3, 2, 1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain only (2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", but " + decorateToStringValue(List(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -629,35 +629,35 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) and contain only ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain only ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain only (3, 2, 2, 1))
+          all (list1s) should (be_== (List(3, 2, 1)) and contain only (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -666,17 +666,17 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector(3, 2, 1)))) should (be (Vector(Vector(3, 2, 1))) and contain only Vector(2, 3, 8))
+          all (Vector(Vector(Vector(3, 2, 1)))) should (be_== (Vector(Vector(3, 2, 1))) and contain only Vector(2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Vector(Vector(3, 2, 1))) + " was equal to " + decorateToStringValue(Vector(Vector(3, 2, 1))) + ", but " + decorateToStringValue(Vector(Vector(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Vector(2, 3, 8)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector("hi", "hello")))) should (be (Vector(Vector("hi", "hello"))) and contain only Vector("ho", "hey", "howdy"))
+          all (Vector(Vector(Vector("hi", "hello")))) should (be_== (Vector(Vector("hi", "hello"))) and contain only Vector("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Vector(Vector("hi", "hello"))) + " was equal to " + decorateToStringValue(Vector(Vector("hi", "hello"))) + ", but " + decorateToStringValue(Vector(Vector("hi", "hello"))) + " did not contain only (" + decorateToStringValue(Vector("ho", "hey", "howdy")) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector("hi", "hello")))), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector(3, 2, 1)))) should (be (Vector(Vector(3, 2, 1))) and contain only Vector(2, 3, 8))
+          all (Vector(Vector(Vector(3, 2, 1)))) should (be_== (Vector(Vector(3, 2, 1))) and contain only Vector(2, 3, 8))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Vector(Vector(3, 2, 1))) + " was equal to " + decorateToStringValue(Vector(Vector(3, 2, 1))) + ", but " + decorateToStringValue(Vector(Vector(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Vector(2, 3, 8)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
       }
@@ -782,28 +782,28 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain only (8, 3, 4))
-        atLeast (2, lists) should (not be (List(3)) and not contain only (8, 3, 4))
-        atMost (2, lists) should (not be (List(4, 3, 2)) and not contain only (3, 4, 2))
-        no (list1s) should (not be (List(3, 2, 1)) and not contain only (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) and not contain only (8, 3, 4))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain only (8, 3, 4))
+        atMost (2, lists) should (not be_== (List(4, 3, 2)) and not contain only (3, 4, 2))
+        no (list1s) should (not be_== (List(3, 2, 1)) and not contain only (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(4, 3, 2)) and not contain only (8, 3, 4))
+          all (lists) should (not be_== (List(4, 3, 2)) and not contain only (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was equal to " + decorateToStringValue(List(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain only (2, 3, 4))
+          all (lists) should (not be_== (List(3)) and not contain only (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(4, 3, 2)) + " contained only " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain only ("ho", "hey", "howdy"))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain only ("hello", "hi"))
+          all (hiLists) should (not be_== (List("ho")) and not contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -811,35 +811,35 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))
+        all (hiLists) should (not be_== (List("ho")) and not contain only ("HO", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))
+          all (hiLists) should (not be_== (List("ho")) and not contain only ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) and not contain only (3, 2, 2, 1))
+          all (list1s) should (not be_== (List(2)) and not contain only (3, 2, 2, 1))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -848,12 +848,12 @@ class ListShouldContainOnlyLogicalAndSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector(3, 2, 1)))) should (not be (List(3)) and not contain only (Vector(3, 2, 1)))
+          all (Vector(Vector(Vector(3, 2, 1)))) should (not be_== (List(3)) and not contain only (Vector(3, 2, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Vector(Vector(3, 2, 1))) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(Vector(Vector(3, 2, 1))) + " contained only (" + decorateToStringValue(Vector(3, 2, 1)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector("hi", "hello")))) should (not be (List("ho")) and not contain only (Vector("hi", "hello")))
+          all (Vector(Vector(Vector("hi", "hello")))) should (not be_== (List("ho")) and not contain only (Vector("hi", "hello")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(Vector(Vector("hi", "hello"))) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(Vector(Vector("hi", "hello"))) + " contained only (" + decorateToStringValue(Vector("hi", "hello")) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector("hi", "hello")))), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -174,40 +174,40 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain only ("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain only ("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain only ("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain only ("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain only ("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain only ("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fie\", \"fee\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain only ("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (be_== (fumList) or contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -216,7 +216,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain only Vector("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain only Vector("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Vector("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
       }
@@ -225,40 +225,40 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (contain only (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain only ("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain only ("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain only ("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain only ("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain only ("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain only ("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or be (fumList))
+          fumList should (contain only ("fee", "fie", "foe", "fie", "fum") or be_== (fumList))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -267,7 +267,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          fumList should (contain only Vector("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain only Vector("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainOnlyElementsWithFriendlyReminder", decorateToStringValue(fumList), decorateToStringValue(Vector("fee", "fie", "foe", "fam"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
@@ -385,40 +385,40 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain only ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (fumList) or not contain only ("fie", "fee", "fuu", "foe"))
-        fumList should (not be (toList) or not contain only ("fee", "fie", "foe", "fum"))
+        fumList should (not be_== (toList) or not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (fumList) or not contain only ("fie", "fee", "fuu", "foe"))
+        fumList should (not be_== (toList) or not contain only ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain only ("fee", "fie", "foe", "fum"))
+          fumList should (not be_== (fumList) or not contain only ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
-        fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))
+        fumList should (not be_== (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))
+        fumList should (not be_== (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain only ("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) or (not contain only ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedOnlyElements", decorateToStringValue(fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (not be (toList) or not contain only ("fee", "fie", "foe", "fie", "fum"))
+          fumList should (not be_== (toList) or not contain only ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -427,7 +427,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          Vector(Vector("fee", "fie", "foe", "fum")) should (not be (Vector(Vector("fee", "fie", "foe", "fum"))) or not contain only (Vector("fee", "fie", "foe", "fum")))
+          Vector(Vector("fee", "fie", "foe", "fum")) should (not be_== (Vector(Vector("fee", "fie", "foe", "fum"))) or not contain only (Vector("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(Vector(Vector("fee", "fie", "foe", "fum")))) + ", and " + Resources("containedOnlyElementsWithFriendlyReminder", decorateToStringValue(Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(Vector("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
@@ -517,12 +517,12 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain only (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1)) or contain only (1, 2, 3))
-        all (list1s) should (be (List(2, 3, 4)) or contain only (1, 2, 3))
-        all (list1s) should (be (List(3, 2, 1)) or contain only (2, 3, 4))
+        all (list1s) should (be_== (List(3, 2, 1)) or contain only (1, 2, 3))
+        all (list1s) should (be_== (List(2, 3, 4)) or contain only (1, 2, 3))
+        all (list1s) should (be_== (List(3, 2, 1)) or contain only (2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3, 4)) or contain only (2, 3, 4))
+          all (list1s) should (be_== (List(2, 3, 4)) or contain only (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(List(3, 2, 1)) + " did not contain only " + "(2, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -530,30 +530,30 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))
-        all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))
-        all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain only ("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain only ("HELLO", "HO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain only ("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1)) or contain only (1, 2, 2, 3))
+          all (list1s) should (be_== (List(3, 2, 1)) or contain only (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -562,7 +562,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector(3, 2, 1)))) should (be (List(2, 3, 4)) or contain only Vector(2, 3, 4))
+          all (Vector(Vector(Vector(3, 2, 1)))) should (be_== (List(2, 3, 4)) or contain only Vector(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Vector(Vector(3, 2, 1))) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(Vector(Vector(3, 2, 1))) + " did not contain only (" + decorateToStringValue(Vector(2, 3, 4)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
       }
@@ -632,12 +632,12 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain only (...))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain only (8, 3, 4))
-        all (list1s) should (not be (List(3, 2, 1)) or not contain only (8, 3, 4))
-        all (list1s) should (not be (List(2)) or not contain only (1, 2, 3))
+        all (list1s) should (not be_== (List(2)) or not contain only (8, 3, 4))
+        all (list1s) should (not be_== (List(3, 2, 1)) or not contain only (8, 3, 4))
+        all (list1s) should (not be_== (List(2)) or not contain only (1, 2, 3))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(3, 2, 1)) or not contain only (2, 3, 1))
+          all (list1s) should (not be_== (List(3, 2, 1)) or not contain only (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", and " + decorateToStringValue(List(3, 2, 1)) + " contained only " + "(2, 3, 1)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -645,30 +645,30 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain only ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hello", "hi")) or not contain only ("HELLO", "HO"))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain only ("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))
+          all (hiLists) should (not be_== (List("hi", "hello")) or not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (not be (List(2)) or not contain only (1, 2, 2, 3))
+          all (list1s) should (not be_== (List(2)) or not contain only (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -684,7 +684,7 @@ class ListShouldContainOnlyLogicalOrSpec extends Spec {
 
       def `should throw TFE with friendly reminder when single GenTraversable argument is passed and failed` {
         val e1 = intercept[TestFailedException] {
-          all (Vector(Vector(Vector(3, 2, 1)))) should (not be (Vector(Vector(3, 2, 1))) or not contain only (Vector(3, 2, 1)))
+          all (Vector(Vector(Vector(3, 2, 1)))) should (not be_== (Vector(Vector(3, 2, 1))) or not contain only (Vector(3, 2, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(Vector(Vector(3, 2, 1))) + " was equal to " + decorateToStringValue(Vector(Vector(3, 2, 1))) + ", and " + decorateToStringValue(Vector(Vector(3, 2, 1))) + " contained only (" + decorateToStringValue(Vector(3, 2, 1)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -147,82 +147,82 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) and contain theSameElementsAs Set("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
+          fumList should (be_== (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
+          fumList should (be_== (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
+          fumList should (be_== (fumList) and (contain theSameElementsAs Set("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsAs (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and be (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and be (fumList))
+          fumList should (contain theSameElementsAs Set("happy", "birthday", "to", "you") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (toList))
+          fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain theSameElementsAs Set("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
     
@@ -311,38 +311,38 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsAs (Set("happy", "birthday", "to", "you")))
+          fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("happy", "birthday", "to", "you")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (toList) and not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
+        fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
+          fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE"))))
+          fumList should (not be_== (toList) and (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE"))))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -428,40 +428,40 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
-        atLeast (2, lists) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
-        atMost (2, lists) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 1))
-        no (lists) should (be (List(3, 6, 9)) and contain theSameElementsAs Set(3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain theSameElementsAs Set(1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain theSameElementsAs Set(3, 4, 5))
+        all (list1s) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+        atLeast (2, lists) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+        atMost (2, lists) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 1))
+        no (lists) should (be_== (List(3, 6, 9)) and contain theSameElementsAs Set(3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain theSameElementsAs Set(1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain theSameElementsAs Set(3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+          all (lists) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", but " + decorateToStringValue(List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain theSameElementsAs Set("hello", "hi"))
+          all (nils) should (be_== (List("hey")) and contain theSameElementsAs Set("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("ho", "hey", "howdy"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsAs Set("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("ho", "hey", "howdy")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
+          all (listsNil) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(Nil) + " was not equal to " + decorateToStringValue(List(3, 2, 1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
+          all (list1s) should (be_== (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", but " + decorateToStringValue(List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -469,28 +469,28 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -558,28 +558,28 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain theSameElementsAs (Set(8, 3, 4)))
-        atLeast (2, lists) should (not be (List(3)) and not contain theSameElementsAs (Set(8, 3, 4)))
-        atMost (2, lists) should (not be (List(4, 3, 2)) and not contain theSameElementsAs (Set(3, 4, 2)))
-        no (list1s) should (not be (List(3, 2, 1)) and not contain theSameElementsAs (Set(1, 2, 3)))
+        all (list1s) should (not be_== (List(2)) and not contain theSameElementsAs (Set(8, 3, 4)))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain theSameElementsAs (Set(8, 3, 4)))
+        atMost (2, lists) should (not be_== (List(4, 3, 2)) and not contain theSameElementsAs (Set(3, 4, 2)))
+        no (list1s) should (not be_== (List(3, 2, 1)) and not contain theSameElementsAs (Set(1, 2, 3)))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(4, 3, 2)) and not contain theSameElementsAs (Set(8, 3, 4)))
+          all (lists) should (not be_== (List(4, 3, 2)) and not contain theSameElementsAs (Set(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was equal to " + decorateToStringValue(List(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain theSameElementsAs (Set(2, 3, 4)))
+          all (lists) should (not be_== (List(3)) and not contain theSameElementsAs (Set(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(List(4, 3, 2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(4, 3, 2)) + " contained the same elements as " + decorateToStringValue(Set(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("hello", "hi")))
+          all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsAs (Set("hello", "hi")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -587,28 +587,28 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))
+        all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))
+          all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -135,70 +135,70 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
-        fumList should (be (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (toList) or contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
+          fumList should (be_== (toList) or contain theSameElementsAs Set("fie", "fee", "fam", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fie", "fee", "fam", "foe"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
-        fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))
+        fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
+          fumList should (be_== (toList) or (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsAs (..) and be (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or be (fumList))
-        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be (toList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fam", "foe") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or be (toList))
+          fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fam") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fam"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))
-        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be_== (fumList))
+        fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))
+          fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
     
@@ -275,32 +275,32 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (not be (..) and not contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
-        fumList should (not be (fumList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
-        fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
-        fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
+        fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))
+        fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM"))))
+          fumList should (not be_== (fumList) or (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM"))))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElements", decorateToStringValue(fumList), decorateToStringValue(Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -368,12 +368,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (be (..) and contain theSameElementsAs (..))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(3, 2, 1)) or contain theSameElementsAs Set(1, 2, 3))
-        all (list1s) should (be (List(2, 3, 4)) or contain theSameElementsAs Set(1, 2, 3))
-        all (list1s) should (be (List(3, 2, 1)) or contain theSameElementsAs Set(2, 3, 4))
+        all (list1s) should (be_== (List(3, 2, 1)) or contain theSameElementsAs Set(1, 2, 3))
+        all (list1s) should (be_== (List(2, 3, 4)) or contain theSameElementsAs Set(1, 2, 3))
+        all (list1s) should (be_== (List(3, 2, 1)) or contain theSameElementsAs Set(2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3, 4)) or contain theSameElementsAs Set(2, 3, 4))
+          all (list1s) should (be_== (List(2, 3, 4)) or contain theSameElementsAs Set(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(Set(2, 3, 4)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -381,23 +381,23 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
-        all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
-        all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -444,12 +444,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
     object `when used with (not be (...) and not contain theSameElementsAs (...))` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) or not contain theSameElementsAs (Set(8, 3, 4)))
-        all (list1s) should (not be (List(3, 2, 1)) or not contain theSameElementsAs (Set(8, 3, 4)))
-        all (list1s) should (not be (List(2)) or not contain theSameElementsAs (Set(1, 2, 3)))
+        all (list1s) should (not be_== (List(2)) or not contain theSameElementsAs (Set(8, 3, 4)))
+        all (list1s) should (not be_== (List(3, 2, 1)) or not contain theSameElementsAs (Set(8, 3, 4)))
+        all (list1s) should (not be_== (List(2)) or not contain theSameElementsAs (Set(1, 2, 3)))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(3, 2, 1)) or not contain theSameElementsAs (Set(2, 3, 1)))
+          all (list1s) should (not be_== (List(3, 2, 1)) or not contain theSameElementsAs (Set(2, 3, 1)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(3, 2, 1)) + " was equal to " + decorateToStringValue(List(3, 2, 1)) + ", and " + decorateToStringValue(List(3, 2, 1)) + " contained the same elements as " + decorateToStringValue(Set(2, 3, 1)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -457,23 +457,23 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))
-        all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))
+        all (hiLists) should (not be_== (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))
+          all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -148,82 +148,82 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (be xx and contain theSameElementsInOrderAs xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+          fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+          fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (be (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (fumList) and (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", but " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) and contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) and contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
     object `when used with (contain theSameElementsInOrderAs xx and be xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and be (fumList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") and be_== (fumList))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (fumList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (be (fumList)))
+          fumList should (contain theSameElementsInOrderAs LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU") and (be_== (fumList)))
         }
         checkMessageStackDepth(e2, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") and be_== (fumList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") and be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") and be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
     
@@ -310,38 +310,38 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain theSameElementsInOrderAs xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+          fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+          fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))), fileName, thisLineNumber - 2)
       }
       
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          fumList should (not be (toList) and (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
+          fumList should (not be_== (toList) and (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (toList) and not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", but " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) and not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsInOrderAs (LinkedList(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (LinkedList(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -427,40 +427,40 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (be xx and contain theSameElementsInOrderAs xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        atLeast (2, lists) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        atMost (2, lists) should (be (List(3, 2, 1)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        no (lists) should (be (List(3, 6, 9)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
-        no (nils) should (be (List(1, 6, 8)) and contain theSameElementsInOrderAs LinkedList(1, 3, 4))
-        no (listsNil) should (be (List(2, 6, 8)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
+        all (list1s) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        atLeast (2, lists) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        atMost (2, lists) should (be_== (List(3, 2, 1)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        no (lists) should (be_== (List(3, 6, 9)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
+        no (nils) should (be_== (List(1, 6, 8)) and contain theSameElementsInOrderAs LinkedList(1, 3, 4))
+        no (listsNil) should (be_== (List(2, 6, 8)) and contain theSameElementsInOrderAs LinkedList(3, 4, 5))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+          all (lists) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(List(2, 3, 4)) + " was not equal to " + decorateToStringValue(List(1, 2, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
+          all (list1s) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List(1, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 3)) + ", but " + decorateToStringValue(List(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (nils) should (be (List("hey")) and contain theSameElementsInOrderAs LinkedList("hi", "hello"))
+          all (nils) should (be_== (List("hey")) and contain theSameElementsInOrderAs LinkedList("hi", "hello"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(nils(0)) + " was not equal to " + decorateToStringValue(List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("hello", "hi"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e5 = intercept[TestFailedException] {
-          all (listsNil) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+          all (listsNil) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(1, 2, 3))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(listsNil(2)) + " was not equal to " + decorateToStringValue(List(1, 2, 3)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
         
         val e6 = intercept[TestFailedException] {
-          all (list1s) should (be (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
+          all (list1s) should (be_== (List(1, 2, 3)) and contain theSameElementsInOrderAs LinkedList(2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(List(1, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 3)) + ", but " + decorateToStringValue(List(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -468,28 +468,28 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+          all (hiLists) should (be_== (List("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+          all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("HI", "HELLO")) and contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("hi", "hello")) and contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", but " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -557,28 +557,28 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
     object `when used with (not be xx and not contain theSameElementsInOrderAs xx)` {
       
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (list1s) should (not be (List(2)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        atLeast (2, lists) should (not be (List(3)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        atMost (2, lists) should (not be (List(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
-        no (list1s) should (not be (List(1, 2, 3)) and not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+        all (list1s) should (not be_== (List(2)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        atLeast (2, lists) should (not be_== (List(3)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        atMost (2, lists) should (not be_== (List(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
+        no (list1s) should (not be_== (List(1, 2, 3)) and not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
         
         val e1 = intercept[TestFailedException] {
-          all (lists) should (not be (List(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+          all (lists) should (not be_== (List(2, 3, 4)) and not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(lists(2)) + " was equal to " + decorateToStringValue(List(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (lists) should (not be (List(3)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
+          all (lists) should (not be_== (List(3)) and not contain theSameElementsInOrderAs (LinkedList(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(lists(2)) + " was not equal to " + decorateToStringValue(List(3)) + ", but " + decorateToStringValue(List(2, 3, 4)) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
         
         val e3 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("ho", "hey", "howdy")))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("hi", "hello")))
+          all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("hi", "hello")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(hiLists(0)) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -586,28 +586,28 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends Spec {
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))
+        all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))
+          all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+          all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       def `should use an explicitly provided Equality` {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HO", "HELLO")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) and not contain theSameElementsInOrderAs (LinkedList("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("ho")) and not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho")) + ", but " + decorateToStringValue(List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -136,70 +136,70 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (be xx and contain theSameElementsInOrderAs xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
+          fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
-        fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))
+        fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
-          fumList should (be (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
+          fumList should (be_== (toList) or (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be_== (toList) or contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)) + ", and " + Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be_== (fumList) or contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
       }
     }
 
     "when used with (contain theSameElementsInOrderAs xx and be xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("fum", "foe", "fie", "fee") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("fee", "fie", "foe", "fum") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fee", "fie", "foe", "fum"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))
-        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (fumList))
+        fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (toList))
         val e1 = intercept[TestFailedException] {
-          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))
+          fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (toList))
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs LinkedList("FUM", "FOE", "FIE", "FEE") or be_== (toList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs LinkedList("FEE", "FIE", "FOE", "FUM") or be_== (toList))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("didNotContainSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources("wasNotEqualTo", decorateToStringValue(fumList), decorateToStringValue(toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs LinkedList(" FUM ", " FOE ", " FIE ", " FEE ") or be_== (fumList))) (after being lowerCased and trimmed)
       }
     }
     
@@ -274,32 +274,32 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (not be xx and not contain theSameElementsInOrderAs xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
-        fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("fee", "fie", "foe", "fum")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
+          fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("fum", "foe", "fie", "fee")))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("fum", "foe", "fie", "fee"))), fileName, thisLineNumber - 2)
       }
       
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
-        fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
-        fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))
+        fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))
         val e1 = intercept[TestFailedException] {
-          fumList should (not be (fumList) or (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
+          fumList should (not be_== (fumList) or (not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE"))))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be_== (toList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be_== (fumList) or not contain theSameElementsInOrderAs (LinkedList("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(fumList), decorateToStringValue(fumList)) + ", and " + Resources("containedSameElementsInOrder", decorateToStringValue(fumList), decorateToStringValue(LinkedList("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
@@ -367,12 +367,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (be xx and contain theSameElementsInOrderAs xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (be (List(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        all (list1s) should (be (List(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
-        all (list1s) should (be (List(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
+        all (list1s) should (be_== (List(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        all (list1s) should (be_== (List(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(1, 2, 3))
+        all (list1s) should (be_== (List(1, 2, 3)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (be (List(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
+          all (list1s) should (be_== (List(2, 3, 4)) or contain theSameElementsInOrderAs LinkedList(2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1, 2, 3)) + " was not equal to " + decorateToStringValue(List(2, 3, 4)) + ", and " + decorateToStringValue(List(1, 2, 3)) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(2, 3, 4)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -380,23 +380,23 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
-        all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
-        all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))
+        all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
+          all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be_== (List("hi", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be_== (List("ho", "hello")) or contain theSameElementsInOrderAs LinkedList("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was not equal to " + decorateToStringValue(List("ho", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -443,12 +443,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
     "when used with (not be xx and not contain theSameElementsInOrderAs xx)" - {
       
       "should do nothing if valid, else throw a TFE with an appropriate error message" in {
-        all (list1s) should (not be (List(2)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        all (list1s) should (not be (List(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
-        all (list1s) should (not be (List(2)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+        all (list1s) should (not be_== (List(2)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        all (list1s) should (not be_== (List(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(8, 3, 4)))
+        all (list1s) should (not be_== (List(2)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
         
         val e1 = intercept[TestFailedException] {
-          all (list1s) should (not be (List(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
+          all (list1s) should (not be_== (List(1, 2, 3)) or not contain theSameElementsInOrderAs (LinkedList(1, 2, 3)))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List(1, 2, 3)) + " was equal to " + decorateToStringValue(List(1, 2, 3)) + ", and " + decorateToStringValue(List(1, 2, 3)) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList(1, 2, 3)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
@@ -456,23 +456,23 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends FreeSpec {
       "should use the implicit Equality in scope" in {
         implicit val ise = upperCaseStringEquality
         
-        all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
-        all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
-        all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
+        all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))
+        all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
         
         val e1 = intercept[TestFailedException] {
-          all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
+          all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HELLO", "HO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be_== (List("hello", "ho")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be_== (List("hi", "hello")) or not contain theSameElementsInOrderAs (LinkedList("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(List("hi", "hello")) + " was equal to " + decorateToStringValue(List("hi", "hello")) + ", and " + decorateToStringValue(List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(LinkedList("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
@@ -103,49 +103,49 @@ class OptionShouldContainOneOfLogicalAndSpec extends FunSpec {
     describe("when used with (be (...) and contain oneOf (...))") {
 
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
-        fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))
+        fumSome should (be_== (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))
         
         val e1 = intercept[TestFailedException] {
-          fumSome should (be (toSome) and contain oneOf ("fee", "fie", "foe", "fum"))
+          fumSome should (be_== (toSome) and contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          fumSome should (be (fumSome) and contain oneOf ("happy", "birthday", "to", "you"))
+          fumSome should (be_== (fumSome) and contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumSome), decorateToStringValue(fumSome)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         
-        fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+        fumSome should (be_== (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         
         val e1 = intercept[TestFailedException] {
-          fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
+          fumSome should (be_== (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))
+          fumSome should (be_== (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumSome), decorateToStringValue(fumSome)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumSome should (be_== (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumSome should (be_== (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be_== (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(fumSome), decorateToStringValue(fumSome)) + ", but " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          fumSome should (be_== (fumSome) and contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -217,43 +217,43 @@ class OptionShouldContainOneOfLogicalAndSpec extends FunSpec {
     describe("when used with (not be (...) and not contain oneOf (...))") {
 
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
-        toSome should (not be (fumSome) and not contain oneOf ("fee", "fie", "fum", "foe"))
+        toSome should (not be_== (fumSome) and not contain oneOf ("fee", "fie", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
-          toSome should (not be (toSome) and not contain oneOf ("fee", "fie", "foe", "fum"))
+          toSome should (not be_== (toSome) and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))
+          toSome should (not be_== (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(toSome), decorateToStringValue(fumSome)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))
+        toSome should (not be_== (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))
         val e1 = intercept[TestFailedException] {
-          toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))
+          toSome should (not be_== (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+          toSome should (not be_== (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(toSome), decorateToStringValue(fumSome)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (toSome should (not be_== (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (toSome should (not be_== (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toSome should (not be_== (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources("wasNotEqualTo", decorateToStringValue(toSome), decorateToStringValue(fumSome)) + ", but " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
-          toSome should (not be (fumSome) and not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          toSome should (not be_== (fumSome) and not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -352,62 +352,62 @@ class OptionShouldContainOneOfLogicalAndSpec extends FunSpec {
     describe("when used with (be (...) and contain oneOf (...))") {
 
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
-        all (some1s) should (be (Some(1)) and contain oneOf (1, 6, 8))
-        atLeast (2, somes) should (be (Some(1)) and contain oneOf (1, 6, 8)) 
-        atMost (2, somes) should (be (Some(1)) and contain oneOf (2, 6, 8))
-        no (somes) should (be (Some(3)) and contain oneOf (7, 8, 9))
+        all (some1s) should (be_== (Some(1)) and contain oneOf (1, 6, 8))
+        atLeast (2, somes) should (be_== (Some(1)) and contain oneOf (1, 6, 8))
+        atMost (2, somes) should (be_== (Some(1)) and contain oneOf (2, 6, 8))
+        no (somes) should (be_== (Some(3)) and contain oneOf (7, 8, 9))
 
         val e1 = intercept[TestFailedException] {
-          all (somes) should (be (Some(1)) and contain oneOf (1, 2, 8)) 
+          all (somes) should (be_== (Some(1)) and contain oneOf (1, 2, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(2, "Some(2) was not equal to Some(1)", thisLineNumber - 2, somes), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          all (some1s) should (be (Some(1)) and contain oneOf (2, 3, 8)) 
+          all (some1s) should (be_== (Some(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(1) was equal to Some(1), but " + FailureMessages("didNotContainOneOfElements", some1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, some1s), fileName, thisLineNumber - 2)
 
         val e3 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("hei")) and contain oneOf ("ho", "hi", "howdy"))
+          all (hiSomes) should (be_== (Some("hei")) and contain oneOf ("ho", "hi", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"hei\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         
         val e4 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("hi")) and contain oneOf ("ho", "hey", "howdy"))
+          all (hiSomes) should (be_== (Some("hi")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
 
       it("should use the implicit Equality in scope") {
-        all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))
+        all (hiSomes) should (be_== (Some("hi")) and contain oneOf ("hi", "he"))
         intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))
+          all (hiSomes) should (be_== (Some("ho")) and contain oneOf ("HI", "HE"))
         }
         implicit val ise = upperCaseStringEquality
         all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))
         val e1 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))
+          all (hiSomes) should (be_== (Some("ho")) and contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))
+          all (hiSomes) should (be_== (Some("hi")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be_== (Some("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be_== (Some("ho")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be_== (Some("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (some1s) should (be (Some(1)) and contain oneOf (1, 2, 2, 3))
+          all (some1s) should (be_== (Some(1)) and contain oneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -471,42 +471,42 @@ class OptionShouldContainOneOfLogicalAndSpec extends FunSpec {
     describe("when used with (not be (...) and not contain oneOf (...))") {
 
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
-        all (toSomes) should (not be (Some("fee")) and not contain oneOf ("have", "a", "nice", "day"))
+        all (toSomes) should (not be_== (Some("fee")) and not contain oneOf ("have", "a", "nice", "day"))
         val e1 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("to")) and not contain oneOf ("have", "a", "nice", "day"))
+          all (toSomes) should (not be_== (Some("to")) and not contain oneOf ("have", "a", "nice", "day"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("nice")) and not contain oneOf ("happy", "birthday", "to", "you"))
+          all (toSomes) should (not be_== (Some("nice")) and not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"nice\"), but " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))
+        all (toSomes) should (not be_== (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))
         val e1 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))
+          all (toSomes) should (not be_== (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("hi")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+          all (toSomes) should (not be_== (Some("hi")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"hi\"), but " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be_== (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be_== (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be_== (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"he\"), but " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (toSomes) should (not be (Some("fee")) and not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          all (toSomes) should (not be_== (Some("fee")) and not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
@@ -94,40 +94,40 @@ class OptionShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (...) or contain oneOf (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))
-        fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))
-        fumSome should (be (fumSome) or contain oneOf ("happy", "birthday", "to", "you"))
+        fumSome should (be_== (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))
+        fumSome should (be_== (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))
+        fumSome should (be_== (fumSome) or contain oneOf ("happy", "birthday", "to", "you"))
         
         val e1 = intercept[TestFailedException] {
-          fumSome should (be (toSome) or contain oneOf ("happy", "birthday", "to", "you"))
+          fumSome should (be_== (toSome) or contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
         
-        fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))
-        fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))
-        fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))
+        fumSome should (be_== (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))
+        fumSome should (be_== (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))
+        fumSome should (be_== (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))
         
         val e1 = intercept[TestFailedException] {
-          fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))
+          fumSome should (be_== (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       def `should use an explicitly provided Equality` {
-        (fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumSome should (be_== (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumSome should (be_== (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumSome should (be_== (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be_== (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasNotEqualTo", decorateToStringValue(fumSome), decorateToStringValue(toSome)) + ", and " + Resources("didNotContainOneOfElements", decorateToStringValue(fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          fumSome should (be_== (fumSome) or contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -185,36 +185,36 @@ class OptionShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (...) or not contain oneOf (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        toSome should (not be (fumSome) or not contain oneOf ("fee", "fie", "fum", "foe"))
-        toSome should (not be (toSome) or not contain oneOf ("fee", "fie", "fum", "foe"))
-        toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))
+        toSome should (not be_== (fumSome) or not contain oneOf ("fee", "fie", "fum", "foe"))
+        toSome should (not be_== (toSome) or not contain oneOf ("fee", "fie", "fum", "foe"))
+        toSome should (not be_== (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))
         val e2 = intercept[TestFailedException] {
-          toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))
+          toSome should (not be_== (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e2, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))
-        toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))
-        toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+        toSome should (not be_== (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))
+        toSome should (not be_== (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))
+        toSome should (not be_== (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         val e1 = intercept[TestFailedException] {
-          toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+          toSome should (not be_== (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       def `should use an explicitly provided Equality` {
-        (toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (toSome should (not be_== (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (toSome should (not be_== (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (toSome should (not be_== (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toSome should (not be_== (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources("wasEqualTo", decorateToStringValue(toSome), decorateToStringValue(toSome)) + ", and " + Resources("containedOneOfElements", decorateToStringValue(toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          toSome should (not be (fumSome) or not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          toSome should (not be_== (fumSome) or not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -300,49 +300,49 @@ class OptionShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (be (...) or contain oneOf (...))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (some1s) should (be (Some(1)) or contain oneOf (1, 6, 8))
-        all (some1s) should (be (Some(2)) or contain oneOf (1, 6, 8))
-        all (some1s) should (be (Some(1)) or contain oneOf (2, 6, 8))
+        all (some1s) should (be_== (Some(1)) or contain oneOf (1, 6, 8))
+        all (some1s) should (be_== (Some(2)) or contain oneOf (1, 6, 8))
+        all (some1s) should (be_== (Some(1)) or contain oneOf (2, 6, 8))
 
         val e1 = intercept[TestFailedException] {
-          all (some1s) should (be (Some(2)) or contain oneOf (2, 3, 8)) 
+          all (some1s) should (be_== (Some(2)) or contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(1) was not equal to Some(2), and " + FailureMessages("didNotContainOneOfElements", some1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, some1s), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("to")) or contain oneOf ("ho", "hey", "howdy"))
+          all (hiSomes) should (be_== (Some("to")) or contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"to\"), and " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
 
       def `should use the implicit Equality in scope` {
-        all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))
-        all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))
-        all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))
+        all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("hi", "he"))
+        all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("HI", "HE"))
+        all (hiSomes) should (be_== (Some("he")) or contain oneOf ("hi", "he"))
         intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("ho")) or contain oneOf ("HI", "HE"))
+          all (hiSomes) should (be_== (Some("ho")) or contain oneOf ("HI", "HE"))
         }
         implicit val ise = upperCaseStringEquality
-        all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))
-        all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))
-        all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))
+        all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("HI", "HE"))
+        all (hiSomes) should (be_== (Some("he")) or contain oneOf ("HI", "HE"))
+        all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("hi", "he"))
         val e1 = intercept[TestFailedException] {
-          all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))
+          all (hiSomes) should (be_== (Some("he")) or contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
       def `should use an explicitly provided Equality` {
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be_== (Some("he")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be_== (Some("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be_== (Some("he")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages("didNotContainOneOfElements", hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (some1s) should (be (Some(1)) or contain oneOf (1, 2, 2, 3))
+          all (some1s) should (be_== (Some(1)) or contain oneOf (1, 2, 2, 3))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
@@ -400,36 +400,36 @@ class OptionShouldContainOneOfLogicalOrSpec extends Spec {
     object `when used with (not be (..) or not contain oneOf (..))` {
 
       def `should do nothing if valid, else throw a TFE with an appropriate error message` {
-        all (toSomes) should (not be (Some("fee")) or not contain oneOf ("have", "a", "nice", "day"))
-        all (toSomes) should (not be (Some("to")) or not contain oneOf ("have", "a", "nice", "day"))
-        all (toSomes) should (not be (Some("fee")) or not contain oneOf ("happy", "birthday", "to", "you"))
+        all (toSomes) should (not be_== (Some("fee")) or not contain oneOf ("have", "a", "nice", "day"))
+        all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("have", "a", "nice", "day"))
+        all (toSomes) should (not be_== (Some("fee")) or not contain oneOf ("happy", "birthday", "to", "you"))
         val e1 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))
+          all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       def `should use the implicit Equality in scope` {
         implicit val ise = upperCaseStringEquality
-        all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))
-        all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))
-        all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+        all (toSomes) should (not be_== (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))
+        all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))
+        all (toSomes) should (not be_== (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         val e1 = intercept[TestFailedException] {
-          all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
+          all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       def `should use an explicitly provided Equality` {
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be_== (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be_== (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be_== (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages("containedOneOfElements", toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       def `should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value` {
         val e1 = intercept[exceptions.NotAllowedException] {
-          all (toSomes) should (not be (Some("fee")) or not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
+          all (toSomes) should (not be_== (Some("fee")) or not contain oneOf ("fee", "fie", "foe", "fie", "fum"))
         }
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         (something should (equal (something) and be (defined))) (defaultEquality[Thing{val isDefined: Boolean}], definition)
         (something should (be (defined) and equal (something))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         
-        (something should (be (something) and be (defined))) (definition)
-        (something should (be (defined) and be (something))) (definition)
+        (something should (be_== (something) and be (defined))) (definition)
+        (something should (be (defined) and be_== (something))) (definition)
       }
       
       def `should throw TestFailedException with correct stack depth when thing is not defined` {
@@ -91,14 +91,14 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nothing should (be (nothing) and be (defined))) (definition)
+          (nothing should (be_== (nothing) and be (defined))) (definition)
         }
         assert(caught3.message === Some(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nothing should (be (defined) and be (nothing))) (definition)
+          (nothing should (be (defined) and be_== (nothing))) (definition)
         }
         assert(caught4.message === Some(wasNotDefined(nothing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         (nothing should (not equal something and not be defined)) (defaultEquality[Thing{val isDefined: Boolean}], definition)
         (nothing should (not be defined and not equal something)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         
-        (nothing should (not be something and not be defined)) (definition)
-        (nothing should (not be defined and not be something)) (definition)
+        (nothing should (not be_== something and not be defined)) (definition)
+        (nothing should (not be defined and not be_== something)) (definition)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not defined` {
@@ -132,14 +132,14 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (something should (not be nothing and not be defined)) (definition)
+          (something should (not be_== nothing and not be defined)) (definition)
         }
         assert(caught3.message === Some(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (something should (not be defined and not be nothing)) (definition)
+          (something should (not be defined and not be_== nothing)) (definition)
         }
         assert(caught4.message === Some(wasDefined(something)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (defined)'` {
       
       def `should do nothing when all(xs) is defined` {
-        (all(List(something)) should (be (something) and be (defined))) (definition)
-        (all(List(something)) should (be (defined) and be (something))) (definition)
+        (all(List(something)) should (be_== (something) and be (defined))) (definition)
+        (all(List(something)) should (be (defined) and be_== (something))) (definition)
         
         (all(List(something)) should (equal (something) and be (defined))) (defaultEquality[Thing{val isDefined: Boolean}], definition)
         (all(List(something)) should (be (defined) and equal (something))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
@@ -160,7 +160,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not defined` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (nothing) and be (defined))) (definition)
+          (all(left1) should (be_== (nothing) and be (defined))) (definition)
         }
         assert(caught1.message === Some(allError(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (defined) and be (nothing))) (definition)
+          (all(left2) should (be (defined) and be_== (nothing))) (definition)
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be defined'` {
       def `should do nothing when all(xs) is not defined` {
-        (all(List(nothing)) should (not be defined and not be something)) (definition)
-        (all(List(nothing)) should (not be something and not be defined)) (definition)
+        (all(List(nothing)) should (not be defined and not be_== something)) (definition)
+        (all(List(nothing)) should (not be_== something and not be defined)) (definition)
         
         (all(List(nothing)) should (not be defined and not equal something)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         (all(List(nothing)) should (not equal something and not be defined)) (defaultEquality[Thing{val isDefined: Boolean}], definition)
@@ -204,7 +204,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is defined` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be nothing and not be defined)) (definition)
+          (all(left1) should (not be_== nothing and not be defined)) (definition)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be defined and not be nothing)) (definition)
+          (all(left2) should (not be defined and not be_== nothing)) (definition)
         }
         assert(caught2.message === Some(allError(wasDefined(something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndImplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         something should (equal (something) and be (defined))
         something should (be (defined) and equal (something))
         
-        something should (be (something) and be (defined))
-        something should (be (defined) and be (something))
+        something should (be_== (something) and be (defined))
+        something should (be (defined) and be_== (something))
       }
       
       def `should throw TestFailedException with correct stack depth when thing is not defined` {
@@ -91,14 +91,14 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          nothing should (be (nothing) and be (defined))
+          nothing should (be_== (nothing) and be (defined))
         }
         assert(caught3.message === Some(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          nothing should (be (defined) and be (nothing))
+          nothing should (be (defined) and be_== (nothing))
         }
         assert(caught4.message === Some(wasNotDefined(nothing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         nothing should (not equal something and not be defined)
         nothing should (not be defined and not equal something)
         
-        nothing should (not be something and not be defined)
-        nothing should (not be defined and not be something)
+        nothing should (not be_== something and not be defined)
+        nothing should (not be defined and not be_== something)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not defined` {
@@ -132,14 +132,14 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          something should (not be nothing and not be defined)
+          something should (not be_== nothing and not be defined)
         }
         assert(caught3.message === Some(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          something should (not be defined and not be nothing)
+          something should (not be defined and not be_== nothing)
         }
         assert(caught4.message === Some(wasDefined(something)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (defined)'` {
       
       def `should do nothing when all(xs) is defined` {
-        all(List(something)) should (be (something) and be (defined))
-        all(List(something)) should (be (defined) and be (something))
+        all(List(something)) should (be_== (something) and be (defined))
+        all(List(something)) should (be (defined) and be_== (something))
         
         all(List(something)) should (equal (something) and be (defined))
         all(List(something)) should (be (defined) and equal (something))
@@ -160,7 +160,7 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not defined` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (nothing) and be (defined))
+          all(left1) should (be_== (nothing) and be (defined))
         }
         assert(caught1.message === Some(allError(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (defined) and be (nothing))
+          all(left2) should (be (defined) and be_== (nothing))
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be defined'` {
       def `should do nothing when all(xs) is not defined` {
-        all(List(nothing)) should (not be defined and not be something)
-        all(List(nothing)) should (not be something and not be defined)
+        all(List(nothing)) should (not be defined and not be_== something)
+        all(List(nothing)) should (not be_== something and not be defined)
         
         all(List(nothing)) should (not be defined and not equal something)
         all(List(nothing)) should (not equal something and not be defined)
@@ -204,7 +204,7 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is defined` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be nothing and not be defined)
+          all(left1) should (not be_== nothing and not be defined)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeDefinedLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be defined and not be nothing)
+          all(left2) should (not be defined and not be_== nothing)
         }
         assert(caught2.message === Some(allError(wasDefined(something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndSpec.scala
@@ -56,8 +56,8 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         something should (equal (something) and be (defined))
         something should (be (defined) and equal (something))
         
-        something should (be (something) and be (defined))
-        something should (be (defined) and be (something))
+        something should (be_== (something) and be (defined))
+        something should (be (defined) and be_== (something))
       }
       
       def `should throw TestFailedException with correct stack depth when opt is not defined` {
@@ -76,14 +76,14 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          nothing should (be (nothing) and be (defined))
+          nothing should (be_== (nothing) and be (defined))
         }
         assert(caught3.message === Some(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing)))
         assert(caught3.failedCodeFileName === Some(optName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          nothing should (be (defined) and be (nothing))
+          nothing should (be (defined) and be_== (nothing))
         }
         assert(caught4.message === Some(wasNotDefined(nothing)))
         assert(caught4.failedCodeFileName === Some(optName))
@@ -97,8 +97,8 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         nothing should (not equal something and not be defined)
         nothing should (not be defined and not equal something)
         
-        nothing should (not be something and not be defined)
-        nothing should (not be defined and not be something)
+        nothing should (not be_== something and not be defined)
+        nothing should (not be defined and not be_== something)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -117,14 +117,14 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          something should (not be nothing and not be defined)
+          something should (not be_== nothing and not be defined)
         }
         assert(caught3.message === Some(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something)))
         assert(caught3.failedCodeFileName === Some(optName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          something should (not be defined and not be nothing)
+          something should (not be defined and not be_== nothing)
         }
         assert(caught4.message === Some(wasDefined(something)))
         assert(caught4.failedCodeFileName === Some(optName))
@@ -135,8 +135,8 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
     object `when work with 'all(xs) should be (defined)'` {
       
       def `should do nothing when all(xs) is defined` {
-        all(List(something)) should (be (something) and be (defined))
-        all(List(something)) should (be (defined) and be (something))
+        all(List(something)) should (be_== (something) and be (defined))
+        all(List(something)) should (be (defined) and be_== (something))
         
         all(List(something)) should (equal (something) and be (defined))
         all(List(something)) should (be (defined) and equal (something))
@@ -145,7 +145,7 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not defined` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (nothing) and be (defined))
+          all(left1) should (be_== (nothing) and be (defined))
         }
         assert(caught1.message === Some(allError(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(optName))
@@ -153,7 +153,7 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (defined) and be (nothing))
+          all(left2) should (be (defined) and be_== (nothing))
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(optName))
@@ -179,8 +179,8 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
     
     object `when work with 'all(xs) should not be defined'` {
       def `should do nothing when all(xs) is not defined` {
-        all(List(nothing)) should (not be defined and not be something)
-        all(List(nothing)) should (not be something and not be defined)
+        all(List(nothing)) should (not be defined and not be_== something)
+        all(List(nothing)) should (not be_== something and not be defined)
         
         all(List(nothing)) should (not be defined and not equal something)
         all(List(nothing)) should (not equal something and not be defined)
@@ -189,7 +189,7 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is defined` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be nothing and not be defined)
+          all(left1) should (not be_== nothing and not be defined)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(optName))
@@ -197,7 +197,7 @@ class ShouldBeDefinedLogicalAndSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be defined and not be nothing)
+          all(left2) should (not be defined and not be_== nothing)
         }
         assert(caught2.message === Some(allError(wasDefined(something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(optName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
@@ -69,13 +69,13 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
       
       def `should do nothing when thing is defined ` {
         
-        (something should (be (defined ) or be (something))) (definition)
-        (nothing should (be (defined ) or be (nothing))) (definition)
-        (something should (be (defined ) or be (nothing))) (definition)
+        (something should (be (defined ) or be_== (something))) (definition)
+        (nothing should (be (defined ) or be_== (nothing))) (definition)
+        (something should (be (defined ) or be_== (nothing))) (definition)
         
-        (something should (be (something) or be (defined ))) (definition)
-        (something should (be (nothing) or be (defined ))) (definition)
-        (nothing should (be (nothing) or be (defined ))) (definition)
+        (something should (be_== (something) or be (defined ))) (definition)
+        (something should (be_== (nothing) or be (defined ))) (definition)
+        (nothing should (be_== (nothing) or be (defined ))) (definition)
         
         (something should (be (defined ) or equal (something))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         (nothing should (be (defined ) or equal (nothing))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
@@ -88,14 +88,14 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when thing is not defined ` {
         val caught1 = intercept[TestFailedException] {
-          (nothing should (be (defined ) or be (something))) (definition)
+          (nothing should (be (defined ) or be_== (something))) (definition)
         }
         assert(caught1.message === Some(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nothing should (be (something) or be (defined ))) (definition)
+          (nothing should (be_== (something) or be (defined ))) (definition)
         }
         assert(caught2.message === Some(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -120,13 +120,13 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
     object `when work with 'thing should not be defined '` {
       
       def `should do nothing when thing is not defined ` {
-        (nothing should (not be defined  or not be something)) (definition)
-        (something should (not be defined  or not be nothing)) (definition)
-        (nothing should (not be defined  or not be nothing)) (definition)
+        (nothing should (not be defined  or not be_== something)) (definition)
+        (something should (not be defined  or not be_== nothing)) (definition)
+        (nothing should (not be defined  or not be_== nothing)) (definition)
         
-        (nothing should (not be something or not be defined )) (definition)
-        (nothing should (not be nothing or not be defined )) (definition)
-        (something should (not be nothing or not be defined )) (definition)
+        (nothing should (not be_== something or not be defined )) (definition)
+        (nothing should (not be_== nothing or not be defined )) (definition)
+        (something should (not be_== nothing or not be defined )) (definition)
         
         (nothing should (not be defined  or not equal something)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         (something should (not be defined  or not equal nothing)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
@@ -139,14 +139,14 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when thing is defined ` {
         val caught1 = intercept[TestFailedException] {
-          (something should (not be defined  or not be something)) (definition)
+          (something should (not be defined  or not be_== something)) (definition)
         }
         assert(caught1.message === Some(wasDefined(something) + ", and " + wasEqualTo(something, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (something should (not be something or not be defined )) (definition)
+          (something should (not be_== something or not be defined )) (definition)
         }
         assert(caught2.message === Some(wasEqualTo(something, something) + ", and " + wasDefined(something)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -171,13 +171,13 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (defined )'` {
       
       def `should do nothing when all(xs) is defined ` {
-        (all(List(something)) should (be (defined ) or be (something))) (definition)
-        (all(List(nothing)) should (be (defined ) or be (nothing))) (definition)
-        (all(List(something)) should (be (defined ) or be (nothing))) (definition)
+        (all(List(something)) should (be (defined ) or be_== (something))) (definition)
+        (all(List(nothing)) should (be (defined ) or be_== (nothing))) (definition)
+        (all(List(something)) should (be (defined ) or be_== (nothing))) (definition)
         
-        (all(List(something)) should (be (something) or be (defined ))) (definition)
-        (all(List(something)) should (be (nothing) or be (defined ))) (definition)
-        (all(List(nothing)) should (be (nothing) or be (defined ))) (definition)
+        (all(List(something)) should (be_== (something) or be (defined ))) (definition)
+        (all(List(something)) should (be_== (nothing) or be (defined ))) (definition)
+        (all(List(nothing)) should (be_== (nothing) or be (defined ))) (definition)
         
         (all(List(something)) should (be (defined ) or equal (something))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         (all(List(nothing)) should (be (defined ) or equal (nothing))) (definition, defaultEquality[Thing{val isDefined: Boolean}])
@@ -191,7 +191,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not defined ` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (something) or be (defined ))) (definition)
+          (all(left1) should (be_== (something) or be (defined ))) (definition)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -199,7 +199,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (defined ) or be (something))) (definition)
+          (all(left2) should (be (defined ) or be_== (something))) (definition)
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be defined '` {
       def `should do nothing when xs is not defined ` {
-        (all(List(nothing)) should (not be defined  or not be something)) (definition)
-        (all(List(something)) should (not be defined  or not be nothing)) (definition)
-        (all(List(nothing)) should (not be defined  or not be nothing)) (definition)
+        (all(List(nothing)) should (not be defined  or not be_== something)) (definition)
+        (all(List(something)) should (not be defined  or not be_== nothing)) (definition)
+        (all(List(nothing)) should (not be defined  or not be_== nothing)) (definition)
         
-        (all(List(nothing)) should (not be something or not be defined )) (definition)
-        (all(List(nothing)) should (not be nothing or not be defined )) (definition)
-        (all(List(something)) should (not be nothing or not be defined )) (definition)
+        (all(List(nothing)) should (not be_== something or not be defined )) (definition)
+        (all(List(nothing)) should (not be_== nothing or not be defined )) (definition)
+        (all(List(something)) should (not be_== nothing or not be defined )) (definition)
         
         (all(List(nothing)) should (not be defined  or not equal something)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
         (all(List(something)) should (not be defined  or not equal nothing)) (definition, defaultEquality[Thing{val isDefined: Boolean}])
@@ -245,7 +245,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not defined ` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be something or not be defined )) (definition)
+          (all(left1) should (not be_== something or not be defined )) (definition)
         }
         assert(caught1.message === Some(allError(wasEqualTo(something, something) + ", and " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -253,7 +253,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be defined  or not be something)) (definition)
+          (all(left2) should (not be defined  or not be_== something)) (definition)
         }
         assert(caught2.message === Some(allError(wasDefined(something) + ", and " + wasEqualTo(something, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrImplicitSpec.scala
@@ -69,13 +69,13 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
       
       def `should do nothing when thing is defined` {
         
-        something should (be (defined) or be (something))
-        nothing should (be (defined) or be (nothing))
-        something should (be (defined) or be (nothing))
+        something should (be (defined) or be_== (something))
+        nothing should (be (defined) or be_== (nothing))
+        something should (be (defined) or be_== (nothing))
         
-        something should (be (something) or be (defined))
-        something should (be (nothing) or be (defined))
-        nothing should (be (nothing) or be (defined))
+        something should (be_== (something) or be (defined))
+        something should (be_== (nothing) or be (defined))
+        nothing should (be_== (nothing) or be (defined))
         
         something should (be (defined) or equal (something))
         nothing should (be (defined) or equal (nothing))
@@ -88,14 +88,14 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when thing is not defined` {
         val caught1 = intercept[TestFailedException] {
-          nothing should (be (defined) or be (something))
+          nothing should (be (defined) or be_== (something))
         }
         assert(caught1.message === Some(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          nothing should (be (something) or be (defined))
+          nothing should (be_== (something) or be (defined))
         }
         assert(caught2.message === Some(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -120,13 +120,13 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
     object `when work with 'thing should not be defined'` {
       
       def `should do nothing when thing is not defined` {
-        nothing should (not be defined or not be something)
-        something should (not be defined or not be nothing)
-        nothing should (not be defined or not be nothing)
+        nothing should (not be defined or not be_== something)
+        something should (not be defined or not be_== nothing)
+        nothing should (not be defined or not be_== nothing)
         
-        nothing should (not be something or not be defined)
-        nothing should (not be nothing or not be defined)
-        something should (not be nothing or not be defined)
+        nothing should (not be_== something or not be defined)
+        nothing should (not be_== nothing or not be defined)
+        something should (not be_== nothing or not be defined)
         
         nothing should (not be defined or not equal something)
         something should (not be defined or not equal nothing)
@@ -139,14 +139,14 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when thing is defined` {
         val caught1 = intercept[TestFailedException] {
-          something should (not be defined or not be something)
+          something should (not be defined or not be_== something)
         }
         assert(caught1.message === Some(wasDefined(something) + ", and " + wasEqualTo(something, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          something should (not be something or not be defined)
+          something should (not be_== something or not be defined)
         }
         assert(caught2.message === Some(wasEqualTo(something, something) + ", and " + wasDefined(something)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -171,13 +171,13 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (defined)'` {
       
       def `should do nothing when all(xs) is defined` {
-        all(List(something)) should (be (defined) or be (something))
-        all(List(nothing)) should (be (defined) or be (nothing))
-        all(List(something)) should (be (defined) or be (nothing))
+        all(List(something)) should (be (defined) or be_== (something))
+        all(List(nothing)) should (be (defined) or be_== (nothing))
+        all(List(something)) should (be (defined) or be_== (nothing))
         
-        all(List(something)) should (be (something) or be (defined))
-        all(List(something)) should (be (nothing) or be (defined))
-        all(List(nothing)) should (be (nothing) or be (defined))
+        all(List(something)) should (be_== (something) or be (defined))
+        all(List(something)) should (be_== (nothing) or be (defined))
+        all(List(nothing)) should (be_== (nothing) or be (defined))
         
         all(List(something)) should (be (defined) or equal (something))
         all(List(nothing)) should (be (defined) or equal (nothing))
@@ -191,7 +191,7 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not defined` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (something) or be (defined))
+          all(left1) should (be_== (something) or be (defined))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -199,7 +199,7 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (defined) or be (something))
+          all(left2) should (be (defined) or be_== (something))
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be defined'` {
       def `should do nothing when xs is not defined` {
-        all(List(nothing)) should (not be defined or not be something)
-        all(List(something)) should (not be defined or not be nothing)
-        all(List(nothing)) should (not be defined or not be nothing)
+        all(List(nothing)) should (not be defined or not be_== something)
+        all(List(something)) should (not be defined or not be_== nothing)
+        all(List(nothing)) should (not be defined or not be_== nothing)
         
-        all(List(nothing)) should (not be something or not be defined)
-        all(List(nothing)) should (not be nothing or not be defined)
-        all(List(something)) should (not be nothing or not be defined)
+        all(List(nothing)) should (not be_== something or not be defined)
+        all(List(nothing)) should (not be_== nothing or not be defined)
+        all(List(something)) should (not be_== nothing or not be defined)
         
         all(List(nothing)) should (not be defined or not equal something)
         all(List(something)) should (not be defined or not equal nothing)
@@ -245,7 +245,7 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not defined` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be something or not be defined)
+          all(left1) should (not be_== something or not be defined)
         }
         assert(caught1.message === Some(allError(wasEqualTo(something, something) + ", and " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -253,7 +253,7 @@ class ShouldBeDefinedLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be defined or not be something)
+          all(left2) should (not be defined or not be_== something)
         }
         assert(caught2.message === Some(allError(wasDefined(something) + ", and " + wasEqualTo(something, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrSpec.scala
@@ -54,13 +54,13 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
       
       def `should do nothing when opt is defined` {
         
-        something should (be (defined) or be (something))
-        nothing should (be (defined) or be (nothing))
-        something should (be (defined) or be (nothing))
+        something should (be (defined) or be_== (something))
+        nothing should (be (defined) or be_== (nothing))
+        something should (be (defined) or be_== (nothing))
         
-        something should (be (something) or be (defined))
-        something should (be (nothing) or be (defined))
-        nothing should (be (nothing) or be (defined))
+        something should (be_== (something) or be (defined))
+        something should (be_== (nothing) or be (defined))
+        nothing should (be_== (nothing) or be (defined))
         
         something should (be (defined) or equal (something))
         nothing should (be (defined) or equal (nothing))
@@ -73,14 +73,14 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when opt is not defined` {
         val caught1 = intercept[TestFailedException] {
-          nothing should (be (defined) or be (something))
+          nothing should (be (defined) or be_== (something))
         }
         assert(caught1.message === Some(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          nothing should (be (something) or be (defined))
+          nothing should (be_== (something) or be (defined))
         }
         assert(caught2.message === Some(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -105,13 +105,13 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
     object `when work with 'opt should not be defined'` {
       
       def `should do nothing when opt is not defined` {
-        nothing should (not be defined or not be something)
-        something should (not be defined or not be nothing)
-        nothing should (not be defined or not be nothing)
+        nothing should (not be defined or not be_== something)
+        something should (not be defined or not be_== nothing)
+        nothing should (not be defined or not be_== nothing)
         
-        nothing should (not be something or not be defined)
-        nothing should (not be nothing or not be defined)
-        something should (not be nothing or not be defined)
+        nothing should (not be_== something or not be defined)
+        nothing should (not be_== nothing or not be defined)
+        something should (not be_== nothing or not be defined)
         
         nothing should (not be defined or not equal something)
         something should (not be defined or not equal nothing)
@@ -124,14 +124,14 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when opt is defined` {
         val caught1 = intercept[TestFailedException] {
-          something should (not be defined or not be something)
+          something should (not be defined or not be_== something)
         }
         assert(caught1.message === Some(wasDefined(something) + ", and " + wasEqualTo(something, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          something should (not be something or not be defined)
+          something should (not be_== something or not be defined)
         }
         assert(caught2.message === Some(wasEqualTo(something, something) + ", and " + wasDefined(something)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -156,13 +156,13 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
     object `when work with 'all(xs) should be (defined)'` {
       
       def `should do nothing when all(xs) is defined` {
-        all(List(something)) should (be (defined) or be (something))
-        all(List(nothing)) should (be (defined) or be (nothing))
-        all(List(something)) should (be (defined) or be (nothing))
+        all(List(something)) should (be (defined) or be_== (something))
+        all(List(nothing)) should (be (defined) or be_== (nothing))
+        all(List(something)) should (be (defined) or be_== (nothing))
         
-        all(List(something)) should (be (something) or be (defined))
-        all(List(something)) should (be (nothing) or be (defined))
-        all(List(nothing)) should (be (nothing) or be (defined))
+        all(List(something)) should (be_== (something) or be (defined))
+        all(List(something)) should (be_== (nothing) or be (defined))
+        all(List(nothing)) should (be_== (nothing) or be (defined))
         
         all(List(something)) should (be (defined) or equal (something))
         all(List(nothing)) should (be (defined) or equal (nothing))
@@ -176,7 +176,7 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (something) or be (defined))
+          all(left1) should (be_== (something) or be (defined))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -184,7 +184,7 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (defined) or be (something))
+          all(left2) should (be (defined) or be_== (something))
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -210,13 +210,13 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(nothing)) should (not be defined or not be something)
-        all(List(something)) should (not be defined or not be nothing)
-        all(List(nothing)) should (not be defined or not be nothing)
+        all(List(nothing)) should (not be defined or not be_== something)
+        all(List(something)) should (not be defined or not be_== nothing)
+        all(List(nothing)) should (not be defined or not be_== nothing)
         
-        all(List(nothing)) should (not be something or not be defined)
-        all(List(nothing)) should (not be nothing or not be defined)
-        all(List(something)) should (not be nothing or not be defined)
+        all(List(nothing)) should (not be_== something or not be defined)
+        all(List(nothing)) should (not be_== nothing or not be defined)
+        all(List(something)) should (not be_== nothing or not be defined)
         
         all(List(nothing)) should (not be defined or not equal something)
         all(List(something)) should (not be defined or not equal nothing)
@@ -230,7 +230,7 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be something or not be defined)
+          all(left1) should (not be_== something or not be defined)
         }
         assert(caught1.message === Some(allError(wasEqualTo(something, something) + ", and " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -238,7 +238,7 @@ class ShouldBeDefinedLogicalOrSpec extends Spec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be defined or not be something)
+          all(left2) should (not be defined or not be_== something)
         }
         assert(caught2.message === Some(allError(wasDefined(something) + ", and " + wasEqualTo(something, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalAndSpec.scala
@@ -53,8 +53,8 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) and equal (objTrue))
         objTrue should (equal (objTrue) and be (defined))
-        objTrue should (be (defined) and be (objTrue))
-        objTrue should (be (objTrue) and be (defined))
+        objTrue should (be (defined) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (defined))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -73,14 +73,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objFalse))
+          objFalse should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (defined))
+          objTrue should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -103,14 +103,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (defined) and be (objFalse))
+          objTrue should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasDefined(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (defined))
+          objFalse should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -133,14 +133,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objTrue))
+          objFalse should (be (defined) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (defined))
+          objFalse should (be_== (objTrue) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -160,8 +160,8 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) and equal (objTrue))
         objTrue should (equal (objTrue) and be (defined))
-        objTrue should (be (defined) and be (objTrue))
-        objTrue should (be (objTrue) and be (defined))
+        objTrue should (be (defined) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (defined))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -180,14 +180,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objFalse))
+          objFalse should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (defined))
+          objTrue should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -210,14 +210,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (defined) and be (objFalse))
+          objTrue should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasDefined(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (defined))
+          objFalse should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -240,14 +240,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objTrue))
+          objFalse should (be (defined) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (defined))
+          objFalse should (be_== (objTrue) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -267,8 +267,8 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) and equal (objTrue))
         objTrue should (equal (objTrue) and be (defined))
-        objTrue should (be (defined) and be (objTrue))
-        objTrue should (be (objTrue) and be (defined))
+        objTrue should (be (defined) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (defined))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -287,14 +287,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objFalse))
+          objFalse should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (defined))
+          objTrue should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -317,14 +317,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (defined) and be (objFalse))
+          objTrue should (be (defined) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasDefined(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (defined))
+          objFalse should (be_== (objFalse) and be (defined))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -347,14 +347,14 @@ class ShouldBeDefinedStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) and be (objTrue))
+          objFalse should (be (defined) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (defined))
+          objFalse should (be_== (objTrue) and be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalOrSpec.scala
@@ -53,22 +53,22 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) or equal (objTrue))
         objTrue should (equal (objTrue) or be (defined))
-        objTrue should (be (defined) or be (objTrue))
-        objTrue should (be (objTrue) or be (defined))
+        objTrue should (be (defined) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (defined))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (defined) or equal (objFalse))
         objTrue should (equal (objFalse) or be (defined))
-        objFalse should (be (defined) or be (objFalse))
-        objTrue should (be (objFalse) or be (defined))
+        objFalse should (be (defined) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (defined))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (defined) or equal (objFalse))
         objFalse should (equal (objFalse) or be (defined))
-        objTrue should (be (defined) or be (objFalse))
-        objFalse should (be (objFalse) or be (defined))
+        objTrue should (be (defined) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (defined))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -87,14 +87,14 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) or be (objTrue))
+          objFalse should (be (defined) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (defined))
+          objFalse should (be_== (objTrue) or be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -114,22 +114,22 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) or equal (objTrue))
         objTrue should (equal (objTrue) or be (defined))
-        objTrue should (be (defined) or be (objTrue))
-        objTrue should (be (objTrue) or be (defined))
+        objTrue should (be (defined) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (defined))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (defined) or equal (objFalse))
         objTrue should (equal (objFalse) or be (defined))
-        objFalse should (be (defined) or be (objFalse))
-        objTrue should (be (objFalse) or be (defined))
+        objFalse should (be (defined) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (defined))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (defined) or equal (objFalse))
         objFalse should (equal (objFalse) or be (defined))
-        objTrue should (be (defined) or be (objFalse))
-        objFalse should (be (objFalse) or be (defined))
+        objTrue should (be (defined) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (defined))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -148,14 +148,14 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) or be (objTrue))
+          objFalse should (be (defined) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (defined))
+          objFalse should (be_== (objTrue) or be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -175,22 +175,22 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (defined) or equal (objTrue))
         objTrue should (equal (objTrue) or be (defined))
-        objTrue should (be (defined) or be (objTrue))
-        objTrue should (be (objTrue) or be (defined))
+        objTrue should (be (defined) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (defined))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (defined) or equal (objFalse))
         objTrue should (equal (objFalse) or be (defined))
-        objFalse should (be (defined) or be (objFalse))
-        objTrue should (be (objFalse) or be (defined))
+        objFalse should (be (defined) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (defined))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (defined) or equal (objFalse))
         objFalse should (equal (objFalse) or be (defined))
-        objTrue should (be (defined) or be (objFalse))
-        objFalse should (be (objFalse) or be (defined))
+        objTrue should (be (defined) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (defined))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -209,14 +209,14 @@ class ShouldBeDefinedStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (defined) or be (objTrue))
+          objFalse should (be (defined) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotDefined(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (defined))
+          objFalse should (be_== (objTrue) or be (defined))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotDefined(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
@@ -70,8 +70,8 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         (emptyThing should (equal (emptyThing) and be (empty))) (defaultEquality[Thing{val isEmpty: Boolean}], emptiness)
         (emptyThing should (be (empty) and equal (emptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         
-        (emptyThing should (be (emptyThing) and be (empty))) (emptiness)
-        (emptyThing should (be (empty) and be (emptyThing))) (emptiness)
+        (emptyThing should (be_== (emptyThing) and be (empty))) (emptiness)
+        (emptyThing should (be (empty) and be_== (emptyThing))) (emptiness)
       }
       
       def `should throw TestFailedException with correct stack depth when list is not empty` {
@@ -90,14 +90,14 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (nonEmptyThing) and be (empty))) (emptiness)
+          (nonEmptyThing should (be_== (nonEmptyThing) and be (empty))) (emptiness)
         }
         assert(caught3.message === Some(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) and be (nonEmptyThing))) (emptiness)
+          (nonEmptyThing should (be (empty) and be_== (nonEmptyThing))) (emptiness)
         }
         assert(caught4.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -111,8 +111,8 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         (nonEmptyThing should (not equal emptyThing and not be empty)) (defaultEquality[Thing{val isEmpty: Boolean}], emptiness)
         (nonEmptyThing should (not be empty and not equal emptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         
-        (nonEmptyThing should (not be emptyThing and not be empty)) (emptiness)
-        (nonEmptyThing should (not be empty and not be emptyThing)) (emptiness)
+        (nonEmptyThing should (not be_== emptyThing and not be empty)) (emptiness)
+        (nonEmptyThing should (not be empty and not be_== emptyThing)) (emptiness)
       }
       
       def `should throw TestFailedException with correct stack depth when list is not empty` {
@@ -131,14 +131,14 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (emptyThing should (not be nonEmptyThing and not be empty)) (emptiness)
+          (emptyThing should (not be_== nonEmptyThing and not be empty)) (emptiness)
         }
         assert(caught3.message === Some(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (emptyThing should (not be empty and not be nonEmptyThing)) (emptiness)
+          (emptyThing should (not be empty and not be_== nonEmptyThing)) (emptiness)
         }
         assert(caught4.message === Some(wasEmpty(emptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -149,8 +149,8 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (empty)'` {
       
       def `should do nothing when all(xs) is empty` {
-        (all(List(emptyThing)) should (be (emptyThing) and be (empty))) (emptiness)
-        (all(List(emptyThing)) should (be (empty) and be (emptyThing))) (emptiness)
+        (all(List(emptyThing)) should (be_== (emptyThing) and be (empty))) (emptiness)
+        (all(List(emptyThing)) should (be (empty) and be_== (emptyThing))) (emptiness)
         
         (all(List(emptyThing)) should (equal (emptyThing) and be (empty))) (defaultEquality[Thing{val isEmpty: Boolean}], emptiness)
         (all(List(emptyThing)) should (be (empty) and equal (emptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
@@ -159,7 +159,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not empty` {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (nonEmptyThing) and be (empty))) (emptiness)
+          (all(left1) should (be_== (nonEmptyThing) and be (empty))) (emptiness)
         }
         assert(caught1.message === Some(allError(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -167,7 +167,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (empty) and be (nonEmptyThing))) (emptiness)
+          (all(left2) should (be (empty) and be_== (nonEmptyThing))) (emptiness)
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -193,8 +193,8 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be empty'` {
       def `should do nothing when all(xs) is not empty` {
-        (all(List(nonEmptyThing)) should (not be empty and not be emptyThing)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be emptyThing and not be empty)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be empty and not be_== emptyThing)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be_== emptyThing and not be empty)) (emptiness)
         
         (all(List(nonEmptyThing)) should (not be empty and not equal emptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         (all(List(nonEmptyThing)) should (not equal emptyThing and not be empty)) (defaultEquality[Thing{val isEmpty: Boolean}], emptiness)
@@ -203,7 +203,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is empty` {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be nonEmptyThing and not be empty)) (emptiness)
+          (all(left1) should (not be_== nonEmptyThing and not be empty)) (emptiness)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -211,7 +211,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be empty and not be nonEmptyThing)) (emptiness)
+          (all(left2) should (not be empty and not be_== nonEmptyThing)) (emptiness)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndImplicitSpec.scala
@@ -70,8 +70,8 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         emptyThing should (equal (emptyThing) and be (empty))
         emptyThing should (be (empty) and equal (emptyThing))
         
-        emptyThing should (be (emptyThing) and be (empty))
-        emptyThing should (be (empty) and be (emptyThing))
+        emptyThing should (be_== (emptyThing) and be (empty))
+        emptyThing should (be (empty) and be_== (emptyThing))
       }
       
       def `should throw TestFailedException with correct stack depth when list is not empty` {
@@ -90,14 +90,14 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          nonEmptyThing should (be (nonEmptyThing) and be (empty))
+          nonEmptyThing should (be_== (nonEmptyThing) and be (empty))
         }
         assert(caught3.message === Some(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          nonEmptyThing should (be (empty) and be (nonEmptyThing))
+          nonEmptyThing should (be (empty) and be_== (nonEmptyThing))
         }
         assert(caught4.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -111,8 +111,8 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         nonEmptyThing should (not equal emptyThing and not be empty)
         nonEmptyThing should (not be empty and not equal emptyThing)
         
-        nonEmptyThing should (not be emptyThing and not be empty)
-        nonEmptyThing should (not be empty and not be emptyThing)
+        nonEmptyThing should (not be_== emptyThing and not be empty)
+        nonEmptyThing should (not be empty and not be_== emptyThing)
       }
       
       def `should throw TestFailedException with correct stack depth when list is not empty` {
@@ -131,14 +131,14 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          emptyThing should (not be nonEmptyThing and not be empty)
+          emptyThing should (not be_== nonEmptyThing and not be empty)
         }
         assert(caught3.message === Some(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          emptyThing should (not be empty and not be nonEmptyThing)
+          emptyThing should (not be empty and not be_== nonEmptyThing)
         }
         assert(caught4.message === Some(wasEmpty(emptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -149,8 +149,8 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (empty)'` {
       
       def `should do nothing when all(xs) is empty` {
-        all(List(emptyThing)) should (be (emptyThing) and be (empty))
-        all(List(emptyThing)) should (be (empty) and be (emptyThing))
+        all(List(emptyThing)) should (be_== (emptyThing) and be (empty))
+        all(List(emptyThing)) should (be (empty) and be_== (emptyThing))
         
         all(List(emptyThing)) should (equal (emptyThing) and be (empty))
         all(List(emptyThing)) should (be (empty) and equal (emptyThing))
@@ -159,7 +159,7 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not empty` {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (nonEmptyThing) and be (empty))
+          all(left1) should (be_== (nonEmptyThing) and be (empty))
         }
         assert(caught1.message === Some(allError(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -167,7 +167,7 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (empty) and be (nonEmptyThing))
+          all(left2) should (be (empty) and be_== (nonEmptyThing))
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -193,8 +193,8 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be empty'` {
       def `should do nothing when all(xs) is not empty` {
-        all(List(nonEmptyThing)) should (not be empty and not be emptyThing)
-        all(List(nonEmptyThing)) should (not be emptyThing and not be empty)
+        all(List(nonEmptyThing)) should (not be empty and not be_== emptyThing)
+        all(List(nonEmptyThing)) should (not be_== emptyThing and not be empty)
         
         all(List(nonEmptyThing)) should (not be empty and not equal emptyThing)
         all(List(nonEmptyThing)) should (not equal emptyThing and not be empty)
@@ -203,7 +203,7 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is empty` {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be nonEmptyThing and not be empty)
+          all(left1) should (not be_== nonEmptyThing and not be empty)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -211,7 +211,7 @@ class ShouldBeEmptyLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be empty and not be nonEmptyThing)
+          all(left2) should (not be empty and not be_== nonEmptyThing)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
@@ -68,13 +68,13 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
       
       def `should do nothing when list is empty` {
         
-        (emptyThing should (be (empty) or be (emptyThing))) (emptiness)
-        (nonEmptyThing should (be (empty) or be (nonEmptyThing))) (emptiness)
-        (emptyThing should (be (empty) or be (nonEmptyThing))) (emptiness)
+        (emptyThing should (be (empty) or be_== (emptyThing))) (emptiness)
+        (nonEmptyThing should (be (empty) or be_== (nonEmptyThing))) (emptiness)
+        (emptyThing should (be (empty) or be_== (nonEmptyThing))) (emptiness)
         
-        (emptyThing should (be (emptyThing) or be (empty))) (emptiness)
-        (emptyThing should (be (nonEmptyThing) or be (empty))) (emptiness)
-        (nonEmptyThing should (be (nonEmptyThing) or be (empty))) (emptiness)
+        (emptyThing should (be_== (emptyThing) or be (empty))) (emptiness)
+        (emptyThing should (be_== (nonEmptyThing) or be (empty))) (emptiness)
+        (nonEmptyThing should (be_== (nonEmptyThing) or be (empty))) (emptiness)
         
         (emptyThing should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         (nonEmptyThing should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
@@ -87,14 +87,14 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not empty` {
         val caught1 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) or be (emptyThing))) (emptiness)
+          (nonEmptyThing should (be (empty) or be_== (emptyThing))) (emptiness)
         }
         assert(caught1.message === Some(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (emptyThing) or be (empty))) (emptiness)
+          (nonEmptyThing should (be_== (emptyThing) or be (empty))) (emptiness)
         }
         assert(caught2.message === Some(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -119,13 +119,13 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
     object `when work with 'file should not be empty'` {
       
       def `should do nothing when file is not empty` {
-        (nonEmptyThing should (not be empty or not be emptyThing)) (emptiness)
-        (emptyThing should (not be empty or not be nonEmptyThing)) (emptiness)
-        (nonEmptyThing should (not be empty or not be nonEmptyThing)) (emptiness)
+        (nonEmptyThing should (not be empty or not be_== emptyThing)) (emptiness)
+        (emptyThing should (not be empty or not be_== nonEmptyThing)) (emptiness)
+        (nonEmptyThing should (not be empty or not be_== nonEmptyThing)) (emptiness)
         
-        (nonEmptyThing should (not be emptyThing or not be empty)) (emptiness)
-        (nonEmptyThing should (not be nonEmptyThing or not be empty)) (emptiness)
-        (emptyThing should (not be nonEmptyThing or not be empty)) (emptiness)
+        (nonEmptyThing should (not be_== emptyThing or not be empty)) (emptiness)
+        (nonEmptyThing should (not be_== nonEmptyThing or not be empty)) (emptiness)
+        (emptyThing should (not be_== nonEmptyThing or not be empty)) (emptiness)
         
         (nonEmptyThing should (not be empty or not equal emptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         (emptyThing should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
@@ -138,14 +138,14 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is empty` {
         val caught1 = intercept[TestFailedException] {
-          (emptyThing should (not be empty or not be emptyThing)) (emptiness)
+          (emptyThing should (not be empty or not be_== emptyThing)) (emptiness)
         }
         assert(caught1.message === Some(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (emptyThing should (not be emptyThing or not be empty)) (emptiness)
+          (emptyThing should (not be_== emptyThing or not be empty)) (emptiness)
         }
         assert(caught2.message === Some(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -170,13 +170,13 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (empty)'` {
       
       def `should do nothing when all(xs) is empty` {
-        (all(List(emptyThing)) should (be (empty) or be (emptyThing))) (emptiness)
-        (all(List(nonEmptyThing)) should (be (empty) or be (nonEmptyThing))) (emptiness)
-        (all(List(emptyThing)) should (be (empty) or be (nonEmptyThing))) (emptiness)
+        (all(List(emptyThing)) should (be (empty) or be_== (emptyThing))) (emptiness)
+        (all(List(nonEmptyThing)) should (be (empty) or be_== (nonEmptyThing))) (emptiness)
+        (all(List(emptyThing)) should (be (empty) or be_== (nonEmptyThing))) (emptiness)
         
-        (all(List(emptyThing)) should (be (emptyThing) or be (empty))) (emptiness)
-        (all(List(emptyThing)) should (be (nonEmptyThing) or be (empty))) (emptiness)
-        (all(List(nonEmptyThing)) should (be (nonEmptyThing) or be (empty))) (emptiness)
+        (all(List(emptyThing)) should (be_== (emptyThing) or be (empty))) (emptiness)
+        (all(List(emptyThing)) should (be_== (nonEmptyThing) or be (empty))) (emptiness)
+        (all(List(nonEmptyThing)) should (be_== (nonEmptyThing) or be (empty))) (emptiness)
         
         (all(List(emptyThing)) should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         (all(List(nonEmptyThing)) should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
@@ -190,7 +190,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (emptyThing) or be (empty))) (emptiness)
+          (all(left1) should (be_== (emptyThing) or be (empty))) (emptiness)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -198,7 +198,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (empty) or be (emptyThing))) (emptiness)
+          (all(left2) should (be (empty) or be_== (emptyThing))) (emptiness)
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -224,13 +224,13 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        (all(List(nonEmptyThing)) should (not be empty or not be emptyThing)) (emptiness)
-        (all(List(emptyThing)) should (not be empty or not be nonEmptyThing)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be empty or not be nonEmptyThing)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be empty or not be_== emptyThing)) (emptiness)
+        (all(List(emptyThing)) should (not be empty or not be_== nonEmptyThing)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be empty or not be_== nonEmptyThing)) (emptiness)
         
-        (all(List(nonEmptyThing)) should (not be emptyThing or not be empty)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be nonEmptyThing or not be empty)) (emptiness)
-        (all(List(emptyThing)) should (not be nonEmptyThing or not be empty)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be_== emptyThing or not be empty)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be_== nonEmptyThing or not be empty)) (emptiness)
+        (all(List(emptyThing)) should (not be_== nonEmptyThing or not be empty)) (emptiness)
         
         (all(List(nonEmptyThing)) should (not be empty or not equal emptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
         (all(List(emptyThing)) should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality[Thing{val isEmpty: Boolean}])
@@ -244,7 +244,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be emptyThing or not be empty)) (emptiness)
+          (all(left1) should (not be_== emptyThing or not be empty)) (emptiness)
         }
         assert(caught1.message === Some(allError(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -252,7 +252,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be empty or not be emptyThing)) (emptiness)
+          (all(left2) should (not be empty or not be_== emptyThing)) (emptiness)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrImplicitSpec.scala
@@ -68,13 +68,13 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
       
       def `should do nothing when list is empty` {
         
-        emptyThing should (be (empty) or be (emptyThing))
-        nonEmptyThing should (be (empty) or be (nonEmptyThing))
-        emptyThing should (be (empty) or be (nonEmptyThing))
+        emptyThing should (be (empty) or be_== (emptyThing))
+        nonEmptyThing should (be (empty) or be_== (nonEmptyThing))
+        emptyThing should (be (empty) or be_== (nonEmptyThing))
         
-        emptyThing should (be (emptyThing) or be (empty))
-        emptyThing should (be (nonEmptyThing) or be (empty))
-        nonEmptyThing should (be (nonEmptyThing) or be (empty))
+        emptyThing should (be_== (emptyThing) or be (empty))
+        emptyThing should (be_== (nonEmptyThing) or be (empty))
+        nonEmptyThing should (be_== (nonEmptyThing) or be (empty))
         
         emptyThing should (be (empty) or equal (emptyThing))
         nonEmptyThing should (be (empty) or equal (nonEmptyThing))
@@ -87,14 +87,14 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not empty` {
         val caught1 = intercept[TestFailedException] {
-          nonEmptyThing should (be (empty) or be (emptyThing))
+          nonEmptyThing should (be (empty) or be_== (emptyThing))
         }
         assert(caught1.message === Some(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          nonEmptyThing should (be (emptyThing) or be (empty))
+          nonEmptyThing should (be_== (emptyThing) or be (empty))
         }
         assert(caught2.message === Some(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -119,13 +119,13 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
     object `when work with 'file should not be empty'` {
       
       def `should do nothing when file is not empty` {
-        nonEmptyThing should (not be empty or not be emptyThing)
-        emptyThing should (not be empty or not be nonEmptyThing)
-        nonEmptyThing should (not be empty or not be nonEmptyThing)
+        nonEmptyThing should (not be empty or not be_== emptyThing)
+        emptyThing should (not be empty or not be_== nonEmptyThing)
+        nonEmptyThing should (not be empty or not be_== nonEmptyThing)
         
-        nonEmptyThing should (not be emptyThing or not be empty)
-        nonEmptyThing should (not be nonEmptyThing or not be empty)
-        emptyThing should (not be nonEmptyThing or not be empty)
+        nonEmptyThing should (not be_== emptyThing or not be empty)
+        nonEmptyThing should (not be_== nonEmptyThing or not be empty)
+        emptyThing should (not be_== nonEmptyThing or not be empty)
         
         nonEmptyThing should (not be empty or not equal emptyThing)
         emptyThing should (not be empty or not equal nonEmptyThing)
@@ -138,14 +138,14 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is empty` {
         val caught1 = intercept[TestFailedException] {
-          emptyThing should (not be empty or not be emptyThing)
+          emptyThing should (not be empty or not be_== emptyThing)
         }
         assert(caught1.message === Some(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          emptyThing should (not be emptyThing or not be empty)
+          emptyThing should (not be_== emptyThing or not be empty)
         }
         assert(caught2.message === Some(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -170,13 +170,13 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (empty)'` {
       
       def `should do nothing when all(xs) is empty` {
-        all(List(emptyThing)) should (be (empty) or be (emptyThing))
-        all(List(nonEmptyThing)) should (be (empty) or be (nonEmptyThing))
-        all(List(emptyThing)) should (be (empty) or be (nonEmptyThing))
+        all(List(emptyThing)) should (be (empty) or be_== (emptyThing))
+        all(List(nonEmptyThing)) should (be (empty) or be_== (nonEmptyThing))
+        all(List(emptyThing)) should (be (empty) or be_== (nonEmptyThing))
         
-        all(List(emptyThing)) should (be (emptyThing) or be (empty))
-        all(List(emptyThing)) should (be (nonEmptyThing) or be (empty))
-        all(List(nonEmptyThing)) should (be (nonEmptyThing) or be (empty))
+        all(List(emptyThing)) should (be_== (emptyThing) or be (empty))
+        all(List(emptyThing)) should (be_== (nonEmptyThing) or be (empty))
+        all(List(nonEmptyThing)) should (be_== (nonEmptyThing) or be (empty))
         
         all(List(emptyThing)) should (be (empty) or equal (emptyThing))
         all(List(nonEmptyThing)) should (be (empty) or equal (nonEmptyThing))
@@ -190,7 +190,7 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (emptyThing) or be (empty))
+          all(left1) should (be_== (emptyThing) or be (empty))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -198,7 +198,7 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (empty) or be (emptyThing))
+          all(left2) should (be (empty) or be_== (emptyThing))
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -224,13 +224,13 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(nonEmptyThing)) should (not be empty or not be emptyThing)
-        all(List(emptyThing)) should (not be empty or not be nonEmptyThing)
-        all(List(nonEmptyThing)) should (not be empty or not be nonEmptyThing)
+        all(List(nonEmptyThing)) should (not be empty or not be_== emptyThing)
+        all(List(emptyThing)) should (not be empty or not be_== nonEmptyThing)
+        all(List(nonEmptyThing)) should (not be empty or not be_== nonEmptyThing)
         
-        all(List(nonEmptyThing)) should (not be emptyThing or not be empty)
-        all(List(nonEmptyThing)) should (not be nonEmptyThing or not be empty)
-        all(List(emptyThing)) should (not be nonEmptyThing or not be empty)
+        all(List(nonEmptyThing)) should (not be_== emptyThing or not be empty)
+        all(List(nonEmptyThing)) should (not be_== nonEmptyThing or not be empty)
+        all(List(emptyThing)) should (not be_== nonEmptyThing or not be empty)
         
         all(List(nonEmptyThing)) should (not be empty or not equal emptyThing)
         all(List(emptyThing)) should (not be empty or not equal nonEmptyThing)
@@ -244,7 +244,7 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be emptyThing or not be empty)
+          all(left1) should (not be_== emptyThing or not be empty)
         }
         assert(caught1.message === Some(allError(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -252,7 +252,7 @@ class ShouldBeEmptyLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be empty or not be emptyThing)
+          all(left2) should (not be empty or not be_== emptyThing)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalAndSpec.scala
@@ -54,8 +54,8 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) and equal (objTrue))
         objTrue should (equal (objTrue) and be (empty))
-        objTrue should (be (empty) and be (objTrue))
-        objTrue should (be (objTrue) and be (empty))
+        objTrue should (be (empty) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (empty))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -74,14 +74,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objFalse))
+          objFalse should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (empty))
+          objTrue should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -104,14 +104,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (empty) and be (objFalse))
+          objTrue should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasEmpty(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (empty))
+          objFalse should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -134,14 +134,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objTrue))
+          objFalse should (be (empty) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (empty))
+          objFalse should (be_== (objTrue) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -161,8 +161,8 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) and equal (objTrue))
         objTrue should (equal (objTrue) and be (empty))
-        objTrue should (be (empty) and be (objTrue))
-        objTrue should (be (objTrue) and be (empty))
+        objTrue should (be (empty) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (empty))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -181,14 +181,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objFalse))
+          objFalse should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (empty))
+          objTrue should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -211,14 +211,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (empty) and be (objFalse))
+          objTrue should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasEmpty(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (empty))
+          objFalse should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -241,14 +241,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objTrue))
+          objFalse should (be (empty) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (empty))
+          objFalse should (be_== (objTrue) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -268,8 +268,8 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) and equal (objTrue))
         objTrue should (equal (objTrue) and be (empty))
-        objTrue should (be (empty) and be (objTrue))
-        objTrue should (be (objTrue) and be (empty))
+        objTrue should (be (empty) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (empty))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -288,14 +288,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objFalse))
+          objFalse should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (empty))
+          objTrue should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -318,14 +318,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (empty) and be (objFalse))
+          objTrue should (be (empty) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasEmpty(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (empty))
+          objFalse should (be_== (objFalse) and be (empty))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -348,14 +348,14 @@ class ShouldBeEmptyStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) and be (objTrue))
+          objFalse should (be (empty) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (empty))
+          objFalse should (be_== (objTrue) and be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalOrSpec.scala
@@ -54,22 +54,22 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) or equal (objTrue))
         objTrue should (equal (objTrue) or be (empty))
-        objTrue should (be (empty) or be (objTrue))
-        objTrue should (be (objTrue) or be (empty))
+        objTrue should (be (empty) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (empty))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (empty) or equal (objFalse))
         objTrue should (equal (objFalse) or be (empty))
-        objFalse should (be (empty) or be (objFalse))
-        objTrue should (be (objFalse) or be (empty))
+        objFalse should (be (empty) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (empty))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (empty) or equal (objFalse))
         objFalse should (equal (objFalse) or be (empty))
-        objTrue should (be (empty) or be (objFalse))
-        objFalse should (be (objFalse) or be (empty))
+        objTrue should (be (empty) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (empty))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -88,14 +88,14 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) or be (objTrue))
+          objFalse should (be (empty) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (empty))
+          objFalse should (be_== (objTrue) or be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -115,22 +115,22 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) or equal (objTrue))
         objTrue should (equal (objTrue) or be (empty))
-        objTrue should (be (empty) or be (objTrue))
-        objTrue should (be (objTrue) or be (empty))
+        objTrue should (be (empty) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (empty))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (empty) or equal (objFalse))
         objTrue should (equal (objFalse) or be (empty))
-        objFalse should (be (empty) or be (objFalse))
-        objTrue should (be (objFalse) or be (empty))
+        objFalse should (be (empty) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (empty))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (empty) or equal (objFalse))
         objFalse should (equal (objFalse) or be (empty))
-        objTrue should (be (empty) or be (objFalse))
-        objFalse should (be (objFalse) or be (empty))
+        objTrue should (be (empty) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (empty))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -149,14 +149,14 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) or be (objTrue))
+          objFalse should (be (empty) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (empty))
+          objFalse should (be_== (objTrue) or be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -176,22 +176,22 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (empty) or equal (objTrue))
         objTrue should (equal (objTrue) or be (empty))
-        objTrue should (be (empty) or be (objTrue))
-        objTrue should (be (objTrue) or be (empty))
+        objTrue should (be (empty) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (empty))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (empty) or equal (objFalse))
         objTrue should (equal (objFalse) or be (empty))
-        objFalse should (be (empty) or be (objFalse))
-        objTrue should (be (objFalse) or be (empty))
+        objFalse should (be (empty) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (empty))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (empty) or equal (objFalse))
         objFalse should (equal (objFalse) or be (empty))
-        objTrue should (be (empty) or be (objFalse))
-        objFalse should (be (objFalse) or be (empty))
+        objTrue should (be (empty) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (empty))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -210,14 +210,14 @@ class ShouldBeEmptyStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (empty) or be (objTrue))
+          objFalse should (be (empty) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotEmpty(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (empty))
+          objFalse should (be_== (objTrue) or be (empty))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotEmpty(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         (book should (equal (book) and be (readable))) (defaultEquality[Thing{val canRead: Boolean}], readability)
         (book should (be (readable) and equal (book))) (readability, defaultEquality[Thing{val canRead: Boolean}])
         
-        (book should (be (book) and be (readable))) (readability)
-        (book should (be (readable) and be (book))) (readability)
+        (book should (be_== (book) and be (readable))) (readability)
+        (book should (be (readable) and be_== (book))) (readability)
       }
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
@@ -91,14 +91,14 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (stone) and be (readable))) (readability)
+          (stone should (be_== (stone) and be (readable))) (readability)
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (stone should (be (readable) and be (stone))) (readability)
+          (stone should (be (readable) and be_== (stone))) (readability)
         }
         assert(caught4.message === Some(wasNotReadable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         (stone should (not equal book and not be readable)) (defaultEquality[Thing{val canRead: Boolean}], readability)
         (stone should (not be readable and not equal book)) (readability, defaultEquality[Thing{val canRead: Boolean}])
         
-        (stone should (not be book and not be readable)) (readability)
-        (stone should (not be readable and not be book)) (readability)
+        (stone should (not be_== book and not be readable)) (readability)
+        (stone should (not be readable and not be_== book)) (readability)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -132,14 +132,14 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (book should (not be stone and not be readable)) (readability)
+          (book should (not be_== stone and not be readable)) (readability)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasReadable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (book should (not be readable and not be stone)) (readability)
+          (book should (not be readable and not be_== stone)) (readability)
         }
         assert(caught4.message === Some(wasReadable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        (all(List(book)) should (be (book) and be (readable))) (readability)
-        (all(List(book)) should (be (readable) and be (book))) (readability)
+        (all(List(book)) should (be_== (book) and be (readable))) (readability)
+        (all(List(book)) should (be (readable) and be_== (book))) (readability)
         
         (all(List(book)) should (equal (book) and be (readable))) (defaultEquality[Thing{val canRead: Boolean}], readability)
         (all(List(book)) should (be (readable) and equal (book))) (readability, defaultEquality[Thing{val canRead: Boolean}])
@@ -160,7 +160,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not readable` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (stone) and be (readable))) (readability)
+          (all(left1) should (be_== (stone) and be (readable))) (readability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (readable) and be (stone))) (readability)
+          (all(left2) should (be (readable) and be_== (stone))) (readability)
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be readable'` {
       def `should do nothing when all(xs) is not readable` {
-        (all(List(stone)) should (not be readable and not be book)) (readability)
-        (all(List(stone)) should (not be book and not be readable)) (readability)
+        (all(List(stone)) should (not be readable and not be_== book)) (readability)
+        (all(List(stone)) should (not be_== book and not be readable)) (readability)
         
         (all(List(stone)) should (not be readable and not equal book)) (readability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(stone)) should (not equal book and not be readable)) (defaultEquality[Thing{val canRead: Boolean}], readability)
@@ -204,7 +204,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is readable` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be stone and not be readable)) (readability)
+          (all(left1) should (not be_== stone and not be readable)) (readability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be readable and not be stone)) (readability)
+          (all(left2) should (not be readable and not be_== stone)) (readability)
         }
         assert(caught2.message === Some(allError(wasReadable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndImplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         book should (equal (book) and be (readable))
         book should (be (readable) and equal (book))
         
-        book should (be (book) and be (readable))
-        book should (be (readable) and be (book))
+        book should (be_== (book) and be (readable))
+        book should (be (readable) and be_== (book))
       }
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
@@ -91,14 +91,14 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          stone should (be (stone) and be (readable))
+          stone should (be_== (stone) and be (readable))
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          stone should (be (readable) and be (stone))
+          stone should (be (readable) and be_== (stone))
         }
         assert(caught4.message === Some(wasNotReadable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         stone should (not equal book and not be readable)
         stone should (not be readable and not equal book)
         
-        stone should (not be book and not be readable)
-        stone should (not be readable and not be book)
+        stone should (not be_== book and not be readable)
+        stone should (not be readable and not be_== book)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -132,14 +132,14 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          book should (not be stone and not be readable)
+          book should (not be_== stone and not be readable)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasReadable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          book should (not be readable and not be stone)
+          book should (not be readable and not be_== stone)
         }
         assert(caught4.message === Some(wasReadable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        all(List(book)) should (be (book) and be (readable))
-        all(List(book)) should (be (readable) and be (book))
+        all(List(book)) should (be_== (book) and be (readable))
+        all(List(book)) should (be (readable) and be_== (book))
         
         all(List(book)) should (equal (book) and be (readable))
         all(List(book)) should (be (readable) and equal (book))
@@ -160,7 +160,7 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not readable` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (stone) and be (readable))
+          all(left1) should (be_== (stone) and be (readable))
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (readable) and be (stone))
+          all(left2) should (be (readable) and be_== (stone))
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be readable'` {
       def `should do nothing when all(xs) is not readable` {
-        all(List(stone)) should (not be readable and not be book)
-        all(List(stone)) should (not be book and not be readable)
+        all(List(stone)) should (not be readable and not be_== book)
+        all(List(stone)) should (not be_== book and not be readable)
         
         all(List(stone)) should (not be readable and not equal book)
         all(List(stone)) should (not equal book and not be readable)
@@ -204,7 +204,7 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is readable` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be stone and not be readable)
+          all(left1) should (not be_== stone and not be readable)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeReadableLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be readable and not be stone)
+          all(left2) should (not be readable and not be_== stone)
         }
         assert(caught2.message === Some(allError(wasReadable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndSpec.scala
@@ -61,8 +61,8 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         readableFile should (equal (readableFile) and be (readable))
         readableFile should (be (readable) and equal (readableFile))
         
-        readableFile should (be (readableFile) and be (readable))
-        readableFile should (be (readable) and be (readableFile))
+        readableFile should (be_== (readableFile) and be (readable))
+        readableFile should (be (readable) and be_== (readableFile))
       }
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
@@ -81,14 +81,14 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          secretFile should (be (secretFile) and be (readable))
+          secretFile should (be_== (secretFile) and be (readable))
         }
         assert(caught3.message === Some(wasEqualTo(secretFile, secretFile) + ", but " + wasNotReadable(secretFile)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          secretFile should (be (readable) and be (secretFile))
+          secretFile should (be (readable) and be_== (secretFile))
         }
         assert(caught4.message === Some(wasNotReadable(secretFile)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -102,8 +102,8 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         secretFile should (not equal readableFile and not be readable)
         secretFile should (not be readable and not equal readableFile)
         
-        secretFile should (not be readableFile and not be readable)
-        secretFile should (not be readable and not be readableFile)
+        secretFile should (not be_== readableFile and not be readable)
+        secretFile should (not be readable and not be_== readableFile)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -122,14 +122,14 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          readableFile should (not be secretFile and not be readable)
+          readableFile should (not be_== secretFile and not be readable)
         }
         assert(caught3.message === Some(wasNotEqualTo(readableFile, secretFile) + ", but " + wasReadable(readableFile)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          readableFile should (not be readable and not be secretFile)
+          readableFile should (not be readable and not be_== secretFile)
         }
         assert(caught4.message === Some(wasReadable(readableFile)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -140,8 +140,8 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        all(List(readableFile)) should (be (readableFile) and be (readable))
-        all(List(readableFile)) should (be (readable) and be (readableFile))
+        all(List(readableFile)) should (be_== (readableFile) and be (readable))
+        all(List(readableFile)) should (be (readable) and be_== (readableFile))
         
         all(List(readableFile)) should (equal (readableFile) and be (readable))
         all(List(readableFile)) should (be (readable) and equal (readableFile))
@@ -150,7 +150,7 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not readable` {
         val left1 = List(secretFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (secretFile) and be (readable))
+          all(left1) should (be_== (secretFile) and be (readable))
         }
         assert(caught1.message === Some(allError(wasEqualTo(secretFile, secretFile) + ", but " + wasNotReadable(secretFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -158,7 +158,7 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         
         val left2 = List(secretFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (readable) and be (secretFile))
+          all(left2) should (be (readable) and be_== (secretFile))
         }
         assert(caught2.message === Some(allError(wasNotReadable(secretFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -184,8 +184,8 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
     
     object `when work with 'all(xs) should not be readable'` {
       def `should do nothing when all(xs) is not readable` {
-        all(List(secretFile)) should (not be readable and not be readableFile)
-        all(List(secretFile)) should (not be readableFile and not be readable)
+        all(List(secretFile)) should (not be readable and not be_== readableFile)
+        all(List(secretFile)) should (not be_== readableFile and not be readable)
         
         all(List(secretFile)) should (not be readable and not equal readableFile)
         all(List(secretFile)) should (not equal readableFile and not be readable)
@@ -194,7 +194,7 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is readable` {
         val left1 = List(readableFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be secretFile and not be readable)
+          all(left1) should (not be_== secretFile and not be readable)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(readableFile, secretFile) + ", but " + wasReadable(readableFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -202,7 +202,7 @@ class ShouldBeReadableLogicalAndSpec extends Spec {
         
         val left2 = List(readableFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be readable and not be secretFile)
+          all(left2) should (not be readable and not be_== secretFile)
         }
         assert(caught2.message === Some(allError(wasReadable(readableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
@@ -69,13 +69,13 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
       
       def `should do nothing when file is readable` {
         
-        (book should (be (readable) or be (book))) (readability)
-        (stone should (be (readable) or be (stone))) (readability)
-        (book should (be (readable) or be (stone))) (readability)
+        (book should (be (readable) or be_== (book))) (readability)
+        (stone should (be (readable) or be_== (stone))) (readability)
+        (book should (be (readable) or be_== (stone))) (readability)
         
-        (book should (be (book) or be (readable))) (readability)
-        (book should (be (stone) or be (readable))) (readability)
-        (stone should (be (stone) or be (readable))) (readability)
+        (book should (be_== (book) or be (readable))) (readability)
+        (book should (be_== (stone) or be (readable))) (readability)
+        (stone should (be_== (stone) or be (readable))) (readability)
         
         (book should (be (readable) or equal (book))) (readability, defaultEquality[Thing{val canRead: Boolean}])
         (stone should (be (readable) or equal (stone))) (readability, defaultEquality[Thing{val canRead: Boolean}])
@@ -88,14 +88,14 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
         val caught1 = intercept[TestFailedException] {
-          (stone should (be (readable) or be (book))) (readability)
+          (stone should (be (readable) or be_== (book))) (readability)
         }
         assert(caught1.message === Some(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (book) or be (readable))) (readability)
+          (stone should (be_== (book) or be (readable))) (readability)
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -120,13 +120,13 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
     object `when work with 'file should not be readable'` {
       
       def `should do nothing when file is not readable` {
-        (stone should (not be readable or not be book)) (readability)
-        (book should (not be readable or not be stone)) (readability)
-        (stone should (not be readable or not be stone)) (readability)
+        (stone should (not be readable or not be_== book)) (readability)
+        (book should (not be readable or not be_== stone)) (readability)
+        (stone should (not be readable or not be_== stone)) (readability)
         
-        (stone should (not be book or not be readable)) (readability)
-        (stone should (not be stone or not be readable)) (readability)
-        (book should (not be stone or not be readable)) (readability)
+        (stone should (not be_== book or not be readable)) (readability)
+        (stone should (not be_== stone or not be readable)) (readability)
+        (book should (not be_== stone or not be readable)) (readability)
         
         (stone should (not be readable or not equal book)) (readability, defaultEquality[Thing{val canRead: Boolean}])
         (book should (not be readable or not equal stone)) (readability, defaultEquality[Thing{val canRead: Boolean}])
@@ -139,14 +139,14 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is readable` {
         val caught1 = intercept[TestFailedException] {
-          (book should (not be readable or not be book)) (readability)
+          (book should (not be readable or not be_== book)) (readability)
         }
         assert(caught1.message === Some(wasReadable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (book should (not be book or not be readable)) (readability)
+          (book should (not be_== book or not be readable)) (readability)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasReadable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -171,13 +171,13 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        (all(List(book)) should (be (readable) or be (book))) (readability)
-        (all(List(stone)) should (be (readable) or be (stone))) (readability)
-        (all(List(book)) should (be (readable) or be (stone))) (readability)
+        (all(List(book)) should (be (readable) or be_== (book))) (readability)
+        (all(List(stone)) should (be (readable) or be_== (stone))) (readability)
+        (all(List(book)) should (be (readable) or be_== (stone))) (readability)
         
-        (all(List(book)) should (be (book) or be (readable))) (readability)
-        (all(List(book)) should (be (stone) or be (readable))) (readability)
-        (all(List(stone)) should (be (stone) or be (readable))) (readability)
+        (all(List(book)) should (be_== (book) or be (readable))) (readability)
+        (all(List(book)) should (be_== (stone) or be (readable))) (readability)
+        (all(List(stone)) should (be_== (stone) or be (readable))) (readability)
         
         (all(List(book)) should (be (readable) or equal (book))) (readability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(stone)) should (be (readable) or equal (stone))) (readability, defaultEquality[Thing{val canRead: Boolean}])
@@ -191,7 +191,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (book) or be (readable))) (readability)
+          (all(left1) should (be_== (book) or be (readable))) (readability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -199,7 +199,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (readable) or be (book))) (readability)
+          (all(left2) should (be (readable) or be_== (book))) (readability)
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        (all(List(stone)) should (not be readable or not be book)) (readability)
-        (all(List(book)) should (not be readable or not be stone)) (readability)
-        (all(List(stone)) should (not be readable or not be stone)) (readability)
+        (all(List(stone)) should (not be readable or not be_== book)) (readability)
+        (all(List(book)) should (not be readable or not be_== stone)) (readability)
+        (all(List(stone)) should (not be readable or not be_== stone)) (readability)
         
-        (all(List(stone)) should (not be book or not be readable)) (readability)
-        (all(List(stone)) should (not be stone or not be readable)) (readability)
-        (all(List(book)) should (not be stone or not be readable)) (readability)
+        (all(List(stone)) should (not be_== book or not be readable)) (readability)
+        (all(List(stone)) should (not be_== stone or not be readable)) (readability)
+        (all(List(book)) should (not be_== stone or not be readable)) (readability)
         
         (all(List(stone)) should (not be readable or not equal book)) (readability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(book)) should (not be readable or not equal stone)) (readability, defaultEquality[Thing{val canRead: Boolean}])
@@ -245,7 +245,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be book or not be readable)) (readability)
+          (all(left1) should (not be_== book or not be readable)) (readability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -253,7 +253,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be readable or not be book)) (readability)
+          (all(left2) should (not be readable or not be_== book)) (readability)
         }
         assert(caught2.message === Some(allError(wasReadable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrImplicitSpec.scala
@@ -69,13 +69,13 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
       
       def `should do nothing when file is readable` {
         
-        book should (be (readable) or be (book))
-        stone should (be (readable) or be (stone))
-        book should (be (readable) or be (stone))
+        book should (be (readable) or be_== (book))
+        stone should (be (readable) or be_== (stone))
+        book should (be (readable) or be_== (stone))
         
-        book should (be (book) or be (readable))
-        book should (be (stone) or be (readable))
-        stone should (be (stone) or be (readable))
+        book should (be_== (book) or be (readable))
+        book should (be_== (stone) or be (readable))
+        stone should (be_== (stone) or be (readable))
         
         book should (be (readable) or equal (book))
         stone should (be (readable) or equal (stone))
@@ -88,14 +88,14 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
         val caught1 = intercept[TestFailedException] {
-          stone should (be (readable) or be (book))
+          stone should (be (readable) or be_== (book))
         }
         assert(caught1.message === Some(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          stone should (be (book) or be (readable))
+          stone should (be_== (book) or be (readable))
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -120,13 +120,13 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
     object `when work with 'file should not be readable'` {
       
       def `should do nothing when file is not readable` {
-        stone should (not be readable or not be book)
-        book should (not be readable or not be stone)
-        stone should (not be readable or not be stone)
+        stone should (not be readable or not be_== book)
+        book should (not be readable or not be_== stone)
+        stone should (not be readable or not be_== stone)
         
-        stone should (not be book or not be readable)
-        stone should (not be stone or not be readable)
-        book should (not be stone or not be readable)
+        stone should (not be_== book or not be readable)
+        stone should (not be_== stone or not be readable)
+        book should (not be_== stone or not be readable)
         
         stone should (not be readable or not equal book)
         book should (not be readable or not equal stone)
@@ -139,14 +139,14 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is readable` {
         val caught1 = intercept[TestFailedException] {
-          book should (not be readable or not be book)
+          book should (not be readable or not be_== book)
         }
         assert(caught1.message === Some(wasReadable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          book should (not be book or not be readable)
+          book should (not be_== book or not be readable)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasReadable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -171,13 +171,13 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        all(List(book)) should (be (readable) or be (book))
-        all(List(stone)) should (be (readable) or be (stone))
-        all(List(book)) should (be (readable) or be (stone))
+        all(List(book)) should (be (readable) or be_== (book))
+        all(List(stone)) should (be (readable) or be_== (stone))
+        all(List(book)) should (be (readable) or be_== (stone))
         
-        all(List(book)) should (be (book) or be (readable))
-        all(List(book)) should (be (stone) or be (readable))
-        all(List(stone)) should (be (stone) or be (readable))
+        all(List(book)) should (be_== (book) or be (readable))
+        all(List(book)) should (be_== (stone) or be (readable))
+        all(List(stone)) should (be_== (stone) or be (readable))
         
         all(List(book)) should (be (readable) or equal (book))
         all(List(stone)) should (be (readable) or equal (stone))
@@ -191,7 +191,7 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (book) or be (readable))
+          all(left1) should (be_== (book) or be (readable))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -199,7 +199,7 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (readable) or be (book))
+          all(left2) should (be (readable) or be_== (book))
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(stone)) should (not be readable or not be book)
-        all(List(book)) should (not be readable or not be stone)
-        all(List(stone)) should (not be readable or not be stone)
+        all(List(stone)) should (not be readable or not be_== book)
+        all(List(book)) should (not be readable or not be_== stone)
+        all(List(stone)) should (not be readable or not be_== stone)
         
-        all(List(stone)) should (not be book or not be readable)
-        all(List(stone)) should (not be stone or not be readable)
-        all(List(book)) should (not be stone or not be readable)
+        all(List(stone)) should (not be_== book or not be readable)
+        all(List(stone)) should (not be_== stone or not be readable)
+        all(List(book)) should (not be_== stone or not be readable)
         
         all(List(stone)) should (not be readable or not equal book)
         all(List(book)) should (not be readable or not equal stone)
@@ -245,7 +245,7 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be book or not be readable)
+          all(left1) should (not be_== book or not be readable)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -253,7 +253,7 @@ class ShouldBeReadableLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be readable or not be book)
+          all(left2) should (not be readable or not be_== book)
         }
         assert(caught2.message === Some(allError(wasReadable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrSpec.scala
@@ -59,13 +59,13 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
       
       def `should do nothing when file is readable` {
         
-        readableFile should (be (readable) or be (readableFile))
-        secretFile should (be (readable) or be (secretFile))
-        readableFile should (be (readable) or be (secretFile))
+        readableFile should (be (readable) or be_== (readableFile))
+        secretFile should (be (readable) or be_== (secretFile))
+        readableFile should (be (readable) or be_== (secretFile))
         
-        readableFile should (be (readableFile) or be (readable))
-        readableFile should (be (secretFile) or be (readable))
-        secretFile should (be (secretFile) or be (readable))
+        readableFile should (be_== (readableFile) or be (readable))
+        readableFile should (be_== (secretFile) or be (readable))
+        secretFile should (be_== (secretFile) or be (readable))
         
         readableFile should (be (readable) or equal (readableFile))
         secretFile should (be (readable) or equal (secretFile))
@@ -78,14 +78,14 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not readable` {
         val caught1 = intercept[TestFailedException] {
-          secretFile should (be (readable) or be (readableFile))
+          secretFile should (be (readable) or be_== (readableFile))
         }
         assert(caught1.message === Some(wasNotReadable(secretFile) + ", and " + wasNotEqualTo(secretFile, readableFile)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          secretFile should (be (readableFile) or be (readable))
+          secretFile should (be_== (readableFile) or be (readable))
         }
         assert(caught2.message === Some(wasNotEqualTo(secretFile, readableFile) + ", and " + wasNotReadable(secretFile)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -110,13 +110,13 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
     object `when work with 'file should not be readable'` {
       
       def `should do nothing when file is not readable` {
-        secretFile should (not be readable or not be readableFile)
-        readableFile should (not be readable or not be secretFile)
-        secretFile should (not be readable or not be secretFile)
+        secretFile should (not be readable or not be_== readableFile)
+        readableFile should (not be readable or not be_== secretFile)
+        secretFile should (not be readable or not be_== secretFile)
         
-        secretFile should (not be readableFile or not be readable)
-        secretFile should (not be secretFile or not be readable)
-        readableFile should (not be secretFile or not be readable)
+        secretFile should (not be_== readableFile or not be readable)
+        secretFile should (not be_== secretFile or not be readable)
+        readableFile should (not be_== secretFile or not be readable)
         
         secretFile should (not be readable or not equal readableFile)
         readableFile should (not be readable or not equal secretFile)
@@ -129,14 +129,14 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is readable` {
         val caught1 = intercept[TestFailedException] {
-          readableFile should (not be readable or not be readableFile)
+          readableFile should (not be readable or not be_== readableFile)
         }
         assert(caught1.message === Some(wasReadable(readableFile) + ", and " + wasEqualTo(readableFile, readableFile)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          readableFile should (not be readableFile or not be readable)
+          readableFile should (not be_== readableFile or not be readable)
         }
         assert(caught2.message === Some(wasEqualTo(readableFile, readableFile) + ", and " + wasReadable(readableFile)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -161,13 +161,13 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
     object `when work with 'all(xs) should be (readable)'` {
       
       def `should do nothing when all(xs) is readable` {
-        all(List(readableFile)) should (be (readable) or be (readableFile))
-        all(List(secretFile)) should (be (readable) or be (secretFile))
-        all(List(readableFile)) should (be (readable) or be (secretFile))
+        all(List(readableFile)) should (be (readable) or be_== (readableFile))
+        all(List(secretFile)) should (be (readable) or be_== (secretFile))
+        all(List(readableFile)) should (be (readable) or be_== (secretFile))
         
-        all(List(readableFile)) should (be (readableFile) or be (readable))
-        all(List(readableFile)) should (be (secretFile) or be (readable))
-        all(List(secretFile)) should (be (secretFile) or be (readable))
+        all(List(readableFile)) should (be_== (readableFile) or be (readable))
+        all(List(readableFile)) should (be_== (secretFile) or be (readable))
+        all(List(secretFile)) should (be_== (secretFile) or be (readable))
         
         all(List(readableFile)) should (be (readable) or equal (readableFile))
         all(List(secretFile)) should (be (readable) or equal (secretFile))
@@ -181,7 +181,7 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(secretFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (readableFile) or be (readable))
+          all(left1) should (be_== (readableFile) or be (readable))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(secretFile, readableFile) + ", and " + wasNotReadable(secretFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -189,7 +189,7 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
         
         val left2 = List(secretFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (readable) or be (readableFile))
+          all(left2) should (be (readable) or be_== (readableFile))
         }
         assert(caught2.message === Some(allError(wasNotReadable(secretFile) + ", and " + wasNotEqualTo(secretFile, readableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -215,13 +215,13 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(secretFile)) should (not be readable or not be readableFile)
-        all(List(readableFile)) should (not be readable or not be secretFile)
-        all(List(secretFile)) should (not be readable or not be secretFile)
+        all(List(secretFile)) should (not be readable or not be_== readableFile)
+        all(List(readableFile)) should (not be readable or not be_== secretFile)
+        all(List(secretFile)) should (not be readable or not be_== secretFile)
         
-        all(List(secretFile)) should (not be readableFile or not be readable)
-        all(List(secretFile)) should (not be secretFile or not be readable)
-        all(List(readableFile)) should (not be secretFile or not be readable)
+        all(List(secretFile)) should (not be_== readableFile or not be readable)
+        all(List(secretFile)) should (not be_== secretFile or not be readable)
+        all(List(readableFile)) should (not be_== secretFile or not be readable)
         
         all(List(secretFile)) should (not be readable or not equal readableFile)
         all(List(readableFile)) should (not be readable or not equal secretFile)
@@ -235,7 +235,7 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(readableFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be readableFile or not be readable)
+          all(left1) should (not be_== readableFile or not be readable)
         }
         assert(caught1.message === Some(allError(wasEqualTo(readableFile, readableFile) + ", and " + wasReadable(readableFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -243,7 +243,7 @@ class ShouldBeReadableLogicalOrSpec extends Spec {
         
         val left2 = List(readableFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be readable or not be readableFile)
+          all(left2) should (not be readable or not be_== readableFile)
         }
         assert(caught2.message === Some(allError(wasReadable(readableFile) + ", and " + wasEqualTo(readableFile, readableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalAndSpec.scala
@@ -53,8 +53,8 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (readable))
-        objTrue should (be (readable) and be (objTrue))
-        objTrue should (be (objTrue) and be (readable))
+        objTrue should (be (readable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (readable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -73,14 +73,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objFalse))
+          objFalse should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (readable))
+          objTrue should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -103,14 +103,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (readable) and be (objFalse))
+          objTrue should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasReadable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (readable))
+          objFalse should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -133,14 +133,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objTrue))
+          objFalse should (be (readable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (readable))
+          objFalse should (be_== (objTrue) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -160,8 +160,8 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (readable))
-        objTrue should (be (readable) and be (objTrue))
-        objTrue should (be (objTrue) and be (readable))
+        objTrue should (be (readable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (readable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -180,14 +180,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objFalse))
+          objFalse should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (readable))
+          objTrue should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -210,14 +210,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (readable) and be (objFalse))
+          objTrue should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasReadable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (readable))
+          objFalse should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -240,14 +240,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objTrue))
+          objFalse should (be (readable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (readable))
+          objFalse should (be_== (objTrue) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -267,8 +267,8 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (readable))
-        objTrue should (be (readable) and be (objTrue))
-        objTrue should (be (objTrue) and be (readable))
+        objTrue should (be (readable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (readable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -287,14 +287,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objFalse))
+          objFalse should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (readable))
+          objTrue should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -317,14 +317,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (readable) and be (objFalse))
+          objTrue should (be (readable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasReadable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (readable))
+          objFalse should (be_== (objFalse) and be (readable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -347,14 +347,14 @@ class ShouldBeReadableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) and be (objTrue))
+          objFalse should (be (readable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (readable))
+          objFalse should (be_== (objTrue) and be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalOrSpec.scala
@@ -52,22 +52,22 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (readable))
-        objTrue should (be (readable) or be (objTrue))
-        objTrue should (be (objTrue) or be (readable))
+        objTrue should (be (readable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (readable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (readable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (readable))
-        objFalse should (be (readable) or be (objFalse))
-        objTrue should (be (objFalse) or be (readable))
+        objFalse should (be (readable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (readable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (readable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (readable))
-        objTrue should (be (readable) or be (objFalse))
-        objFalse should (be (objFalse) or be (readable))
+        objTrue should (be (readable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (readable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -86,14 +86,14 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) or be (objTrue))
+          objFalse should (be (readable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (readable))
+          objFalse should (be_== (objTrue) or be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -113,22 +113,22 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (readable))
-        objTrue should (be (readable) or be (objTrue))
-        objTrue should (be (objTrue) or be (readable))
+        objTrue should (be (readable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (readable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (readable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (readable))
-        objFalse should (be (readable) or be (objFalse))
-        objTrue should (be (objFalse) or be (readable))
+        objFalse should (be (readable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (readable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (readable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (readable))
-        objTrue should (be (readable) or be (objFalse))
-        objFalse should (be (objFalse) or be (readable))
+        objTrue should (be (readable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (readable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -147,14 +147,14 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) or be (objTrue))
+          objFalse should (be (readable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (readable))
+          objFalse should (be_== (objTrue) or be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -174,22 +174,22 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
       it("should do nothing for when both passed") {
         objTrue should (be (readable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (readable))
-        objTrue should (be (readable) or be (objTrue))
-        objTrue should (be (objTrue) or be (readable))
+        objTrue should (be (readable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (readable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (readable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (readable))
-        objFalse should (be (readable) or be (objFalse))
-        objTrue should (be (objFalse) or be (readable))
+        objFalse should (be (readable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (readable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (readable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (readable))
-        objTrue should (be (readable) or be (objFalse))
-        objFalse should (be (objFalse) or be (readable))
+        objTrue should (be (readable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (readable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -208,14 +208,14 @@ class ShouldBeReadableStructuralLogicalOrSpec extends FunSpec with Matchers {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (readable) or be (objTrue))
+          objFalse should (be (readable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotReadable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (readable))
+          objFalse should (be_== (objTrue) or be (readable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotReadable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
@@ -77,28 +77,28 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should do nothing when xs is sorted` {
         orderedInts should (be (sorted) and be (sorted))
-        orderedInts should (be (sorted) and be (orderedInts))
-        orderedInts should (be (orderedInts) and be (sorted))
+        orderedInts should (be (sorted) and be_== (orderedInts))
+        orderedInts should (be_== (orderedInts) and be (sorted))
         
         orderedStudents should (be (sorted) and be (sorted))
         orderedStudents should (be (sorted) and equal (orderedStudents))
         orderedStudents should (equal (orderedStudents) and be (sorted))
 
         orderedString should (be (sorted) and be (sorted))
-        orderedString should (be (sorted) and be (orderedString))
-        orderedString should (be (orderedString) and be (sorted))
+        orderedString should (be (sorted) and be_== (orderedString))
+        orderedString should (be_== (orderedString) and be (sorted))
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val caught1 = intercept[TestFailedException] {
-          outOfOrderInts should (be (outOfOrderInts) and be (sorted))
+          outOfOrderInts should (be_== (outOfOrderInts) and be (sorted))
         }
         assert(caught1.message === Some(wasEqualTo(outOfOrderInts, outOfOrderInts) + ", but " + wasNotSorted(outOfOrderInts)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          outOfOrderInts should (be (sorted) and be (outOfOrderInts))
+          outOfOrderInts should (be (sorted) and be_== (outOfOrderInts))
         }
         assert(caught2.message === Some(wasNotSorted(outOfOrderInts)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -119,14 +119,14 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught5 = intercept[TestFailedException] {
-          outOfOrderString should (be (outOfOrderString) and be (sorted))
+          outOfOrderString should (be_== (outOfOrderString) and be (sorted))
         }
         assert(caught5.message === Some(wasEqualTo(outOfOrderString, outOfOrderString) + ", but " + wasNotSorted(outOfOrderString)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
         assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught6 = intercept[TestFailedException] {
-          outOfOrderString should (be (sorted) and be (outOfOrderString))
+          outOfOrderString should (be (sorted) and be_== (outOfOrderString))
         }
         assert(caught6.message === Some(wasNotSorted(outOfOrderString)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -135,10 +135,10 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          outOfOrderInts should (be (sorted) and be (outOfOrderInts))
+          outOfOrderInts should (be (sorted) and be_== (outOfOrderInts))
         }
         implicit val imp = trueSortable
-        outOfOrderInts should (be (sorted) and be (outOfOrderInts))
+        outOfOrderInts should (be (sorted) and be_== (outOfOrderInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -152,26 +152,26 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
     object `when work with 'xs should not be sorted'` {
       
       def `should do nothing when xs is not sorted` {
-        outOfOrderInts should (not be sorted and not be outOfOrderStudents)
-        outOfOrderInts should (not be outOfOrderStudents and not be sorted)
+        outOfOrderInts should (not be sorted and not be_== outOfOrderStudents)
+        outOfOrderInts should (not be_== outOfOrderStudents and not be sorted)
         
         outOfOrderStudents should (not be sorted and not equal outOfOrderInts)
         outOfOrderStudents should (not equal outOfOrderInts and not be sorted)
 
-        outOfOrderString should (not be sorted and not be outOfOrderStudents)
-        outOfOrderString should (not be outOfOrderStudents and not be sorted)
+        outOfOrderString should (not be sorted and not be_== outOfOrderStudents)
+        outOfOrderString should (not be_== outOfOrderStudents and not be sorted)
       }
 
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val caught1 = intercept[TestFailedException] {
-          orderedInts should (not be outOfOrderStudents and not be sorted)
+          orderedInts should (not be_== outOfOrderStudents and not be sorted)
         }
         assert(caught1.message === Some(wasNotEqualTo(orderedInts, outOfOrderStudents) + ", but " + wasSorted(orderedInts)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          orderedInts should (not be sorted and not be outOfOrderStudents)
+          orderedInts should (not be sorted and not be_== outOfOrderStudents)
         }
         assert(caught2.message === Some(wasSorted(orderedInts)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -192,14 +192,14 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught5 = intercept[TestFailedException] {
-          orderedString should (not be outOfOrderStudents and not be sorted)
+          orderedString should (not be_== outOfOrderStudents and not be sorted)
         }
         assert(caught5.message === Some(wasNotEqualTo(orderedString, outOfOrderStudents) + ", but " + wasSorted(orderedString)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
         assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught6 = intercept[TestFailedException] {
-          orderedString should (not be sorted and not be outOfOrderStudents)
+          orderedString should (not be sorted and not be_== outOfOrderStudents)
         }
         assert(caught6.message === Some(wasSorted(orderedString)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -208,10 +208,10 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          orderedInts should (not be (sorted) and not be (outOfOrderInts))
+          orderedInts should (not be (sorted) and not be_== (outOfOrderInts))
         }
         implicit val imp = falseSortable
-        orderedInts should (not be (sorted) and not be (outOfOrderInts))
+        orderedInts should (not be (sorted) and not be_== (outOfOrderInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -226,22 +226,22 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should do nothing when xs is sorted` {
         all(List(orderedInts)) should (be (sorted) and be (sorted))
-        all(List(orderedInts)) should (be (sorted) and be (orderedInts))
-        all(List(orderedInts)) should (be (orderedInts) and be (sorted))
+        all(List(orderedInts)) should (be (sorted) and be_== (orderedInts))
+        all(List(orderedInts)) should (be_== (orderedInts) and be (sorted))
         
         all(List(orderedStudents)) should (be (sorted) and be (sorted))
         all(List(orderedStudents)) should (be (sorted) and equal (orderedStudents))
         all(List(orderedStudents)) should (equal (orderedStudents) and be (sorted))
 
         all(List(orderedString)) should (be (sorted) and be (sorted))
-        all(List(orderedString)) should (be (sorted) and be (orderedString))
-        all(List(orderedString)) should (be (orderedString) and be (sorted))
+        all(List(orderedString)) should (be (sorted) and be_== (orderedString))
+        all(List(orderedString)) should (be_== (orderedString) and be (sorted))
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(outOfOrderInts)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (outOfOrderInts) and be (sorted))
+          all(left1) should (be_== (outOfOrderInts) and be (sorted))
         }
         assert(caught1.message === Some(allInspectionFailed(0, wasEqualTo(outOfOrderInts, outOfOrderInts) + ", but " + wasNotSorted(outOfOrderInts), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -249,7 +249,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         
         val left2 = List(outOfOrderInts)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (sorted) and be (outOfOrderInts))
+          all(left2) should (be (sorted) and be_== (outOfOrderInts))
         }
         assert(caught2.message === Some(allInspectionFailed(0, wasNotSorted(outOfOrderInts), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -273,7 +273,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
 
         val left5 = List(outOfOrderString)
         val caught5 = intercept[TestFailedException] {
-          all(left5) should (be (outOfOrderString) and be (sorted))
+          all(left5) should (be_== (outOfOrderString) and be (sorted))
         }
         assert(caught5.message === Some(allInspectionFailed(0, wasEqualTo(outOfOrderString, outOfOrderString) + ", but " + wasNotSorted(outOfOrderString), thisLineNumber - 2, left5)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -281,7 +281,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         
         val left6 = List(outOfOrderString)
         val caught6 = intercept[TestFailedException] {
-          all(left6) should (be (sorted) and be (outOfOrderString))
+          all(left6) should (be (sorted) and be_== (outOfOrderString))
         }
         assert(caught6.message === Some(allInspectionFailed(0, wasNotSorted(outOfOrderString), thisLineNumber - 2, left6)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -290,10 +290,10 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          all(List(outOfOrderInts)) should (be (sorted) and be (outOfOrderInts))
+          all(List(outOfOrderInts)) should (be (sorted) and be_== (outOfOrderInts))
         }
         implicit val imp = trueSortable
-        all(List(outOfOrderInts)) should (be (sorted) and be (outOfOrderInts))
+        all(List(outOfOrderInts)) should (be (sorted) and be_== (outOfOrderInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -306,20 +306,20 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(outOfOrderInts)) should (not be sorted and not be outOfOrderStudents)
-        all(List(outOfOrderInts)) should (not be outOfOrderStudents and not be sorted)
+        all(List(outOfOrderInts)) should (not be sorted and not be_== outOfOrderStudents)
+        all(List(outOfOrderInts)) should (not be_== outOfOrderStudents and not be sorted)
         
         all(List(outOfOrderStudents)) should (not be sorted and not equal outOfOrderInts)
         all(List(outOfOrderStudents)) should (not equal outOfOrderInts and not be sorted)
 
-        all(List(outOfOrderString)) should (not be sorted and not be outOfOrderStudents)
-        all(List(outOfOrderString)) should (not be outOfOrderStudents and not be sorted)
+        all(List(outOfOrderString)) should (not be sorted and not be_== outOfOrderStudents)
+        all(List(outOfOrderString)) should (not be_== outOfOrderStudents and not be sorted)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(orderedInts)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be outOfOrderStudents and not be sorted)
+          all(left1) should (not be_== outOfOrderStudents and not be sorted)
         }
         assert(caught1.message === Some(allInspectionFailed(0, wasNotEqualTo(orderedInts, outOfOrderStudents) + ", but " + wasSorted(orderedInts), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -327,7 +327,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         
         val left2 = List(orderedInts)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be sorted and not be outOfOrderStudents)
+          all(left2) should (not be sorted and not be_== outOfOrderStudents)
         }
         assert(caught2.message === Some(allInspectionFailed(0, wasSorted(orderedInts), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -351,7 +351,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
 
         val left5 = List(orderedString)
         val caught5 = intercept[TestFailedException] {
-          all(left5) should (not be outOfOrderStudents and not be sorted)
+          all(left5) should (not be_== outOfOrderStudents and not be sorted)
         }
         assert(caught5.message === Some(allInspectionFailed(0, wasNotEqualTo(orderedString, outOfOrderStudents) + ", but " + wasSorted(orderedString), thisLineNumber - 2, left5)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -359,7 +359,7 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
         
         val left6 = List(orderedString)
         val caught6 = intercept[TestFailedException] {
-          all(left6) should (not be sorted and not be outOfOrderStudents)
+          all(left6) should (not be sorted and not be_== outOfOrderStudents)
         }
         assert(caught6.message === Some(allInspectionFailed(0, wasSorted(orderedString), thisLineNumber - 2, left6)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalAndSpec.scala"))
@@ -368,10 +368,10 @@ class ShouldBeSortedLogicalAndSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          all(List(orderedInts)) should (not be (sorted) and not be (outOfOrderInts))
+          all(List(orderedInts)) should (not be (sorted) and not be_== (outOfOrderInts))
         }
         implicit val imp = falseSortable
-        all(List(orderedInts)) should (not be (sorted) and not be (outOfOrderInts))
+        all(List(orderedInts)) should (not be (sorted) and not be_== (outOfOrderInts))
       }
       
       def `should use explicitly specified Sortable` {

--- a/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
@@ -81,8 +81,8 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         orderedInts should (equal (orderedStudents) or be (sorted))
         
         orderedStudents should (be (sorted) or be (sorted))
-        orderedStudents should (be (sorted) or be (orderedInts))
-        orderedStudents should (be (orderedInts) or be (sorted))
+        orderedStudents should (be (sorted) or be_== (orderedInts))
+        orderedStudents should (be_== (orderedInts) or be (sorted))
         
         orderedString should (be (sorted) or be (sorted))
         orderedString should (be (sorted) or equal (orderedStudents))
@@ -91,14 +91,14 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val caught1 = intercept[TestFailedException] {
-          outOfOrderInts should (be (outOfOrderStudents) or be (sorted))
+          outOfOrderInts should (be_== (outOfOrderStudents) or be (sorted))
         }
         assert(caught1.message === Some(wasNotEqualTo(outOfOrderInts, outOfOrderStudents) + ", and " + wasNotSorted(outOfOrderInts)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          outOfOrderInts should (be (sorted) or be (outOfOrderStudents))
+          outOfOrderInts should (be (sorted) or be_== (outOfOrderStudents))
         }
         assert(caught2.message === Some(wasNotSorted(outOfOrderInts) + ", and " + wasNotEqualTo(outOfOrderInts, outOfOrderStudents)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -119,14 +119,14 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught5 = intercept[TestFailedException] {
-          outOfOrderString should (be (outOfOrderStudents) or be (sorted))
+          outOfOrderString should (be_== (outOfOrderStudents) or be (sorted))
         }
         assert(caught5.message === Some(wasNotEqualTo(outOfOrderString, outOfOrderStudents) + ", and " + wasNotSorted(outOfOrderString)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
         assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught6 = intercept[TestFailedException] {
-          outOfOrderString should (be (sorted) or be (outOfOrderStudents))
+          outOfOrderString should (be (sorted) or be_== (outOfOrderStudents))
         }
         assert(caught6.message === Some(wasNotSorted(outOfOrderString) + ", and " + wasNotEqualTo(outOfOrderString, outOfOrderStudents)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -135,10 +135,10 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          outOfOrderInts should (be (sorted) or be (orderedInts))
+          outOfOrderInts should (be (sorted) or be_== (orderedInts))
         }
         implicit val imp = trueSortable
-        outOfOrderInts should (be (sorted) or be (orderedInts))
+        outOfOrderInts should (be (sorted) or be_== (orderedInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -152,8 +152,8 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
     object `when work with 'xs should not be sorted'` {
       
       def `should do nothing when xs is not sorted` {
-        outOfOrderInts should (not be sorted or not be outOfOrderInts)
-        outOfOrderInts should (not be outOfOrderInts or not be sorted)
+        outOfOrderInts should (not be sorted or not be_== outOfOrderInts)
+        outOfOrderInts should (not be_== outOfOrderInts or not be sorted)
         
         outOfOrderStudents should (not be sorted or not equal outOfOrderStudents)
         outOfOrderStudents should (not equal outOfOrderStudents or not be sorted)
@@ -161,14 +161,14 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val caught1 = intercept[TestFailedException] {
-          orderedInts should (not be orderedInts or not be sorted)
+          orderedInts should (not be_== orderedInts or not be sorted)
         }
         assert(caught1.message === Some(wasEqualTo(orderedInts, orderedInts) + ", and " + wasSorted(orderedInts)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          orderedInts should (not be sorted or not be orderedInts)
+          orderedInts should (not be sorted or not be_== orderedInts)
         }
         assert(caught2.message === Some(wasSorted(orderedInts) + ", and " + wasEqualTo(orderedInts, orderedInts)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -189,14 +189,14 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught5 = intercept[TestFailedException] {
-          orderedString should (not be orderedString or not be sorted)
+          orderedString should (not be_== orderedString or not be sorted)
         }
         assert(caught5.message === Some(wasEqualTo(orderedString, orderedString) + ", and " + wasSorted(orderedString)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
         assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught6 = intercept[TestFailedException] {
-          orderedString should (not be sorted or not be orderedString)
+          orderedString should (not be sorted or not be_== orderedString)
         }
         assert(caught6.message === Some(wasSorted(orderedString) + ", and " + wasEqualTo(orderedString, orderedString)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -205,10 +205,10 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          orderedInts should (not be (sorted) or not be (orderedInts))
+          orderedInts should (not be (sorted) or not be_== (orderedInts))
         }
         implicit val imp = falseSortable
-        orderedInts should (not be (sorted) or not be (orderedInts))
+        orderedInts should (not be (sorted) or not be_== (orderedInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -227,8 +227,8 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         all(List(orderedInts)) should (equal (orderedStudents) or be (sorted))
 
         all(List(orderedStudents)) should (be (sorted) or be (sorted))
-        all(List(orderedStudents)) should (be (sorted) or be (orderedInts))
-        all(List(orderedStudents)) should (be (orderedInts) or be (sorted))
+        all(List(orderedStudents)) should (be (sorted) or be_== (orderedInts))
+        all(List(orderedStudents)) should (be_== (orderedInts) or be (sorted))
         
         all(List(orderedString)) should (be (sorted) or be (sorted))
         all(List(orderedString)) should (be (sorted) or equal (orderedStudents))
@@ -238,7 +238,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(outOfOrderInts)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (orderedInts) or be (sorted))
+          all(left1) should (be_== (orderedInts) or be (sorted))
         }
         assert(caught1.message === Some(allInspectionFailed(0, wasNotEqualTo(outOfOrderInts, orderedInts) + ", and " + wasNotSorted(outOfOrderInts), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -246,7 +246,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         
         val left2 = List(outOfOrderInts)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (sorted) or be (orderedInts))
+          all(left2) should (be (sorted) or be_== (orderedInts))
         }
         assert(caught2.message === Some(allInspectionFailed(0, wasNotSorted(outOfOrderInts) + ", and " + wasNotEqualTo(outOfOrderInts, orderedInts), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -270,7 +270,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
 
         val left5 = List(outOfOrderString)
         val caught5 = intercept[TestFailedException] {
-          all(left5) should (be (orderedString) or be (sorted))
+          all(left5) should (be_== (orderedString) or be (sorted))
         }
         assert(caught5.message === Some(allInspectionFailed(0, wasNotEqualTo(outOfOrderString, orderedString) + ", and " + wasNotSorted(outOfOrderString), thisLineNumber - 2, left5)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -278,7 +278,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         
         val left6 = List(outOfOrderString)
         val caught6 = intercept[TestFailedException] {
-          all(left6) should (be (sorted) or be (orderedString))
+          all(left6) should (be (sorted) or be_== (orderedString))
         }
         assert(caught6.message === Some(allInspectionFailed(0, wasNotSorted(outOfOrderString) + ", and " + wasNotEqualTo(outOfOrderString, orderedString), thisLineNumber - 2, left6)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -287,10 +287,10 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          all(List(outOfOrderInts)) should (be (sorted) or be (orderedInts))
+          all(List(outOfOrderInts)) should (be (sorted) or be_== (orderedInts))
         }
         implicit val imp = trueSortable
-        all(List(outOfOrderInts)) should (be (sorted) or be (orderedInts))
+        all(List(outOfOrderInts)) should (be (sorted) or be_== (orderedInts))
       }
       
       def `should use explicitly specified Sortable` {
@@ -303,20 +303,20 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(outOfOrderInts)) should (not be sorted or not be orderedStudents)
-        all(List(outOfOrderInts)) should (not be orderedStudents or not be sorted)
+        all(List(outOfOrderInts)) should (not be sorted or not be_== orderedStudents)
+        all(List(outOfOrderInts)) should (not be_== orderedStudents or not be sorted)
         
         all(List(outOfOrderStudents)) should (not be sorted or not equal orderedInts)
         all(List(outOfOrderStudents)) should (not equal orderedInts or not be sorted)
 
-        all(List(outOfOrderString)) should (not be sorted or not be orderedStudents)
-        all(List(outOfOrderString)) should (not be orderedStudents or not be sorted)
+        all(List(outOfOrderString)) should (not be sorted or not be_== orderedStudents)
+        all(List(outOfOrderString)) should (not be_== orderedStudents or not be sorted)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(orderedInts)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be orderedInts or not be sorted)
+          all(left1) should (not be_== orderedInts or not be sorted)
         }
         assert(caught1.message === Some(allInspectionFailed(0, wasEqualTo(orderedInts, orderedInts) + ", and " + wasSorted(orderedInts), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -324,7 +324,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         
         val left2 = List(orderedInts)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be sorted or not be orderedInts)
+          all(left2) should (not be sorted or not be_== orderedInts)
         }
         assert(caught2.message === Some(allInspectionFailed(0, wasSorted(orderedInts) + ", and " + wasEqualTo(orderedInts, orderedInts), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -348,7 +348,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
 
         val left5 = List(orderedString)
         val caught5 = intercept[TestFailedException] {
-          all(left5) should (not be orderedString or not be sorted)
+          all(left5) should (not be_== orderedString or not be sorted)
         }
         assert(caught5.message === Some(allInspectionFailed(0, wasEqualTo(orderedString, orderedString) + ", and " + wasSorted(orderedString), thisLineNumber - 2, left5)))
         assert(caught5.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -356,7 +356,7 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
         
         val left6 = List(orderedString)
         val caught6 = intercept[TestFailedException] {
-          all(left6) should (not be sorted or not be orderedString)
+          all(left6) should (not be sorted or not be_== orderedString)
         }
         assert(caught6.message === Some(allInspectionFailed(0, wasSorted(orderedString) + ", and " + wasEqualTo(orderedString, orderedString), thisLineNumber - 2, left6)))
         assert(caught6.failedCodeFileName === Some("ShouldBeSortedLogicalOrSpec.scala"))
@@ -365,10 +365,10 @@ class ShouldBeSortedLogicalOrSpec extends Spec {
       
       def `should use implicit Sortable when available` {
         intercept[TestFailedException] {
-          all(List(orderedInts)) should (not be (sorted) or not be (orderedInts))
+          all(List(orderedInts)) should (not be (sorted) or not be_== (orderedInts))
         }
         implicit val imp = falseSortable
-        all(List(orderedInts)) should (not be (sorted) or not be (orderedInts))
+        all(List(orderedInts)) should (not be (sorted) or not be_== (orderedInts))
       }
       
       def `should use explicitly specified Sortable` {

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         (book should (equal (book) and be (writable))) (defaultEquality[Thing{val canRead: Boolean}], writability)
         (book should (be (writable) and equal (book))) (writability, defaultEquality[Thing{val canRead: Boolean}])
         
-        (book should (be (book) and be (writable))) (writability)
-        (book should (be (writable) and be (book))) (writability)
+        (book should (be_== (book) and be (writable))) (writability)
+        (book should (be (writable) and be_== (book))) (writability)
       }
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
@@ -91,14 +91,14 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (stone) and be (writable))) (writability)
+          (stone should (be_== (stone) and be (writable))) (writability)
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (stone should (be (writable) and be (stone))) (writability)
+          (stone should (be (writable) and be_== (stone))) (writability)
         }
         assert(caught4.message === Some(wasNotWritable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         (stone should (not equal book and not be writable)) (defaultEquality[Thing{val canRead: Boolean}], writability)
         (stone should (not be writable and not equal book)) (writability, defaultEquality[Thing{val canRead: Boolean}])
         
-        (stone should (not be book and not be writable)) (writability)
-        (stone should (not be writable and not be book)) (writability)
+        (stone should (not be_== book and not be writable)) (writability)
+        (stone should (not be writable and not be_== book)) (writability)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -132,14 +132,14 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (book should (not be stone and not be writable)) (writability)
+          (book should (not be_== stone and not be writable)) (writability)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasWritable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (book should (not be writable and not be stone)) (writability)
+          (book should (not be writable and not be_== stone)) (writability)
         }
         assert(caught4.message === Some(wasWritable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        (all(List(book)) should (be (book) and be (writable))) (writability)
-        (all(List(book)) should (be (writable) and be (book))) (writability)
+        (all(List(book)) should (be_== (book) and be (writable))) (writability)
+        (all(List(book)) should (be (writable) and be_== (book))) (writability)
         
         (all(List(book)) should (equal (book) and be (writable))) (defaultEquality[Thing{val canRead: Boolean}], writability)
         (all(List(book)) should (be (writable) and equal (book))) (writability, defaultEquality[Thing{val canRead: Boolean}])
@@ -160,7 +160,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not writable` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (stone) and be (writable))) (writability)
+          (all(left1) should (be_== (stone) and be (writable))) (writability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (writable) and be (stone))) (writability)
+          (all(left2) should (be (writable) and be_== (stone))) (writability)
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be writable'` {
       def `should do nothing when all(xs) is not writable` {
-        (all(List(stone)) should (not be writable and not be book)) (writability)
-        (all(List(stone)) should (not be book and not be writable)) (writability)
+        (all(List(stone)) should (not be writable and not be_== book)) (writability)
+        (all(List(stone)) should (not be_== book and not be writable)) (writability)
         
         (all(List(stone)) should (not be writable and not equal book)) (writability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(stone)) should (not equal book and not be writable)) (defaultEquality[Thing{val canRead: Boolean}], writability)
@@ -204,7 +204,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is writable` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be stone and not be writable)) (writability)
+          (all(left1) should (not be_== stone and not be writable)) (writability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be writable and not be stone)) (writability)
+          (all(left2) should (not be writable and not be_== stone)) (writability)
         }
         assert(caught2.message === Some(allError(wasWritable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndImplicitSpec.scala
@@ -71,8 +71,8 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         book should (equal (book) and be (writable))
         book should (be (writable) and equal (book))
         
-        book should (be (book) and be (writable))
-        book should (be (writable) and be (book))
+        book should (be_== (book) and be (writable))
+        book should (be (writable) and be_== (book))
       }
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
@@ -91,14 +91,14 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          stone should (be (stone) and be (writable))
+          stone should (be_== (stone) and be (writable))
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          stone should (be (writable) and be (stone))
+          stone should (be (writable) and be_== (stone))
         }
         assert(caught4.message === Some(wasNotWritable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -112,8 +112,8 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         stone should (not equal book and not be writable)
         stone should (not be writable and not equal book)
         
-        stone should (not be book and not be writable)
-        stone should (not be writable and not be book)
+        stone should (not be_== book and not be writable)
+        stone should (not be writable and not be_== book)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -132,14 +132,14 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          book should (not be stone and not be writable)
+          book should (not be_== stone and not be writable)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasWritable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          book should (not be writable and not be stone)
+          book should (not be writable and not be_== stone)
         }
         assert(caught4.message === Some(wasWritable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -150,8 +150,8 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        all(List(book)) should (be (book) and be (writable))
-        all(List(book)) should (be (writable) and be (book))
+        all(List(book)) should (be_== (book) and be (writable))
+        all(List(book)) should (be (writable) and be_== (book))
         
         all(List(book)) should (equal (book) and be (writable))
         all(List(book)) should (be (writable) and equal (book))
@@ -160,7 +160,7 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not writable` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (stone) and be (writable))
+          all(left1) should (be_== (stone) and be (writable))
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -168,7 +168,7 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (writable) and be (stone))
+          all(left2) should (be (writable) and be_== (stone))
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -194,8 +194,8 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be writable'` {
       def `should do nothing when all(xs) is not writable` {
-        all(List(stone)) should (not be writable and not be book)
-        all(List(stone)) should (not be book and not be writable)
+        all(List(stone)) should (not be writable and not be_== book)
+        all(List(stone)) should (not be_== book and not be writable)
         
         all(List(stone)) should (not be writable and not equal book)
         all(List(stone)) should (not equal book and not be writable)
@@ -204,7 +204,7 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is writable` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be stone and not be writable)
+          all(left1) should (not be_== stone and not be writable)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeWritableLogicalAndImplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be writable and not be stone)
+          all(left2) should (not be writable and not be_== stone)
         }
         assert(caught2.message === Some(allError(wasWritable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
@@ -61,8 +61,8 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         writableFile should (equal (writableFile) and be (writable))
         writableFile should (be (writable) and equal (writableFile))
         
-        writableFile should (be (writableFile) and be (writable))
-        writableFile should (be (writable) and be (writableFile))
+        writableFile should (be_== (writableFile) and be (writable))
+        writableFile should (be (writable) and be_== (writableFile))
       }
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
@@ -81,14 +81,14 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          secretFile should (be (secretFile) and be (writable))
+          secretFile should (be_== (secretFile) and be (writable))
         }
         assert(caught3.message === Some(wasEqualTo(secretFile, secretFile) + ", but " + wasNotWritable(secretFile)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          secretFile should (be (writable) and be (secretFile))
+          secretFile should (be (writable) and be_== (secretFile))
         }
         assert(caught4.message === Some(wasNotWritable(secretFile)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -102,8 +102,8 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         secretFile should (not equal writableFile and not be writable)
         secretFile should (not be writable and not equal writableFile)
         
-        secretFile should (not be writableFile and not be writable)
-        secretFile should (not be writable and not be writableFile)
+        secretFile should (not be_== writableFile and not be writable)
+        secretFile should (not be writable and not be_== writableFile)
       }
       
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
@@ -122,14 +122,14 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          writableFile should (not be secretFile and not be writable)
+          writableFile should (not be_== secretFile and not be writable)
         }
         assert(caught3.message === Some(wasNotEqualTo(writableFile, secretFile) + ", but " + wasWritable(writableFile)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          writableFile should (not be writable and not be secretFile)
+          writableFile should (not be writable and not be_== secretFile)
         }
         assert(caught4.message === Some(wasWritable(writableFile)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -140,8 +140,8 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        all(List(writableFile)) should (be (writableFile) and be (writable))
-        all(List(writableFile)) should (be (writable) and be (writableFile))
+        all(List(writableFile)) should (be_== (writableFile) and be (writable))
+        all(List(writableFile)) should (be (writable) and be_== (writableFile))
         
         all(List(writableFile)) should (equal (writableFile) and be (writable))
         all(List(writableFile)) should (be (writable) and equal (writableFile))
@@ -150,7 +150,7 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is not writable` {
         val left1 = List(secretFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (secretFile) and be (writable))
+          all(left1) should (be_== (secretFile) and be (writable))
         }
         assert(caught1.message === Some(allError(wasEqualTo(secretFile, secretFile) + ", but " + wasNotWritable(secretFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -158,7 +158,7 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         
         val left2 = List(secretFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (writable) and be (secretFile))
+          all(left2) should (be (writable) and be_== (secretFile))
         }
         assert(caught2.message === Some(allError(wasNotWritable(secretFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -184,8 +184,8 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
     
     object `when work with 'all(xs) should not be writable'` {
       def `should do nothing when all(xs) is not writable` {
-        all(List(secretFile)) should (not be writable and not be writableFile)
-        all(List(secretFile)) should (not be writableFile and not be writable)
+        all(List(secretFile)) should (not be writable and not be_== writableFile)
+        all(List(secretFile)) should (not be_== writableFile and not be writable)
         
         all(List(secretFile)) should (not be writable and not equal writableFile)
         all(List(secretFile)) should (not equal writableFile and not be writable)
@@ -194,7 +194,7 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when all(xs) is writable` {
         val left1 = List(writableFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be secretFile and not be writable)
+          all(left1) should (not be_== secretFile and not be writable)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(writableFile, secretFile) + ", but " + wasWritable(writableFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -202,7 +202,7 @@ class ShouldBeWritableLogicalAndSpec extends Spec {
         
         val left2 = List(writableFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be writable and not be secretFile)
+          all(left2) should (not be writable and not be_== secretFile)
         }
         assert(caught2.message === Some(allError(wasWritable(writableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
@@ -68,13 +68,13 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
       
       def `should do nothing when file is writable` {
         
-        (book should (be (writable) or be (book))) (writability)
-        (stone should (be (writable) or be (stone))) (writability)
-        (book should (be (writable) or be (stone))) (writability)
+        (book should (be (writable) or be_== (book))) (writability)
+        (stone should (be (writable) or be_== (stone))) (writability)
+        (book should (be (writable) or be_== (stone))) (writability)
         
-        (book should (be (book) or be (writable))) (writability)
-        (book should (be (stone) or be (writable))) (writability)
-        (stone should (be (stone) or be (writable))) (writability)
+        (book should (be_== (book) or be (writable))) (writability)
+        (book should (be_== (stone) or be (writable))) (writability)
+        (stone should (be_== (stone) or be (writable))) (writability)
         
         (book should (be (writable) or equal (book))) (writability, defaultEquality[Thing{val canRead: Boolean}])
         (stone should (be (writable) or equal (stone))) (writability, defaultEquality[Thing{val canRead: Boolean}])
@@ -87,14 +87,14 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
         val caught1 = intercept[TestFailedException] {
-          (stone should (be (writable) or be (book))) (writability)
+          (stone should (be (writable) or be_== (book))) (writability)
         }
         assert(caught1.message === Some(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (book) or be (writable))) (writability)
+          (stone should (be_== (book) or be (writable))) (writability)
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -119,13 +119,13 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
     object `when work with 'file should not be writable'` {
       
       def `should do nothing when file is not writable` {
-        (stone should (not be writable or not be book)) (writability)
-        (book should (not be writable or not be stone)) (writability)
-        (stone should (not be writable or not be stone)) (writability)
+        (stone should (not be writable or not be_== book)) (writability)
+        (book should (not be writable or not be_== stone)) (writability)
+        (stone should (not be writable or not be_== stone)) (writability)
         
-        (stone should (not be book or not be writable)) (writability)
-        (stone should (not be stone or not be writable)) (writability)
-        (book should (not be stone or not be writable)) (writability)
+        (stone should (not be_== book or not be writable)) (writability)
+        (stone should (not be_== stone or not be writable)) (writability)
+        (book should (not be_== stone or not be writable)) (writability)
         
         (stone should (not be writable or not equal book)) (writability, defaultEquality[Thing{val canRead: Boolean}])
         (book should (not be writable or not equal stone)) (writability, defaultEquality[Thing{val canRead: Boolean}])
@@ -138,14 +138,14 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
       
       def `should throw TestFailedException with correct stack depth when file is writable` {
         val caught1 = intercept[TestFailedException] {
-          (book should (not be writable or not be book)) (writability)
+          (book should (not be writable or not be_== book)) (writability)
         }
         assert(caught1.message === Some(wasWritable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (book should (not be book or not be writable)) (writability)
+          (book should (not be_== book or not be writable)) (writability)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasWritable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -170,13 +170,13 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        (all(List(book)) should (be (writable) or be (book))) (writability)
-        (all(List(stone)) should (be (writable) or be (stone))) (writability)
-        (all(List(book)) should (be (writable) or be (stone))) (writability)
+        (all(List(book)) should (be (writable) or be_== (book))) (writability)
+        (all(List(stone)) should (be (writable) or be_== (stone))) (writability)
+        (all(List(book)) should (be (writable) or be_== (stone))) (writability)
         
-        (all(List(book)) should (be (book) or be (writable))) (writability)
-        (all(List(book)) should (be (stone) or be (writable))) (writability)
-        (all(List(stone)) should (be (stone) or be (writable))) (writability)
+        (all(List(book)) should (be_== (book) or be (writable))) (writability)
+        (all(List(book)) should (be_== (stone) or be (writable))) (writability)
+        (all(List(stone)) should (be_== (stone) or be (writable))) (writability)
         
         (all(List(book)) should (be (writable) or equal (book))) (writability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(stone)) should (be (writable) or equal (stone))) (writability, defaultEquality[Thing{val canRead: Boolean}])
@@ -190,7 +190,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (book) or be (writable))) (writability)
+          (all(left1) should (be_== (book) or be (writable))) (writability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -198,7 +198,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (writable) or be (book))) (writability)
+          (all(left2) should (be (writable) or be_== (book))) (writability)
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -224,13 +224,13 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        (all(List(stone)) should (not be writable or not be book)) (writability)
-        (all(List(book)) should (not be writable or not be stone)) (writability)
-        (all(List(stone)) should (not be writable or not be stone)) (writability)
+        (all(List(stone)) should (not be writable or not be_== book)) (writability)
+        (all(List(book)) should (not be writable or not be_== stone)) (writability)
+        (all(List(stone)) should (not be writable or not be_== stone)) (writability)
         
-        (all(List(stone)) should (not be book or not be writable)) (writability)
-        (all(List(stone)) should (not be stone or not be writable)) (writability)
-        (all(List(book)) should (not be stone or not be writable)) (writability)
+        (all(List(stone)) should (not be_== book or not be writable)) (writability)
+        (all(List(stone)) should (not be_== stone or not be writable)) (writability)
+        (all(List(book)) should (not be_== stone or not be writable)) (writability)
         
         (all(List(stone)) should (not be writable or not equal book)) (writability, defaultEquality[Thing{val canRead: Boolean}])
         (all(List(book)) should (not be writable or not equal stone)) (writability, defaultEquality[Thing{val canRead: Boolean}])
@@ -244,7 +244,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be book or not be writable)) (writability)
+          (all(left1) should (not be_== book or not be writable)) (writability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -252,7 +252,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends Spec with Matchers {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be writable or not be book)) (writability)
+          (all(left2) should (not be writable or not be_== book)) (writability)
         }
         assert(caught2.message === Some(allError(wasWritable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrImplicitSpec.scala
@@ -69,13 +69,13 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
       
       def `should do nothing when file is writable` {
         
-        book should (be (writable) or be (book))
-        stone should (be (writable) or be (stone))
-        book should (be (writable) or be (stone))
+        book should (be (writable) or be_== (book))
+        stone should (be (writable) or be_== (stone))
+        book should (be (writable) or be_== (stone))
         
-        book should (be (book) or be (writable))
-        book should (be (stone) or be (writable))
-        stone should (be (stone) or be (writable))
+        book should (be_== (book) or be (writable))
+        book should (be_== (stone) or be (writable))
+        stone should (be_== (stone) or be (writable))
         
         book should (be (writable) or equal (book))
         stone should (be (writable) or equal (stone))
@@ -88,14 +88,14 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
         val caught1 = intercept[TestFailedException] {
-          stone should (be (writable) or be (book))
+          stone should (be (writable) or be_== (book))
         }
         assert(caught1.message === Some(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          stone should (be (book) or be (writable))
+          stone should (be_== (book) or be (writable))
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -120,13 +120,13 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
     object `when work with 'file should not be writable'` {
       
       def `should do nothing when file is not writable` {
-        stone should (not be writable or not be book)
-        book should (not be writable or not be stone)
-        stone should (not be writable or not be stone)
+        stone should (not be writable or not be_== book)
+        book should (not be writable or not be_== stone)
+        stone should (not be writable or not be_== stone)
         
-        stone should (not be book or not be writable)
-        stone should (not be stone or not be writable)
-        book should (not be stone or not be writable)
+        stone should (not be_== book or not be writable)
+        stone should (not be_== stone or not be writable)
+        book should (not be_== stone or not be writable)
         
         stone should (not be writable or not equal book)
         book should (not be writable or not equal stone)
@@ -139,14 +139,14 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is writable` {
         val caught1 = intercept[TestFailedException] {
-          book should (not be writable or not be book)
+          book should (not be writable or not be_== book)
         }
         assert(caught1.message === Some(wasWritable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          book should (not be book or not be writable)
+          book should (not be_== book or not be writable)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasWritable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -171,13 +171,13 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        all(List(book)) should (be (writable) or be (book))
-        all(List(stone)) should (be (writable) or be (stone))
-        all(List(book)) should (be (writable) or be (stone))
+        all(List(book)) should (be (writable) or be_== (book))
+        all(List(stone)) should (be (writable) or be_== (stone))
+        all(List(book)) should (be (writable) or be_== (stone))
         
-        all(List(book)) should (be (book) or be (writable))
-        all(List(book)) should (be (stone) or be (writable))
-        all(List(stone)) should (be (stone) or be (writable))
+        all(List(book)) should (be_== (book) or be (writable))
+        all(List(book)) should (be_== (stone) or be (writable))
+        all(List(stone)) should (be_== (stone) or be (writable))
         
         all(List(book)) should (be (writable) or equal (book))
         all(List(stone)) should (be (writable) or equal (stone))
@@ -191,7 +191,7 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (book) or be (writable))
+          all(left1) should (be_== (book) or be (writable))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -199,7 +199,7 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (writable) or be (book))
+          all(left2) should (be (writable) or be_== (book))
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(stone)) should (not be writable or not be book)
-        all(List(book)) should (not be writable or not be stone)
-        all(List(stone)) should (not be writable or not be stone)
+        all(List(stone)) should (not be writable or not be_== book)
+        all(List(book)) should (not be writable or not be_== stone)
+        all(List(stone)) should (not be writable or not be_== stone)
         
-        all(List(stone)) should (not be book or not be writable)
-        all(List(stone)) should (not be stone or not be writable)
-        all(List(book)) should (not be stone or not be writable)
+        all(List(stone)) should (not be_== book or not be writable)
+        all(List(stone)) should (not be_== stone or not be writable)
+        all(List(book)) should (not be_== stone or not be writable)
         
         all(List(stone)) should (not be writable or not equal book)
         all(List(book)) should (not be writable or not equal stone)
@@ -245,7 +245,7 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be book or not be writable)
+          all(left1) should (not be_== book or not be writable)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -253,7 +253,7 @@ class ShouldBeWritableLogicalOrImplicitSpec extends Spec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be writable or not be book)
+          all(left2) should (not be writable or not be_== book)
         }
         assert(caught2.message === Some(allError(wasWritable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
@@ -59,13 +59,13 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
       
       def `should do nothing when file is writable` {
         
-        writableFile should (be (writable) or be (writableFile))
-        secretFile should (be (writable) or be (secretFile))
-        writableFile should (be (writable) or be (secretFile))
+        writableFile should (be (writable) or be_== (writableFile))
+        secretFile should (be (writable) or be_== (secretFile))
+        writableFile should (be (writable) or be_== (secretFile))
         
-        writableFile should (be (writableFile) or be (writable))
-        writableFile should (be (secretFile) or be (writable))
-        secretFile should (be (secretFile) or be (writable))
+        writableFile should (be_== (writableFile) or be (writable))
+        writableFile should (be_== (secretFile) or be (writable))
+        secretFile should (be_== (secretFile) or be (writable))
         
         writableFile should (be (writable) or equal (writableFile))
         secretFile should (be (writable) or equal (secretFile))
@@ -78,14 +78,14 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is not writable` {
         val caught1 = intercept[TestFailedException] {
-          secretFile should (be (writable) or be (writableFile))
+          secretFile should (be (writable) or be_== (writableFile))
         }
         assert(caught1.message === Some(wasNotWritable(secretFile) + ", and " + wasNotEqualTo(secretFile, writableFile)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          secretFile should (be (writableFile) or be (writable))
+          secretFile should (be_== (writableFile) or be (writable))
         }
         assert(caught2.message === Some(wasNotEqualTo(secretFile, writableFile) + ", and " + wasNotWritable(secretFile)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -110,13 +110,13 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
     object `when work with 'file should not be writable'` {
       
       def `should do nothing when file is not writable` {
-        secretFile should (not be writable or not be writableFile)
-        writableFile should (not be writable or not be secretFile)
-        secretFile should (not be writable or not be secretFile)
+        secretFile should (not be writable or not be_== writableFile)
+        writableFile should (not be writable or not be_== secretFile)
+        secretFile should (not be writable or not be_== secretFile)
         
-        secretFile should (not be writableFile or not be writable)
-        secretFile should (not be secretFile or not be writable)
-        writableFile should (not be secretFile or not be writable)
+        secretFile should (not be_== writableFile or not be writable)
+        secretFile should (not be_== secretFile or not be writable)
+        writableFile should (not be_== secretFile or not be writable)
         
         secretFile should (not be writable or not equal writableFile)
         writableFile should (not be writable or not equal secretFile)
@@ -129,14 +129,14 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
       
       def `should throw TestFailedException with correct stack depth when file is writable` {
         val caught1 = intercept[TestFailedException] {
-          writableFile should (not be writable or not be writableFile)
+          writableFile should (not be writable or not be_== writableFile)
         }
         assert(caught1.message === Some(wasWritable(writableFile) + ", and " + wasEqualTo(writableFile, writableFile)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          writableFile should (not be writableFile or not be writable)
+          writableFile should (not be_== writableFile or not be writable)
         }
         assert(caught2.message === Some(wasEqualTo(writableFile, writableFile) + ", and " + wasWritable(writableFile)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -161,13 +161,13 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
     object `when work with 'all(xs) should be (writable)'` {
       
       def `should do nothing when all(xs) is writable` {
-        all(List(writableFile)) should (be (writable) or be (writableFile))
-        all(List(secretFile)) should (be (writable) or be (secretFile))
-        all(List(writableFile)) should (be (writable) or be (secretFile))
+        all(List(writableFile)) should (be (writable) or be_== (writableFile))
+        all(List(secretFile)) should (be (writable) or be_== (secretFile))
+        all(List(writableFile)) should (be (writable) or be_== (secretFile))
         
-        all(List(writableFile)) should (be (writableFile) or be (writable))
-        all(List(writableFile)) should (be (secretFile) or be (writable))
-        all(List(secretFile)) should (be (secretFile) or be (writable))
+        all(List(writableFile)) should (be_== (writableFile) or be (writable))
+        all(List(writableFile)) should (be_== (secretFile) or be (writable))
+        all(List(secretFile)) should (be_== (secretFile) or be (writable))
         
         all(List(writableFile)) should (be (writable) or equal (writableFile))
         all(List(secretFile)) should (be (writable) or equal (secretFile))
@@ -181,7 +181,7 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(secretFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (be (writableFile) or be (writable))
+          all(left1) should (be_== (writableFile) or be (writable))
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(secretFile, writableFile) + ", and " + wasNotWritable(secretFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -189,7 +189,7 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
         
         val left2 = List(secretFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (be (writable) or be (writableFile))
+          all(left2) should (be (writable) or be_== (writableFile))
         }
         assert(caught2.message === Some(allError(wasNotWritable(secretFile) + ", and " + wasNotEqualTo(secretFile, writableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -215,13 +215,13 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
     
     object `when work with 'all(xs) should not be sorted'` {
       def `should do nothing when xs is not sorted` {
-        all(List(secretFile)) should (not be writable or not be writableFile)
-        all(List(writableFile)) should (not be writable or not be secretFile)
-        all(List(secretFile)) should (not be writable or not be secretFile)
+        all(List(secretFile)) should (not be writable or not be_== writableFile)
+        all(List(writableFile)) should (not be writable or not be_== secretFile)
+        all(List(secretFile)) should (not be writable or not be_== secretFile)
         
-        all(List(secretFile)) should (not be writableFile or not be writable)
-        all(List(secretFile)) should (not be secretFile or not be writable)
-        all(List(writableFile)) should (not be secretFile or not be writable)
+        all(List(secretFile)) should (not be_== writableFile or not be writable)
+        all(List(secretFile)) should (not be_== secretFile or not be writable)
+        all(List(writableFile)) should (not be_== secretFile or not be writable)
         
         all(List(secretFile)) should (not be writable or not equal writableFile)
         all(List(writableFile)) should (not be writable or not equal secretFile)
@@ -235,7 +235,7 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
       def `should throw TestFailedException with correct stack depth when xs is not sorted` {
         val left1 = List(writableFile)
         val caught1 = intercept[TestFailedException] {
-          all(left1) should (not be writableFile or not be writable)
+          all(left1) should (not be_== writableFile or not be writable)
         }
         assert(caught1.message === Some(allError(wasEqualTo(writableFile, writableFile) + ", and " + wasWritable(writableFile), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -243,7 +243,7 @@ class ShouldBeWritableLogicalOrSpec extends Spec {
         
         val left2 = List(writableFile)
         val caught2 = intercept[TestFailedException] {
-          all(left2) should (not be writable or not be writableFile)
+          all(left2) should (not be writable or not be_== writableFile)
         }
         assert(caught2.message === Some(allError(wasWritable(writableFile) + ", and " + wasEqualTo(writableFile, writableFile), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalAndSpec.scala
@@ -54,8 +54,8 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (writable))
-        objTrue should (be (writable) and be (objTrue))
-        objTrue should (be (objTrue) and be (writable))
+        objTrue should (be (writable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (writable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -74,14 +74,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objFalse))
+          objFalse should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (writable))
+          objTrue should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -104,14 +104,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (writable) and be (objFalse))
+          objTrue should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasWritable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (writable))
+          objFalse should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -134,14 +134,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objTrue))
+          objFalse should (be (writable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (writable))
+          objFalse should (be_== (objTrue) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -161,8 +161,8 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (writable))
-        objTrue should (be (writable) and be (objTrue))
-        objTrue should (be (objTrue) and be (writable))
+        objTrue should (be (writable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (writable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -181,14 +181,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objFalse))
+          objFalse should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (writable))
+          objTrue should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -211,14 +211,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (writable) and be (objFalse))
+          objTrue should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasWritable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (writable))
+          objFalse should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -241,14 +241,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objTrue))
+          objFalse should (be (writable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (writable))
+          objFalse should (be_== (objTrue) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -268,8 +268,8 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) and equal (objTrue))
         objTrue should (equal (objTrue) and be (writable))
-        objTrue should (be (writable) and be (objTrue))
-        objTrue should (be (objTrue) and be (writable))
+        objTrue should (be (writable) and be_== (objTrue))
+        objTrue should (be_== (objTrue) and be (writable))
       }
       
       it("should throw correct TFE when first check failed") {
@@ -288,14 +288,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objFalse))
+          objFalse should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objTrue should (be (objFalse) and be (writable))
+          objTrue should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objTrue, objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -318,14 +318,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objTrue should (be (writable) and be (objFalse))
+          objTrue should (be (writable) and be_== (objFalse))
         }
         assert(caught3.message === Some(wasWritable(objTrue) + ", but " + wasNotEqualTo(objTrue, objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objFalse) and be (writable))
+          objFalse should (be_== (objFalse) and be (writable))
         }
         assert(caught4.message === Some(wasEqualTo(objFalse, objFalse) + ", but " +  wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -348,14 +348,14 @@ class ShouldBeWritableStructuralLogicalAndSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) and be (objTrue))
+          objFalse should (be (writable) and be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) and be (writable))
+          objFalse should (be_== (objTrue) and be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalOrSpec.scala
@@ -54,22 +54,22 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (writable))
-        objTrue should (be (writable) or be (objTrue))
-        objTrue should (be (objTrue) or be (writable))
+        objTrue should (be (writable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (writable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (writable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (writable))
-        objFalse should (be (writable) or be (objFalse))
-        objTrue should (be (objFalse) or be (writable))
+        objFalse should (be (writable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (writable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (writable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (writable))
-        objTrue should (be (writable) or be (objFalse))
-        objFalse should (be (objFalse) or be (writable))
+        objTrue should (be (writable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (writable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -88,14 +88,14 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) or be (objTrue))
+          objFalse should (be (writable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (writable))
+          objFalse should (be_== (objTrue) or be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -115,22 +115,22 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (writable))
-        objTrue should (be (writable) or be (objTrue))
-        objTrue should (be (objTrue) or be (writable))
+        objTrue should (be (writable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (writable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (writable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (writable))
-        objFalse should (be (writable) or be (objFalse))
-        objTrue should (be (objFalse) or be (writable))
+        objFalse should (be (writable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (writable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (writable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (writable))
-        objTrue should (be (writable) or be (objFalse))
-        objFalse should (be (objFalse) or be (writable))
+        objTrue should (be (writable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (writable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -149,14 +149,14 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) or be (objTrue))
+          objFalse should (be (writable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (writable))
+          objFalse should (be_== (objTrue) or be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -176,22 +176,22 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
       it("should do nothing for when both passed") {
         objTrue should (be (writable) or equal (objTrue))
         objTrue should (equal (objTrue) or be (writable))
-        objTrue should (be (writable) or be (objTrue))
-        objTrue should (be (objTrue) or be (writable))
+        objTrue should (be (writable) or be_== (objTrue))
+        objTrue should (be_== (objTrue) or be (writable))
       }
       
       it("should do nothing when first check failed") {
         objFalse should (be (writable) or equal (objFalse))
         objTrue should (equal (objFalse) or be (writable))
-        objFalse should (be (writable) or be (objFalse))
-        objTrue should (be (objFalse) or be (writable))
+        objFalse should (be (writable) or be_== (objFalse))
+        objTrue should (be_== (objFalse) or be (writable))
       }
       
       it("should do nothing when second check failed") {
         objTrue should (be (writable) or equal (objFalse))
         objFalse should (equal (objFalse) or be (writable))
-        objTrue should (be (writable) or be (objFalse))
-        objFalse should (be (objFalse) or be (writable))
+        objTrue should (be (writable) or be_== (objFalse))
+        objFalse should (be_== (objFalse) or be (writable))
       }
       
       it("should throw correct TFE when both check failed") {
@@ -210,14 +210,14 @@ class ShouldBeWritableStructuralLogicalOrSpec extends FunSpec {
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          objFalse should (be (writable) or be (objTrue))
+          objFalse should (be (writable) or be_== (objTrue))
         }
         assert(caught3.message === Some(wasNotWritable(objFalse) + ", and " + wasNotEqualTo(objFalse, objTrue)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          objFalse should (be (objTrue) or be (writable))
+          objFalse should (be_== (objTrue) or be (writable))
         }
         assert(caught4.message === Some(wasNotEqualTo(objFalse, objTrue) + ", and " + wasNotWritable(objFalse)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
@@ -68,8 +68,8 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
     def `should do nothing when the file exists` {
       (something should (equal (something) and exist)) (defaultEquality[Thing{val exist: Boolean}], existence)
       (something should (exist and equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
-      (something should (be (something) and exist)) (existence)
-      (something should (exist and be (something))) (existence)
+      (something should (be_== (something) and exist)) (existence)
+      (something should (exist and be_== (something))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -88,14 +88,14 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (nothing should (be (nothing) and exist)) (existence)
+        (nothing should (be_== (nothing) and exist)) (existence)
       }
       assert(e3.message === Some(wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (something should (exist and be (nothing))) (existence)
+        (something should (exist and be_== (nothing))) (existence)
       }
       assert(e4.message === Some(exists(something) + ", but " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -105,8 +105,8 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       (nothing should (equal (nothing) and not (exist))) (defaultEquality[Thing{val exist: Boolean}], existence)
       (nothing should (not (exist) and equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
-      (nothing should (be (nothing) and not (exist))) (existence)
-      (nothing should (not (exist) and be (nothing))) (existence)
+      (nothing should (be_== (nothing) and not (exist))) (existence)
+      (nothing should (not (exist) and be_== (nothing))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -125,14 +125,14 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (something should (be (something) and not (exist))) (existence)
+        (something should (be_== (something) and not (exist))) (existence)
       }
       assert(e3.message === Some(wasEqualTo(something, something) + ", but " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (nothing should (not (exist) and be (something))) (existence)
+        (nothing should (not (exist) and be_== (something))) (existence)
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -145,8 +145,8 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
     def `should do nothing when the file exists` {
       (all(List(something)) should (equal (something) and exist)) (defaultEquality[Thing{val exist: Boolean}], existence)
       (all(List(something)) should (exist and equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
-      (all(List(something)) should (be (something) and exist)) (existence)
-      (all(List(something)) should (exist and be (something))) (existence)
+      (all(List(something)) should (be_== (something) and exist)) (existence)
+      (all(List(something)) should (exist and be_== (something))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -168,7 +168,7 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (nothing) and exist)) (existence)
+        (all(left3) should (be_== (nothing) and exist)) (existence)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -176,7 +176,7 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (exist and be (nothing))) (existence)
+        (all(left4) should (exist and be_== (nothing))) (existence)
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", but " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -186,8 +186,8 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       (all(List(nothing)) should (equal (nothing) and not (exist))) (defaultEquality[Thing{val exist: Boolean}], existence)
       (all(List(nothing)) should (not (exist) and equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
-      (all(List(nothing)) should (be (nothing) and not (exist))) (existence)
-      (all(List(nothing)) should (not (exist) and be (nothing))) (existence)
+      (all(List(nothing)) should (be_== (nothing) and not (exist))) (existence)
+      (all(List(nothing)) should (not (exist) and be_== (nothing))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -209,7 +209,7 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (something) and not (exist))) (existence)
+        (all(left3) should (be_== (something) and not (exist))) (existence)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(something, something) + ", but " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -217,7 +217,7 @@ class ShouldExistLogicalAndExplicitSpec extends Spec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (not (exist) and be (something))) (existence)
+        (all(left4) should (not (exist) and be_== (something))) (existence)
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalAndImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalAndImplicitSpec.scala
@@ -69,8 +69,8 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
     def `should do nothing when the file exists` {
       something should (equal (something) and exist)
       something should (exist and equal (something))
-      something should (be (something) and exist)
-      something should (exist and be (something))
+      something should (be_== (something) and exist)
+      something should (exist and be_== (something))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -89,14 +89,14 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        nothing should (be (nothing) and exist)
+        nothing should (be_== (nothing) and exist)
       }
       assert(e3.message === Some(wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        something should (exist and be (nothing))
+        something should (exist and be_== (nothing))
       }
       assert(e4.message === Some(exists(something) + ", but " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -106,8 +106,8 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       nothing should (equal (nothing) and not (exist))
       nothing should (not (exist) and equal (nothing))
-      nothing should (be (nothing) and not (exist))
-      nothing should (not (exist) and be (nothing))
+      nothing should (be_== (nothing) and not (exist))
+      nothing should (not (exist) and be_== (nothing))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -126,14 +126,14 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        something should (be (something) and not (exist))
+        something should (be_== (something) and not (exist))
       }
       assert(e3.message === Some(wasEqualTo(something, something) + ", but " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        nothing should (not (exist) and be (something))
+        nothing should (not (exist) and be_== (something))
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -146,8 +146,8 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
     def `should do nothing when the file exists` {
       all(List(something)) should (equal (something) and exist)
       all(List(something)) should (exist and equal (something))
-      all(List(something)) should (be (something) and exist)
-      all(List(something)) should (exist and be (something))
+      all(List(something)) should (be_== (something) and exist)
+      all(List(something)) should (exist and be_== (something))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -169,7 +169,7 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (nothing) and exist)
+        all(left3) should (be_== (nothing) and exist)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -177,7 +177,7 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (exist and be (nothing))
+        all(left4) should (exist and be_== (nothing))
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", but " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -187,8 +187,8 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       all(List(nothing)) should (equal (nothing) and not (exist))
       all(List(nothing)) should (not (exist) and equal (nothing))
-      all(List(nothing)) should (be (nothing) and not (exist))
-      all(List(nothing)) should (not (exist) and be (nothing))
+      all(List(nothing)) should (be_== (nothing) and not (exist))
+      all(List(nothing)) should (not (exist) and be_== (nothing))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -210,7 +210,7 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (something) and not (exist))
+        all(left3) should (be_== (something) and not (exist))
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(something, something) + ", but " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -218,7 +218,7 @@ class ShouldExistLogicalAndImplicitSpec extends Spec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (not (exist) and be (something))
+        all(left4) should (not (exist) and be_== (something))
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
@@ -55,8 +55,8 @@ class ShouldExistLogicalAndSpec extends Spec {
     def `should do nothing when the file exists` {
       existFile should (equal (existFile) and exist)
       existFile should (exist and equal (existFile))
-      existFile should (be (existFile) and exist)
-      existFile should (exist and be (existFile))
+      existFile should (be_== (existFile) and exist)
+      existFile should (exist and be_== (existFile))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -75,14 +75,14 @@ class ShouldExistLogicalAndSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        imaginaryFile should (be (imaginaryFile) and exist)
+        imaginaryFile should (be_== (imaginaryFile) and exist)
       }
       assert(e3.message === Some(wasEqualTo(imaginaryFile, imaginaryFile) + ", but " + doesNotExist(imaginaryFile)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        existFile should (exist and be (imaginaryFile))
+        existFile should (exist and be_== (imaginaryFile))
       }
       assert(e4.message === Some(exists(existFile) + ", but " + wasNotEqualTo(existFile, imaginaryFile)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -92,8 +92,8 @@ class ShouldExistLogicalAndSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       imaginaryFile should (equal (imaginaryFile) and not (exist))
       imaginaryFile should (not (exist) and equal (imaginaryFile))
-      imaginaryFile should (be (imaginaryFile) and not (exist))
-      imaginaryFile should (not (exist) and be (imaginaryFile))
+      imaginaryFile should (be_== (imaginaryFile) and not (exist))
+      imaginaryFile should (not (exist) and be_== (imaginaryFile))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -112,14 +112,14 @@ class ShouldExistLogicalAndSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        existFile should (be (existFile) and not (exist))
+        existFile should (be_== (existFile) and not (exist))
       }
       assert(e3.message === Some(wasEqualTo(existFile, existFile) + ", but " + exists(existFile)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        imaginaryFile should (not (exist) and be (existFile))
+        imaginaryFile should (not (exist) and be_== (existFile))
       }
       assert(e4.message === Some(doesNotExist(imaginaryFile) + ", but " + wasNotEqualTo(imaginaryFile, existFile)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -132,8 +132,8 @@ class ShouldExistLogicalAndSpec extends Spec {
     def `should do nothing when the file exists` {
       all(List(existFile)) should (equal (existFile) and exist)
       all(List(existFile)) should (exist and equal (existFile))
-      all(List(existFile)) should (be (existFile) and exist)
-      all(List(existFile)) should (exist and be (existFile))
+      all(List(existFile)) should (be_== (existFile) and exist)
+      all(List(existFile)) should (exist and be_== (existFile))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -155,7 +155,7 @@ class ShouldExistLogicalAndSpec extends Spec {
       
       val left3 = List(imaginaryFile)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (imaginaryFile) and exist)
+        all(left3) should (be_== (imaginaryFile) and exist)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(imaginaryFile, imaginaryFile) + ", but " + doesNotExist(imaginaryFile), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -163,7 +163,7 @@ class ShouldExistLogicalAndSpec extends Spec {
       
       val left4 = List(existFile)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (exist and be (imaginaryFile))
+        all(left4) should (exist and be_== (imaginaryFile))
       }
       assert(e4.message === Some(allError(left4, exists(existFile) + ", but " + wasNotEqualTo(existFile, imaginaryFile), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -173,8 +173,8 @@ class ShouldExistLogicalAndSpec extends Spec {
     def `should do nothing when it is used with not and the file does not exists` {
       all(List(imaginaryFile)) should (equal (imaginaryFile) and not (exist))
       all(List(imaginaryFile)) should (not (exist) and equal (imaginaryFile))
-      all(List(imaginaryFile)) should (be (imaginaryFile) and not (exist))
-      all(List(imaginaryFile)) should (not (exist) and be (imaginaryFile))
+      all(List(imaginaryFile)) should (be_== (imaginaryFile) and not (exist))
+      all(List(imaginaryFile)) should (not (exist) and be_== (imaginaryFile))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -196,7 +196,7 @@ class ShouldExistLogicalAndSpec extends Spec {
       
       val left3 = List(existFile)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (existFile) and not (exist))
+        all(left3) should (be_== (existFile) and not (exist))
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(existFile, existFile) + ", but " + exists(existFile), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -204,7 +204,7 @@ class ShouldExistLogicalAndSpec extends Spec {
       
       val left4 = List(imaginaryFile)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (not (exist) and be (existFile))
+        all(left4) should (not (exist) and be_== (existFile))
       }
       assert(e4.message === Some(allError(left4, doesNotExist(imaginaryFile) + ", but " + wasNotEqualTo(imaginaryFile, existFile), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
@@ -74,13 +74,13 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       (nothing should (exist or equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
       (something should (exist or equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
       
-      (something should (be (something) or exist)) (existence)
-      (something should (be (nothing) or exist)) (existence)
-      (nothing should (be (nothing) or exist)) (existence)
+      (something should (be_== (something) or exist)) (existence)
+      (something should (be_== (nothing) or exist)) (existence)
+      (nothing should (be_== (nothing) or exist)) (existence)
       
-      (something should (exist or be (something))) (existence)
-      (nothing should (exist or be (nothing))) (existence)
-      (something should (exist or be (nothing))) (existence)
+      (something should (exist or be_== (something))) (existence)
+      (nothing should (exist or be_== (nothing))) (existence)
+      (something should (exist or be_== (nothing))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -99,14 +99,14 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (nothing should (be (something) or exist)) (existence)
+        (nothing should (be_== (something) or exist)) (existence)
       }
       assert(e3.message === Some(wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (nothing should (exist or be (something))) (existence)
+        (nothing should (exist or be_== (something))) (existence)
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -122,13 +122,13 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       (something should (not (exist) or equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
       (nothing should (not (exist) or equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
       
-      (nothing should (be (nothing) or not (exist))) (existence)
-      (nothing should (be (something) or not (exist))) (existence)
-      (something should (be (something) or not (exist))) (existence)
+      (nothing should (be_== (nothing) or not (exist))) (existence)
+      (nothing should (be_== (something) or not (exist))) (existence)
+      (something should (be_== (something) or not (exist))) (existence)
       
-      (nothing should (not (exist) or be (nothing))) (existence)
-      (something should (not (exist) or be (something))) (existence)
-      (nothing should (not (exist) or be (something))) (existence)
+      (nothing should (not (exist) or be_== (nothing))) (existence)
+      (something should (not (exist) or be_== (something))) (existence)
+      (nothing should (not (exist) or be_== (something))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -147,14 +147,14 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (something should (be (nothing) or not (exist))) (existence)
+        (something should (be_== (nothing) or not (exist))) (existence)
       }
       assert(e3.message === Some(wasNotEqualTo(something, nothing) + ", and " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (something should (not (exist) or be (nothing))) (existence)
+        (something should (not (exist) or be_== (nothing))) (existence)
       }
       assert(e4.message === Some(exists(something) + ", and " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -173,13 +173,13 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       (all(List(nothing)) should (exist or equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
       (all(List(something)) should (exist or equal (nothing))) (existence, defaultEquality[Thing{val exist: Boolean}])
       
-      (all(List(something)) should (be (something) or exist)) (existence)
-      (all(List(something)) should (be (nothing) or exist)) (existence)
-      (all(List(nothing)) should (be (nothing) or exist)) (existence)
+      (all(List(something)) should (be_== (something) or exist)) (existence)
+      (all(List(something)) should (be_== (nothing) or exist)) (existence)
+      (all(List(nothing)) should (be_== (nothing) or exist)) (existence)
       
-      (all(List(something)) should (exist or be (something))) (existence)
-      (all(List(nothing)) should (exist or be (nothing))) (existence)
-      (all(List(something)) should (exist or be (nothing))) (existence)
+      (all(List(something)) should (exist or be_== (something))) (existence)
+      (all(List(nothing)) should (exist or be_== (nothing))) (existence)
+      (all(List(something)) should (exist or be_== (nothing))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -201,7 +201,7 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (something) or exist)) (existence)
+        (all(left3) should (be_== (something) or exist)) (existence)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -209,7 +209,7 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (exist or be (something))) (existence)
+        (all(left4) should (exist or be_== (something))) (existence)
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -225,13 +225,13 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       (all(List(something)) should (not (exist) or equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
       (all(List(nothing)) should (not (exist) or equal (something))) (existence, defaultEquality[Thing{val exist: Boolean}])
       
-      (all(List(nothing)) should (be (nothing) or not (exist))) (existence)
-      (all(List(nothing)) should (be (something) or not (exist))) (existence)
-      (all(List(something)) should (be (something) or not (exist))) (existence)
+      (all(List(nothing)) should (be_== (nothing) or not (exist))) (existence)
+      (all(List(nothing)) should (be_== (something) or not (exist))) (existence)
+      (all(List(something)) should (be_== (something) or not (exist))) (existence)
       
-      (all(List(nothing)) should (not (exist) or be (nothing))) (existence)
-      (all(List(something)) should (not (exist) or be (something))) (existence)
-      (all(List(nothing)) should (not (exist) or be (something))) (existence)
+      (all(List(nothing)) should (not (exist) or be_== (nothing))) (existence)
+      (all(List(something)) should (not (exist) or be_== (something))) (existence)
+      (all(List(nothing)) should (not (exist) or be_== (something))) (existence)
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -253,7 +253,7 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (nothing) or not (exist))) (existence)
+        (all(left3) should (be_== (nothing) or not (exist))) (existence)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(something, nothing) + ", and " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -261,7 +261,7 @@ class ShouldExistLogicalOrExplicitSpec extends Spec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (not (exist) or be (nothing))) (existence)
+        (all(left4) should (not (exist) or be_== (nothing))) (existence)
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", and " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalOrImplicitSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalOrImplicitSpec.scala
@@ -75,13 +75,13 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       nothing should (exist or equal (nothing))
       something should (exist or equal (nothing))
       
-      something should (be (something) or exist)
-      something should (be (nothing) or exist)
-      nothing should (be (nothing) or exist)
+      something should (be_== (something) or exist)
+      something should (be_== (nothing) or exist)
+      nothing should (be_== (nothing) or exist)
       
-      something should (exist or be (something))
-      nothing should (exist or be (nothing))
-      something should (exist or be (nothing))
+      something should (exist or be_== (something))
+      nothing should (exist or be_== (nothing))
+      something should (exist or be_== (nothing))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -100,14 +100,14 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        nothing should (be (something) or exist)
+        nothing should (be_== (something) or exist)
       }
       assert(e3.message === Some(wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        nothing should (exist or be (something))
+        nothing should (exist or be_== (something))
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -123,13 +123,13 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       something should (not (exist) or equal (something))
       nothing should (not (exist) or equal (something))
       
-      nothing should (be (nothing) or not (exist))
-      nothing should (be (something) or not (exist))
-      something should (be (something) or not (exist))
+      nothing should (be_== (nothing) or not (exist))
+      nothing should (be_== (something) or not (exist))
+      something should (be_== (something) or not (exist))
       
-      nothing should (not (exist) or be (nothing))
-      something should (not (exist) or be (something))
-      nothing should (not (exist) or be (something))
+      nothing should (not (exist) or be_== (nothing))
+      something should (not (exist) or be_== (something))
+      nothing should (not (exist) or be_== (something))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -148,14 +148,14 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        something should (be (nothing) or not (exist))
+        something should (be_== (nothing) or not (exist))
       }
       assert(e3.message === Some(wasNotEqualTo(something, nothing) + ", and " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        something should (not (exist) or be (nothing))
+        something should (not (exist) or be_== (nothing))
       }
       assert(e4.message === Some(exists(something) + ", and " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -174,13 +174,13 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       all(List(nothing)) should (exist or equal (nothing))
       all(List(something)) should (exist or equal (nothing))
       
-      all(List(something)) should (be (something) or exist)
-      all(List(something)) should (be (nothing) or exist)
-      all(List(nothing)) should (be (nothing) or exist)
+      all(List(something)) should (be_== (something) or exist)
+      all(List(something)) should (be_== (nothing) or exist)
+      all(List(nothing)) should (be_== (nothing) or exist)
       
-      all(List(something)) should (exist or be (something))
-      all(List(nothing)) should (exist or be (nothing))
-      all(List(something)) should (exist or be (nothing))
+      all(List(something)) should (exist or be_== (something))
+      all(List(nothing)) should (exist or be_== (nothing))
+      all(List(something)) should (exist or be_== (nothing))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -202,7 +202,7 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (something) or exist)
+        all(left3) should (be_== (something) or exist)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -210,7 +210,7 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (exist or be (something))
+        all(left4) should (exist or be_== (something))
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -226,13 +226,13 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       all(List(something)) should (not (exist) or equal (something))
       all(List(nothing)) should (not (exist) or equal (something))
       
-      all(List(nothing)) should (be (nothing) or not (exist))
-      all(List(nothing)) should (be (something) or not (exist))
-      all(List(something)) should (be (something) or not (exist))
+      all(List(nothing)) should (be_== (nothing) or not (exist))
+      all(List(nothing)) should (be_== (something) or not (exist))
+      all(List(something)) should (be_== (something) or not (exist))
       
-      all(List(nothing)) should (not (exist) or be (nothing))
-      all(List(something)) should (not (exist) or be (something))
-      all(List(nothing)) should (not (exist) or be (something))
+      all(List(nothing)) should (not (exist) or be_== (nothing))
+      all(List(something)) should (not (exist) or be_== (something))
+      all(List(nothing)) should (not (exist) or be_== (something))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -254,7 +254,7 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (nothing) or not (exist))
+        all(left3) should (be_== (nothing) or not (exist))
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(something, nothing) + ", and " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -262,7 +262,7 @@ class ShouldExistLogicalOrImplicitSpec extends Spec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (not (exist) or be (nothing))
+        all(left4) should (not (exist) or be_== (nothing))
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", and " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
+++ b/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
@@ -61,13 +61,13 @@ class ShouldExistLogicalOrSpec extends Spec {
       imaginaryFile should (exist or equal (imaginaryFile))
       existFile should (exist or equal (imaginaryFile))
       
-      existFile should (be (existFile) or exist)
-      existFile should (be (imaginaryFile) or exist)
-      imaginaryFile should (be (imaginaryFile) or exist)
+      existFile should (be_== (existFile) or exist)
+      existFile should (be_== (imaginaryFile) or exist)
+      imaginaryFile should (be_== (imaginaryFile) or exist)
       
-      existFile should (exist or be (existFile))
-      imaginaryFile should (exist or be (imaginaryFile))
-      existFile should (exist or be (imaginaryFile))
+      existFile should (exist or be_== (existFile))
+      imaginaryFile should (exist or be_== (imaginaryFile))
+      existFile should (exist or be_== (imaginaryFile))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -86,14 +86,14 @@ class ShouldExistLogicalOrSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        imaginaryFile should (be (existFile) or exist)
+        imaginaryFile should (be_== (existFile) or exist)
       }
       assert(e3.message === Some(wasNotEqualTo(imaginaryFile, existFile) + ", and " + doesNotExist(imaginaryFile)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        imaginaryFile should (exist or be (existFile))
+        imaginaryFile should (exist or be_== (existFile))
       }
       assert(e4.message === Some(doesNotExist(imaginaryFile) + ", and " + wasNotEqualTo(imaginaryFile, existFile)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -109,13 +109,13 @@ class ShouldExistLogicalOrSpec extends Spec {
       existFile should (not (exist) or equal (existFile))
       imaginaryFile should (not (exist) or equal (existFile))
       
-      imaginaryFile should (be (imaginaryFile) or not (exist))
-      imaginaryFile should (be (existFile) or not (exist))
-      existFile should (be (existFile) or not (exist))
+      imaginaryFile should (be_== (imaginaryFile) or not (exist))
+      imaginaryFile should (be_== (existFile) or not (exist))
+      existFile should (be_== (existFile) or not (exist))
       
-      imaginaryFile should (not (exist) or be (imaginaryFile))
-      existFile should (not (exist) or be (existFile))
-      imaginaryFile should (not (exist) or be (existFile))
+      imaginaryFile should (not (exist) or be_== (imaginaryFile))
+      existFile should (not (exist) or be_== (existFile))
+      imaginaryFile should (not (exist) or be_== (existFile))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -134,14 +134,14 @@ class ShouldExistLogicalOrSpec extends Spec {
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        existFile should (be (imaginaryFile) or not (exist))
+        existFile should (be_== (imaginaryFile) or not (exist))
       }
       assert(e3.message === Some(wasNotEqualTo(existFile, imaginaryFile) + ", and " + exists(existFile)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        existFile should (not (exist) or be (imaginaryFile))
+        existFile should (not (exist) or be_== (imaginaryFile))
       }
       assert(e4.message === Some(exists(existFile) + ", and " + wasNotEqualTo(existFile, imaginaryFile)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -160,13 +160,13 @@ class ShouldExistLogicalOrSpec extends Spec {
       all(List(imaginaryFile)) should (exist or equal (imaginaryFile))
       all(List(existFile)) should (exist or equal (imaginaryFile))
       
-      all(List(existFile)) should (be (existFile) or exist)
-      all(List(existFile)) should (be (imaginaryFile) or exist)
-      all(List(imaginaryFile)) should (be (imaginaryFile) or exist)
+      all(List(existFile)) should (be_== (existFile) or exist)
+      all(List(existFile)) should (be_== (imaginaryFile) or exist)
+      all(List(imaginaryFile)) should (be_== (imaginaryFile) or exist)
       
-      all(List(existFile)) should (exist or be (existFile))
-      all(List(imaginaryFile)) should (exist or be (imaginaryFile))
-      all(List(existFile)) should (exist or be (imaginaryFile))
+      all(List(existFile)) should (exist or be_== (existFile))
+      all(List(imaginaryFile)) should (exist or be_== (imaginaryFile))
+      all(List(existFile)) should (exist or be_== (imaginaryFile))
     }
     
     def `should throw TFE with correct stack depth and message when the file does not exist` {
@@ -188,7 +188,7 @@ class ShouldExistLogicalOrSpec extends Spec {
       
       val left3 = List(imaginaryFile)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (existFile) or exist)
+        all(left3) should (be_== (existFile) or exist)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(imaginaryFile, existFile) + ", and " + doesNotExist(imaginaryFile), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -196,7 +196,7 @@ class ShouldExistLogicalOrSpec extends Spec {
       
       val left4 = List(imaginaryFile)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (exist or be (existFile))
+        all(left4) should (exist or be_== (existFile))
       }
       assert(e4.message === Some(allError(left4, doesNotExist(imaginaryFile) + ", and " + wasNotEqualTo(imaginaryFile, existFile), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -212,13 +212,13 @@ class ShouldExistLogicalOrSpec extends Spec {
       all(List(existFile)) should (not (exist) or equal (existFile))
       all(List(imaginaryFile)) should (not (exist) or equal (existFile))
       
-      all(List(imaginaryFile)) should (be (imaginaryFile) or not (exist))
-      all(List(imaginaryFile)) should (be (existFile) or not (exist))
-      all(List(existFile)) should (be (existFile) or not (exist))
+      all(List(imaginaryFile)) should (be_== (imaginaryFile) or not (exist))
+      all(List(imaginaryFile)) should (be_== (existFile) or not (exist))
+      all(List(existFile)) should (be_== (existFile) or not (exist))
       
-      all(List(imaginaryFile)) should (not (exist) or be (imaginaryFile))
-      all(List(existFile)) should (not (exist) or be (existFile))
-      all(List(imaginaryFile)) should (not (exist) or be (existFile))
+      all(List(imaginaryFile)) should (not (exist) or be_== (imaginaryFile))
+      all(List(existFile)) should (not (exist) or be_== (existFile))
+      all(List(imaginaryFile)) should (not (exist) or be_== (existFile))
     }
     
     def `should throw TFE with correct stack depth and message when it is used with not and  the file exists` {
@@ -240,7 +240,7 @@ class ShouldExistLogicalOrSpec extends Spec {
       
       val left3 = List(existFile)
       val e3 = intercept[exceptions.TestFailedException] {
-        all(left3) should (be (imaginaryFile) or not (exist))
+        all(left3) should (be_== (imaginaryFile) or not (exist))
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(existFile, imaginaryFile) + ", and " + exists(existFile), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -248,7 +248,7 @@ class ShouldExistLogicalOrSpec extends Spec {
       
       val left4 = List(existFile)
       val e4 = intercept[exceptions.TestFailedException] {
-        all(left4) should (not (exist) or be (imaginaryFile))
+        all(left4) should (not (exist) or be_== (imaginaryFile))
       }
       assert(e4.message === Some(allError(left4, exists(existFile) + ", and " + wasNotEqualTo(existFile, imaginaryFile), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/src/test/scala/org/scalatest/matchers/MatcherSpec.scala
+++ b/src/test/scala/org/scalatest/matchers/MatcherSpec.scala
@@ -29,13 +29,15 @@ class MatcherSpec extends Spec {
     
     object `AndNotWord ` {
       
-      object `equal(Null) method returns Matcher` {
+      object `equal(Null) method returns MatcherFactory` {
         
         val aNullRef: String = null
-        val mt = not be ("hi") and not equal (null)
+        val mtf = not be ("hi") and not equal (null)
+        val mt = mtf.matcher[String]
       
         def `should have pretty toString` {
-          mt.toString should be ("(not be \"hi\") and (not equal null)")
+          mtf.toString should be ("(not be (\"hi\")) and (not equal null)")
+          mt.toString should be ("(not be (\"hi\")) and (not equal null)")
         }
         
         val mr = mt("Bob")
@@ -104,13 +106,15 @@ class MatcherSpec extends Spec {
     
     object `OrNotWord ` {
       
-      object `equal(Null) method returns Matcher` {
+      object `equal(Null) method returns MatcherFactory` {
         
         val aNullRef: String = null
-        val mt = not be ("Bob") or not equal (null)
+        val mtf = not be ("Bob") or not equal (null)
+        val mt = mtf.matcher[String]
       
         def `should have pretty toString` {
-          mt.toString should be ("(not be \"Bob\") or (not equal null)")
+          mtf.toString should be ("(not be (\"Bob\")) or (not equal null)")
+          mt.toString should be ("(not be (\"Bob\")) or (not equal null)")
         }
         
         val mr = mt("Bob")

--- a/src/test/scala/org/scalatest/words/BeWordSpec.scala
+++ b/src/test/scala/org/scalatest/words/BeWordSpec.scala
@@ -991,7 +991,7 @@ class BeWordSpec extends Spec with FileMocks {
       }
     }
     
-    object `apply(Any) method returns Matcher` {
+    object `apply(Any) method returns MatcherFactory` {
       
       case class MyFile(
         val name: String,
@@ -1002,7 +1002,8 @@ class BeWordSpec extends Spec with FileMocks {
       val myFileLeft = MyFile("test left", true, false)
       val myFileRight = MyFile("test right", true, false)
       
-      val mt = be (myFileRight)
+      val mtf = be (myFileRight)
+      val mt = mtf.matcher[MyFile]
       
       def `should have pretty toString` {
         mt.toString should be ("be (" + myFileRight + ")")

--- a/src/test/scala/org/scalatest/words/NotWordSpec.scala
+++ b/src/test/scala/org/scalatest/words/NotWordSpec.scala
@@ -1417,7 +1417,7 @@ class NotWordSpec extends Spec with FileMocks {
       }
     }
     
-    object `be(Any) method returns Matcher` {
+    object `be(Any) method returns MatcherFactory` {
       
       case class MyFile(
         val name: String,
@@ -1427,15 +1427,17 @@ class NotWordSpec extends Spec with FileMocks {
 
       val myFileRight = MyFile("test right", true, false)
       
-      val mt = not be (myFileRight)
+      val mtf = not be (myFileRight)
+      val mt = mtf.matcher[MyFile]
       
       def `should have pretty toString` {
-        mt.toString should be ("not be " + myFileRight)
+        mt.toString should be ("not be (" + myFileRight + ")")
       }
       
       object `when left is not null` {
       
         val myFileLeft = MyFile("test left", true, false)
+
         val mr = mt(myFileLeft)
       
         def `should have correct MatcherResult` {
@@ -1485,18 +1487,18 @@ class NotWordSpec extends Spec with FileMocks {
         def `should have correct MatcherResult` {
           mr should have (
             'matches (true),
-            'failureMessage ("The reference was null"),
-            'negatedFailureMessage (myFileRight + " was not null"),
-            'midSentenceFailureMessage ("the reference was null"),
-            'midSentenceNegatedFailureMessage (myFileRight + " was not null"),
-            'rawFailureMessage ("The reference was null"),
-            'rawNegatedFailureMessage ("{0} was not null"),
-            'rawMidSentenceFailureMessage ("the reference was null"),
-            'rawMidSentenceNegatedFailureMessage ("{0} was not null"),
-            'failureMessageArgs(Vector.empty),
-            'negatedFailureMessageArgs(Vector(myFileRight)),
-            'midSentenceFailureMessageArgs(Vector.empty),
-            'midSentenceNegatedFailureMessageArgs(Vector(myFileRight))    
+            'failureMessage (myFileLeft + " was equal to " + myFileRight),
+            'negatedFailureMessage (myFileLeft + " was not equal to " + myFileRight),
+            'midSentenceFailureMessage (myFileLeft + " was equal to " + myFileRight),
+            'midSentenceNegatedFailureMessage (myFileLeft + " was not equal to " + myFileRight),
+            'rawFailureMessage ("{0} was equal to {1}"),
+            'rawNegatedFailureMessage ("{0} was not equal to {1}"),
+            'rawMidSentenceFailureMessage ("{0} was equal to {1}"),
+            'rawMidSentenceNegatedFailureMessage ("{0} was not equal to {1}"),
+            'failureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'negatedFailureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'midSentenceFailureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'midSentenceNegatedFailureMessageArgs(Vector(myFileLeft, myFileRight))
           )
         }
       
@@ -1505,18 +1507,18 @@ class NotWordSpec extends Spec with FileMocks {
         def `should have correct negated MatcherResult` {
           nmr should have (
             'matches (false),
-            'failureMessage (myFileRight + " was not null"),
-            'negatedFailureMessage ("The reference was null"),
-            'midSentenceFailureMessage (myFileRight + " was not null"),
-            'midSentenceNegatedFailureMessage ("the reference was null"),
-            'rawFailureMessage ("{0} was not null"),
-            'rawNegatedFailureMessage ("The reference was null"),
-            'rawMidSentenceFailureMessage ("{0} was not null"),
-            'rawMidSentenceNegatedFailureMessage ("the reference was null"),
-            'failureMessageArgs(Vector(myFileRight)),
-            'negatedFailureMessageArgs(Vector.empty),
-            'midSentenceFailureMessageArgs(Vector(myFileRight)),
-            'midSentenceNegatedFailureMessageArgs(Vector.empty)    
+            'failureMessage (myFileLeft + " was not equal to " + myFileRight),
+            'negatedFailureMessage (myFileLeft + " was equal to " + myFileRight),
+            'midSentenceFailureMessage (myFileLeft + " was not equal to " + myFileRight),
+            'midSentenceNegatedFailureMessage (myFileLeft + " was equal to " + myFileRight),
+            'rawFailureMessage ("{0} was not equal to {1}"),
+            'rawNegatedFailureMessage ("{0} was equal to {1}"),
+            'rawMidSentenceFailureMessage ("{0} was not equal to {1}"),
+            'rawMidSentenceNegatedFailureMessage ("{0} was equal to {1}"),
+            'failureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'negatedFailureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'midSentenceFailureMessageArgs(Vector(myFileLeft, myFileRight)),
+            'midSentenceNegatedFailureMessageArgs(Vector(myFileLeft, myFileRight))
           )
         }
       }


### PR DESCRIPTION
Part 1 of the 'be' method refactoring: 
-added be_== as drop in replacement for old be
-some initial work for making be tobehave same as equal.
