### PR TITLE
Fix for Macro Expansion Problem with 'org' name

### DIFF
--- a/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -122,7 +122,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -153,7 +156,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -187,7 +193,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -221,7 +230,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -244,7 +256,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -266,7 +281,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -293,7 +311,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -324,7 +345,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")
@@ -352,7 +376,10 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalactic")
           ),
           newTermName("Bool")

--- a/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
+++ b/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
@@ -81,7 +81,10 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
       Select(
         Select(
           Select(
-            Ident(newTermName("org")),
+            Select(
+              Ident(newTermName("_root_")),
+              newTermName("org")
+            ),
             newTermName("scalatest")
           ),
           newTermName("DiagrammedExpr")
@@ -138,7 +141,10 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
         Select(
           Select(
             Select(
-              Ident(newTermName("org")),
+              Select(
+                Ident(newTermName("_root_")),
+                newTermName("org")
+              ),
               newTermName("scalatest")
             ),
             newTermName("DiagrammedExpr")
@@ -266,7 +272,10 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
         Select(
           Select(
             Select(
-              Ident(newTermName("org")),
+              Select(
+                Ident(newTermName("_root_")),
+                newTermName("org")
+              ),
               newTermName("scalatest")
             ),
             newTermName("DiagrammedExpr")

--- a/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -1105,6 +1105,93 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == didNotEqual("woof", "meow"))
     }
 
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |require(org == "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |require(org === "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    require(org === "test")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |require(org.aCustomMethod)
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |require(!org)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.isEmpty)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.isInstanceOf[String])
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |require(org.size == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.length == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |require(org.exists(_ == 'b'))
+        """.stripMargin)
+    }
+
   }
 
   describe("The require(boolean, clue) method") {
@@ -2092,6 +2179,93 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == didNotEqual("woof", "meow") + ", dude")
     }
 
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |require(org == "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |require(org === "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    require(org === "test", ", dude")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |require(org.aCustomMethod, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |require(!org, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.isEmpty, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.isInstanceOf[String], ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |require(org.size == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |require(org.length == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |require(org.exists(_ == 'b'), ", dude")
+        """.stripMargin)
+    }
+
   }
 
   describe("The requireState(boolean) method") {
@@ -3037,6 +3211,93 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         requireState(woof { meow(y = 5) } == "meow")
       }
       assert(e.getMessage == didNotEqual("woof", "meow"))
+    }
+
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |requireState(org == "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |requireState(org === "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    requireState(org === "test")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |requireState(org.aCustomMethod)
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |requireState(!org)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.isEmpty)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.isInstanceOf[String])
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |requireState(org.size == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.length == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |requireState(org.exists(_ == 'b'))
+        """.stripMargin)
     }
 
   }
@@ -4026,6 +4287,93 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == didNotEqual("woof", "meow") + ", dude")
     }
 
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |requireState(org == "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |requireState(org === "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    requireState(org === "test", ", dude")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |requireState(org.aCustomMethod, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |requireState(!org, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.isEmpty, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.isInstanceOf[String], ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |requireState(org.size == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |requireState(org.length == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |requireState(org.exists(_ == 'b'), ", dude")
+        """.stripMargin)
+    }
+
   }
 
   describe("The requireNonNull(...) method") {
@@ -4091,6 +4439,15 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         requireNonNull(prefix, returnNull, suffix)
       }
       assert(e.getMessage == "returnNull was null")
+    }
+
+    it("should compile correctly when variable with name 'org' is passed in") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |requireNonNull(org)
+        """.stripMargin
+      )
     }
 
   }

--- a/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -1530,6 +1530,93 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
+
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+        |val org = "test"
+        |assert(org == "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assert(org === "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    assert(org === "test")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |assert(org.aCustomMethod)
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |assert(!org)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.isEmpty)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.isInstanceOf[String])
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |assert(org.size == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.length == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |assert(org.exists(_ == 'b'))
+        """.stripMargin)
+    }
   }
 
   describe("The assert(boolean, clue) method") {
@@ -2764,6 +2851,93 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
 
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assert(org == "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assert(org === "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    assert(org === "test", ", dude")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |assert(org.aCustomMethod, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |assert(!org, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.isEmpty, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.isInstanceOf[String], ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |assert(org.size == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assert(org.length == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |assert(org.exists(_ == 'b'), ", dude")
+        """.stripMargin)
+    }
+
   }
 
   describe("The assume(boolean) method") {
@@ -3989,6 +4163,93 @@ class AssertionsSpec extends FunSpec {
       assert(e.message == Some(didNotEqual("woof", "meow")))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assume(org == "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assume(org === "test")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    assume(org === "test")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |assume(org.aCustomMethod)
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |assume(!org)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.isEmpty)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.isInstanceOf[String])
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |assume(org.size == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.length == 0)
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |assume(org.exists(_ == 'b'))
+        """.stripMargin)
     }
   }
 
@@ -5222,6 +5483,93 @@ class AssertionsSpec extends FunSpec {
       assert(e.message == Some(didNotEqual("woof", "meow") + ", dude"))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should compile when used with org == xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assume(org == "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = "test"
+          |assume(org === "test", ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+          |  it("testing here") {
+          |    val org = "test"
+          |    assume(org === "test", ", dude")
+          |  }
+          |}
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |class Test {
+          |  def aCustomMethod: Boolean = true
+          |}
+          |val org = new Test
+          |assume(org.aCustomMethod, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with !org that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = false
+          |assume(!org, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isEmpty that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.isEmpty, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.isInstanceOf[String], ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.size == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = Array.empty[String]
+          |assume(org.size == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.length == 0 that shadow org.scalactic") {
+      assertCompiles(
+        """
+          |val org = ""
+          |assume(org.length == 0, ", dude")
+        """.stripMargin)
+    }
+
+    it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+      assertCompiles(
+        """
+          |val org = "abc"
+          |assume(org.exists(_ == 'b'), ", dude")
+        """.stripMargin)
     }
 
   }

--- a/src/test/scala/org/scalatest/DiagrammedAssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/DiagrammedAssertionsSpec.scala
@@ -2357,6 +2357,93 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
           )
         )
       }
+
+      it("should compile when used with org == xxx that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assert(org == "test")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assert(org === "test")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+            |  it("testing here") {
+            |    val org = "test"
+            |    assert(org === "test")
+            |  }
+            |}
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class Test {
+            |  def aCustomMethod: Boolean = true
+            |}
+            |val org = new Test
+            |assert(org.aCustomMethod)
+          """.stripMargin)
+      }
+
+      it("should compile when used with !org that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = false
+            |assert(!org)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isEmpty that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.isEmpty)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.isInstanceOf[String])
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.size == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = Array.empty[String]
+            |assert(org.size == 0)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.length == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.length == 0)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "abc"
+            |assert(org.exists(_ == 'b'))
+          """.stripMargin)
+      }
     }
 
     describe("The assert(boolean, clue) method") {
@@ -4615,6 +4702,93 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
               |""".stripMargin
           )
         )
+      }
+
+      it("should compile when used with org == xxx that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assert(org == "test", "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assert(org === "test", "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+            |  it("testing here") {
+            |    val org = "test"
+            |    assert(org === "test", "this is a clue")
+            |  }
+            |}
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class Test {
+            |  def aCustomMethod: Boolean = true
+            |}
+            |val org = new Test
+            |assert(org.aCustomMethod, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with !org that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = false
+            |assert(!org, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isEmpty that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.isEmpty, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.isInstanceOf[String], "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.size == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = Array.empty[String]
+            |assert(org.size == 0, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.length == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assert(org.length == 0, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "abc"
+            |assert(org.exists(_ == 'b'), "this is a clue")
+          """.stripMargin)
       }
     }
 
@@ -6875,6 +7049,93 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
           )
         )
       }
+
+      it("should compile when used with org == xxx that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assume(org == "test")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assume(org === "test")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+            |  it("testing here") {
+            |    val org = "test"
+            |    assume(org === "test")
+            |  }
+            |}
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class Test {
+            |  def aCustomMethod: Boolean = true
+            |}
+            |val org = new Test
+            |assume(org.aCustomMethod)
+          """.stripMargin)
+      }
+
+      it("should compile when used with !org that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = false
+            |assume(!org)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isEmpty that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.isEmpty)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.isInstanceOf[String])
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.size == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = Array.empty[String]
+            |assume(org.size == 0)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.length == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.length == 0)
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "abc"
+            |assume(org.exists(_ == 'b'))
+          """.stripMargin)
+      }
     }
 
     describe("The assume(boolean, clue) method") {
@@ -9133,6 +9394,93 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
               |""".stripMargin
           )
         )
+      }
+
+      it("should compile when used with org == xxx that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assume(org == "test", "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = "test"
+            |assume(org === "test", "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org === xxx with TypeCheckedTripleEquals that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class TestSpec extends FunSpec with org.scalactic.TypeCheckedTripleEquals {
+            |  it("testing here") {
+            |    val org = "test"
+            |    assume(org === "test", "this is a clue")
+            |  }
+            |}
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.aCustomMethod that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |class Test {
+            |  def aCustomMethod: Boolean = true
+            |}
+            |val org = new Test
+            |assume(org.aCustomMethod, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with !org that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = false
+            |assume(!org, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isEmpty that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.isEmpty, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.isInstanceOf that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.isInstanceOf[String], "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.size == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = Array.empty[String]
+            |assume(org.size == 0, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.length == 0 that shadow org.scalactic") {
+        assertCompiles(
+          """
+            |val org = ""
+            |assume(org.length == 0, "this is a clue")
+          """.stripMargin)
+      }
+
+      it("should compile when used with org.exists(_ == 'b') that shadow org.scalactic ") {
+        assertCompiles(
+          """
+            |val org = "abc"
+            |assume(org.exists(_ == 'b'), "this is a clue")
+          """.stripMargin)
       }
     }
 


### PR DESCRIPTION
Fixed org name shadowed problem in macros.
