### PR TITLE
DiagrammedAssertions Fix for New Expression

### DIFF
--- a/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
+++ b/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
@@ -76,7 +76,7 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
    *
    * org.scalatest.DiagrammedExpr.simpleExpr(expr, anchorOfExpr)
    */
-  def simpleExpr(tree: Tree): Apply =
+  def simpleExpr(tree: Tree): Apply = {
     Apply(
       Select(
         Select(
@@ -96,6 +96,7 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
         Literal(Constant(getAnchor(tree)))
       )
     )
+  }
 
   // A data holder for result of traverseApply
   case class ApplyInfo(select: Select, applyList: List[GenericApply])
@@ -368,6 +369,7 @@ private[org] class DiagrammedExprMacro[C <: Context](val context: C, helperName:
   // Transform the input expression by parsing out the anchor and generate expression that can support diagram rendering
   def transformAst(tree: Tree): Tree = {
     tree match {
+      case Apply(Select(New(_), _), _) => simpleExpr(tree)  // delegate to simpleExpr if it is a New expression
       case apply: Apply if isXmlSugar(apply) => simpleExpr(tree)
       case apply: GenericApply => applyExpr(apply) // delegate to applyExpr if it is Apply
       case Select(This(_), _) => simpleExpr(tree) // delegate to simpleExpr if it is a Select for this, e.g. referring a to instance member.

--- a/src/test/scala/org/scalatest/DiagrammedAssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/DiagrammedAssertionsSpec.scala
@@ -2444,6 +2444,29 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
             |assert(org.exists(_ == 'b'))
           """.stripMargin)
       }
+
+      it("should do nothing when is used to check new String(\"test\") != \"test\"") {
+        assert(new String("test") == "test")
+      }
+
+      it("should throw TestFailedException with correct message and stack depth when is used to check new String(\"test\") != \"testing\"") {
+        val e = intercept[TestFailedException] {
+          assert(new String("test") == "testing")
+        }
+        e.message should be (
+          Some(
+            """
+              |
+              |assert(new String("test") == "testing")
+              |       |                  |  |
+              |       "test"             |  "testing"
+              |                          false
+              |""".stripMargin
+          )
+        )
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 14))
+      }
     }
 
     describe("The assert(boolean, clue) method") {
@@ -4789,6 +4812,29 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
             |val org = "abc"
             |assert(org.exists(_ == 'b'), "this is a clue")
           """.stripMargin)
+      }
+
+      it("should do nothing when is used to check new String(\"test\") != \"test\"") {
+        assert(new String("test") == "test", "this is a clue")
+      }
+
+      it("should throw TestFailedException with correct message and stack depth when is used to check new String(\"test\") != \"testing\"") {
+        val e = intercept[TestFailedException] {
+          assert(new String("test") == "testing", "this is a clue")
+        }
+        e.message should be (
+          Some(
+            """this is a clue
+              |
+              |assert(new String("test") == "testing", "this is a clue")
+              |       |                  |  |
+              |       "test"             |  "testing"
+              |                          false
+              |""".stripMargin
+          )
+        )
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 14))
       }
     }
 
@@ -7136,6 +7182,29 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
             |assume(org.exists(_ == 'b'))
           """.stripMargin)
       }
+
+      it("should do nothing when is used to check new String(\"test\") != \"test\"") {
+        assume(new String("test") == "test")
+      }
+
+      it("should throw TestCanceledException with correct message and stack depth when is used to check new String(\"test\") != \"testing\"") {
+        val e = intercept[TestCanceledException] {
+          assume(new String("test") == "testing")
+        }
+        e.message should be (
+          Some(
+            """
+              |
+              |assume(new String("test") == "testing")
+              |       |                  |  |
+              |       "test"             |  "testing"
+              |                          false
+              |""".stripMargin
+          )
+        )
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 14))
+      }
     }
 
     describe("The assume(boolean, clue) method") {
@@ -9481,6 +9550,29 @@ class DiagrammedAssertionsSpec extends FunSpec with Matchers with DiagrammedAsse
             |val org = "abc"
             |assume(org.exists(_ == 'b'), "this is a clue")
           """.stripMargin)
+      }
+
+      it("should do nothing when is used to check new String(\"test\") != \"test\"") {
+        assume(new String("test") == "test", "this is a clue")
+      }
+
+      it("should throw TestCanceledException with correct message and stack depth when is used to check new String(\"test\") != \"testing\"") {
+        val e = intercept[TestCanceledException] {
+          assume(new String("test") == "testing", "this is a clue")
+        }
+        e.message should be (
+          Some(
+            """this is a clue
+              |
+              |assume(new String("test") == "testing", "this is a clue")
+              |       |                  |  |
+              |       "test"             |  "testing"
+              |                          false
+              |""".stripMargin
+          )
+        )
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 14))
       }
     }
 


### PR DESCRIPTION
Fixed broken compile problem when new expression is used in diagrammed assertions.
