### PR TITLE
EquaSets Cleanup

### DIFF
--- a/src/main/scala/org/scalactic/EquaSets.scala
+++ b/src/main/scala/org/scalactic/EquaSets.scala
@@ -1336,9 +1336,17 @@ class EquaSets[T](val equality: HashingEquality[T]) { thisEquaSets =>
 
     /**
      * Converts this `EquaSet` to a stream.
+     *
      * @return a stream containing all elements of this `EquaSet`.
      */
     def toStream: Stream[T]
+
+    /**
+     * Converts this `EquaSet` to a stream of `EquaBox`es containing the elements.
+     *
+     * @return a stream containing all elements of this `EquaSet`, boxed in `EquaBox`.
+     */
+    def toEquaBoxStream: Stream[thisEquaSets.EquaBox]
 
     /**
      * Converts this `EquaSet` to a `Traversable`.
@@ -1807,6 +1815,7 @@ class EquaSets[T](val equality: HashingEquality[T]) { thisEquaSets =>
     def toSet: Set[T] = underlying.map(_.value)
     def toEquaBoxSet: Set[thisEquaSets.EquaBox] = underlying
     def toStream: Stream[T] = underlying.toStream.map(_.value)
+    def toEquaBoxStream: Stream[thisEquaSets.EquaBox] = underlying.toStream
     def toTraversable: GenTraversable[T] = underlying.map(_.value)
     def toEquaBoxTraversable: GenTraversable[thisEquaSets.EquaBox] = underlying.toTraversable
     def toVector: Vector[T] = underlying.toVector.map(_.value)

--- a/src/main/scala/org/scalactic/SortedEquaSets.scala
+++ b/src/main/scala/org/scalactic/SortedEquaSets.scala
@@ -869,6 +869,7 @@ class SortedEquaSets[T](override val equality: OrderingEquality[T]) extends Equa
     }
     def toEquaBoxSet: TreeSet[thisEquaSets.EquaBox] = underlying
     def toStream: Stream[T] = underlying.toStream.map(_.value)
+    def toEquaBoxStream: Stream[thisEquaSets.EquaBox] = underlying.toStream
     def toTraversable: GenTraversable[T] = underlying.map(_.value)
     def toEquaBoxTraversable: GenTraversable[thisEquaSets.EquaBox] = underlying.toTraversable
     def toVector: Vector[T] = underlying.toVector.map(_.value)

--- a/src/test/scala/org/scalactic/EquaSetSpec.scala
+++ b/src/test/scala/org/scalactic/EquaSetSpec.scala
@@ -2172,6 +2172,11 @@ class EquaSetSpec extends UnitSpec {
     lower.EquaSet("a", "b").toStream shouldBe (Stream("a", "b"))
     number.EquaSet(1).toStream shouldBe(Stream(1))
   }
+  it should "have a toEquaBoxStream method" in {
+    number.EquaSet(1, 2, 3).toEquaBoxStream shouldBe (Stream(number.EquaBox(1), number.EquaBox(2), number.EquaBox(3)))
+    lower.EquaSet("a", "b").toEquaBoxStream shouldBe (Stream(lower.EquaBox("a"), lower.EquaBox("b")))
+    number.EquaSet(1).toEquaBoxStream shouldBe(Stream(number.EquaBox(1)))
+  }
   it should "have a toEquaBoxTraversable method" in {
     number.EquaSet(1, 2, 3).toEquaBoxTraversable shouldBe (Set(number.EquaBox(1), number.EquaBox(2), number.EquaBox(3)))
     lower.EquaSet("a", "b").toEquaBoxTraversable shouldBe (Set(lower.EquaBox("a"), lower.EquaBox("b")))

--- a/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
+++ b/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
@@ -2081,6 +2081,11 @@ class SortedEquaSetSpec extends UnitSpec {
     lower.SortedEquaSet("a", "b").toStream shouldBe (Stream("a", "b"))
     number.SortedEquaSet(1).toStream shouldBe(Stream(1))
   }
+  it should "have a toEquaBoxStream method" in {
+    number.SortedEquaSet(1, 2, 3).toEquaBoxStream shouldBe (Stream(number.EquaBox(1), number.EquaBox(2), number.EquaBox(3)))
+    lower.SortedEquaSet("a", "b").toEquaBoxStream shouldBe (Stream(lower.EquaBox("a"), lower.EquaBox("b")))
+    number.SortedEquaSet(1).toEquaBoxStream shouldBe(Stream(number.EquaBox(1)))
+  }
   it should "have a toTraversable method" in {
     implicit val numberOrdering = new Ordering[number.EquaBox] {
       def compare(x: number.EquaBox, y: number.EquaBox): Int = x.value - y.value


### PR DESCRIPTION
-Changed find to return Option[T].
-Added scaladocs to map, flatMap, filter and foreach methods of EquaSet/SortedEquaSet.. 
-Added initial implementation for withFilter method in EquaSet.
-Added Scaladoc for into. 
-Fixed the Scaladoc on repr. 
-Added Scaladoc for size. 
-Changed EquaSet's isTraversableAgain to always return true, unless overriden.
-Changed a `EquaSet` to an `EquaSet`, and updated transpose method scaladoc.
