### PR TITLE
Stateful Status Comments

### DIFF
--- a/src/main/scala/org/scalatest/Status.scala
+++ b/src/main/scala/org/scalatest/Status.scala
@@ -190,6 +190,8 @@ private[scalatest] final class ScalaTestStatefulStatus extends Status with Seria
     for (f <- queue.iterator.asScala)
       f(succeeded)
     synchronized {
+      // Only release the latch after the callbacks finish execution, to avoid race condition with other thread(s) that wait
+      // for this Status to complete.
       latch.countDown()
     }
   }
@@ -279,6 +281,8 @@ final class StatefulStatus extends Status with Serializable {
     for (f <- queue.iterator.asScala)
       f(succeeded)
     synchronized {
+      // Only release the latch after the callbacks finish execution, to avoid race condition with other thread(s) that wait
+      // for this Status to complete.
       latch.countDown()
     }
   }


### PR DESCRIPTION
Added comments to setCompleted method in Stateful status to explain the reason the latch.countDown() should come after the callback methods execution.
