### PR TITLE
Add support for 'whenever' method to Inspectors#forAll and #forEvery.

### DIFF
--- a/src/main/scala/org/scalatest/Inspectors.scala
+++ b/src/main/scala/org/scalatest/Inspectors.scala
@@ -692,6 +692,8 @@ private[scalatest] object InspectorsHelper {
             messageList
           }
           catch {
+            case e if shouldSkip(e) =>
+               messageList
             case e if !shouldPropagate(e) => 
               val resourceNamePrefix = getResourceNamePrefix(original)
               val messageKey = head match {

--- a/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -1520,6 +1520,39 @@ class InspectorsSpec extends Spec with Inspectors with TableDrivenPropertyChecks
         }
       }
     }
+
+    object `when used with whenever` {
+      def `should succeed when all whenever conditions are false` {
+        forAll(examples) { colFun =>
+          val col = colFun(Set(1, 2, 3))
+          forEvery(col) { e => whenever (e > 3) { fail("if whenever check fails") } }
+        } 
+      }
+      def `should succeed when all whenever conditions are true and conditions pass` {
+        forAll(examples) { colFun =>
+          val col = colFun(Set(1, 2, 3))
+          forEvery(col) { e => whenever (e > 0) { e should be > 0 } }
+        } 
+      }
+      def `should fail when whenever conditions are true and conditions fail` {
+        forAll(examples) { colFun =>
+          val col = colFun(Set(1, 2, 3))
+          val e = intercept[exceptions.TestFailedException] {
+            forEvery(col) { e => 
+              whenever (e > 0) {  
+                e should be < 2 
+              } 
+            }
+          }
+          e.failedCodeFileName should be (Some("InspectorsSpec.scala"))
+          e.failedCodeLineNumber should be (Some(thisLineNumber - 7))
+          e.message.get should startWith ("forEvery failed, because: \n" +
+                                     "  at index 1, 2 was not less than 2 (InspectorsSpec.scala:" + (thisLineNumber - 7) + "), \n" +
+                                     "  at index 2, 3 was not less than 2 (InspectorsSpec.scala:" + (thisLineNumber - 8) + ") \n" +
+                                     "in")
+        } 
+      }
+    }
   }
   
   object `forAll nested` {


### PR DESCRIPTION
If more information from failures is desired, could add a 'skippedCount' to the ForResult case class.   No support for the other for\* methods in Inspectors (forAtLeast, etc).
