### PR TITLE
Use call-by-name for the `orElse` parameter in `Or.from(Option, orElse)`

### DIFF
--- a/src/main/scala/org/scalactic/Or.scala
+++ b/src/main/scala/org/scalactic/Or.scala
@@ -883,7 +883,7 @@ object Or {
       case Left(b) => Bad(b)
     }
 
-  def from[G, B](option: Option[G], orElse: B): G Or B =
+  def from[G, B](option: Option[G], orElse: => B): G Or B =
     option match {
       case Some(g) => Good(g)
       case None => Bad(orElse)


### PR DESCRIPTION
The passed `orElse` expression should be evaluated only if `option` is equal to
`None`.

Fix #454
