### PR TITLE
Adding jquery helpers for Selenium testing

### DIFF
--- a/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -4531,6 +4531,27 @@ trait WebBrowser {
     val ae: WebElement = driver.switchTo.activeElement
     ae.sendKeys(value)
   }
+
+  object jquery {
+    import org.openqa.selenium.NoSuchElementException
+
+    private def exactlyOne(selector:String, matched:Seq[Element]):Element = {
+      if(matched.length == 1) matched.head
+      else throw new NoSuchElementException("$('"+selector+"') matched "+matched.length+" elements")
+    }
+
+    def $$(selector:String)(implicit webDriver: WebDriver): Seq[Element] =
+      webDriver.findElements(By.cssSelector(selector)).asScala.map(createTypedElement)
+    def $(selector:String)(implicit webDriver: WebDriver): Element =
+      exactlyOne(selector, $$(selector))
+
+    implicit class EnhancedElement(val e:Element) {
+      def findAll(selector:String): Seq[Element] =
+        e.underlying.findElements(By.cssSelector(selector)).asScala.map(createTypedElement)
+      def find(selector:String):Element =
+        exactlyOne(selector, findAll(selector))
+    }
+  }
 }
 
 /**

--- a/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
+++ b/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
@@ -2029,7 +2029,80 @@ class WebBrowserSpec extends JettySpec with Matchers with SpanSugar with WebBrow
       """ should compile
     }
   }
-  
+
+  describe("jquery.$$") {
+    import jquery._
+
+    it("should return an empty list when no matching elements are found") {
+      goTo(host + "jquery.html")
+      $$("#nonexistent").size should be (0)
+    }
+
+    it("should return 3 elements containing our spans") {
+      goTo(host + "jquery.html")
+      val inners = $$(".inner")
+      inners.size should be (3)
+      inners foreach (_.tagName should be ("span"))
+    }
+  }
+
+  describe("jquery.$") {
+    import org.openqa.selenium.NoSuchElementException
+    import jquery._
+
+    it("should find an individual element that exists") {
+      goTo(host + "jquery.html")
+      $("#main").tagName should be ("div")
+    }
+
+    it("should throw an exception when no elements are found") {
+      goTo(host + "jquery.html")
+      intercept[NoSuchElementException]($(".nonexistent"))
+    }
+
+    it("should throw an exception when more than one element is found") {
+      goTo(host + "jquery.html")
+      intercept[NoSuchElementException]($(".inner"))
+    }
+  }
+
+  describe("jquery.EnhancedElement.findAll") {
+    import org.openqa.selenium.NoSuchElementException
+    import jquery._
+
+    it("should return an empty list when no matching elements are found") {
+      goTo(host + "jquery.html")
+      $("#main").findAll(".nonexistent").size should be (0)
+    }
+
+    it("should return 3 elements containing our spans") {
+      goTo(host + "jquery.html")
+      val inners = $("#main").findAll(".inner")
+      inners.size should be (3)
+      inners foreach (_.tagName should be ("span"))
+    }
+  }
+
+  describe("jquery.EnhancedElement.find") {
+    import org.openqa.selenium.NoSuchElementException
+    import jquery._
+
+    it("should find an individual element that exists") {
+      goTo(host + "jquery.html")
+      $(".outer").find(".zero").text should be ("0")
+    }
+
+    it("should throw an exception when no elements are found") {
+      goTo(host + "jquery.html")
+      intercept[NoSuchElementException]($(".outer").find(".nonexistent"))
+    }
+
+    it("should throw an exception when more than one element is found") {
+      goTo(host + "jquery.html")
+      intercept[NoSuchElementException]($(".outer").find(".inner"))
+    }
+  }
+
   def thisLineNumber = {
     val st = Thread.currentThread.getStackTrace
 

--- a/webapp/jquery.html
+++ b/webapp/jquery.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title></title>
+</head>
+<body>
+
+<div id="main" class="outer">
+  <span class="zero">0</span>
+  <span class="inner">1</span>
+  <span class="inner">2</span>
+  <span class="inner">3</span>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
I wrote this little tidbit today at work while working with Selenium.  It's not a substantial enhancement, but I think it kicks the Selenium DSL story up a notch.  With this enhancement you can write tests like this:

``` scala
class BlogSpec extends FlatSpec with ShouldMatchers with WebBrowser with Eventually {
  implicit val webDriver: WebDriver = new HtmlUnitDriver
  import jquery._

  go to "https://twitter.com"
  $("#signin-email").click()
  pressKeys("joescii")
  $(".primary-btn").click()

  eventually {
    $$(".tweet-text").foreach(tweet => // ...
    )
    // OR
    $("#timeline").findAll(".tweet-text").foreach(tweet => // ...
    )
  }
}
```

Anyway, it's here if you decide you'd like to include it in scalatest.  I'll gladly contribute to updating the **Using Selenium** section of the guide.  Thanks for all of the great work!
