### PR TITLE
Fix gentests dependences, broken by extracting out scalactic macros.

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -340,7 +340,7 @@ object ScalatestBuild extends Build {
       genTestsHelperTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gentestshelper", "GenTestsHelper.scala")(GenTestsHelper.genTest)
-    ).dependsOn(scalatest)
+    ).dependsOn(scalatest, scalacticMacro % "compile-internal, test-internal")
 
   lazy val genRegularTests1 = Project("genRegularTests1", file("gentests/GenRegular1"))
     .settings(gentestsSharedSettings: _*)
@@ -348,7 +348,7 @@ object ScalatestBuild extends Build {
       genRegularTask1,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genregular1", "GenRegular1.scala")(GenRegularTests1.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genRegularTests2 = Project("genRegularTests2", file("gentests/GenRegular2"))
     .settings(gentestsSharedSettings: _*)
@@ -356,7 +356,7 @@ object ScalatestBuild extends Build {
       genRegularTask2,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genregular2", "GenRegular2.scala")(GenRegularTests2.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genRegularTests3 = Project("genRegularTests3", file("gentests/GenRegular3"))
     .settings(gentestsSharedSettings: _*)
@@ -364,7 +364,7 @@ object ScalatestBuild extends Build {
       genRegularTask3,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genregular3", "GenRegular3.scala")(GenRegularTests3.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genRegularTests4 = Project("genRegularTests4", file("gentests/GenRegular4"))
     .settings(gentestsSharedSettings: _*)
@@ -374,7 +374,7 @@ object ScalatestBuild extends Build {
       testOptions in Test := scalatestTestOptions,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genregular4", "GenRegularTests1.scala")(GenRegularTests4.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genRegularTests5 = Project("genRegularTests5", file("gentests/GenRegular5"))
     .settings(gentestsSharedSettings: _*)
@@ -384,7 +384,7 @@ object ScalatestBuild extends Build {
       testOptions in Test := scalatestTestOptions,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genregular5", "GenRegularTests1.scala")(GenRegularTests5.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genMustMatchersTests1 = Project("genMustMatchersTests1", file("gentests/MustMatchers1"))
     .settings(gentestsSharedSettings: _*)
@@ -392,7 +392,7 @@ object ScalatestBuild extends Build {
       genMustMatchersTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genmatchers1", "GenMustMatchersTests.scala")(GenMustMatchersTests1.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genMustMatchersTests2 = Project("genMustMatchersTests2", file("gentests/MustMatchers2"))
     .settings(gentestsSharedSettings: _*)
@@ -400,7 +400,7 @@ object ScalatestBuild extends Build {
       genMustMatchersTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genmatchers2", "GenMustMatchersTests.scala")(GenMustMatchersTests2.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genMustMatchersTests3 = Project("genMustMatchersTests3", file("gentests/MustMatchers3"))
     .settings(gentestsSharedSettings: _*)
@@ -408,7 +408,7 @@ object ScalatestBuild extends Build {
       genMustMatchersTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genmatchers3", "GenMustMatchersTests.scala")(GenMustMatchersTests3.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genMustMatchersTests4 = Project("genMustMatchersTests4", file("gentests/MustMatchers4"))
     .settings(gentestsSharedSettings: _*)
@@ -416,7 +416,7 @@ object ScalatestBuild extends Build {
       genMustMatchersTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genmatchers4", "GenMustMatchersTests.scala")(GenMustMatchersTests4.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genGenTests = Project("genGenTests", file("gentests/GenGen"))
     .settings(gentestsSharedSettings: _*)
@@ -424,7 +424,7 @@ object ScalatestBuild extends Build {
       genGenTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gengen", "GenGen.scala")(GenGen.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genTablesTests = Project("genTablesTests", file("gentests/GenTables"))
     .settings(gentestsSharedSettings: _*)
@@ -432,7 +432,7 @@ object ScalatestBuild extends Build {
       genTablesTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gentables", "GenTable.scala")(GenTable.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genInspectorsTests = Project("genInspectorsTests", file("gentests/GenInspectors"))
     .settings(gentestsSharedSettings: _*)
@@ -440,7 +440,7 @@ object ScalatestBuild extends Build {
       genInspectorsTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("geninspectors", "GenInspectors.scala")(GenInspectors.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genInspectorsShorthandsTests1 = Project("genInspectorsShorthandsTests1", file("gentests/GenInspectorsShorthands1"))
     .settings(gentestsSharedSettings: _*)
@@ -448,7 +448,7 @@ object ScalatestBuild extends Build {
       genInspectorsShorthandsTask1,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("geninspectorsshorthands1", "GenInspectorsShorthands.scala")(GenInspectorsShorthands1.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genInspectorsShorthandsTests2 = Project("genInspectorsShorthandsTests2", file("gentests/GenInspectorsShorthands2"))
     .settings(gentestsSharedSettings: _*)
@@ -456,7 +456,7 @@ object ScalatestBuild extends Build {
       genInspectorsShorthandsTask2,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("geninspectorsshorthands2", "GenInspectorsShorthands.scala")(GenInspectorsShorthands2.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genTheyTests = Project("genTheyTests", file("gentests/GenThey"))
     .settings(gentestsSharedSettings: _*)
@@ -464,7 +464,7 @@ object ScalatestBuild extends Build {
       genTheyWordTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genthey", "GenTheyWord.scala")(GenTheyWord.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genContainTests1 = Project("genContainTests1", file("gentests/GenContain1"))
     .settings(gentestsSharedSettings: _*)
@@ -472,7 +472,7 @@ object ScalatestBuild extends Build {
       genContainTask1,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gencontain1", "GenContain1.scala")(GenContain1.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genContainTests2 = Project("genContainTests2", file("gentests/GenContain2"))
     .settings(gentestsSharedSettings: _*)
@@ -480,7 +480,7 @@ object ScalatestBuild extends Build {
       genContainTask2,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gencontain2", "GenContain2.scala")(GenContain2.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genSortedTests = Project("genSortedTests", file("gentests/GenSorted"))
     .settings(gentestsSharedSettings: _*)
@@ -488,7 +488,7 @@ object ScalatestBuild extends Build {
       genSortedTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gensorted", "GenSorted.scala")(GenSorted.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genLoneElementTests = Project("genLoneElementTests", file("gentests/GenLoneElement"))
     .settings(gentestsSharedSettings: _*)
@@ -496,7 +496,7 @@ object ScalatestBuild extends Build {
       genLoneElementTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genloneelement", "GenLoneElement.scala")(GenLoneElement.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val genEmptyTests = Project("genEmptyTests", file("gentests/GenEmpty"))
     .settings(gentestsSharedSettings: _*)
@@ -504,7 +504,7 @@ object ScalatestBuild extends Build {
       genEmptyTask,
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genempty", "GenEmpty.scala")(GenEmpty.genTest)
-    ).dependsOn(scalatest, gentestsHelper % "test->test")
+    ).dependsOn(scalatest, gentestsHelper % "test->test", scalacticMacro % "compile-internal, test-internal")
 
   lazy val gentests = Project("gentests", file("gentests"))
     .aggregate(genMustMatchersTests1, genMustMatchersTests2, genMustMatchersTests3, genMustMatchersTests4, genGenTests, genTablesTests, genInspectorsTests, genInspectorsShorthandsTests1,


### PR DESCRIPTION
Compilation of generated test projects fail due to errors such as:

  exception during macro expansion: 
    [error] java.lang.ClassNotFoundException: org.scalactic.BooleanMacro

See, e.g. https://travis-ci.org/scalatest/scalatest/jobs/44572339

This was caused by #457 
