### PR TITLE
Add "exists" to TableDrivenPropertyChecks

### DIFF
--- a/project/GenTable.scala
+++ b/project/GenTable.scala
@@ -1184,6 +1184,45 @@ $columnsOfTwos$
     }
   }
 
+  def `table exists $n$ that succeeds` {
+
+    val examples =
+      Table(
+        ($argNames$),
+$columnOfMinusOnes$
+$columnsOfOnes$
+      )
+
+    exists (examples) { ($names$) => assert($sumOfArgs$ === ($n$)) }
+  }
+
+  def `table exists $n$, which succeeds even though DiscardedEvaluationException is thrown` {
+    val numbers =
+      Table(
+        ($argNames$),
+$columnOfMinusOnes$
+$columnsOfOnes$
+      )
+
+    exists (numbers) { ($names$) =>
+      whenever (a > 0) {
+        assert(a > 0)
+      }
+    }
+  }
+
+  def `table exists $n$, which fails` {
+    val examples =
+      Table(
+        ($argNames$),
+$columnsOfTwos$
+      )
+
+    intercept[exceptions.TestFailedException] {
+      exists (examples) { ($names$) => assert($sumOfArgs$ === ($n$)) }
+    }
+  }
+
   def `table for $n$ apply, length, and iterator methods work correctly` {
 
     val examples =
@@ -1384,7 +1423,7 @@ $columnsOfIndexes$
         val columnsOfOnes = List.fill(i)("        (" + rowOfOnes + ")").mkString(",\n")
         val columnOfMinusOnes = "        (" + rowOfMinusOnes + "),"
         val columnsOfTwos = List.fill(i)("        (" + rowOfTwos + ")").mkString(",\n")
-        val rawRows =                              
+        val rawRows =
           for (idx <- 0 to 9) yield                
             List.fill(i)("  " + idx).mkString("        (", ", ", ")")
         val columnsOfIndexes = rawRows.mkString(",\n")

--- a/project/GenTable.scala
+++ b/project/GenTable.scala
@@ -886,54 +886,74 @@ val propertyCheckForAllTemplate = """
 """
 
 val propertyCheckForEveryPreamble = """
-  /**
-  */
-  private[scalatest] def doForEvery[T <: Product](namesOfArgs: List[String], rows: Seq[T], resourceName: String, sourceFileName: String, methodName: String, stackDepthAdjustment: Int)(fun: T => Unit): Unit = {
+
+  case class ForResult[T](passedCount: Int = 0,
+                          discardedCount: Int = 0,
+                          messageAcc: IndexedSeq[String] = IndexedSeq.empty,
+                          passedElements: IndexedSeq[(Int, T)] = IndexedSeq.empty,
+                          failedElements: IndexedSeq[(Int, T, Throwable)] = IndexedSeq.empty)
+
+
+  def runAndCollectResult[T <: Product](namesOfArgs: List[String], rows: Seq[T], resourceName: String, sourceFileName: String, methodName: String, stackDepthAdjustment: Int)(fun: T => Unit) = {
     import InspectorsHelper.{shouldPropagate, indentErrorMessages}
     @tailrec
-    def runAndCollectErrorMessage[T <: Product](itr: Iterator[T], messageList: IndexedSeq[exceptions.TableDrivenPropertyCheckFailedException], index: Int)(fun: T => Unit): IndexedSeq[exceptions.TableDrivenPropertyCheckFailedException] = {
+    def innerRunAndCollectResult[T <: Product](itr: Iterator[T], result: ForResult[T], index: Int)(fun: T => Unit): ForResult[T] = {
       if (itr.hasNext) {
         val head = itr.next
-        val newMessageList =
+        val newResult =
           try {
             fun(head)
-            messageList
+            result.copy(passedCount = result.passedCount + 1, passedElements = result.passedElements :+ (index, head))
           }
           catch {
-            case _: exceptions.DiscardedEvaluationException => messageList // discard this evaluation and move on to the next
+            case _: exceptions.DiscardedEvaluationException => result.copy(discardedCount = result.discardedCount + 1) // discard this evaluation and move on to the next
             case ex if !shouldPropagate(ex) =>
-              messageList :+ new exceptions.TableDrivenPropertyCheckFailedException(
-                (sde => FailureMessages("propertyException", UnquotedString(ex.getClass.getSimpleName)) +
-                  ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
-                  "  " + FailureMessages("thrownExceptionsMessage", if (ex.getMessage == null) "None" else UnquotedString(ex.getMessage)) + "\n" +
-                  (
-                    ex match {
-                      case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
-                        "  " + FailureMessages("thrownExceptionsLocation", UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
-                      case _ => ""
-                    }
-                    ) +
-                  "  " + FailureMessages("occurredAtRow", index) + "\n" +
-                  indentErrorMessages(namesOfArgs.zip(head.productIterator.toSeq).map { case (name, value) =>
-                    name + " = " + value
-                  }.toIndexedSeq).mkString("\n") +
-                  "  )"),
-                Some(ex),
-                getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment),
-                None,
-                FailureMessages("undecoratedPropertyCheckFailureMessage"),
-                head.productIterator.toList,
-                namesOfArgs,
-                index
+              result.copy(failedElements =
+                result.failedElements :+ (index,
+                  head,
+                  new exceptions.TableDrivenPropertyCheckFailedException(
+                    (sde => FailureMessages("propertyException", UnquotedString(ex.getClass.getSimpleName)) +
+                      (sde.failedCodeFileNameAndLineNumberString match {
+                        case Some(s) => " (" + s + ")";
+                        case None => ""
+                      }) + "\n" +
+                      "  " + FailureMessages("thrownExceptionsMessage", if (ex.getMessage == null) "None" else UnquotedString(ex.getMessage)) + "\n" +
+                      (
+                        ex match {
+                          case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+                            "  " + FailureMessages("thrownExceptionsLocation", UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
+                          case _ => ""
+                        }
+                        ) +
+                      "  " + FailureMessages("occurredAtRow", index) + "\n" +
+                      indentErrorMessages(namesOfArgs.zip(head.productIterator.toSeq).map { case (name, value) =>
+                        name + " = " + value
+                      }.toIndexedSeq).mkString("\n") +
+                      "  )"),
+                    Some(ex),
+                    getStackDepthFun(sourceFileName, methodName, stackDepthAdjustment),
+                    None,
+                    FailureMessages("undecoratedPropertyCheckFailureMessage"),
+                    head.productIterator.toList,
+                    namesOfArgs,
+                    index
+                  )
+                )
               )
           }
 
-        runAndCollectErrorMessage(itr, newMessageList, index + 1)(fun)
+        innerRunAndCollectResult(itr, newResult, index + 1)(fun)
       }
       else
-        messageList
+        result
     }
-    val messageList = runAndCollectErrorMessage(rows.toIterator, IndexedSeq.empty, 0)(fun)
+    innerRunAndCollectResult(rows.toIterator, ForResult(), 0)(fun)
+  }
+
+  private[scalatest] def doForEvery[T <: Product](namesOfArgs: List[String], rows: Seq[T], resourceName: String, sourceFileName: String, methodName: String, stackDepthAdjustment: Int)(fun: T => Unit): Unit = {
+    import InspectorsHelper.indentErrorMessages
+    val result = runAndCollectResult(namesOfArgs, rows, resourceName, sourceFileName, methodName, stackDepthAdjustment + 2)(fun)
+    val messageList = result.failedElements.map(_._3)
     if (messageList.size > 0)
       throw new exceptions.TestFailedException(
         sde => Some(FailureMessages(resourceName, UnquotedString(indentErrorMessages(messageList.map(_.toString)).mkString(", \n")))),

--- a/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -454,6 +454,7 @@ propertyFailed=Falsified after {0} successful property evaluations.
 propertyExhausted=Gave up after {0} successful property evaluations. {1} evaluations were discarded.
 undecoratedPropertyCheckFailureMessage=Property check failed.
 tableDrivenForEveryFailed=forEvery failed, because: \n{0}
+tableDrivenExistsFailed=exists failed, because: \n{0}
 propertyException={0} was thrown during property evaluation.
 generatorException={0} was thrown during argument generation.
 thrownExceptionsMessage=Message: {0}

--- a/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
+++ b/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
@@ -1,4 +1,5 @@
-package org.scalatest.prop
+package org.scalatest
+package prop
 
 import java.lang.annotation.AnnotationFormatError
 import java.nio.charset.CoderMalfunctionError
@@ -12,7 +13,7 @@ import org.scalatest._
 /**
  * Separate non-generated tests, for completeness
  */
-class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with TableDrivenPropertyChecks with OptionValues {
+class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with NonGeneratedTableDrivenPropertyChecks with OptionValues {
 
   object `forEvery/1 ` {
     def colFun[A](s: Set[A]): TableFor1[A] = {
@@ -263,6 +264,274 @@ class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with 
       }
     }
   }
+
+  object `exists/1 ` {
+    def colFun[A](s: Set[A]): TableFor1[A] = {
+
+      val table = Table(("column1"), s.toSeq: _*)
+      table
+    }
+    def `should pass when one element passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { e => e should be (2) }
+    }
+
+    def `should pass when more than one element passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { e => e should be < 3 }
+    }
+
+    def `should throw TestFailedException with correct stack depth and message when none of the elements passed` {
+      val col = colFun(Set(1, 2, 3))
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { e =>
+          e should be > 5
+        }
+      }
+      e.failedCodeFileName should be (Some("NonGeneratedTableDrivenPropertyChecksSpec.scala"))
+      e.failedCodeLineNumber should be (Some(thisLineNumber - 5))
+      val itr = col.toIterator
+      val first = itr.next
+      val second = itr.next
+      val third = itr.next; println("Message: " + e.message.value)
+      e.message.value should be(s"exists failed, because: \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 11})\n" +
+        s"    Message: 1 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 12})\n" +
+        s"    Occurred at table row 0 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 1  ), \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 16})\n" +
+        s"    Message: 2 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 17})\n" +
+        s"    Occurred at table row 1 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 2  ), \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 21})\n" +
+        s"    Message: 3 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 22})\n" +
+        s"    Occurred at table row 2 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 3  )"
+      )
+      e.getCause should not be (null)
+    }
+
+    def `should pass when all of the elements passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { e => e should be < 5 }
+    }
+
+    def `should fail in empty case when all of the elements failed` {
+      val col = colFun(Set[Int]())
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { e => fail("<there are no elements>") }
+      }
+    }
+
+    def `should propagate not DiscardedEvaluationException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { _ => throw new DiscardedEvaluationException}
+      }
+    }
+
+    def `should propagate TestPendingException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[exceptions.TestPendingException] {
+        exists(col) { e => pending }
+      }
+    }
+
+    def `should propagate TestCanceledException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[exceptions.TestCanceledException] {
+        exists(col) { e => cancel }
+      }
+    }
+
+    def `should propagate java.lang.annotation.AnnotationFormatError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[AnnotationFormatError] {
+        exists(col) { e => throw new AnnotationFormatError("test") }
+      }
+    }
+
+    def `should propagate java.nio.charset.CoderMalfunctionError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[CoderMalfunctionError] {
+        exists(col) { e => throw new CoderMalfunctionError(new RuntimeException("test")) }
+      }
+    }
+
+    def `should propagate javax.xml.parsers.FactoryConfigurationError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[FactoryConfigurationError] {
+        exists(col) { e => throw new FactoryConfigurationError() }
+      }
+    }
+
+    def `should propagate java.lang.LinkageError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[LinkageError] {
+        exists(col) { e => throw new LinkageError() }
+      }
+    }
+
+    def `should propagate java.lang.ThreadDeath thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[ThreadDeath] {
+        exists(col) { e => throw new ThreadDeath() }
+      }
+    }
+
+    def `should propagate javax.xml.transform.TransformerFactoryConfigurationError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[TransformerFactoryConfigurationError] {
+        exists(col) { e => throw new TransformerFactoryConfigurationError() }
+      }
+    }
+
+    def `should propagate java.lang.VirtualMachineError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[VirtualMachineError] {
+        exists(col) { e => throw new VirtualMachineError() {} }
+      }
+    }
+  }
+
+  object `exists/2 ` {
+    def colFun[A](s: Set[A]): TableFor2[A, A] = {
+      val table = Table(("column1", "column2"), s.map(x => (x, x)).toSeq: _*)
+      table
+    }
+
+    def `should pass when one element passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { (e, _) => e should be (2) }
+    }
+
+    def `should pass when more than one element passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { (e, _) => e should be < 3 }
+    }
+
+    def `should throw TestFailedException with correct stack depth and message when none of the elements passed` {
+      val col = colFun(Set(1, 2, 3))
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { (e, _) =>
+          e should be > 5
+        }
+      }
+      e.failedCodeFileName should be (Some("NonGeneratedTableDrivenPropertyChecksSpec.scala"))
+      e.failedCodeLineNumber should be (Some(thisLineNumber - 5))
+      val itr = col.toIterator
+      val first = itr.next
+      val second = itr.next
+      val third = itr.next; println("Message: " + e.message.value)
+      e.message.value should be(s"exists failed, because: \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 11})\n" +
+        s"    Message: 1 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 12})\n" +
+        s"    Occurred at table row 0 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 1\n" +
+        s"    column2 = 1  ), \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 17})\n" +
+        s"    Message: 2 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 18})\n" +
+        s"    Occurred at table row 1 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 2\n" +
+        s"    column2 = 2  ), \n" +
+        s"  org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 23})\n" +
+        s"    Message: 3 was not greater than 5\n" +
+        s"    Location: (NonGeneratedTableDrivenPropertyChecksSpec.scala:${thisLineNumber - 24})\n" +
+        s"    Occurred at table row 2 (zero based, not counting headings), which had values (\n" +
+        s"    column1 = 3\n" +
+        s"    column2 = 3  )"
+      )
+      e.getCause should not be (null)
+    }
+
+    def `should pass when all of the elements passed` {
+      val col = colFun(Set(1, 2, 3))
+      exists(col) { (e, _) => e should be < 5 }
+    }
+
+    def `should fail in empty case when all of the elements failed` {
+      val col = colFun(Set[Int]())
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { (e, _) => fail("<there are no elements>") }
+      }
+    }
+
+    def `should propagate not DiscardedEvaluationException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      val e = intercept[exceptions.TestFailedException] {
+        exists(col) { (_, _) => throw new DiscardedEvaluationException}
+      }
+    }
+
+    def `should propagate TestPendingException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[exceptions.TestPendingException] {
+        exists(col) { (_, _) => pending }
+      }
+    }
+
+    def `should propagate TestCanceledException thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[exceptions.TestCanceledException] {
+        exists(col) { (_, _) => cancel }
+      }
+    }
+
+    def `should propagate java.lang.annotation.AnnotationFormatError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[AnnotationFormatError] {
+        exists(col) { (_, _) => throw new AnnotationFormatError("test") }
+      }
+    }
+
+    def `should propagate java.nio.charset.CoderMalfunctionError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[CoderMalfunctionError] {
+        exists(col) { (_, _) => throw new CoderMalfunctionError(new RuntimeException("test")) }
+      }
+    }
+
+    def `should propagate javax.xml.parsers.FactoryConfigurationError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[FactoryConfigurationError] {
+        exists(col) { (_, _) => throw new FactoryConfigurationError() }
+      }
+    }
+
+    def `should propagate java.lang.LinkageError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[LinkageError] {
+        exists(col) { (_, _) => throw new LinkageError() }
+      }
+    }
+
+    def `should propagate java.lang.ThreadDeath thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[ThreadDeath] {
+        exists(col) { (_, _) => throw new ThreadDeath() }
+      }
+    }
+
+    def `should propagate javax.xml.transform.TransformerFactoryConfigurationError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[TransformerFactoryConfigurationError] {
+        exists(col) { (_, _) => throw new TransformerFactoryConfigurationError() }
+      }
+    }
+
+    def `should propagate java.lang.VirtualMachineError thrown from assertion` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[VirtualMachineError] {
+        exists(col) { (_, _) => throw new VirtualMachineError() {} }
+      }
+    }
+  }
+
 }
 
   /*

--- a/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
+++ b/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest._
 /**
  * Separate non-generated tests, for completeness
  */
-class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with NonGeneratedTableDrivenPropertyChecks with OptionValues {
+class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with TableDrivenPropertyChecks with OptionValues {
 
   object `forEvery/1 ` {
     def colFun[A](s: Set[A]): TableFor1[A] = {

--- a/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
+++ b/src/test/scala/org/scalatest/prop/NonGeneratedTableDrivenPropertyChecksSpec.scala
@@ -9,6 +9,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError
 import org.scalatest.FailureMessages._
 import org.scalatest.SharedHelpers._
 import org.scalatest._
+import org.scalatest.exceptions.TestCanceledException
 
 /**
  * Separate non-generated tests, for completeness
@@ -280,6 +281,17 @@ class NonGeneratedTableDrivenPropertyChecksSpec extends Spec with Matchers with 
       val col = colFun(Set(1, 2, 3))
       exists(col) { e => e should be < 3 }
     }
+
+    def `should evaluate all elements, and allow test to be canceled after one element passed` {
+      val col = colFun(Set(1, 2, 3))
+      intercept[TestCanceledException] {
+        exists(col) { e =>
+          if (e == 3) cancel("You got to three")
+          e should be < 3
+        }
+      }
+    }
+
 
     def `should throw TestFailedException with correct stack depth and message when none of the elements passed` {
       val col = colFun(Set(1, 2, 3))


### PR DESCRIPTION
Also factored out runAndCollectResult internally, so future extensions such as forAtMost or similar would be easier to add.