### PR TITLE
Add "exists" to GeneratorDrivenPropertyCheckers

### DIFF
--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -1141,7 +1141,7 @@ val generatorSuitePostamble = """
   val sevenEleven: Gen[String] =
     Gen.sized { (size: Int) =>
       if (size >= 7 && size <= 11)
-        Gen.value("OKAY")
+        Gen.const("OKAY")
       else
         throw new Exception("expected 7 <= size <= 11 but got " + size)
     }
@@ -1149,7 +1149,7 @@ val generatorSuitePostamble = """
   val fiveFive: Gen[String] =
     Gen.sized { (size: Int) =>
       if (size == 5)
-        Gen.value("OKAY")
+        Gen.const("OKAY")
       else
         throw new Exception("expected size 5 but got " + size)
     }

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -968,7 +968,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    *   values in the <code>PropertyCheckConfiguration</code> implicitly passed to the <code>apply</code> methods of the <code>ConfiguredPropertyExistsCheck</code>
    *   object returned by this method.
    */
-  def exists(configParams: PropertyCheckConfigParam*): ConfiguredPropertyExistsCheck = new ConfiguredPropertyExistsCheck(configParams)
+  def exists(configParams: PropertyExistsCheckConfigParam*): ConfiguredPropertyExistsCheck = new ConfiguredPropertyExistsCheck(configParams)
 
   /**
    * Performs a configured property checks by applying property check functions passed to its <code>apply</code> methods to arguments
@@ -977,7 +977,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    *
    * <p>
    * Instances of this class are returned by trait <code>GeneratorDrivenPropertyChecks</code> <code>exists</code> method that accepts a variable length
-   * argument list of <code>PropertyCheckConfigParam</code> objects. Thus it is used with functions of arity-1.
+   * argument list of <code>PropertyExistsCheckConfigParam</code> objects. Thus it is used with functions of arity-1.
    * Here are some examples:
    * </p>
    *
@@ -1005,12 +1005,12 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    * }
    * </pre>
    *
-   * @param configParams a variable length list of <code>PropertyCheckConfigParam</code> objects that should override corresponding
+   * @param configParams a variable length list of <code>PropertyExistsCheckConfigParam</code> objects that should override corresponding
    *   values in the <code>PropertyCheckConfiguration</code> implicitly passed to the <code>apply</code> methods of instances of this class.
    *
    * @author Bill Venners
   */
-  class ConfiguredPropertyExistsCheck(configParams: Seq[PropertyCheckConfigParam]) {
+  class ConfiguredPropertyExistsCheck(configParams: Seq[PropertyExistsCheckConfigParam]) {
 
   /**
    * Performs an <code>exists</code> property check by applying the specified property check function to arguments
@@ -1112,7 +1112,7 @@ $arbShrinks$
    *
    * @param fun the property check function to apply to the generated arguments
    */
-  def exists[$alphaUpper$]($argNameNamesAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
+  def exists[$alphaUpper$]($argNameNamesAndTypes$, configParams: PropertyExistsCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
     (implicit
       config: PropertyCheckConfigurable,
 $arbShrinks$
@@ -1159,7 +1159,7 @@ $arbShrinks$
    *
    * @param fun the property check function to apply to the generated arguments
    */
-  def exists[$alphaUpper$]($genArgsAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
+  def exists[$alphaUpper$]($genArgsAndTypes$, configParams: PropertyExistsCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
     (implicit
       config: PropertyCheckConfigurable,
 $shrinks$
@@ -1206,7 +1206,7 @@ $shrinks$
    *
    * @param fun the property check function to apply to the generated arguments
    */
-  def exists[$alphaUpper$]($nameAndGenArgsAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
+  def exists[$alphaUpper$]($nameAndGenArgsAndTypes$, configParams: PropertyExistsCheckConfigParam*)(fun: ($alphaUpper$) => Unit)
     (implicit
       config: PropertyCheckConfigurable,
 $shrinks$
@@ -1574,286 +1574,6 @@ val generatorSuiteExistsTemplate = """
       exists ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
         assert($sumOfArgLengths$ < 0)
       }
-    }
-  }
-
-  // Same thing, but set minSuccessful to 5 with param, prop fails after 5
-  def `generator-driven exists property that takes $n$ args, which succeeds, with minSuccessful param set to 5` {
-
-    var i = 0
-    exists (minSuccessful(5)) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args, which fails, with minSuccessful param set to 5, but exists ignores` {
-      var i = 0
-      exists (minSuccessful(5)) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which succeeds, with minSuccessful param set to 5` {
-
-    var i = 0
-    exists ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which fails, with minSuccessful param set to 5, but exists ignores config and passes anyway` {
-
-      var i = 0
-      exists ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5` {
-
-    var i = 0
-    exists ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which fails, with minSuccessful param set to 5, but exists ignores config and passes anyway` {
-
-      var i = 0
-      exists ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which succeeds, with minSuccessful param set to 5` {
-
-    var i = 0
-    exists ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which fails, with minSuccessful param set to 5, but exists ignores config and passes anyway` {
-
-      var i = 0
-      exists ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  // Same thing, but set default minSuccessful to 5, prop fails after 5
-  def `generator-driven exists property that takes $n$ args, which succeeds, with default minSuccessful param set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    var i = 0
-    exists { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args, which fails, with default minSuccessful param set to 5, but exists ignores config and passes anyway` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-      var i = 0
-      exists { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which succeeds, with default minSuccessful param set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    var i = 0
-    exists ($argNames$) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which fails, with default minSuccessful param set to 5, but exists ignores config and passes anyway` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-      var i = 0
-      exists ($argNames$) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    var i = 0
-    exists ($famousArgs$) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which fails, with default minSuccessful param set to 5, but exists ignores` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-      var i = 0
-      exists ($famousArgs$) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which succeeds, with default minSuccessful param set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    var i = 0
-    exists ($nameGenTuples$) { ($namesAndTypes$) =>
-      i += 1
-      assert(i != 6)
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which fails, with default minSuccessful param set to 5, but exists ignores` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-      var i = 0
-      exists ($nameGenTuples$) { ($namesAndTypes$) =>
-        i += 1
-        assert(i != 5)
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ args, which fails, with maxDiscarded param set to 5, but exists ignores` {
-
-      var i = 0
-      exists (maxDiscarded(5)) { ($namesAndTypes$) =>
-        i += 1
-        whenever (i > 6) { assert(1 + 1 === (2)) }
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which succeeds, with maxDiscarded param set to 5` {
-
-    var i = 0
-    exists ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which fails, with maxDiscarded param set to 5, but exists ignores config and passes anyway` {
-
-      var i = 0
-      exists ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
-        i += 1
-        whenever (i > 6) { assert(1 + 1 === (2)) }
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5` {
-
-    var i = 0
-    exists ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which fails, with maxDiscarded param set to 5, but exists ignores config and passes anyway` {
-      var i = 0
-      exists ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
-        i += 1
-        whenever (i > 6) { assert(1 + 1 === (2)) }
-      }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which succeeds, with maxDiscarded param set to 5` {
-
-    var i = 0
-    exists ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which fails, with maxDiscarded param set to 5, but exists ignores config and passes anyway` {
-
-      var i = 0
-      exists ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
-        i += 1
-        whenever (i > 6) { assert(1 + 1 === (2)) }
-      }
-  }
-
-  // Same thing, but set default maxDiscarded to 5, prop fails after 5
-  def `generator-driven exists property that takes $n$ args, which succeeds, with default maxDiscarded set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
-
-    var i = 0
-    exists { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args, which succeeds, with default maxDiscarded set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
-
-    var i = 0
-    exists ($argNames$) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
-
-    var i = 0
-    exists ($famousArgs$) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
-    }
-  }
-
-  def `generator-driven exists property that takes $n$ named args and generators, which succeeds, with default maxDiscarded set to 5` {
-
-    // Hides the member
-    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
-
-    var i = 0
-    exists ($nameGenTuples$) { ($namesAndTypes$) =>
-      i += 1
-      whenever (i > 5) { assert(1 + 1 === (2)) }
     }
   }
 

--- a/src/main/scala/org/scalatest/prop/Configuration.scala
+++ b/src/main/scala/org/scalatest/prop/Configuration.scala
@@ -171,6 +171,19 @@ trait Configuration {
    * @author Bill Venners
    */
   sealed abstract class PropertyCheckConfigParam
+
+  /**
+   * Abstract class defining a family of configuration parameters for exists property checks.
+   *
+   * <p>
+   * The subclasses of this abstract class are used to pass configuration information to
+   * the <code>exists</code> or <code>forAll</code> methods of traits <code>PropertyChecks</code> (for ScalaTest-style
+   * property checks).
+   * </p>
+   *
+   * @author Bill Venners
+   */
+   sealed abstract class PropertyExistsCheckConfigParam extends PropertyCheckConfigParam
   
   /**
    * A <code>PropertyCheckConfigParam</code> that specifies the minimum number of successful
@@ -241,7 +254,7 @@ trait Configuration {
    *
    * @author Bill Venners
    */
-  case class MinSize(value: PozInt) extends PropertyCheckConfigParam
+  case class MinSize(value: PozInt) extends PropertyExistsCheckConfigParam
   
   /**
    * A <code>PropertyCheckConfigParam</code> that specifies the maximum size parameter to
@@ -260,7 +273,7 @@ trait Configuration {
    * @author Bill Venners
    */
   @deprecated("use SizeRange instead")
-  case class MaxSize(value: Int) extends PropertyCheckConfigParam {
+  case class MaxSize(value: Int) extends PropertyExistsCheckConfigParam {
     require(value >= 0)
   }
 
@@ -276,7 +289,7 @@ trait Configuration {
    *
    * @author Bill Venners
    */
-  case class SizeRange(value: PozInt) extends PropertyCheckConfigParam
+  case class SizeRange(value: PozInt) extends PropertyExistsCheckConfigParam
 
   /**
    * A <code>PropertyCheckConfigParam</code> that specifies the number of worker threads
@@ -286,7 +299,7 @@ trait Configuration {
    *
    * @author Bill Venners
    */
-  case class Workers(value: PosInt) extends PropertyCheckConfigParam
+  case class Workers(value: PosInt) extends PropertyExistsCheckConfigParam
   
   /**
    * Returns a <code>MinSuccessful</code> property check configuration parameter containing the passed value, which specifies the minimum number of successful


### PR DESCRIPTION
Two things to note about this, based on ScalaCheck's Prop.exists method implementation.

  1. Like ScalaCheck, only single-arity functions are supported (e.g. exists(...) { a: String => assert(a.length == 1)  }, but not { (a: String, b: String) => ...}
  2. MinSuccessful and MaxDiscardedFactor config settings appear to *not* be supported by Prop.exists.   That is, checking Prop.exists with different maxDiscardedRatio values does not appear to affect the result.   I've disabled directly passing minSuccessful, etc property values, but confusion could arise because the user can still set the minSuccessful, etc properties on a PropertyCheckConfiguration instance.