### PR TITLE
Add flatten to the Monad typeclass and adapters. [SCALATEST-487]

### DIFF
--- a/src/main/scala/org/scalatest/laws/MonadLaws.scala
+++ b/src/main/scala/org/scalatest/laws/MonadLaws.scala
@@ -21,7 +21,7 @@ import org.scalactic.algebra._
 import org.scalatest.Matchers._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 
-import Monad.adapters
+import Monad.adapters._
 
 import scala.language.higherKinds
 


### PR DESCRIPTION
I coudn't see how to do this without creating a second adapter and implicit conversion to match the nested context signature (Context[Context[A]]).  This means that "import Monad.adapters._" must be used instead of "import Monad.adapters".

I can make corresponding changes to Functor and Applicative in order to be consistent, if desired.