### PR TITLE
Final Changes for 2.2.4

### DIFF
--- a/project/GenScalactic.scala
+++ b/project/GenScalactic.scala
@@ -44,7 +44,7 @@ object GenScalactic {
       val destFile = new File(scalacticPackageDir, sourceFile.getName)
       copyFile(sourceFile, destFile)
     }
-    GenVersions.genMain(scalacticPackageDir, version, scalaVersion)
+    GenVersions.genScalacticVersions(scalacticPackageDir, version, scalaVersion)
 
     val scalautilsPackageDir = new File(targetDir, "org/scalautils")
     scalautilsPackageDir.mkdirs()

--- a/project/GenVersions.scala
+++ b/project/GenVersions.scala
@@ -2,7 +2,7 @@ import java.io.{File, FileWriter, BufferedWriter}
 
 object GenVersions {
 
-  def genMain(targetDir: File, version: String, scalaVersion: String) {
+  def genScalacticVersions(targetDir: File, version: String, scalaVersion: String): Unit = {
     val shortScalaVersion = scalaVersion.split("\\.").take(2).mkString(".")
     targetDir.mkdirs()
 
@@ -22,6 +22,12 @@ object GenVersions {
     scalacticVersionsFileWriter.flush()
     scalacticVersionsFileWriter.close()
     println("Generated " + scalacticVersionsFile.getAbsolutePath)
+  }
+
+  def genScalaTestVersions(targetDir: File, version: String, scalaVersion: String): Unit = {
+    val shortScalaVersion = scalaVersion.split("\\.").take(2).mkString(".")
+
+    genScalacticVersions(targetDir, version, scalaVersion)
 
     val scalaTestVersionsFile = new File(targetDir, "ScalaTestVersions.scala")
     val scalaTestVersionsFileWriter = new BufferedWriter(new FileWriter(scalaTestVersionsFile))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -10,8 +10,8 @@ object ScalatestBuild extends Build {
 
   val buildScalaVersion = "2.11.2"
 
-  val releaseVersion = "2.2.3"
-  val githubTag = "release-2.2.3-for-scala-2.11-and-2.10" // for scaladoc source urls
+  val releaseVersion = "2.2.4"
+  val githubTag = "release-2.2.4-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =
     "https://github.com/scalatest/scalatest/tree/"+ githubTag +
@@ -184,7 +184,7 @@ object ScalatestBuild extends Build {
      sourceGenerators in Compile <+=
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gencompcls", "GenCompatibleClasses.scala")(GenCompatibleClasses.genMain),
      sourceGenerators in Compile <+=
-         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genversions", "GenVersions.scala")(GenVersions.genMain),
+         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genversions", "GenVersions.scala")(GenVersions.genScalaTestVersions),
      testOptions in Test := Seq(Tests.Argument("-l", "org.scalatest.tags.Slow",
                                                "-m", "org.scalatest",
                                                "-m", "org.scalactic",
@@ -457,7 +457,7 @@ object ScalatestBuild extends Build {
 
   val genVersions = TaskKey[Unit]("genversions", "Generate Versions object")
   val genVersionsTask = genVersions <<= (sourceManaged in Compile, sourceManaged in Test, version, scalaVersion) map { (mainTargetDir: File, testTargetDir: File, theVersion: String, theScalaVersion: String) =>
-    GenVersions.genMain(new File(mainTargetDir, "scala/gencompclass"), theVersion, theScalaVersion)
+    GenVersions.genScalaTestVersions(new File(mainTargetDir, "scala/gencompclass"), theVersion, theScalaVersion)
   }
   
   val genContain = TaskKey[Unit]("gencontain", "Generate contain matcher tests")


### PR DESCRIPTION
Bump up version to 2.2.4, and GenScalactic should generate ScalacticVersions only.