### PR TITLE
Travis Maven Cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ notifications:
     - bill@artima.com
     - cheeseng@amaseng.com
 
+cache:
+  directories:
+  - $HOME/.m2
+
 #after_success:
 #  # only 'scalatest/scalatest' 'master' branch is published from the first node
 #  - |


### PR DESCRIPTION
Added cache to .travis.yml to cache maven dir.  This should improve the build time and reduce a factor of failure due to download error of dependency artifacts.