### PR TITLE
SuiteAborted Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/SuiteSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/SuiteSuite.scala
@@ -358,6 +358,17 @@ class SuiteSuite extends Spec with SeveredStackTraces {
       formatterForSuiteStarting(nonEmptySuiteContainingNestedSuites) !==
         Some(MotionToSuppress))
   }
+
+  def `Suite.execute should propagate fatal error` = {
+    class ExampleSpec extends FunSpec {
+      override def run(testName: Option[String], args: Args): Status =
+        throw new VirtualMachineError("purposely") {}
+    }
+
+    intercept[VirtualMachineError] {
+      (new ExampleSpec).execute()
+    }
+  }
 }
 
 @DoNotDiscover

--- a/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/AbortedSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/AbortedSuite.scala
@@ -39,3 +39,7 @@ class AbortedSuite extends WordSpec {
   override def nestedSuites = Vector(new NestedSuite)
 
 }
+
+class AbortedSuite2 extends WordSpec {
+  throw new VirtualMachineError("Fails during construction time.") {}
+}

--- a/scalatest/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+private[scalatest] class DeferredAbortedSuite(t: Throwable) extends Suite {
+
+  override def run(testName: Option[String], args: Args): Status = {
+    throw t
+  }
+
+}

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -864,6 +864,8 @@ trait Suite extends Assertions with Serializable { thisSuite =>
       case e: Throwable =>
         dispatchSuiteAborted(e)
         dispatch(RunAborted(tracker.nextOrdinal(), Resources.bigProblems(e), Some(e), Some(System.currentTimeMillis - runStartTime)))
+        if (!NonFatal(e))
+          throw e
     }
     finally {
       dispatch.dispatchDisposeAndWaitUntilDone()

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -72,6 +72,8 @@ import collection.immutable
 import OutcomeOf.outcomeOf
 import org.scalactic.Prettifier
 
+import scala.util.control.NonFatal
+
 /*
  * <h2>Using <code>info</code> and <code>markup</code></h2>
  *
@@ -1402,7 +1404,10 @@ trait Suite extends Assertions with Serializable { thisSuite =>
 
             val duration = System.currentTimeMillis - suiteStartTime
             report(SuiteAborted(tracker.nextOrdinal(), rawString, nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
-            FailedStatus
+            if (NonFatal(e.getCause))
+              FailedStatus
+            else
+              throw e.getCause
           }
         }
       }

--- a/scalatest/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
@@ -78,10 +78,10 @@ private[scalatest] object DiscoverySuite {
       }
     }
     catch {
-      case e: Exception => { // TODO: Maybe include the e.getClass.getName and the message for e in the message cannotLoadDiscoveredSuite, because Jess had the problem
+      case t: Throwable => { // TODO: Maybe include the e.getClass.getName and the message for e in the message cannotLoadDiscoveredSuite, because Jess had the problem
                              // That gradle cut off the stack trace so she couldn't see the cause.
         val msg = Resources("cannotLoadDiscoveredSuite", suiteClassName)
-        throw new RuntimeException(msg, e)
+        new DeferredAbortedSuite(new RuntimeException(msg, t))
       }
     }
   }


### PR DESCRIPTION
- Changed code to fire SuiteAborted when error occurs during suite construction, and rethrow if it is an fatal error (use NonFatal to determine).
- Make Suite.execute to propagate fatal error.