### PR TITLE
Enhancenment WebSocketTests

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -167,8 +167,10 @@ object ScalatestBuild extends Build {
       "org.seleniumhq.selenium" % "selenium-java" % "2.35.0" % "optional",
       "org.apache.ant" % "ant" % "1.7.1" % "optional",
       "commons-io" % "commons-io" % "1.3.2" % "test",
-      "org.eclipse.jetty" % "jetty-server" % "8.1.8.v20121106" % "test",
-      "org.eclipse.jetty" % "jetty-webapp" % "8.1.8.v20121106" % "test",
+      "org.eclipse.jetty" % "jetty-server" % "9.2.6.v20141205" % "test",
+      "org.eclipse.jetty" % "jetty-webapp" % "9.2.6.v20141205" % "test",
+      "org.eclipse.jetty.websocket" % "websocket-server" % "9.2.6.v20141205" % "test",
+      "org.eclipse.jetty.websocket" % "websocket-client" % "9.2.6.v20141205" % "optional",
       "org.ow2.asm" % "asm-all" % "4.1" % "optional",
       "org.pegdown" % "pegdown" % "1.4.2" % "optional"
     )

--- a/scalatest-test/src/test/scala/org/scalatest/selenium/JettySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/selenium/JettySpec.scala
@@ -16,14 +16,14 @@
 package org.scalatest.selenium
 
 import org.scalatest._
-import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.{ServerConnector, Server}
 import org.eclipse.jetty.webapp.WebAppContext
 
 trait JettySpec extends FunSpec {
-  
+
   private val serverThread = new Thread() {
     private val server = new Server(0)
-    
+
     override def run() {
       val webapp = new WebAppContext("webapp", "/")
       server.setHandler(webapp)
@@ -31,27 +31,30 @@ trait JettySpec extends FunSpec {
       server.start()
       server.join()
     }
-    
+
     def done() {
       server.stop()
     }
-    
+
     def isStarted = server.isStarted()
+
     def getHost = {
-      val conn = server.getConnectors()(0)
-      "http://localhost:" + conn.getLocalPort + "/"
+      val conn = server.getConnectors collectFirst {
+        case conn: ServerConnector =>
+          "http://localhost:" + conn.getLocalPort + "/"
+      } get
     }
   }
 
   import scala.language.reflectiveCalls
-  
+
   lazy val host = serverThread.getHost
 
   override def run(testName: Option[String], args: Args): Status = {
     serverThread.start()
     while (!serverThread.isStarted)
       Thread.sleep(10)
-    
+
     try super.run(testName, args)
     finally serverThread.done()
   }

--- a/scalatest-test/src/test/scala/org/scalatest/websocket/WebSocketSuiteExample.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/websocket/WebSocketSuiteExample.scala
@@ -1,0 +1,69 @@
+package org.scalatest.websocket
+
+import java.net.URI
+
+import org.eclipse.jetty.server.handler.HandlerList
+import org.eclipse.jetty.server.{Server, ServerConnector}
+import org.eclipse.jetty.servlet.ServletHandler
+import org.eclipse.jetty.websocket.api.WebSocketAdapter
+import org.eclipse.jetty.websocket.servlet.{WebSocketServlet, WebSocketServletFactory}
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfter, FlatSpec, Suite, WebSocketTests}
+
+import scala.concurrent.duration._
+
+trait EmbeddedJetty extends BeforeAndAfter {
+  self: Suite =>
+
+  def handlerList: HandlerList
+
+  private var srv: Server = _
+
+  def port = srv.getConnectors collectFirst {
+    case con: ServerConnector => con.getLocalPort
+  }
+
+  before {
+    srv = new Server(-1)
+    srv.setHandler(handlerList)
+    srv.start()
+  }
+
+  after {
+    srv.stop()
+  }
+}
+
+class WebSocketSuiteExample extends FlatSpec with WebSocketTests with EmbeddedJetty {
+
+  class EchoSocket extends WebSocketAdapter {
+    override def onWebSocketText(message: String): Unit =
+      getRemote.sendString(s"echo: $message") 
+  }
+
+  class EchoServlet extends WebSocketServlet {
+    override def configure(webSocketServletFactory: WebSocketServletFactory): Unit =
+      webSocketServletFactory.register(classOf[EchoSocket])
+  }
+
+  override def handlerList: HandlerList = {
+    val list = new HandlerList
+    val servletHandler = new ServletHandler
+    servletHandler.addServletWithMapping(classOf[EchoServlet], "/echo")
+    list.addHandler(servletHandler)
+    list
+  }
+
+  override def endpoint: URI = URI.create(s"ws://localhost:$port/echo")
+
+  "EchoServer" should "echo any text message" in {
+    connect {
+      session:WebSocketSessionType =>
+        session.getRemote.sendString("Hello World!")
+    }
+
+    verify(ws, timeout(5.seconds.toMillis.toInt)).onWebSocketText(anyString())
+  }
+
+}

--- a/scalatest/src/main/scala/org/scalatest/websocket/WebSocketTests.scala
+++ b/scalatest/src/main/scala/org/scalatest/websocket/WebSocketTests.scala
@@ -1,0 +1,56 @@
+package org.scalatest
+
+import java.net.URI
+
+import org.eclipse.jetty.websocket.api.{Session, WebSocketListener}
+import org.eclipse.jetty.websocket.client.WebSocketClient
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+
+trait WebSocketTests
+  extends BeforeAndAfter // with SuiteMixin
+  with MockitoSugar {
+  self: Suite =>
+
+  type WebSocketClientType = WebSocketClient
+  type WebSocketType = WebSocketListener
+  type WebSocketSessionType = Session
+
+  def endpoint: URI
+
+  protected var client: WebSocketClientType = _
+  var ws: WebSocketType = _
+
+  before {
+    ws = mock[WebSocketType]
+
+    client = classOf[WebSocketClientType].newInstance()
+    client.start()
+  }
+
+  def connect(onConnect: WebSocketSessionType => Unit):Unit =
+    doConnect(Some(onConnect))
+
+  def doConnect(onConnectOpt: Option[WebSocketSessionType => Unit] = None):Unit = {
+    client.connect(ws, endpoint)
+
+    onConnectOpt match {
+      case Some(onConnect) =>
+        when(ws.onWebSocketConnect(any[WebSocketSessionType])).then(new Answer[Unit] {
+          override def answer(invocationOnMock: InvocationOnMock): Unit = {
+            val session = invocationOnMock.getArguments.head.asInstanceOf[WebSocketSessionType]
+            onConnect(session)
+          }
+        })
+      case None => // test may define custom behaviour of mocked _ws_
+    }
+  }
+
+  after {
+    client.stop()
+  }
+}


### PR DESCRIPTION
In need of testing scalatra atmosphere I did not find a dedicated testing framework for async websockets.

So this pull-request contains a testing based on jetty-websocket-client mixed as a Suite. See an easy-to-understand example with an websocket-echo-server.
(I had to upgrade the version of jetty contained, and the existing JettySpec is fixed / should be still working.)

Don't hesitate to comment.

Kind regards, Jan
