### PR TITLE
Add zipAll and zipWithIndex to LazyBag

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
@@ -75,5 +75,30 @@ class LazyBagSpec extends UnitSpec {
     b1 should contain theSameElementsAs bag1.toList
     b2 should contain theSameElementsAs bag2.toList
   }
+
+  it should "have a zipAll method" in {
+    val shortBag1 = LazyBag(1,2,3)
+    val longBag1 = LazyBag(1,2,3,4)
+    val shortBag2 = LazyBag("a", "b", "c")
+    val longBag2 = LazyBag("a", "b", "c", "d")
+
+    def assertSameElements(thisBag: LazyBag[_], thatBag: LazyBag[_]): Unit = {
+      val zipped = thisBag.zipAll(thatBag, 4, "d")
+      val (unzip1, unzip2) = zipped.toList.unzip
+      unzip1 should contain theSameElementsAs longBag1.toList
+      unzip2 should contain theSameElementsAs longBag2.toList
+    }
+    assertSameElements(shortBag1, longBag2)
+    assertSameElements(longBag1, shortBag2)
+    assertSameElements(longBag1, longBag2)
+  }
+
+  it should "have a zipWithIndex method" in {
+    val bag = LazyBag("a", "b", "c")
+    val zipped = bag.zipWithIndex
+    val (b1, b2) = zipped.toList.unzip
+    b1 should contain theSameElementsAs bag.toList
+    b2 should contain theSameElementsAs List(0, 1, 2)
+  }
 }
 

--- a/scalactic/src/main/scala/org/scalactic/LazySeq.scala
+++ b/scalactic/src/main/scala/org/scalactic/LazySeq.scala
@@ -23,6 +23,8 @@ trait LazySeq[+T] extends LazyBag[T] {
   def toList: List[T]
   def size: Int
   def zip[U](that: LazyBag[U]): LazyBag[(T, U)]
+  def zipAll[U, T1 >: T](that: LazyBag[U], thisElem: T1, thatElem: U): LazyBag[(T1, U)]
+  def zipWithIndex: LazyBag[(T, Int)]
 }
 
 object LazySeq {
@@ -34,6 +36,9 @@ object LazySeq {
     def toList: List[T] = args
     def size: Int = args.size
     def zip[U](that: LazyBag[U]): LazyBag[(T, U)] = ???
+    def zipAll[U, T1 >: T](that: LazyBag[U], thisElem: T1, thatElem: U): LazyBag[(T1, U)] = ???
+    def zipWithIndex: LazyBag[(T, Int)] = ???
+
     override def toString = args.mkString("LazySeq(", ",", ")")
     override def equals(other: Any): Boolean = ???
     override def hashCode: Int = ???
@@ -51,6 +56,9 @@ object LazySeq {
     def toList: List[U] = lazySeq.toList.map(f)
     def size: Int = toList.size
     def zip[V](that: LazyBag[V]): LazyBag[(U, V)] = ???
+    def zipAll[V, U1 >: U](that: LazyBag[V], thisElem: U1, thatElem: V): LazyBag[(U1, V)] = ???
+    def zipWithIndex: LazyBag[(U, Int)] = ???
+
     override def toString: String = toList.mkString("LazySeq(", ",", ")")
     override def equals(other: Any): Boolean =
       other match {
@@ -71,6 +79,8 @@ object LazySeq {
     def toList: List[U] = lazySeq.toList.flatMap(f.andThen(_.toList))
     def size: Int = toList.size
     def zip[V](that: LazyBag[V]): LazyBag[(U, V)] = ???
+    def zipAll[V, U1 >: U](that: LazyBag[V], thisElem: U1, thatElem: V): LazyBag[(U1, V)] = ???
+    def zipWithIndex: LazyBag[(U, Int)] = ???
     override def toString: String = toList.mkString("LazySeq(", ",", ")")
     override def equals(other: Any): Boolean = ???
     override def hashCode: Int = ???


### PR DESCRIPTION
This moves the rest of the zip-like methods into LazyBag.

The signatures were also added to LazySeq, since LazySeq extends LazyBag, but without implementations.