### PR TITLE
Contain Only Matcher Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -103,6 +103,12 @@ class ListShouldContainOnlySpec extends Spec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message.get should be (Resources.didNotContainOnlyElementsWithFriendlyReminder(decorateToStringValue(fumList), decorateToStringValue(Vector("happy", "birthday", "to", "you"))))
       }
+
+      def `should throw TestFailedException when used to check Vector(2, 3) should contain only (1, 2, 3)` {
+        val e1 = intercept[exceptions.TestFailedException] {
+          Vector(2, 3) should contain only (1, 2, 3)
+        }
+      }
     }
 
     object `when used with (contain only (..))` {

--- a/scalatest/src/main/scala/org/scalatest/enablers/Aggregating.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Aggregating.scala
@@ -180,38 +180,9 @@ object Aggregating {
     !counts.exists(e => e.leftCount != e.rightCount)
   }
   
-  private[scalatest] def checkOnly[T](left: GenTraversable[T], right: GenTraversable[Any], equality: Equality[T]): Boolean = {
-    @tailrec
-    def findNext(value: T, rightItr: Iterator[Any], processedSet: Set[Any]): Set[Any] = 
-      if (rightItr.hasNext) {
-        val nextRight = rightItr.next
-        if (tryEquality(nextRight, value, equality))
-          processedSet + nextRight
-        else
-          findNext(value, rightItr, processedSet + nextRight)
-      }
-      else
-        processedSet
-
-    @tailrec
-    def checkEqual(leftItr: Iterator[T], rightItr: Iterator[Any], processedSet: Set[Any]): Boolean = {
-      if (leftItr.hasNext) {
-        val nextLeft = leftItr.next
-        if (processedSet.find(tryEquality(_, nextLeft, equality)).isDefined) // The nextLeft is contained in right, let's continue next
-          checkEqual(leftItr, rightItr, processedSet)
-        else {
-          val newProcessedSet = findNext(nextLeft, rightItr, processedSet)
-          if (newProcessedSet.find(tryEquality(_, nextLeft, equality)).isDefined) // The nextLeft is contained in right, let's continue next
-            checkEqual(leftItr, rightItr, newProcessedSet)
-          else // The nextLeft is not in right, let's fail early
-            false
-        }
-      }
-      else 
-        !rightItr.hasNext // No more lefts remaining, so we're good so long as no more rights remaining either.
-    }
-    checkEqual(left.toIterator, right.toIterator, Set.empty)
-  }
+  private[scalatest] def checkOnly[T](left: GenTraversable[T], right: GenTraversable[Any], equality: Equality[T]): Boolean =
+    left.forall(l => right.find(r => tryEquality(l, r, equality)).isDefined) &&
+    right.forall(r => left.find(l => tryEquality(r, l, equality)).isDefined)
   
   private[scalatest] def checkAllOf[T](left: GenTraversable[T], right: GenTraversable[Any], equality: Equality[T]): Boolean = {
     @tailrec


### PR DESCRIPTION
Make contain only matcher to pass only when LHS contains only RHS, and RHS contains only LHS.