### PR TITLE
Move unzip/unzip3 from EquaSet/SortedEquaSet to LazyBag/LazySeq.

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
@@ -1950,56 +1950,6 @@ class EquaSetSpec extends UnitSpec {
     result8 shouldBe numberList.FastEquaSet(List(1, 2, 3), List(4, 5, 6), List(7, 8, 9))
     result8.shouldHaveExactType[numberList.FastEquaSet]
   }
-  it should "have an unzip method" in {
-    val result1 = numberLower.EquaSet((1, "2")).unzip(number, lower)
-    result1 shouldBe ((number.EquaSet(1), lower.EquaSet("2")))
-    result1.shouldHaveExactType[(number.EquaSet, lower.EquaSet)]
-
-    val result2 = numberLower.EquaSet((1, "2"), (3, "4")).unzip(number, lower)
-    result2 shouldBe ((number.EquaSet(1, 3), lower.EquaSet("2", "4")))
-    result2.shouldHaveExactType[(number.EquaSet, lower.EquaSet)]
-
-    val result3 = numberLower.EquaSet((1, "2"), (3, "4"), (5, "6")).unzip(number, lower)
-    result3 shouldBe ((number.EquaSet(1, 3, 5), lower.EquaSet("2", "4", "6")))
-    result3.shouldHaveExactType[(number.EquaSet, lower.EquaSet)]
-
-    val result4 = numberLower.FastEquaSet((1, "2")).unzip(number, lower)
-    result4 shouldBe ((number.FastEquaSet(1), lower.FastEquaSet("2")))
-    result4.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet)]
-
-    val result5 = numberLower.FastEquaSet((1, "2"), (3, "4")).unzip(number, lower)
-    result5 shouldBe ((number.FastEquaSet(1, 3), lower.FastEquaSet("2", "4")))
-    result5.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet)]
-
-    val result6 = numberLower.FastEquaSet((1, "2"), (3, "4"), (5, "6")).unzip(number, lower)
-    result6 shouldBe ((number.FastEquaSet(1, 3, 5), lower.FastEquaSet("2", "4", "6")))
-    result6.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet)]
-  }
-  it should "have an unzip3 method" in {
-    val result1 = numberLowerTrimmed.EquaSet((1, "2", "3")).unzip3(number, lower, trimmed)
-    result1 shouldBe (number.EquaSet(1), lower.EquaSet("2"), trimmed.EquaSet("3"))
-    result1.shouldHaveExactType[(number.EquaSet, lower.EquaSet, trimmed.EquaSet)]
-
-    val result2 = numberLowerTrimmed.EquaSet((1, "2", "3"), (4, "5", "6")).unzip3(number, lower, trimmed)
-    result2 shouldBe (number.EquaSet(1, 4), lower.EquaSet("2", "5"), trimmed.EquaSet("3", "6"))
-    result2.shouldHaveExactType[(number.EquaSet, lower.EquaSet, trimmed.EquaSet)]
-
-    val result3 = numberLowerTrimmed.EquaSet((1, "2", "3"), (4, "5", "6"), (7, "8", "9")).unzip3(number, lower, trimmed)
-    result3 shouldBe (number.EquaSet(1, 4, 7), lower.EquaSet("2", "5", "8"), trimmed.EquaSet("3", "6", "9"))
-    result3.shouldHaveExactType[(number.EquaSet, lower.EquaSet, trimmed.EquaSet)]
-
-    val result4 = numberLowerTrimmed.FastEquaSet((1, "2", "3")).unzip3(number, lower, trimmed)
-    result4 shouldBe (number.FastEquaSet(1), lower.FastEquaSet("2"), trimmed.FastEquaSet("3"))
-    result4.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet, trimmed.FastEquaSet)]
-
-    val result5 = numberLowerTrimmed.FastEquaSet((1, "2", "3"), (4, "5", "6")).unzip3(number, lower, trimmed)
-    result5 shouldBe (number.FastEquaSet(1, 4), lower.FastEquaSet("2", "5"), trimmed.FastEquaSet("3", "6"))
-    result5.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet, trimmed.FastEquaSet)]
-
-    val result6 = numberLowerTrimmed.FastEquaSet((1, "2", "3"), (4, "5", "6"), (7, "8", "9")).unzip3(number, lower, trimmed)
-    result6 shouldBe (number.FastEquaSet(1, 4, 7), lower.FastEquaSet("2", "5", "8"), trimmed.FastEquaSet("3", "6", "9"))
-    result6.shouldHaveExactType[(number.FastEquaSet, lower.FastEquaSet, trimmed.FastEquaSet)]
-  }
   it should "have a withFilter method" in {
     var a = 0
     var b = 0

--- a/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
@@ -680,22 +680,6 @@ class EquaSetSpec extends UnitSpec {
   }
   it should "have an into.collect method" is pending
 
-  it should "have a collect method that only accepts functions that result in the path-enclosed type" in {
-    /*
-    scala> List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collect { case i if i % 2 == 0 => i * 2 }
-    res3: List[Int] = List(4, 8, 12, 16, 20)
-
-    scala> List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collect { case i if i > 10 == 0 => i * 2 }
-    res4: List[Int] = List()
-    */
-    val result1 = number.EquaSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) collect { case i if i % 2 == 0 => i * 2 }
-    result1 shouldBe number.EquaSet(4, 8, 12, 16, 20)
-    result1.shouldHaveExactType[number.EquaSet]
-    number.EquaSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) collect { case i if i > 10 => i * 2 } shouldBe number.EquaSet.empty
-    val result2 = number.FastEquaSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) collect { case i if i % 2 == 0 => i * 2 }
-    result2 shouldBe number.FastEquaSet(4, 8, 12, 16, 20)
-    result2.shouldHaveExactType[number.FastEquaSet]
-  }
   it should "have an compose method, inherited from PartialFunction" in {
     val fn: Int => Boolean = number.EquaSet(1, 2, 3).compose(_ + 1)
     fn(0) shouldBe true
@@ -1353,40 +1337,6 @@ class EquaSetSpec extends UnitSpec {
     number.EquaSet(3).sameElements(List(3)) shouldBe true
   }
   it should "have an into.scanLeft method" is pending
-  it should "have a scanLeft method" in {
-    val result1 = number.EquaSet(1).scanLeft(0)(_ + _)
-    result1 shouldBe number.EquaSet(0, 1)
-    result1.shouldHaveExactType[number.EquaSet]
-
-    val result2 = number.EquaSet(1, 2, 3).scanLeft(0)(_ + _)
-    result2 shouldBe number.EquaSet(0, 1, 3, 6)
-    result2.shouldHaveExactType[number.EquaSet]
-
-    val result3 = number.FastEquaSet(1).scanLeft(0)(_ + _)
-    result3 shouldBe number.FastEquaSet(0, 1)
-    result3.shouldHaveExactType[number.FastEquaSet]
-
-    val result4 = number.FastEquaSet(1, 2, 3).scanLeft(0)(_ + _)
-    result4 shouldBe number.FastEquaSet(0, 1, 3, 6)
-    result4.shouldHaveExactType[number.FastEquaSet]
-  }
-  it should "have a scanRight method" in {
-    val result1 = number.EquaSet(1).scanRight(0)(_ + _)
-    result1 shouldBe number.EquaSet(1, 0)
-    result1.shouldHaveExactType[number.EquaSet]
-
-    val result2 = number.EquaSet(1, 2, 3).scanRight(0)(_ + _)
-    result2 shouldBe number.EquaSet(6, 5, 3, 0)
-    result2.shouldHaveExactType[number.EquaSet]
-
-    val result3 = number.FastEquaSet(1).scanRight(0)(_ + _)
-    result3 shouldBe number.FastEquaSet(1, 0)
-    result3.shouldHaveExactType[number.FastEquaSet]
-
-    val result4 = number.FastEquaSet(1, 2, 3).scanRight(0)(_ + _)
-    result4 shouldBe number.FastEquaSet(6, 5, 3, 0)
-    result4.shouldHaveExactType[number.FastEquaSet]
-  }
   it should "have an into.scanRight method" is pending
   it should "have a slice method" in {
     val result1 = number.EquaSet(3).slice(0, 0)

--- a/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
@@ -67,6 +67,26 @@ class LazyBagSpec extends UnitSpec {
     assertPretty(mapped)
   }
 
+  it should "have an unzip method" in {
+    val zipped = LazyBag(3, 1, 2, -3, 3).zip(LazyBag("z", "a", "b", "c", "z"))
+    val (intBag, stringBag) = zipped.unzip
+    intBag.toList should contain theSameElementsAs LazyBag(3, -3, 3, 2, 1).toList
+    stringBag.toList should contain theSameElementsAs LazyBag("z", "z", "a", "b", "c").toList
+  }
+
+  it should "have an unzip3 method" in {
+    val tuples = List(
+      ("a", 0.0, 3),
+      ("b", 1.1, -3),
+      ("c", 2.2, 0),
+      ("z", -2.2, 0)
+    )
+    val (stringBag, doubleBag, intBag) = LazyBag(tuples: _*).unzip3
+    stringBag.toList should contain theSameElementsAs LazyBag("z", "a", "b", "c").toList
+    doubleBag.toList should contain theSameElementsAs LazyBag(-2.2, 0.0, 1.1, 2.2).toList
+    intBag.toList should contain theSameElementsAs LazyBag(0, 3, -3, 0).toList
+  }
+
   it should "have a zip method" in {
     val bag1 = LazyBag(1,2,3)
     val bag2 = LazyBag("a", "b", "c")

--- a/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazyBagSpec.scala
@@ -120,5 +120,33 @@ class LazyBagSpec extends UnitSpec {
     b1 should contain theSameElementsAs bag.toList
     b2 should contain theSameElementsAs List(0, 1, 2)
   }
+
+  it should "have a collect method" in {
+    val bag = LazyBag(1, 2, 3, 4, 5)
+    val doubledOdds = bag.collect {
+      case n: Int if n % 2 == 1 => n * 2
+    }
+    doubledOdds.toList should contain theSameElementsAs LazyBag(2, 6, 10).toList
+    val noMatch = bag.collect { case n: Int if n < 0 => n }
+    noMatch.toList shouldBe empty
+  }
+
+  it should "have a scan method" in {
+    val bag = LazyBag(1, 2, 3, 4, 5)
+    val scanned = bag.scan(0)(_+_)
+    scanned.toList should contain theSameElementsAs LazyBag(0, 1, 3, 6, 10, 15).toList
+  }
+
+  it should "have a scanLeft method" in {
+    val bag = LazyBag(1, 2, 3, 4, 5)
+    val scanned = bag.scanLeft(0)(_+_)
+    scanned.toList should contain theSameElementsAs LazyBag(0, 1, 3, 6, 10, 15).toList
+  }
+
+  it should "have a scanRight method" in {
+    val bag = LazyBag(1, 2, 3, 4, 5)
+    val scanned = bag.scanRight(0)(_+_)
+    scanned.toList should contain theSameElementsAs LazyBag(0, 5, 9, 12, 14, 15).toList
+  }
 }
 

--- a/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
@@ -70,6 +70,26 @@ class LazySeqSpec extends UnitSpec {
     assertPretty(mapped)
   }
 
+  it should "have an unzip method" in {
+    val zipped = LazySeq(3, 1, 2, -3, 3).zip(LazySeq("z", "a", "b", "c", "z"))
+    val (intSeq, stringSeq) = zipped.unzip
+    intSeq.toList shouldBe LazySeq(3, 1, 2, -3, 3).toList
+    stringSeq.toList shouldBe LazySeq("z", "a", "b", "c", "z").toList
+  }
+
+  it should "have an unzip3 method" in {
+    val tuples = List(
+      ("a", 0.0, 3),
+      ("b", 1.1, -3),
+      ("c", 2.2, 0),
+      ("z", -2.2, 0)
+    )
+    val (stringSeq, doubleSeq, intSeq) = LazySeq(tuples: _*).unzip3
+    stringSeq.toList should contain theSameElementsAs LazySeq("a", "b", "c", "z").toList
+    doubleSeq.toList should contain theSameElementsAs LazySeq(0.0, 1.1, 2.2, -2.2).toList
+    intSeq.toList should contain theSameElementsAs LazySeq(3, -3, 0, 0).toList
+  }
+
   it should "have a zip method" in {
     val seq1 = LazySeq(1,2,3)
     val seq2 = LazySeq("a", "b", "c")

--- a/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
@@ -85,9 +85,9 @@ class LazySeqSpec extends UnitSpec {
       ("z", -2.2, 0)
     )
     val (stringSeq, doubleSeq, intSeq) = LazySeq(tuples: _*).unzip3
-    stringSeq.toList should contain theSameElementsAs LazySeq("a", "b", "c", "z").toList
-    doubleSeq.toList should contain theSameElementsAs LazySeq(0.0, 1.1, 2.2, -2.2).toList
-    intSeq.toList should contain theSameElementsAs LazySeq(3, -3, 0, 0).toList
+    stringSeq.toList shouldBe LazySeq("a", "b", "c", "z").toList
+    doubleSeq.toList shouldBe LazySeq(0.0, 1.1, 2.2, -2.2).toList
+    intSeq.toList shouldBe LazySeq(3, -3, 0, 0).toList
   }
 
   it should "have a zip method" in {

--- a/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/LazySeqSpec.scala
@@ -123,5 +123,33 @@ class LazySeqSpec extends UnitSpec {
     b1 shouldBe bag.toList
     b2 shouldBe List(0, 1, 2)
   }
+
+  it should "have a collect method" in {
+    val seq = LazySeq(1, 2, 3, 4, 5)
+    val doubledOdds = seq.collect {
+      case n: Int if n % 2 == 1 => n * 2
+    }
+    doubledOdds.toList shouldBe LazySeq(2, 6, 10).toList
+    val noMatch = seq.collect { case n: Int if n < 0 => n }
+    noMatch.toList shouldBe empty
+  }
+
+  it should "have a scan method" in {
+    val seq = LazySeq(1, 2, 3, 4, 5)
+    val scanned = seq.scan(0)(_+_)
+    scanned.toList shouldBe LazySeq(0, 1, 3, 6, 10, 15).toList
+  }
+
+  it should "have a scanLeft method" in {
+    val seq = LazySeq(1, 2, 3, 4, 5)
+    val scanned = seq.scanLeft(0)(_+_)
+    scanned.toList shouldBe LazySeq(0, 1, 3, 6, 10, 15).toList
+  }
+
+  it should "have a scanRight method" in {
+    val seq = LazySeq(1, 2, 3, 4, 5)
+    val scanned = seq.scanRight(0)(_+_)
+    scanned.toList shouldBe LazySeq(15, 14, 12, 9, 5, 0).toList
+  }
 }
 

--- a/scalactic-test/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
@@ -1888,16 +1888,6 @@ class SortedEquaSetSpec extends UnitSpec {
     result8 shouldBe numberList.TreeEquaSet(List(1, 2, 3), List(4, 5, 6), List(7, 8, 9))
     result8.shouldHaveExactType[numberList.TreeEquaSet]
   }
-  it should "have an unzip method" in {
-    numberLower.SortedEquaSet((1, "2")).unzip(number, lower) shouldBe ((number.EquaSet(1), lower.EquaSet("2")))
-    numberLower.SortedEquaSet((1, "2"), (3, "4")).unzip(number, lower) shouldBe ((number.EquaSet(1, 3), lower.EquaSet("2", "4")))
-    numberLower.SortedEquaSet((1, "2"), (3, "4"), (5, "6")).unzip(number, lower) shouldBe ((number.EquaSet(1, 3, 5), lower.EquaSet("2", "4", "6")))
-  }
-  it should "have an unzip3 method" in {
-    numberLowerTrimmed.SortedEquaSet((1, "2", "3")).unzip3(number, lower, trimmed) shouldBe (number.EquaSet(1), lower.EquaSet("2"), trimmed.EquaSet("3"))
-    numberLowerTrimmed.SortedEquaSet((1, "2", "3"), (4, "5", "6")).unzip3(number, lower, trimmed) shouldBe (number.EquaSet(1, 4), lower.EquaSet("2", "5"), trimmed.EquaSet("3", "6"))
-    numberLowerTrimmed.SortedEquaSet((1, "2", "3"), (4, "5", "6"), (7, "8", "9")).unzip3(number, lower, trimmed) shouldBe (number.EquaSet(1, 4, 7), lower.EquaSet("2", "5", "8"), trimmed.EquaSet("3", "6", "9"))
-  }
 
   /*
    * TODO: The zip related tests have been changed to use 'should contain theSameElementsAs'

--- a/scalactic/src/main/scala/org/scalactic/EquaPath.scala
+++ b/scalactic/src/main/scala/org/scalactic/EquaPath.scala
@@ -384,21 +384,6 @@ class EquaPath[T](val equality: HashingEquality[T]) { thisEquaPath =>
      */
     def apply(elem: T): Boolean
 
-    /**
-     * Builds a new collection by applying a partial function to all elements of this `EquaSet`
-     * on which the function is defined.
-     *
-     * @param pf the partial function which filters and maps the `EquaSet`.
-     * @return a new collection of type `That` resulting from applying the partial function
-     * `pf` to each element on which it is defined and collecting the results.
-     * The order of the elements is preserved.
-     *
-     * @return a new `EquaSet` resulting from applying the given partial function
-     * `pf` to each element on which it is defined and collecting the results.
-     * The order of the elements is preserved.
-     */
-    def collect(pf: PartialFunction[T, T]): thisEquaPath.EquaSet
-
     /*
       The reason I don't just do this:
 
@@ -933,31 +918,6 @@ class EquaPath[T](val equality: HashingEquality[T]) { thisEquaPath =>
      * @return `true`, if both collections contain the same elements in the same order, `false` otherwise.
      */
     def sameElements[T1 >: T](that: GenIterable[T1]): Boolean
-
-    /**
-     * Produces a collection containing cumulative results of applying the
-     * operator going left to right.
-     *
-     * @param z the initial value
-     * @param op the binary operator applied to the intermediate result and the element
-     * @return `EquaSet` with intermediate results
-     */
-    def scanLeft(z: T)(op: (T, T) => T): thisEquaPath.EquaSet
-
-    /**
-     * Produces a collection containing cumulative results of applying the operator going right to left.
-     * The head of the collection is the last cumulative result.
-     *
-     * Example:
-     * {{{
-     * `EquaSet`(1, 2, 3, 4).scanRight(0)(_ + _) == `EquaSet`(10, 9, 7, 4, 0)
-     * }}}
-     *
-     * @param z the initial value
-     * @param op the binary operator applied to the intermediate result and the element
-     * @return `EquaSet` with intermediate results
-     */
-    def scanRight(z: T)(op: (T, T) => T): thisEquaPath.EquaSet
 
     /**
      * The size of this `EquaSet`.

--- a/scalactic/src/main/scala/org/scalactic/EquaPath.scala
+++ b/scalactic/src/main/scala/org/scalactic/EquaPath.scala
@@ -1364,52 +1364,6 @@ class EquaPath[T](val equality: HashingEquality[T]) { thisEquaPath =>
     def union(that: thisEquaPath.EquaSet): thisEquaPath.EquaSet
 
     /**
-     * Converts this `EquaSet` of pairs into two collections of the first and second
-     * half of each pair.
-     *
-     * {{{
-     * val xs = `EquaSet`(
-     * (1, "one"),
-     * (2, "two"),
-     * (3, "three")).unzip
-     * // xs == (`EquaSet`(1, 2, 3),
-     * // `EquaSet`(one, two, three))
-     * }}}
-     *
-     * @tparam T1 the type of the first half of the element pairs
-     * @tparam T2 the type of the second half of the element pairs
-     * @param asPair an implicit conversion which asserts that the element type
-     * of this `EquaSet` is a pair.
-     * @return a pair of `EquaSet`s, containing the first, respectively second
-     * half of each element pair of this `EquaSet`.
-     */
-    def unzip[T1, T2](t1EquaPath: EquaPath[T1], t2EquaPath: EquaPath[T2])(implicit asPair: T => (T1, T2)): (t1EquaPath.EquaSet, t2EquaPath.EquaSet)
-
-    /**
-     * Converts this `EquaSet` of triples into three collections of the first, second,
-     * and third element of each triple.
-     *
-     * {{{
-     * val xs = `EquaSet`(
-     * (1, "one", '1'),
-     * (2, "two", '2'),
-     * (3, "three", '3')).unzip3
-     * // xs == (`EquaSet`(1, 2, 3),
-     * // `EquaSet`(one, two, three),
-     * // `EquaSet`(1, 2, 3))
-     * }}}
-     *
-     * @tparam T1 the type of the first member of the element triples
-     * @tparam T2 the type of the second member of the element triples
-     * @tparam T3 the type of the third member of the element triples
-     * @param asTriple an implicit conversion which asserts that the element type
-     * of this `EquaSet` is a triple.
-     * @return a triple of `EquaSet`s, containing the first, second, respectively
-     * third member of each element triple of this `EquaSet`.
-     */
-    def unzip3[T1, T2, T3](t1EquaPath: EquaPath[T1], t2EquaPath: EquaPath[T2], t3EquaPath: EquaPath[T3])(implicit asTriple: T => (T1, T2, T3)): (t1EquaPath.EquaSet, t2EquaPath.EquaSet, t3EquaPath.EquaSet)
-
-    /**
      * Creates a non-strict filter of this `EquaSet`.
      *
      * Note: the difference between `c filter p` and `c withFilter p` is that

--- a/scalactic/src/main/scala/org/scalactic/LazyBag.scala
+++ b/scalactic/src/main/scala/org/scalactic/LazyBag.scala
@@ -35,14 +35,14 @@ trait LazyBag[+T] {
    * // `LazyBag`(one, two, three))
    * }}}
    *
-   * @tparam T1 the type of the first half of the element pairs
-   * @tparam T2 the type of the second half of the element pairs
+   * @tparam U1 the type of the first half of the element pairs
+   * @tparam U2 the type of the second half of the element pairs
    * @param asPair an implicit conversion which asserts that the element type
    * of this `LazyBag` is a pair.
    * @return a pair of `LazyBag`s, containing the first, respectively second
    * half of each element pair of this `LazyBag`.
    */
-  def unzip[T1, T2](implicit asPair: T => (T1, T2)): (LazyBag[T1], LazyBag[T2])
+  def unzip[U1, U2](implicit asPair: T => (U1, U2)): (LazyBag[U1], LazyBag[U2])
 
   /**
    * Converts this `LazyBag` of triples into three collections of the first, second,
@@ -58,19 +58,19 @@ trait LazyBag[+T] {
    * // `LazyBag`(1, 2, 3))
    * }}}
    *
-   * @tparam T1 the type of the first member of the element triples
-   * @tparam T2 the type of the second member of the element triples
-   * @tparam T3 the type of the third member of the element triples
+   * @tparam U1 the type of the first member of the element triples
+   * @tparam U2 the type of the second member of the element triples
+   * @tparam U3 the type of the third member of the element triples
    * @param asTriple an implicit conversion which asserts that the element type
    * of this `LazyBag` is a triple.
    * @return a triple of `LazyBag`s, containing the first, second, respectively
    * third member of each element triple of this `LazyBag`.
    */
-  def unzip3[T1, T2, T3](implicit asTriple: T => (T1, T2, T3)): (LazyBag[T1], LazyBag[T2], LazyBag[T3])
+  def unzip3[U1, U2, U3](implicit asTriple: T => (U1, U2, U3)): (LazyBag[U1], LazyBag[U2], LazyBag[U3])
 
 
   /**
-   * Returns an `LazyBag` formed from this `LazyBag` and another iterable collection
+   * Returns a `LazyBag` formed from this `LazyBag` and another iterable collection
    * by combining corresponding elements in pairs.
    * If one of the two collections is longer than the other, its remaining elements are ignored.
    *
@@ -84,7 +84,7 @@ trait LazyBag[+T] {
   def zip[U](that: LazyBag[U]): LazyBag[(T, U)]
 
   /**
-   * Returns an `LazyBag` formed from this `LazyBag` and another iterable collection
+   * Returns a `LazyBag` formed from this `LazyBag` and another iterable collection
    * by combining corresponding elements in pairs.
    * If one of the two collections is shorter than the other,
    * placeholder elements are used to extend the shorter collection to the length of the longer.
@@ -126,11 +126,16 @@ object LazyBag {
     def toList: List[T] = args
     def size: Int = args.size
 
-    def unzip[T1, T2](implicit asPair: T => (T1, T2)): (LazyBag[T1], LazyBag[T2]) =
-      (new UnzipLeftLazyBag(thisLazyBag), new UnzipRightLazyBag(thisLazyBag))
+    def unzip[U1, U2](implicit asPair: T => (U1, U2)): (LazyBag[U1], LazyBag[U2]) = (
+      new UnzipLeftLazyBag[T, U1, U2](thisLazyBag)(asPair),
+      new UnzipRightLazyBag[T, U1, U2](thisLazyBag)(asPair)
+    )
 
-    def unzip3[T1, T2, T3](implicit asTriple: T => (T1, T2, T3)): (LazyBag[T1], LazyBag[T2], LazyBag[T3]) =
-      (new Unzip3LeftLazyBag(thisLazyBag), new Unzip3MiddleLazyBag(thisLazyBag), new Unzip3RightLazyBag(thisLazyBag))
+    def unzip3[U1, U2, U3](implicit asTriple: T => (U1, U2, U3)): (LazyBag[U1], LazyBag[U2], LazyBag[U3]) = (
+      new Unzip3LeftLazyBag(thisLazyBag),
+      new Unzip3MiddleLazyBag(thisLazyBag),
+      new Unzip3RightLazyBag(thisLazyBag)
+    )
 
     def zip[U](thatLazyBag: LazyBag[U]): LazyBag[(T, U)] = new ZipLazyBag(thisLazyBag, thatLazyBag)
     def zipAll[U, T1 >: T](that: LazyBag[U], thisElem: T1, thatElem: U): LazyBag[(T1, U)] =
@@ -158,10 +163,10 @@ object LazyBag {
     def toList: List[U] // This is the lone abstract method
     def size: Int = toList.size
 
-    def unzip[U1, U2](implicit asPair: U => (U1, U2)): (LazyBag[U1], LazyBag[U2]) =
-      (new UnzipLeftLazyBag(thisLazyBag), new UnzipRightLazyBag(thisLazyBag))
+    def unzip[V1, V2](implicit asPair: U => (V1, V2)): (LazyBag[V1], LazyBag[V2]) =
+      (new UnzipLeftLazyBag[U, V1, V2](thisLazyBag)(asPair), new UnzipRightLazyBag[U, V1, V2](thisLazyBag)(asPair))
 
-    def unzip3[U1, U2, U3](implicit asTriple: U => (U1, U2, U3)): (LazyBag[U1], LazyBag[U2], LazyBag[U3]) =
+    def unzip3[V1, V2, V3](implicit asTriple: U => (V1, V2, V3)): (LazyBag[V1], LazyBag[V2], LazyBag[V3]) =
       (new Unzip3LeftLazyBag(thisLazyBag), new Unzip3MiddleLazyBag(thisLazyBag), new Unzip3RightLazyBag(thisLazyBag))
 
     def zip[V](that: LazyBag[V]): LazyBag[(U, V)] = new ZipLazyBag[U, V](thisLazyBag, that)
@@ -186,24 +191,24 @@ object LazyBag {
     def toList: List[U] = lazyBag.toList.flatMap(f.andThen(_.toList))
   }
 
-  private class UnzipLeftLazyBag[T, U, U1, U2](lazyBag: LazyBag[T])(implicit asPair: U => (U1, U2) ) extends TransformLazyBag[T, U] {
+  private class UnzipLeftLazyBag[T, U1, U2](lazyBag: LazyBag[T])(implicit asPair: T => (U1, U2)) extends TransformLazyBag[T, U1] {
     def toList: List[U1] = lazyBag.toList.unzip._1.toList
   }
 
-  private class UnzipRightLazyBag[T, U, U1, U2](lazyBag: LazyBag[T])(implicit asPair: U => (U1, U2)) extends TransformLazyBag[T, U] {
+  private class UnzipRightLazyBag[T, U1, U2](lazyBag: LazyBag[T])(implicit asPair: T => (U1, U2)) extends TransformLazyBag[T, U2] {
     def toList: List[U2] = lazyBag.toList.unzip._2.toList
   }
 
-  private class Unzip3LeftLazyBag[T, U, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: U => (U1, U2, U3)) extends TransformLazyBag[T, U] {
-    def toList: List[U] = lazyBag.toList.unzip3._1.toList
+  private class Unzip3LeftLazyBag[T, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: T => (U1, U2, U3)) extends TransformLazyBag[T, U1] {
+    def toList: List[U1] = lazyBag.toList.unzip3._1.toList
   }
 
-  private class Unzip3MiddleLazyBag[T, U, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: U => (U1, U2, U3)) extends TransformLazyBag[T, U] {
-    def toList: List[U] = lazyBag.toList.unzip3._2.toList
+  private class Unzip3MiddleLazyBag[T, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: T => (U1, U2, U3)) extends TransformLazyBag[T, U2] {
+    def toList: List[U2] = lazyBag.toList.unzip3._2.toList
   }
 
-  private class Unzip3RightLazyBag[T, U, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: U => (U1, U2, U3)) extends TransformLazyBag[T, U] {
-    def toList: List[U] = lazyBag.toList.unzip3._3.toList
+  private class Unzip3RightLazyBag[T, U1, U2, U3](lazyBag: LazyBag[T])(implicit asTriple: T => (U1, U2, U3)) extends TransformLazyBag[T, U3] {
+    def toList: List[U3] = lazyBag.toList.unzip3._3.toList
   }
 
   private class ZipLazyBag[T, U](lazyBag: LazyBag[T], that: LazyBag[U]) extends TransformLazyBag[T, (T, U)] {


### PR DESCRIPTION
This moves the unzip-ish methods from EquaSet and SortedEquaSet into LazyBag and LazySeq.

Note that the tests verify correct semantics, but do not test for laziness.