### PR TITLE
Master: Scalactic.js and ScalaTest.js tests passing

### DIFF
--- a/project/GenMatchers.scala
+++ b/project/GenMatchers.scala
@@ -54,10 +54,17 @@ object GenMatchers {
     val mustMatchersWriter = new BufferedWriter(new FileWriter(mustMatchersFile))
     try {
       val lines = Source.fromFile(new File("scalatest/src/main/scala/org/scalatest/Matchers.scala")).getLines.toList
+      var skipMode = false
       for (line <- lines) {
-        val mustLine = translateShouldToMust(line)
-        mustMatchersWriter.write(mustLine)
-        mustMatchersWriter.newLine()
+        if (line.trim == "// SKIP-SCALATESTJS-START")
+          skipMode = true
+        else if (line.trim == "// SKIP-SCALATESTJS-END")
+          skipMode = false
+        else if (!skipMode) {
+          val mustLine = translateShouldToMust(line)
+          mustMatchersWriter.write(mustLine)
+          mustMatchersWriter.newLine()
+        }
       }
     }
     finally {

--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -115,6 +115,7 @@ object GenScalaTestJS {
               "SuiteMixin.scala",
               "Engine.scala",
               "Tag.scala",
+              "FunSuiteRegistration.scala",
               "FunSuiteLike.scala",
               "FunSuite.scala",
               "TestRegistration.scala",
@@ -125,26 +126,35 @@ object GenScalaTestJS {
               "Transformer.scala",
               "DeferredAbortedSuite.scala",
               "Suites.scala",
+              "FunSpecRegistration.scala",
               "FunSpecLike.scala",
               "FunSpec.scala",
               "UnquotedString.scala",
+              "FlatSpecRegistration.scala",
               "FlatSpecLike.scala",
               "FlatSpec.scala",
+              "WordSpecRegistration.scala",
               "WordSpecLike.scala",
               "WordSpec.scala",
+              "FreeSpecRegistration.scala",
               "FreeSpecLike.scala",
               "FreeSpec.scala",
+              "PropSpecRegistration.scala",
               "PropSpecLike.scala",
               "PropSpec.scala",
+              "FeatureSpecRegistration.scala",
               "FeatureSpecLike.scala",
               "FeatureSpec.scala",
               "MatchersHelper.scala",
               "Matchers.scala",
-              "Entry.scala",
               "Inspectors.scala",
               "OptionValues.scala",
               "Inside.scala",
-              "NonImplicitAssertions.scala"
+              "NonImplicitAssertions.scala",
+              "AsyncOutcome.scala",
+              "ClassicTests.scala",
+              "package.scala",
+              "LoneElement.scala"
             ), targetDir) ++
     copyDir("scalatest/src/main/scala/org/scalatest/fixture", "org/scalatest/fixture",
             List(
@@ -156,20 +166,28 @@ object GenScalaTestJS {
               "NoArg.scala",
               "NoArgTestWrapper.scala",
               "FixtureNodeFamily.scala",
+              "FunSuiteRegistration.scala",
               "FunSuiteLike.scala",
               "FunSuite.scala",
+              "FlatSpecRegistration.scala",
               "FlatSpecLike.scala",
               "FlatSpec.scala",
+              "FunSpecRegistration.scala",
               "FunSpecLike.scala",
               "FunSpec.scala",
+              "WordSpecRegistration.scala",
               "WordSpecLike.scala",
               "WordSpec.scala",
+              "FreeSpecRegistration.scala",
               "FreeSpecLike.scala",
               "FreeSpec.scala",
+              "PropSpecRegistration.scala",
               "PropSpecLike.scala",
               "PropSpec.scala",
+              "FeatureSpecRegistration.scala",
               "FeatureSpecLike.scala",
-              "FeatureSpec.scala"
+              "FeatureSpec.scala",
+              "ClassicTests.scala"
             ), targetDir) ++
     copyDir("scalatest/src/main/scala/org/scalatest/events", "org/scalatest/events",
             List(
@@ -258,7 +276,6 @@ object GenScalaTestJS {
       List(
         "TypeCheckWord.scala",
         "CompileWord.scala",
-        "ArrayWrapper.scala",
         "BehaveWord.scala",
         "ResultOfTaggedAsInvocation.scala",
         "ResultOfStringPassedToVerb.scala",
@@ -326,7 +343,18 @@ object GenScalaTestJS {
         "ResultOfBeWordForNoException.scala",
         "ResultOfContainWord.scala",
         "ResultOfNotWordForAny.scala",
-        "ResultOfTheTypeInvocation.scala"
+        "ResultOfTheTypeInvocation.scala",
+        "ResultOfOneElementOfApplication.scala",
+        "ResultOfAtLeastOneElementOfApplication.scala",
+        "ResultOfNoElementsOfApplication.scala",
+        "ResultOfAllElementsOfApplication.scala",
+        "ResultOfInOrderElementsOfApplication.scala",
+        "ResultOfAtMostOneElementOfApplication.scala",
+        "AggregatingExpression.scala",
+        "ContainingExpression.scala",
+        "SequencingExpression.scala",
+        "EqualityExpression.scala",
+        "BeEqualEqualWord.scala"
       ), targetDir) ++
     copyDir("scalatest/src/main/scala/org/scalatest/enablers", "org/scalatest/enablers",
       List(
@@ -344,7 +372,8 @@ object GenScalaTestJS {
         "Existence.scala",
         "Size.scala",
         "Messaging.scala",
-        "Collecting.scala"
+        "Collecting.scala",
+        "package.scala"
       ), targetDir) ++
     copyDir("scalatest/src/main/scala/org/scalatest/prop", "org/scalatest/prop",
       List(

--- a/project/GenScalacticJS.scala
+++ b/project/GenScalacticJS.scala
@@ -75,6 +75,8 @@ object GenScalacticJS {
 
   def genScala(targetDir: File, version: String, scalaVersion: String): Seq[File] =
     copyDir("scalactic/src/main/scala/org/scalactic", "org/scalactic", targetDir, List.empty) ++
+    copyDir("scalactic/src/main/scala/org/scalactic/enablers", "org/scalactic/enablers", targetDir, List.empty) ++
+    copyDir("scalactic/src/main/scala/org/scalactic/algebra", "org/scalactic/algebra", targetDir, List.empty) ++
     GenVersions.genScalacticVersions(new File(targetDir, "org/scalactic"), version, scalaVersion)
 
   def genMacroScala(targetDir: File, version: String, scalaVersion: String): Seq[File] =

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -478,13 +478,13 @@ object ScalatestBuild extends Build {
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gengen", "GenGen.scala")(GenGen.genMain),*/
       sourceGenerators in Compile <+=
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gentables", "GenTable.scala")(GenTable.genMain),
+      sourceGenerators in Compile <+=
+        (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genmatchers", "MustMatchers.scala")(GenMatchers.genMain),
       /*genMustMatchersTask,
       genGenTask,
       genTablesTask,
       genCodeTask,
       genCompatibleClassesTask,
-      sourceGenerators in Compile <+=
-        (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genmatchers", "MustMatchers.scala")(GenMatchers.genMain),
       sourceGenerators in Compile <+=
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gencompcls", "GenCompatibleClasses.scala")(GenCompatibleClasses.genMain),
       sourceGenerators in Compile <+=

--- a/scalactic-test/src/test/scala/org/scalactic/AsMethodsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/AsMethodsSpec.scala
@@ -17,10 +17,10 @@ package org.scalactic
 
 import org.scalatest._
 
-class AsMethodsSpec extends Spec with Matchers with AsMethods {
+class AsMethodsSpec extends FunSpec with Matchers with AsMethods {
 
-  object `trait AsMethods` {
-    def `should provide a .as method that will convert any type A to the given type B when an implicit conversion from A => B exists` { 
+  describe("trait AsMethods") {
+    it("should provide a .as method that will convert any type A to the given type B when an implicit conversion from A => B exists") { 
       Option(3).map(_.as[Complex]) shouldEqual Option(Complex(3, 0))
     }
   }

--- a/scalactic-test/src/test/scala/org/scalactic/CheckedEqualityCooperatingAnyValsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/CheckedEqualityCooperatingAnyValsSpec.scala
@@ -23,10 +23,10 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
+class CheckedEqualityCooperatingAnyValsSpec extends FunSpec with CheckedEquality {
 
-  object `The CheckedEquality trait` {
-    def `should allow equality comparisons between types that co-operate in Scala` {
+  describe("The CheckedEquality trait") {
+    it("should allow equality comparisons between types that co-operate in Scala") {
 
       val aChar: Char = 'c'
       val aByte: Byte = 99
@@ -35,8 +35,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       val aLong: Long = 99L
       val aFloat: Float = 99.0F
       val aDouble: Double = 99.0
+      // SKIP-SCALATESTJS-START
       val aBigInt: BigInt = BigInt(99)
       val aBigDecimal: BigDecimal = BigDecimal(99.0)
+      // SKIP-SCALATESTJS-END
       val aJavaCharacter: java.lang.Character = new java.lang.Character('c')
       val aJavaByte: java.lang.Byte = new java.lang.Byte(99.toByte)
       val aJavaShort: java.lang.Short = new java.lang.Short(99.toShort)
@@ -55,8 +57,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aChar === aLong)
       assert(aChar === aFloat)
       assert(aChar === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aChar === aBigInt)
       assert(aChar === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aChar === aJavaCharacter)
       assert(aChar === aJavaByte)
       assert(aChar === aJavaShort)
@@ -72,8 +76,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aByte === aLong)
       assert(aByte === aFloat)
       assert(aByte === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aByte === aBigInt)
       assert(aByte === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aByte === aJavaCharacter)
       assert(aByte === aJavaByte)
       assert(aByte === aJavaShort)
@@ -89,8 +95,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aShort === aLong)
       assert(aShort === aFloat)
       assert(aShort === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aShort === aBigInt)
       assert(aShort === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aShort === aJavaCharacter)
       assert(aShort === aJavaByte)
       assert(aShort === aJavaShort)
@@ -106,8 +114,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(anInt === aLong)
       assert(anInt === aFloat)
       assert(anInt === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(anInt === aBigInt)
       assert(anInt === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(anInt === aJavaCharacter)
       assert(anInt === aJavaByte)
       assert(anInt === aJavaShort)
@@ -123,8 +133,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aLong === aLong)
       assert(aLong === aFloat)
       assert(aLong === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aLong === aBigInt)
       assert(aLong === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aLong === aJavaCharacter)
       assert(aLong === aJavaByte)
       assert(aLong === aJavaShort)
@@ -140,8 +152,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aFloat === aLong)
       assert(aFloat === aFloat)
       assert(aFloat === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aFloat === aBigInt)
       assert(aFloat === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aFloat === aJavaCharacter)
       assert(aFloat === aJavaByte)
       assert(aFloat === aJavaShort)
@@ -157,8 +171,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aDouble === aLong)
       assert(aDouble === aFloat)
       assert(aDouble === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aDouble === aBigInt)
       assert(aDouble === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aDouble === aJavaCharacter)
       assert(aDouble === aJavaByte)
       assert(aDouble === aJavaShort)
@@ -167,6 +183,7 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aDouble === aJavaFloat)
       assert(aDouble === aJavaDouble)
 
+      // SKIP-SCALATESTJS-START
       assert(aBigInt === aChar)
       assert(aBigInt === aByte)
       assert(aBigInt === aShort)
@@ -200,6 +217,7 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aBigDecimal === aJavaLong)
       assert(aBigDecimal === aJavaFloat)
       assert(aBigDecimal === aJavaDouble)
+      // SKIP-SCALATESTJS-END
 
       assert(aJavaCharacter === aChar)
       assert(aJavaCharacter === aByte)
@@ -208,8 +226,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaCharacter === aLong)
       assert(aJavaCharacter === aFloat)
       assert(aJavaCharacter === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaCharacter === aBigInt)
       assert(aJavaCharacter === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaCharacter === aJavaCharacter)
       assert(aJavaCharacter === aJavaByte)
       assert(aJavaCharacter === aJavaShort)
@@ -225,8 +245,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaByte === aLong)
       assert(aJavaByte === aFloat)
       assert(aJavaByte === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaByte === aBigInt)
       assert(aJavaByte === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaByte === aJavaCharacter)
       assert(aJavaByte === aJavaByte)
       assert(aJavaByte === aJavaShort)
@@ -242,8 +264,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaShort === aLong)
       assert(aJavaShort === aFloat)
       assert(aJavaShort === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaShort === aBigInt)
       assert(aJavaShort === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaShort === aJavaCharacter)
       assert(aJavaShort === aJavaByte)
       assert(aJavaShort === aJavaShort)
@@ -259,8 +283,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaInteger === aLong)
       assert(aJavaInteger === aFloat)
       assert(aJavaInteger === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaInteger === aBigInt)
       assert(aJavaInteger === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaInteger === aJavaCharacter)
       assert(aJavaInteger === aJavaByte)
       assert(aJavaInteger === aJavaShort)
@@ -276,8 +302,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaLong === aLong)
       assert(aJavaLong === aFloat)
       assert(aJavaLong === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaLong === aBigInt)
       assert(aJavaLong === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaLong === aJavaCharacter)
       assert(aJavaLong === aJavaByte)
       assert(aJavaLong === aJavaShort)
@@ -293,8 +321,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaFloat === aLong)
       assert(aJavaFloat === aFloat)
       assert(aJavaFloat === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaFloat === aBigInt)
       assert(aJavaFloat === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaFloat === aJavaCharacter)
       assert(aJavaFloat === aJavaByte)
       assert(aJavaFloat === aJavaShort)
@@ -310,8 +340,10 @@ class CheckedEqualityCooperatingAnyValsSpec extends Spec with CheckedEquality {
       assert(aJavaDouble === aLong)
       assert(aJavaDouble === aFloat)
       assert(aJavaDouble === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaDouble === aBigInt)
       assert(aJavaDouble === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaDouble === aJavaCharacter)
       assert(aJavaDouble === aJavaByte)
       assert(aJavaDouble === aJavaShort)

--- a/scalactic-test/src/test/scala/org/scalactic/ComplexSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/ComplexSpec.scala
@@ -17,15 +17,15 @@ package org.scalactic
 
 import org.scalatest._
 
-class ComplexSpec extends Spec with Matchers {
-  object `A Complex ` {
-    def `should equal another Complex if both the real and imaginary parts are equal` {
+class ComplexSpec extends FunSpec with Matchers {
+  describe("A Complex ") {
+    it("should equal another Complex if both the real and imaginary parts are equal") {
       Complex(2.0, 3.0) should equal (Complex(2.0, 3.0))
       Complex(2.0, 3.0) should not equal (Complex(1.0, 3.0))
       Complex(2.0, 3.0) should not equal (Complex(2.0, 1.0))
       Complex(2.0, 3.0) should not equal (Complex(1.0, 1.0))
     }
-    def `should have implicit conversions from DigitString, Int, and Double` {
+    it("should have implicit conversions from DigitString, Int, and Double") {
       def iKnowYouAreButWhatAmI(c: Complex): Complex = c
       iKnowYouAreButWhatAmI(Complex(2.0, 3.0)) should equal (Complex(2.0, 3.0))
       iKnowYouAreButWhatAmI(3.0) should equal (Complex(3.0, 0.0))

--- a/scalactic-test/src/test/scala/org/scalactic/CooperativeEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/CooperativeEqualitySpec.scala
@@ -17,10 +17,10 @@ package org.scalactic
 
 import org.scalatest._
 
-class CooperativeEqualitySpec extends Spec with Matchers with NonImplicitAssertions {
-  object `Two Options` {
+class CooperativeEqualitySpec extends FunSpec with Matchers with NonImplicitAssertions {
+  describe("Two Options") {
 
-    object `when cooperative Equality instances are defined for both element types` {
+    describe("when cooperative Equality instances are defined for both element types") {
 
       implicit val intEquality =
         new Equality[Int] {
@@ -44,7 +44,7 @@ class CooperativeEqualitySpec extends Spec with Matchers with NonImplicitAsserti
 
       // This is a sanity check, a test to make sure the test is testing what
       // I think it is testing
-      def `should be comparable under Checked- and EnabledEquality outside of Options` {
+      it("should be comparable under Checked- and EnabledEquality outside of Options") {
         // New policies
         // Both sides Some
         new UncheckedEquality { 42 shouldEqual Complex(42.0, 0.0) }
@@ -82,7 +82,7 @@ class CooperativeEqualitySpec extends Spec with Matchers with NonImplicitAsserti
         new ConversionCheckedTripleEquals { 42 shouldEqual Complex(42.0, 0.0) }
       }
 
-      def `should not by default be comparable under Checked- and EnabledEquality` {
+      it("should not by default be comparable under Checked- and EnabledEquality") {
   
         // New policies
         // Both sides Some
@@ -126,7 +126,7 @@ class CooperativeEqualitySpec extends Spec with Matchers with NonImplicitAsserti
         new ConversionCheckedTripleEquals { Option(42) should not equal Some(Complex(42.0, 0.0)) }
       }
   
-      def `should be comparable under Checked- and EnabledEquality if also under RecursiveOptionEquality` {
+      it("should be comparable under Checked- and EnabledEquality if also under RecursiveOptionEquality") {
   
         import RecursiveOptionEquality._
   

--- a/scalactic-test/src/test/scala/org/scalactic/DigitStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/DigitStringSpec.scala
@@ -17,14 +17,14 @@ package org.scalactic
 
 import org.scalatest._
 
-class DigitStringSpec extends Spec with Matchers {
-  object `A DigitString ` {
-    def `should throw IllegalArgumentException if a non-digit or empty string is passed` {
+class DigitStringSpec extends FunSpec with Matchers {
+  describe("A DigitString ") {
+    it("should throw IllegalArgumentException if a non-digit or empty string is passed") {
       an [IllegalArgumentException] should be thrownBy { DigitString("00B") }
       an [IllegalArgumentException] should be thrownBy { DigitString("") }
       an [IllegalArgumentException] should be thrownBy { DigitString("CafeBabe") }
     }
-    def `should throw IllegalArgumentException if digits are passed that represent an number greater than Int.MaxValue or Int.MinValue` {
+    it("should throw IllegalArgumentException if digits are passed that represent an number greater than Int.MaxValue or Int.MinValue") {
       /*
       scala> Int.MaxValue
       res1: Int = 2147483647
@@ -62,20 +62,20 @@ class DigitStringSpec extends Spec with Matchers {
       an [IllegalArgumentException] should be thrownBy { DigitString("-2147483649") }
       an [IllegalArgumentException] should be thrownBy { DigitString("-1-") }
     }
-    def `should equal another DigitString if both the strings are equal` {
+    it("should equal another DigitString if both the strings are equal") {
       DigitString("5") should equal (DigitString("5"))
       DigitString("06") should equal (DigitString("06"))
       DigitString("007") should equal (DigitString("007"))
       DigitString("08") should not equal (DigitString("008"))
     }
-    def `can be used where an Int is needed` {
+    it("can be used where an Int is needed") {
       def iKnowYouAreButWhatAmI(i: Int): Int = i
       iKnowYouAreButWhatAmI(7) should equal (7)
       iKnowYouAreButWhatAmI(DigitString("7")) should equal (7)
       iKnowYouAreButWhatAmI(DigitString("07")) should equal (7)
       iKnowYouAreButWhatAmI(DigitString("007")) should equal (7)
     }
-    def `can give you an Int by invoking toInt directly on it` {
+    it("can give you an Int by invoking toInt directly on it") {
       DigitString("007").toInt should equal (7)
     }
   }

--- a/scalactic-test/src/test/scala/org/scalactic/EnabledEqualityCooperatingAnyValsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EnabledEqualityCooperatingAnyValsSpec.scala
@@ -23,10 +23,10 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
+class EnabledEqualityCooperatingAnyValsSpec extends FunSpec with EnabledEquality {
 
-  object `The EnabledEquality trait` {
-    def `should allow equality comparisons between types that co-operate in Scala` {
+  describe("The EnabledEquality trait") {
+    it("should allow equality comparisons between types that co-operate in Scala") {
 
       val aChar: Char = 'c'
       val aByte: Byte = 99
@@ -35,8 +35,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       val aLong: Long = 99L
       val aFloat: Float = 99.0F
       val aDouble: Double = 99.0
+      // SKIP-SCALATESTJS-START
       val aBigInt: BigInt = BigInt(99)
       val aBigDecimal: BigDecimal = BigDecimal(99.0)
+      // SKIP-SCALATESTJS-END
       val aJavaCharacter: java.lang.Character = new java.lang.Character('c')
       val aJavaByte: java.lang.Byte = new java.lang.Byte(99.toByte)
       val aJavaShort: java.lang.Short = new java.lang.Short(99.toShort)
@@ -55,8 +57,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aChar === aLong)
       assert(aChar === aFloat)
       assert(aChar === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aChar === aBigInt)
       assert(aChar === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aChar === aJavaCharacter)
       assert(aChar === aJavaByte)
       assert(aChar === aJavaShort)
@@ -72,8 +76,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aByte === aLong)
       assert(aByte === aFloat)
       assert(aByte === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aByte === aBigInt)
       assert(aByte === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aByte === aJavaCharacter)
       assert(aByte === aJavaByte)
       assert(aByte === aJavaShort)
@@ -89,8 +95,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aShort === aLong)
       assert(aShort === aFloat)
       assert(aShort === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aShort === aBigInt)
       assert(aShort === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aShort === aJavaCharacter)
       assert(aShort === aJavaByte)
       assert(aShort === aJavaShort)
@@ -106,8 +114,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(anInt === aLong)
       assert(anInt === aFloat)
       assert(anInt === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(anInt === aBigInt)
       assert(anInt === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(anInt === aJavaCharacter)
       assert(anInt === aJavaByte)
       assert(anInt === aJavaShort)
@@ -123,8 +133,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aLong === aLong)
       assert(aLong === aFloat)
       assert(aLong === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aLong === aBigInt)
       assert(aLong === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aLong === aJavaCharacter)
       assert(aLong === aJavaByte)
       assert(aLong === aJavaShort)
@@ -140,8 +152,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aFloat === aLong)
       assert(aFloat === aFloat)
       assert(aFloat === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aFloat === aBigInt)
       assert(aFloat === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aFloat === aJavaCharacter)
       assert(aFloat === aJavaByte)
       assert(aFloat === aJavaShort)
@@ -157,8 +171,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aDouble === aLong)
       assert(aDouble === aFloat)
       assert(aDouble === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aDouble === aBigInt)
       assert(aDouble === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aDouble === aJavaCharacter)
       assert(aDouble === aJavaByte)
       assert(aDouble === aJavaShort)
@@ -167,6 +183,7 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aDouble === aJavaFloat)
       assert(aDouble === aJavaDouble)
 
+      // SKIP-SCALATESTJS-START
       assert(aBigInt === aChar)
       assert(aBigInt === aByte)
       assert(aBigInt === aShort)
@@ -200,6 +217,7 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aBigDecimal === aJavaLong)
       assert(aBigDecimal === aJavaFloat)
       assert(aBigDecimal === aJavaDouble)
+      // SKIP-SCALATESTJS-END
 
       assert(aJavaCharacter === aChar)
       assert(aJavaCharacter === aByte)
@@ -208,8 +226,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaCharacter === aLong)
       assert(aJavaCharacter === aFloat)
       assert(aJavaCharacter === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaCharacter === aBigInt)
       assert(aJavaCharacter === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaCharacter === aJavaCharacter)
       assert(aJavaCharacter === aJavaByte)
       assert(aJavaCharacter === aJavaShort)
@@ -225,8 +245,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaByte === aLong)
       assert(aJavaByte === aFloat)
       assert(aJavaByte === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaByte === aBigInt)
       assert(aJavaByte === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaByte === aJavaCharacter)
       assert(aJavaByte === aJavaByte)
       assert(aJavaByte === aJavaShort)
@@ -242,8 +264,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaShort === aLong)
       assert(aJavaShort === aFloat)
       assert(aJavaShort === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaShort === aBigInt)
       assert(aJavaShort === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaShort === aJavaCharacter)
       assert(aJavaShort === aJavaByte)
       assert(aJavaShort === aJavaShort)
@@ -259,8 +283,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaInteger === aLong)
       assert(aJavaInteger === aFloat)
       assert(aJavaInteger === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaInteger === aBigInt)
       assert(aJavaInteger === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaInteger === aJavaCharacter)
       assert(aJavaInteger === aJavaByte)
       assert(aJavaInteger === aJavaShort)
@@ -276,8 +302,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaLong === aLong)
       assert(aJavaLong === aFloat)
       assert(aJavaLong === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaLong === aBigInt)
       assert(aJavaLong === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaLong === aJavaCharacter)
       assert(aJavaLong === aJavaByte)
       assert(aJavaLong === aJavaShort)
@@ -293,8 +321,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaFloat === aLong)
       assert(aJavaFloat === aFloat)
       assert(aJavaFloat === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaFloat === aBigInt)
       assert(aJavaFloat === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaFloat === aJavaCharacter)
       assert(aJavaFloat === aJavaByte)
       assert(aJavaFloat === aJavaShort)
@@ -310,8 +340,10 @@ class EnabledEqualityCooperatingAnyValsSpec extends Spec with EnabledEquality {
       assert(aJavaDouble === aLong)
       assert(aJavaDouble === aFloat)
       assert(aJavaDouble === aDouble)
+      // SKIP-SCALATESTJS-START
       assert(aJavaDouble === aBigInt)
       assert(aJavaDouble === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assert(aJavaDouble === aJavaCharacter)
       assert(aJavaDouble === aJavaByte)
       assert(aJavaDouble === aJavaShort)

--- a/scalactic-test/src/test/scala/org/scalactic/EnabledEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EnabledEqualitySpec.scala
@@ -17,15 +17,15 @@ package org.scalactic
 
 import org.scalatest._
 
-class EnabledEqualitySpec extends Spec with Matchers with NonImplicitAssertions {
-  object `EnabledEquality ` {
-    def `should not allow two function1's to be compared` {
+class EnabledEqualitySpec extends FunSpec with Matchers with NonImplicitAssertions {
+  describe("EnabledEquality ") {
+    it("should not allow two function1's to be compared") {
       val fun = (i: Int) => i + 1
       new UncheckedEquality { fun shouldEqual fun }
       new CheckedEquality { fun shouldEqual fun }
       new EnabledEquality { "fun shouldEqual fun" shouldNot typeCheck }
     }
-    def `should not allow anything to be compared with Any` {
+    it("should not allow anything to be compared with Any") {
 
       new UncheckedEquality { "hi" should not equal 1 }
       new UncheckedEquality { "hi" should not equal (1: Any) }
@@ -39,10 +39,10 @@ class EnabledEqualitySpec extends Spec with Matchers with NonImplicitAssertions 
       new EnabledEquality { """"hi" should not equal (1: Any)""" shouldNot typeCheck }
       new EnabledEquality { """("hi": Any) should not equal 1""" shouldNot typeCheck }
     }
-    def `should allow two Strings to be compared` {
+    it("should allow two Strings to be compared") {
       new EnabledEquality { "hi" shouldEqual "hi" }
     }
-    def `should not allow a DigitString to be compared with an Int, despite the DigitString => Int implicit conversion` {
+    it("should not allow a DigitString to be compared with an Int, despite the DigitString => Int implicit conversion") {
       val agent007 = DigitString("007")
       agent007 should not equal DigitString("07")
       DigitString("007") should equal (agent007)
@@ -57,7 +57,7 @@ class EnabledEqualitySpec extends Spec with Matchers with NonImplicitAssertions 
       new EnabledEquality { "agent007 should not equal 7" shouldNot typeCheck }
       new EnabledEquality { "7 should not equal agent007" shouldNot typeCheck }
     }
-    def `should not allow a Double to be compared with a Complex, despite the Double => Complex implicit conversion` {
+    it("should not allow a Double to be compared with a Complex, despite the Double => Complex implicit conversion") {
       val seven = Complex(7.0, 0.0)
       seven should not equal Complex(7.0, 1.0)
       Complex(7.0, 0.0) should equal (seven)

--- a/scalactic-test/src/test/scala/org/scalactic/EntrySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EntrySpec.scala
@@ -20,10 +20,11 @@ import java.util.{HashMap => JHashMap}
 import org.scalatest._
 import Matchers._
 
-class EntrySpec extends Spec {
+class EntrySpec extends FunSpec {
 
-  object `An org.scalatest.Entry` {
-    def `can be compared against an Entry coming from a java.util.Map` {
+  describe("An org.scalatest.Entry") {
+    // SKIP-SCALATESTJS-START
+    it("can be compared against an Entry coming from a java.util.Map") {
       val jmap: JMap[String, Int] = new JHashMap[String, Int]
       jmap.put("one", 1)
       jmap.put("two", 2)
@@ -33,14 +34,16 @@ class EntrySpec extends Spec {
       jmap.entrySet should not contain (Entry("one", 100))
       jmap.entrySet should contain allOf (Entry("one", 1), Entry("two", 2))
     }
-    def `should have a toString consistent with the ones coming from Java` {
+    it("should have a toString consistent with the ones coming from Java") {
       Entry("one", 1).toString should be ("one=1")
       Entry(1, "one").toString should be ("1=one")
     }
+    // SKIP-SCALATESTJS-END
   }
-  object `the loneElement method` {
-    object `when used with java.util.Map` {
-      def `should return an Entry that has key and value methods` {
+  describe("the loneElement method") {
+    // SKIP-SCALATESTJS-START
+    describe("when used with java.util.Map") {
+      it("should return an Entry that has key and value methods") {
         import LoneElement._
         val jmap: JMap[String, Int] = new JHashMap[String, Int]
         jmap.put("one", 1)
@@ -48,5 +51,6 @@ class EntrySpec extends Spec {
         jmap.loneElement.value should be (1)
       }
     }
+    // SKIP-SCALATESTJS-END
   }
 }

--- a/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EquaSetSpec.scala
@@ -1033,7 +1033,9 @@ class EquaSetSpec extends UnitSpec {
     List(number.EquaSet(1, 2, 3), number.EquaSet(1, 2, 3)).flatten shouldBe List(1, 2, 3, 1, 2, 3)
     // TODO: this is not working 2.10, we may want to enable this back when we understand better how flatten is supported by the implicit in 2.10
     //List(number.EquaSet(1, 2, 3), number.EquaSet(1, 2, 3)).toIterator.flatten.toStream shouldBe List(1, 2, 3, 1, 2, 3).toIterator.toStream
+    // SKIP-SCALATESTJS-START
     List(number.EquaSet(1, 2, 3), number.EquaSet(1, 2, 3)).par.flatten shouldBe List(1, 2, 3, 1, 2, 3).par
+    // SKIP-SCALATESTJS-END
   }
   it should "have a flatten method that works on nested GenTraversable" in {
     numberList.EquaSet(List(1, 2), List(3)).flatten shouldBe List(1, 2, 3)
@@ -1871,12 +1873,14 @@ class EquaSetSpec extends UnitSpec {
   it should "have a toMap method" in {
     tuple.EquaSet((1, "one"), (2, "two"), (3, "three")).toMap shouldBe Map(1 -> "one", 2 -> "two", 3 -> "three")
   }
+  // SKIP-SCALATESTJS-START
   it should "have a toParArray method" in {
     number.EquaSet(1, 2, 3).toParArray shouldBe ParArray(1, 2, 3)
   }
   it should "have a toEquaBoxParArray method" in {
     number.EquaSet(1, 2, 3).toEquaBoxParArray shouldBe ParArray(number.EquaBox(1), number.EquaBox(2), number.EquaBox(3))
   }
+  // SKIP-SCALATESTJS-END
   it should "have a toSeq method" in {
     number.EquaSet(1, 2, 3).toSeq shouldBe (Seq(1, 2, 3))
     lower.EquaSet("a", "b").toSeq shouldBe (Seq("a", "b"))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedMapEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedMapEqualityConstraintsSpec.scala
@@ -24,7 +24,7 @@ import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 import scala.collection.{mutable,immutable}
 
-class FreshConversionCheckedMapEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshConversionCheckedMapEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   // TODO: Need to explicitly enable the implicit conversion equality comparison
 
@@ -50,9 +50,9 @@ class FreshConversionCheckedMapEqualityConstraintsSpec extends Spec with NonImpl
     override def hashCode: Int = value.hashCode
   }
 
-  object `the MapEqualityConstraints trait` {
+  describe("the MapEqualityConstraints trait") {
 
-    def `should allow any Map to be compared with any other Map, so long as the key and value types of the two Maps have respective recursive EqualityConstraints` {
+    it("should allow any Map to be compared with any other Map, so long as the key and value types of the two Maps have respective recursive EqualityConstraints") {
       assert(mutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3) === immutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3))
       assert(mutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3) === immutable.HashMap('a' -> 1L, 'b' -> 2L, 'c' -> 3L))
       assert(mutable.HashMap('a' -> 1L, 'b' -> 2L, 'c' -> 3L) === immutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedSeqEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedSeqEqualityConstraintsSpec.scala
@@ -23,7 +23,7 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class FreshConversionCheckedSeqEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshConversionCheckedSeqEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   // TODO: Need to explicitly enable the implicit conversion
 
@@ -49,9 +49,9 @@ class FreshConversionCheckedSeqEqualityConstraintsSpec extends Spec with NonImpl
     override def hashCode: Int = value.hashCode
   }
 
-  object `the SeqEqualityConstraints trait` {
+  describe("the SeqEqualityConstraints trait") {
 
-    def `should allow any Seq to be compared with any other Seq, so long as the element types of the two Seq's have a recursive EqualityConstraint` {
+    it("should allow any Seq to be compared with any other Seq, so long as the element types of the two Seq's have a recursive EqualityConstraint") {
       assert(Vector(1, 2, 3) === List(1, 2, 3))
       assert(Vector(1, 2, 3) === List(1L, 2L, 3L))
       assert(Vector(1L, 2L, 3L) === List(1, 2, 3))
@@ -66,7 +66,7 @@ class FreshConversionCheckedSeqEqualityConstraintsSpec extends Spec with NonImpl
       assertTypeError("List(new Orange, new Orange) === Vector(new Apple, new Apple)")
     }
 
-    def `should allow an Array to be compared with any other Seq, so long as the element types of the two objects have a recursive EqualityConstraint` {
+    it("should allow an Array to be compared with any other Seq, so long as the element types of the two objects have a recursive EqualityConstraint") {
       assert(Array(1, 2, 3) === List(1, 2, 3))
       assert(Array(1, 2, 3) === List(1L, 2L, 3L))
       assert(Array(1L, 2L, 3L) === List(1, 2, 3))
@@ -81,7 +81,7 @@ class FreshConversionCheckedSeqEqualityConstraintsSpec extends Spec with NonImpl
       assertTypeError("Array(new Orange, new Orange) === Vector(new Apple, new Apple)")
     }
 
-    def `should allow any Seq to be compared with an Array, so long as the element types of the two objects have a recursive EqualityConstraint` {
+    it("should allow any Seq to be compared with an Array, so long as the element types of the two objects have a recursive EqualityConstraint") {
       assert(Vector(1, 2, 3) === Array(1, 2, 3))
       assert(Vector(1, 2, 3) === Array(1L, 2L, 3L))
       assert(Vector(1L, 2L, 3L) === Array(1, 2, 3))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedSetEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshConversionCheckedSetEqualityConstraintsSpec.scala
@@ -24,7 +24,7 @@ import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 import scala.collection.{mutable,immutable}
 
-class FreshConversionCheckedSetEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshConversionCheckedSetEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   // TODO: Need to explicitly enable the implicit conversion equality 
 
@@ -50,9 +50,9 @@ class FreshConversionCheckedSetEqualityConstraintsSpec extends Spec with NonImpl
     override def hashCode: Int = value.hashCode
   }
 
-  object `the SetEqualityConstraints trait` {
+  describe("the SetEqualityConstraints trait") {
 
-    def `should allow any Set to be compared with any other Set, so long as the element types of the two Sets adhere have a recursive EqualityConstraint` {
+    it("should allow any Set to be compared with any other Set, so long as the element types of the two Sets adhere have a recursive EqualityConstraint") {
 
       assert(mutable.HashSet(1, 2, 3) === immutable.HashSet(1, 2, 3))
       assert(mutable.HashSet(1, 2, 3) === immutable.HashSet(1L, 2L, 3L))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedMapEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedMapEqualityConstraintsSpec.scala
@@ -24,7 +24,7 @@ import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 import scala.collection.{mutable,immutable}
 
-class FreshTypeCheckedMapEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshTypeCheckedMapEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   case class Super(size: Int)
   class Sub(sz: Int) extends Super(sz)
@@ -48,9 +48,9 @@ class FreshTypeCheckedMapEqualityConstraintsSpec extends Spec with NonImplicitAs
     override def hashCode: Int = value.hashCode
   }
 
-  object `the MapEqualityConstraints trait` {
+  describe("the MapEqualityConstraints trait") {
 
-    def `should allow any Map to be compared with any other Map, so long as the key and value types of the two Maps have respective recursive EqualityConstraints` {
+    it("should allow any Map to be compared with any other Map, so long as the key and value types of the two Maps have respective recursive EqualityConstraints") {
       assert(mutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3) === immutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3))
       assert(mutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3) === immutable.HashMap('a' -> 1L, 'b' -> 2L, 'c' -> 3L))
       assert(mutable.HashMap('a' -> 1L, 'b' -> 2L, 'c' -> 3L) === immutable.HashMap('a' -> 1, 'b' -> 2, 'c' -> 3))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedSeqEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedSeqEqualityConstraintsSpec.scala
@@ -23,7 +23,7 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class FreshTypeCheckedSeqEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshTypeCheckedSeqEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   case class Super(size: Int)
   class Sub(sz: Int) extends Super(sz)
@@ -47,9 +47,9 @@ class FreshTypeCheckedSeqEqualityConstraintsSpec extends Spec with NonImplicitAs
     override def hashCode: Int = value.hashCode
   }
 
-  object `the SeqEqualityConstraints trait` {
+  describe("the SeqEqualityConstraints trait") {
 
-    def `should allow any Seq to be compared with any other Seq, so long as the element types of the two Seq's have a recursive EqualityConstraint` {
+    it("should allow any Seq to be compared with any other Seq, so long as the element types of the two Seq's have a recursive EqualityConstraint") {
       assert(Vector(1, 2, 3) === List(1, 2, 3))
       assert(Vector(1, 2, 3) === List(1L, 2L, 3L))
 
@@ -63,7 +63,7 @@ class FreshTypeCheckedSeqEqualityConstraintsSpec extends Spec with NonImplicitAs
       assertTypeError("List(new Orange, new Orange) === Vector(new Apple, new Apple)")
     }
 
-    def `should allow an Array to be compared with any other Seq, so long as the element types of the two objects have a recursive EqualityConstraint` {
+    it("should allow an Array to be compared with any other Seq, so long as the element types of the two objects have a recursive EqualityConstraint") {
       assert(Array(1, 2, 3) === List(1, 2, 3))
       assert(Array(1, 2, 3) === List(1L, 2L, 3L))
       assert(Array(1L, 2L, 3L) === List(1, 2, 3))
@@ -78,7 +78,7 @@ class FreshTypeCheckedSeqEqualityConstraintsSpec extends Spec with NonImplicitAs
       assertTypeError("Array(new Orange, new Orange) === Vector(new Apple, new Apple)")
     }
 
-    def `should allow any Seq to be compared with an Array, so long as the element types of the two objects have a recursive EqualityConstraint` {
+    it("should allow any Seq to be compared with an Array, so long as the element types of the two objects have a recursive EqualityConstraint") {
       assert(Vector(1, 2, 3) === Array(1, 2, 3))
       assert(Vector(1, 2, 3) === Array(1L, 2L, 3L))
       assert(Vector(1L, 2L, 3L) === Array(1, 2, 3))

--- a/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedSetEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FreshTypeCheckedSetEqualityConstraintsSpec.scala
@@ -24,7 +24,7 @@ import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 import scala.collection.{mutable,immutable}
 
-class FreshTypeCheckedSetEqualityConstraintsSpec extends Spec with NonImplicitAssertions with CheckedEquality {
+class FreshTypeCheckedSetEqualityConstraintsSpec extends FunSpec with NonImplicitAssertions with CheckedEquality {
 
   case class Super(size: Int)
   class Sub(sz: Int) extends Super(sz)
@@ -48,9 +48,9 @@ class FreshTypeCheckedSetEqualityConstraintsSpec extends Spec with NonImplicitAs
     override def hashCode: Int = value.hashCode
   }
 
-  object `the SetEqualityConstraints trait` {
+  describe("the SetEqualityConstraints trait") {
 
-    def `should allow any Set to be compared with any other Set, so long as the element types of the two Sets have a recursive EqualityConstraint` {
+    it("should allow any Set to be compared with any other Set, so long as the element types of the two Sets have a recursive EqualityConstraint") {
 
       assert(mutable.HashSet(1, 2, 3) === immutable.HashSet(1, 2, 3))
       assert(mutable.HashSet(1, 2, 3) === immutable.HashSet(1L, 2L, 3L))

--- a/scalactic-test/src/test/scala/org/scalactic/GeneralContainElementSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/GeneralContainElementSpec.scala
@@ -17,15 +17,17 @@ package org.scalactic
 
 import org.scalatest._
 
-class GeneralContainElementSpec extends Spec with Matchers with CheckedEquality {
+class GeneralContainElementSpec extends FunSpec with Matchers with CheckedEquality {
 
-  object `the contain theSameElementsAs syntax` {
-    def `should work on different types` {
+  describe("the contain theSameElementsAs syntax") {
+    // SKIP-SCALATESTJS-START
+    it("should work on different types") {
       val jul: java.util.List[Int] = new java.util.ArrayList[Int]
       jul.add(3)
       jul.add(2)
       jul.add(1)
       List(1, 2, 3) should (contain theSameElementsAs jul)
     }
+    // SKIP-SCALATESTJS-END
   }
 }

--- a/scalactic-test/src/test/scala/org/scalactic/HashingEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/HashingEqualitySpec.scala
@@ -23,9 +23,9 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class HashingEqualitySpec extends Spec with MustMatchers {
-  object `A Normalization` {
-    def `can be converted to a HashingEquality via toHashingEquality` {
+class HashingEqualitySpec extends FunSpec with MustMatchers {
+  describe("A Normalization") {
+    it("can be converted to a HashingEquality via toHashingEquality") {
       val hashEq = StringNormalizations.lowerCased.toHashingEquality
       hashEq.hashCodeFor("HI") mustEqual hashEq.hashCodeFor("hi")
       hashEq.hashCodeFor("happy") mustEqual hashEq.hashCodeFor("happy")

--- a/scalactic-test/src/test/scala/org/scalactic/OrderingEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/OrderingEqualitySpec.scala
@@ -23,9 +23,9 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class OrderingEqualitySpec extends Spec with MustMatchers {
-  object `A Normalization` {
-    def `can be converted to a OrderingEquality via toOrderingEquality` {
+class OrderingEqualitySpec extends FunSpec with MustMatchers {
+  describe("A Normalization") {
+    it("can be converted to a OrderingEquality via toOrderingEquality") {
       /*
         scala> val ord = implicitly[Ordering[String]]
         ord: Ordering[String] = scala.math.Ordering$String$@f634763

--- a/scalactic-test/src/test/scala/org/scalactic/RecursiveConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/RecursiveConstraintsSpec.scala
@@ -27,10 +27,10 @@ import scala.collection.mutable
 // Nope, not now that it is recursive, but the TODO is to write tests for that.
 //
 
-class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
+class RecursiveConstraintsSpec extends FunSpec with Matchers with CheckedEquality {
 
-  object `Recursive constraints should enable equality comparisons` {
-    def `on Seqs and Arrays` {
+  describe("Recursive constraints should enable equality comparisons") {
+    it("on Seqs and Arrays") {
       List(1, 2, 3) shouldEqual Vector(1L, 2L, 3L)
       List(1, 2, 3) shouldEqual List(1L, 2L, 3L)
       Vector(1, 2, 3) shouldEqual List(1L, 2L, 3L)
@@ -38,32 +38,32 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       Array(1, 2, 3) shouldEqual Array(1L, 2L, 3L)
       Array(1, 2, 3) shouldEqual List(1L, 2L, 3L)
     }
-    def `on nested Seqs` {
+    it("on nested Seqs") {
       Vector(List(1, 2, 3)) shouldEqual List(Vector(1L, 2L, 3L))
       List(List(1, 2, 3)) shouldEqual List(List(1L, 2L, 3L))
       List(Vector(1, 2, 3)) shouldEqual Vector(List(1L, 2L, 3L))
     }
-    def `on Sets` {
+    it("on Sets") {
       Set(1, 2, 3) shouldEqual mutable.HashSet(1L, 2L, 3L)
       Set(1, 2, 3) shouldEqual Set(1L, 2L, 3L)
       mutable.HashSet(1, 2, 3) shouldEqual Set(1L, 2L, 3L)
     }
-    def `on nested Sets` {
+    it("on nested Sets") {
       mutable.HashSet(Set(1, 2, 3)) shouldEqual Set(mutable.HashSet(1L, 2L, 3L))
       Set(Set(1, 2, 3)) shouldEqual Set(Set(1L, 2L, 3L))
       Set(mutable.HashSet(1, 2, 3)) shouldEqual mutable.HashSet(Set(1L, 2L, 3L))
     }
-    def `on Maps` {
+    it("on Maps") {
       Map("1" -> 1, "2" -> 2, "3" -> 3) shouldEqual mutable.HashMap("1" -> 1L, "2" -> 2L, "3" -> 3L)
       Map("1" -> 1, "2" -> 2, "3" -> 3) shouldEqual Map("1" -> 1L, "2" -> 2L, "3" -> 3L)
       mutable.HashMap("1" -> 1, "2" -> 2, "3" -> 3) shouldEqual Map("1" -> 1L, "2" -> 2L, "3" -> 3L)
     }
-    def `on nested Maps` {
+    it("on nested Maps") {
       mutable.HashMap(0 -> Map("1" -> 1, "2" -> 2, "3" -> 3)) shouldEqual Map(0 -> mutable.HashMap("1" -> 1L, "2" -> 2L, "3" -> 3L))
       Map(0 -> Map("1" -> 1, "2" -> 2, "3" -> 3)) shouldEqual Map(0 -> Map("1" -> 1L, "2" -> 2L, "3" -> 3L))
       Map(0 -> mutable.HashMap("1" -> 1, "2" -> 2, "3" -> 3)) shouldEqual mutable.HashMap(0 -> Map("1" -> 1L, "2" -> 2L, "3" -> 3L))
     }
-    def `on Every` {
+    it("on Every") {
       One(1) shouldEqual One(1L)
       Many(1, 2) shouldEqual Many(1L, 2L)
 
@@ -80,7 +80,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       """One(1) === Many(1, 2)""" shouldNot typeCheck
       """Many(1) === One(1, 2)""" shouldNot typeCheck
     }
-    def `on nested Every` {
+    it("on nested Every") {
       List(One(1)) shouldEqual Vector(One(1L))
       List(Many(1, 2)) shouldEqual Vector(Many(1L, 2L))
 
@@ -97,7 +97,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       """List(One(1)) === Vector(Many(1, 2))""" shouldNot typeCheck
       """List(Many(1)) === Vector(One(1, 2))""" shouldNot typeCheck
     }
-    def `on Or` {
+    it("on Or") {
 
       // Both sides Good
       (Good(1): Good[Int]) shouldEqual (Good(1L): Good[Long])
@@ -230,9 +230,9 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       Bad(1).asOr shouldEqual Bad(1L).asOr
       Bad(1L).asOr shouldEqual Bad(1).asOr
     }
-    object `on Nested Or` {
+    describe("on Nested Or") {
 
-      def `with List (which is covariant)` {
+      it("with List (which is covariant)") {
         // Both sides Good
         (List(Good(1)): List[Good[Int]]) shouldEqual (List(Good(1L)): List[Good[Long]])
         (List(Good(1)): List[Good[Int]]) shouldEqual (List(Good(1)): List[Good[Int]])
@@ -365,7 +365,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
         List(Bad(1L).asOr) shouldEqual List(Bad(1).asOr)
       }
 
-      def `with Set (which is invariant)` {
+      it("with Set (which is invariant)") {
         // Both sides Good
         (Set(Good(1)): Set[Good[Int]]) shouldEqual (Set(Good(1L)): Set[Good[Long]])
         (Set(Good(1)): Set[Good[Int]]) shouldEqual (Set(Good(1)): Set[Good[Int]])
@@ -512,7 +512,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       def asEither: Either[L, Nothing] = either
     }
 
-    def `on Either` {
+    it("on Either") {
 
       // Both sides Left
       (Left(1): Left[Int, Int]) shouldEqual (Left(1L): Left[Long, Int])
@@ -645,9 +645,9 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       Right(1).asEither shouldEqual Right(1L).asEither
       Right(1L).asEither shouldEqual Right(1).asEither
     }
-    def `on Nested Either` {
+    describe("on Nested Either") {
 
-      def `with List (which is covariant)` {
+      it("with List (which is covariant)") {
         // Both sides Left
         (List(Left(1)): List[Left[Int, Int]]) shouldEqual (List(Left(1L)): List[Left[Long, Int]])
         (List(Left(1)): List[Left[Int, Int]]) shouldEqual (List(Left(1)): List[Left[Int, Long]])
@@ -779,7 +779,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
         List(Right(1).asEither) shouldEqual List(Right(1L).asEither)
         List(Right(1L).asEither) shouldEqual List(Right(1).asEither)
       }
-      def `with Set (which is invariant)` {
+      it("with Set (which is invariant)") {
         // Both sides Left
         (Set(Left(1)): Set[Left[Int, Int]]) shouldEqual (Set(Left(1L)): Set[Left[Long, Int]])
         (Set(Left(1)): Set[Left[Int, Int]]) shouldEqual (Set(Left(1)): Set[Left[Int, Long]])
@@ -912,7 +912,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
         Set(Right(1L).asEither) shouldEqual Set(Right(1).asEither)
       }
     }
-    def `on Options` {
+    it("on Options") {
       // Both sides Option
       Option(1) shouldEqual Option(1L)
       Option(1L) shouldEqual Option(1L)
@@ -946,7 +946,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       "Some(1) shouldEqual None" shouldNot typeCheck
       "Some(1L) shouldEqual None" shouldNot typeCheck
     }
-    def `on nested Options` {
+    it("on nested Options") {
       // Both sides Option
       Option(Option(1)) shouldEqual Option(Option(1L))
       Option(Option(1L)) shouldEqual Option(Option(1))
@@ -990,7 +990,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
 
     import scala.util.{Try, Success, Failure}
     val ex = new Exception("oops")
-    def `on Try` {
+    it("on Try") {
       // Both sides Try
       Try(1) shouldEqual Try(1L)
       Try(1L) shouldEqual Try(1L)
@@ -1021,7 +1021,7 @@ class RecursiveConstraintsSpec extends Spec with Matchers with CheckedEquality {
       "Success(1) shouldEqual Failure(ex)" shouldNot typeCheck
       "Success(1L) shouldEqual Failure(ex)" shouldNot typeCheck
     }
-    def `on nested Try` {
+    it("on nested Try") {
       // Both sides Try
       Try(Try(1)) shouldEqual Try(Try(1L))
       Try(Try(1L)) shouldEqual Try(Try(1))

--- a/scalactic-test/src/test/scala/org/scalactic/RecursiveEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/RecursiveEqualitySpec.scala
@@ -17,12 +17,12 @@ package org.scalactic
 
 import org.scalatest._
 
-class RecursiveEqualitySpec extends Spec with Matchers with NonImplicitAssertions {
-  object `An Option` {
+class RecursiveEqualitySpec extends FunSpec with Matchers with NonImplicitAssertions {
+  describe("An Option") {
 
     implicit val strEq = StringNormalizations.lowerCased.toEquality
 
-    def `should NOT do recursive equality under the all policies by default` {
+    it("should NOT do recursive equality under the all policies by default") {
 
       // New policies
       // Both sides Some
@@ -205,7 +205,7 @@ class RecursiveEqualitySpec extends Spec with Matchers with NonImplicitAssertion
       }
     }
 
-    def `should do recursive equality under any policy under RecursiveOptionEquality` {
+    it("should do recursive equality under any policy under RecursiveOptionEquality") {
 
       import RecursiveOptionEquality._
 

--- a/scalactic-test/src/test/scala/org/scalactic/SafeSeqsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/SafeSeqsSpec.scala
@@ -17,7 +17,7 @@ package org.scalactic
 
 import org.scalatest._
 
-class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
+class SafeSeqsSpec extends FunSpec with Matchers with SafeSeqs {
 
   abstract class Fruit
   case class Apple(name: String) extends Fruit
@@ -25,9 +25,9 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
   val mac = Apple("Mcintosh")
   val navel = Orange("Navel")
 
-  object `The safeContains syntax should` {
-    object `allow type checked containership tests` {
-      def `on Array` {
+  describe("The safeContains syntax should") {
+    describe("allow type checked containership tests") {
+      it("on Array") {
 
         (Array(1, 2, 3) safeContains 1) shouldBe true
         (Array(1, 2, 3) safeContains 5) shouldBe false
@@ -35,7 +35,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         Array(mac, navel) safeContains mac
       }
-      def `on List` {
+      it("on List") {
 
         (List(1, 2, 3) safeContains 1) shouldBe true
         (List(1, 2, 3) safeContains 5) shouldBe false
@@ -43,7 +43,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         List(mac, navel) safeContains mac
       }
-      def `on Vector` {
+      it("on Vector") {
 
         (Vector(1, 2, 3) safeContains 1) shouldBe true
         (Vector(1, 2, 3) safeContains 5) shouldBe false
@@ -51,7 +51,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         Vector(mac, navel) safeContains mac
       }
-      def `on ListBuffer` {
+      it("on ListBuffer") {
 
         import scala.collection.mutable.ListBuffer
 
@@ -62,8 +62,8 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         ListBuffer(mac, navel) safeContains mac
       }
     }
-    object `allow type checked indexOf` {
-      def `on Array` {
+    describe("allow type checked indexOf") {
+      it("on Array") {
 
         Array(1, 2, 3).safeIndexOf(1) shouldBe 0
         Array(1, 2, 3).safeIndexOf(2) shouldBe 1
@@ -78,7 +78,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         Array(mac, navel).safeIndexOf(mac, 1) shouldBe -1
         Array(mac, navel).safeIndexOf(navel, 1) shouldBe 1
       }
-      def `on List` {
+      it("on List") {
 
         List(1, 2, 3).safeIndexOf(1) shouldBe 0
         List(1, 2, 3).safeIndexOf(2) shouldBe 1
@@ -93,7 +93,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         List(mac, navel).safeIndexOf(mac, 1) shouldBe -1
         List(mac, navel).safeIndexOf(navel, 1) shouldBe 1
       }
-      def `on Vector` {
+      it("on Vector") {
 
         Vector(1, 2, 3).safeIndexOf(1) shouldBe 0
         Vector(1, 2, 3).safeIndexOf(2) shouldBe 1
@@ -108,7 +108,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         Vector(mac, navel).safeIndexOf(mac, 1) shouldBe -1
         Vector(mac, navel).safeIndexOf(navel, 1) shouldBe 1
       }
-      def `on ListBuffer` {
+      it("on ListBuffer") {
 
         import scala.collection.mutable.ListBuffer
 
@@ -127,8 +127,8 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
       }
     }
 
-    object `allow type checked lastIndexOf` {
-      def `on Array` {
+    describe("allow type checked lastIndexOf") {
+      it("on Array") {
 
         Array(1, 2, 3).safeLastIndexOf(1) shouldBe 0
         Array(1, 2, 3).safeLastIndexOf(2) shouldBe 1
@@ -143,7 +143,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         Array(mac, navel).safeLastIndexOf(mac, 1) shouldBe 0
         Array(mac, navel).safeLastIndexOf(navel, 0) shouldBe -1
       }
-      def `on List` {
+      it("on List") {
 
         List(1, 2, 3).safeLastIndexOf(1) shouldBe 0
         List(1, 2, 3).safeLastIndexOf(2) shouldBe 1
@@ -158,7 +158,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         List(mac, navel).safeLastIndexOf(mac, 1) shouldBe 0
         List(mac, navel).safeLastIndexOf(navel, 0) shouldBe -1
       }
-      def `on Vector` {
+      it("on Vector") {
 
         Vector(1, 2, 3).safeLastIndexOf(1) shouldBe 0
         Vector(1, 2, 3).safeLastIndexOf(2) shouldBe 1
@@ -173,7 +173,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
         Vector(mac, navel).safeLastIndexOf(mac, 1) shouldBe 0
         Vector(mac, navel).safeLastIndexOf(navel, 0) shouldBe -1
       }
-      def `on ListBuffer` {
+      it("on ListBuffer") {
 
         import scala.collection.mutable.ListBuffer
 
@@ -192,8 +192,8 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
       }
     }
 
-    object `allow type checked indexOfSlice` {
-      def `on Array` {
+    describe("allow type checked indexOfSlice") {
+      it("on Array") {
 
         Array(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3)) shouldBe 1
         Array(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3), 3) shouldBe -1
@@ -219,7 +219,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """Array("1", "2", "3", "4", "5").safeIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on List` {
+      it("on List") {
 
         List(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3)) shouldBe 1
         List(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3), 3) shouldBe -1
@@ -245,7 +245,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """List("1", "2", "3", "4", "5").safeIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on Vector` {
+      it("on Vector") {
 
         Vector(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3)) shouldBe 1
         Vector(1, 2, 3, 4, 5).safeIndexOfSlice(List(2, 3), 3) shouldBe -1
@@ -271,7 +271,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """Vector("1", "2", "3", "4", "5").safeIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on ListBuffer` {
+      it("on ListBuffer") {
 
         import scala.collection.mutable.ListBuffer
 
@@ -301,8 +301,8 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
       }
     }
 
-    object `allow type checked lastIndexOfSlice` {
-      def `on Array` {
+    describe("allow type checked lastIndexOfSlice") {
+      it("on Array") {
 
         Array(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3)) shouldBe 1
         Array(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3), 3) shouldBe 1
@@ -334,7 +334,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """Array("1", "2", "3", "4", "5").safeLastIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on List` {
+      it("on List") {
 
         List(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3)) shouldBe 1
         List(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3), 3) shouldBe 1
@@ -366,7 +366,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """List("1", "2", "3", "4", "5").safeLastIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on Vector` {
+      it("on Vector") {
 
         Vector(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3)) shouldBe 1
         Vector(1, 2, 3, 4, 5).safeLastIndexOfSlice(List(2, 3), 3) shouldBe 1
@@ -398,7 +398,7 @@ class SafeSeqsSpec extends Spec with Matchers with SafeSeqs {
 
         """List("1", "2", "3", "4", "5").safeLastIndexOfSlice(List(2, 3)) shouldBe 1""" shouldNot typeCheck
       }
-      def `on ListBuffer` {
+      it("on ListBuffer") {
 
         import scala.collection.mutable.ListBuffer
 

--- a/scalactic-test/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/SortedEquaSetSpec.scala
@@ -984,7 +984,9 @@ class SortedEquaSetSpec extends UnitSpec {
     List(number.SortedEquaSet(1, 2, 3), number.SortedEquaSet(1, 2, 3)).flatten shouldBe List(1, 2, 3, 1, 2, 3)
     // TODO: this is not working 2.10, we may want to enable this back when we understand better how flatten is supported by the implicit in 2.10
     //List(number.SortedEquaSet(1, 2, 3), number.SortedEquaSet(1, 2, 3)).toIterator.flatten.toStream shouldBe List(1, 2, 3, 1, 2, 3).toIterator.toStream
+    // SKIP-SCALATESTJS-START
     List(number.SortedEquaSet(1, 2, 3), number.SortedEquaSet(1, 2, 3)).par.flatten shouldBe List(1, 2, 3, 1, 2, 3).par
+    // SKIP-SCALATESTJS-END
   }
   it should "have a flatten method that works on nested GenTraversable" in {
     numberList.SortedEquaSet(List(1, 2), List(3)).flatten shouldBe List(1, 2, 3)
@@ -1797,12 +1799,14 @@ class SortedEquaSetSpec extends UnitSpec {
   it should "have a toMap method" in {
     numberLower.SortedEquaSet((1, "one"), (2, "two"), (3, "three")).toMap shouldBe Map(1 -> "one", 2 -> "two", 3 -> "three")
   }
+  // SKIP-SCALATESTJS-START
   it should "have a toParArray method" in {
     number.SortedEquaSet(1, 2, 3).toParArray shouldBe ParArray(1, 2, 3)
   }
   it should "have a toEquaBoxParArray method" in {
     number.SortedEquaSet(1, 2, 3).toEquaBoxParArray shouldBe ParArray(number.EquaBox(1), number.EquaBox(2), number.EquaBox(3))
   }
+  // SKIP-SCALATESTJS-END
   it should "have a toSeq method" in {
     number.SortedEquaSet(1, 2, 3).toSeq shouldBe (Seq(1, 2, 3))
     lower.SortedEquaSet("a", "b").toSeq shouldBe (Seq("a", "b"))

--- a/scalactic-test/src/test/scala/org/scalactic/StrictEnabledEqualityCooperatingAnyValsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/StrictEnabledEqualityCooperatingAnyValsSpec.scala
@@ -23,10 +23,10 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnabledEquality {
+class StrictEnabledEqualityCooperatingAnyValsSpec extends FunSpec with StrictEnabledEquality {
 
-  object `The StrictEnabledEquality trait` {
-    def `should disallow equality comparisons between types that co-operate in Scala` {
+  describe("The StrictEnabledEquality trait") {
+    it("should disallow equality comparisons between types that co-operate in Scala") {
 
       val aChar: Char = 'c'
       val aByte: Byte = 99
@@ -35,8 +35,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       val aLong: Long = 99L
       val aFloat: Float = 99.0F
       val aDouble: Double = 99.0
+      // SKIP-SCALATESTJS-START
       val aBigInt: BigInt = BigInt(99)
       val aBigDecimal: BigDecimal = BigDecimal(99.0)
+      // SKIP-SCALATESTJS-END
       val aJavaCharacter: java.lang.Character = new java.lang.Character('c')
       val aJavaByte: java.lang.Byte = new java.lang.Byte(99.toByte)
       val aJavaShort: java.lang.Short = new java.lang.Short(99.toShort)
@@ -55,8 +57,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aChar === aLong")
       assertTypeError("aChar === aFloat")
       assertTypeError("aChar === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aChar === aBigInt")
       assertTypeError("aChar === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aChar === aJavaCharacter")
       assertTypeError("aChar === aJavaByte")
       assertTypeError("aChar === aJavaShort")
@@ -72,8 +76,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aByte === aLong")
       assertTypeError("aByte === aFloat")
       assertTypeError("aByte === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aByte === aBigInt")
       assertTypeError("aByte === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aByte === aJavaCharacter")
       assertTypeError("aByte === aJavaByte")
       assertTypeError("aByte === aJavaShort")
@@ -89,8 +95,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aShort === aLong")
       assertTypeError("aShort === aFloat")
       assertTypeError("aShort === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aShort === aBigInt")
       assertTypeError("aShort === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aShort === aJavaCharacter")
       assertTypeError("aShort === aJavaByte")
       assertTypeError("aShort === aJavaShort")
@@ -106,8 +114,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("anInt === aLong")
       assertTypeError("anInt === aFloat")
       assertTypeError("anInt === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("anInt === aBigInt")
       assertTypeError("anInt === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("anInt === aJavaCharacter")
       assertTypeError("anInt === aJavaByte")
       assertTypeError("anInt === aJavaShort")
@@ -123,8 +133,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assert(aLong === aLong)
       assertTypeError("aLong === aFloat")
       assertTypeError("aLong === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aLong === aBigInt")
       assertTypeError("aLong === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aLong === aJavaCharacter")
       assertTypeError("aLong === aJavaByte")
       assertTypeError("aLong === aJavaShort")
@@ -140,8 +152,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aFloat === aLong")
       assert(aFloat === aFloat)
       assertTypeError("aFloat === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aFloat === aBigInt")
       assertTypeError("aFloat === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aFloat === aJavaCharacter")
       assertTypeError("aFloat === aJavaByte")
       assertTypeError("aFloat === aJavaShort")
@@ -157,8 +171,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aDouble === aLong")
       assertTypeError("aDouble === aFloat")
       assert(aDouble === aDouble)
+      // SKIP-SCALATESTJS-START
       assertTypeError("aDouble === aBigInt")
       assertTypeError("aDouble === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aDouble === aJavaCharacter")
       assertTypeError("aDouble === aJavaByte")
       assertTypeError("aDouble === aJavaShort")
@@ -174,8 +190,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aBigInt === aLong")
       assertTypeError("aBigInt === aFloat")
       assertTypeError("aBigInt === aDouble")
+      // SKIP-SCALATESTJS-START
       assert(aBigInt === aBigInt)
       assertTypeError("aBigInt === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aBigInt === aJavaCharacter")
       assertTypeError("aBigInt === aJavaByte")
       assertTypeError("aBigInt === aJavaShort")
@@ -191,8 +209,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aBigDecimal === aLong")
       assertTypeError("aBigDecimal === aFloat")
       assertTypeError("aBigDecimal === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aBigDecimal === aBigInt")
       assert(aBigDecimal === aBigDecimal)
+      // SKIP-SCALATESTJS-END
       assertTypeError("aBigDecimal === aJavaCharacter")
       assertTypeError("aBigDecimal === aJavaByte")
       assertTypeError("aBigDecimal === aJavaShort")
@@ -208,8 +228,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaCharacter === aLong")
       assertTypeError("aJavaCharacter === aFloat")
       assertTypeError("aJavaCharacter === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaCharacter === aBigInt")
       assertTypeError("aJavaCharacter === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assert(aJavaCharacter === aJavaCharacter)
       assertTypeError("aJavaCharacter === aJavaByte")
       assertTypeError("aJavaCharacter === aJavaShort")
@@ -225,8 +247,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaByte === aLong")
       assertTypeError("aJavaByte === aFloat")
       assertTypeError("aJavaByte === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaByte === aBigInt")
       assertTypeError("aJavaByte === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaByte === aJavaCharacter")
       assert(aJavaByte === aJavaByte)
       assertTypeError("aJavaByte === aJavaShort")
@@ -242,8 +266,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaShort === aLong")
       assertTypeError("aJavaShort === aFloat")
       assertTypeError("aJavaShort === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaShort === aBigInt")
       assertTypeError("aJavaShort === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaShort === aJavaCharacter")
       assertTypeError("aJavaShort === aJavaByte")
       assert(aJavaShort === aJavaShort)
@@ -259,8 +285,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaInteger === aLong")
       assertTypeError("aJavaInteger === aFloat")
       assertTypeError("aJavaInteger === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaInteger === aBigInt")
       assertTypeError("aJavaInteger === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaInteger === aJavaCharacter")
       assertTypeError("aJavaInteger === aJavaByte")
       assertTypeError("aJavaInteger === aJavaShort")
@@ -276,8 +304,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaLong === aLong")
       assertTypeError("aJavaLong === aFloat")
       assertTypeError("aJavaLong === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaLong === aBigInt")
       assertTypeError("aJavaLong === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaLong === aJavaCharacter")
       assertTypeError("aJavaLong === aJavaByte")
       assertTypeError("aJavaLong === aJavaShort")
@@ -293,8 +323,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaFloat === aLong")
       assertTypeError("aJavaFloat === aFloat")
       assertTypeError("aJavaFloat === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaFloat === aBigInt")
       assertTypeError("aJavaFloat === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaFloat === aJavaCharacter")
       assertTypeError("aJavaFloat === aJavaByte")
       assertTypeError("aJavaFloat === aJavaShort")
@@ -310,8 +342,10 @@ class StrictEnabledEqualityCooperatingAnyValsSpec extends Spec with StrictEnable
       assertTypeError("aJavaDouble === aLong")
       assertTypeError("aJavaDouble === aFloat")
       assertTypeError("aJavaDouble === aDouble")
+      // SKIP-SCALATESTJS-START
       assertTypeError("aJavaDouble === aBigInt")
       assertTypeError("aJavaDouble === aBigDecimal")
+      // SKIP-SCALATESTJS-END
       assertTypeError("aJavaDouble === aJavaCharacter")
       assertTypeError("aJavaDouble === aJavaByte")
       assertTypeError("aJavaDouble === aJavaShort")

--- a/scalactic-test/src/test/scala/org/scalactic/UncheckedEqualitySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/UncheckedEqualitySpec.scala
@@ -23,7 +23,7 @@ import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
 
-class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
+class UncheckedEqualitySpec extends FunSpec with NonImplicitAssertions {
 
   case class Super(size: Int)
   class Sub(sz: Int) extends Super(sz)
@@ -34,11 +34,11 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
   val sub2: Sub = new Sub(2)
   val nullSuper: Super = null
 
-  object `the custom equality === operator` {
+  describe("the custom equality === operator") {
 
-    object `with UncheckedEquality` {
+    describe("with UncheckedEquality") {
 
-      def `should compare anything with anything` {
+      it("should compare anything with anything") {
 
         new UncheckedEquality {
 
@@ -74,7 +74,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with TypeCheckedTripleEquals locally when UncheckedEquality imported` {
+      it("should be overridable with TypeCheckedTripleEquals locally when UncheckedEquality imported") {
 
         object O extends UncheckedEquality
         import O._
@@ -120,7 +120,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with TypeCheckedTripleEquals locally when UncheckedEquality mixed in` {
+      it("should be overridable with TypeCheckedTripleEquals locally when UncheckedEquality mixed in") {
 
         object O extends UncheckedEquality {
 
@@ -166,7 +166,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with ConversionCheckedTripleEquals locally when UncheckedEquality imported` {
+      it("should be overridable with ConversionCheckedTripleEquals locally when UncheckedEquality imported") {
 
         object O extends UncheckedEquality
         import O._
@@ -213,7 +213,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with ConversionCheckedTripleEquals locally when UncheckedEquality mixed in` {
+      it("should be overridable with ConversionCheckedTripleEquals locally when UncheckedEquality mixed in") {
 
         object O extends UncheckedEquality {
 
@@ -261,9 +261,9 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
       }
     }
 
-    object `with TypeCheckedTripleEquals` {
+    describe("with TypeCheckedTripleEquals") {
 
-      def `should compare supertypes with subtypes on either side` {
+      it("should compare supertypes with subtypes on either side") {
 
         new TypeCheckedTripleEquals {
 
@@ -314,7 +314,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       } // TODO: Do this kind of thing for CheckedEquality
 
-      def `should be overridable with UncheckedEquality locally when TypeCheckedTripleEquals imported` {
+      it("should be overridable with UncheckedEquality locally when TypeCheckedTripleEquals imported") {
 
         object O extends TypeCheckedTripleEquals
         import O._
@@ -345,7 +345,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with UncheckedEquality locally when TypeCheckedTripleEquals mixed in` {
+      it("should be overridable with UncheckedEquality locally when TypeCheckedTripleEquals mixed in") {
 
         object O extends TypeCheckedTripleEquals {
 
@@ -376,7 +376,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with ConversionCheckedTripleEquals locally when TypeCheckedTripleEquals imported` {
+      it("should be overridable with ConversionCheckedTripleEquals locally when TypeCheckedTripleEquals imported") {
 
         object O extends TypeCheckedTripleEquals
         import O._
@@ -423,7 +423,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with ConversionCheckedTripleEquals locally when TypeCheckedTripleEquals mixed in` {
+      it("should be overridable with ConversionCheckedTripleEquals locally when TypeCheckedTripleEquals mixed in") {
 
         object O extends TypeCheckedTripleEquals {
 
@@ -471,9 +471,9 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
       }
     }
 
-    object `with ConversionCheckedTripleEquals` {
+    describe("with ConversionCheckedTripleEquals") {
 
-      def `should compare supertypes with subtypes on either side as well as types with implicit conversions in either direction` {
+      it("should compare supertypes with subtypes on either side as well as types with implicit conversions in either direction") {
 
         new ConversionCheckedTripleEquals {
 
@@ -526,7 +526,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with UncheckedEquality locally when ConversionCheckedTripleEquals imported` {
+      it("should be overridable with UncheckedEquality locally when ConversionCheckedTripleEquals imported") {
 
         object O extends ConversionCheckedTripleEquals
         import O._
@@ -557,7 +557,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with UncheckedEquality locally when ConversionCheckedTripleEquals mixed in` {
+      it("should be overridable with UncheckedEquality locally when ConversionCheckedTripleEquals mixed in") {
 
         object O extends ConversionCheckedTripleEquals {
 
@@ -588,7 +588,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with TypeCheckedTripleEquals locally when ConversionCheckedTripleEquals imported` {
+      it("should be overridable with TypeCheckedTripleEquals locally when ConversionCheckedTripleEquals imported") {
 
         object O extends ConversionCheckedTripleEquals
         import O._
@@ -634,7 +634,7 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
         }
       }
 
-      def `should be overridable with TypeCheckedTripleEquals locally when ConversionCheckedTripleEquals mixed in` {
+      it("should be overridable with TypeCheckedTripleEquals locally when ConversionCheckedTripleEquals mixed in") {
 
         object O extends ConversionCheckedTripleEquals {
 
@@ -682,11 +682,11 @@ class UncheckedEqualitySpec extends Spec with NonImplicitAssertions {
     }
   }
 
-  object `TripleEqualsInvocation ` {
+  describe("TripleEqualsInvocation ") {
     
     import EqualityPolicy.TripleEqualsInvocation
     
-    def `should have pretty toString` {
+    it("should have pretty toString") {
       val result1 = new TripleEqualsInvocation("Bob", true)
       assert(result1.toString == "=== \"Bob\"")
       

--- a/scalatest-test/src/test/scala/org/scalatest/enablers/CollectingSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/enablers/CollectingSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalatest._
 import org.scalactic.{Equality, Entry}

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FeatureSpecLike extends FeatureSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FlatSpecLike extends FlatSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FreeSpecLike extends FreeSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FunSpecLike extends FunSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FunSuiteLike extends FunSuiteRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait PropSpecLike extends PropSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait WordSpecLike extends WordSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/enablers/Collecting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Collecting.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.Every
 import scala.collection.GenTraversable

--- a/scalatest/src/main/scala/org/scalatest/enablers/Definition.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Definition.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 /**
  * Supertrait for typeclasses that enable the <code>be defined</code> matcher syntax.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Emptiness.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Emptiness.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.Equality
 import org.scalactic.ArrayWrapper

--- a/scalatest/src/main/scala/org/scalatest/enablers/Existence.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Existence.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 /**
  * Supertrait for typeclasses that enable the <code>exist</code> matcher syntax.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Length.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Length.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 /**
  * Supertrait for <code>Length</code> typeclasses.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Messaging.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Messaging.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 /**
  * Supertrait for <code>Messaging</code> typeclasses.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Readability.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Readability.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.Equality
 import org.scalactic.ArrayWrapper

--- a/scalatest/src/main/scala/org/scalatest/enablers/Size.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Size.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 /**
  * Supertrait for <code>Size</code> typeclasses.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Slicing.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Slicing.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.{Equality, Every, ArrayWrapper}
 import scala.collection.GenTraversable
@@ -62,7 +62,7 @@ import scala.collection.JavaConverters._
  * versus Aggregating</a> section of the main documentation for trait <code>Containing</code>.
  * </p>
  */
-private[scalactic] trait Slicing[-A] {
+private[scalatest] trait Slicing[-A] {
 
 // TODO: Write tests that a NotAllowedException is thrown when no elements are passed, maybe if only one element is passed, and 
 // likely if an object is repeated in the list.
@@ -105,7 +105,7 @@ private[scalactic] trait Slicing[-A] {
  * <li><code>java.util.Map</code></li>
  * </ul>
  */
-private[scalactic] object Slicing {
+private[scalatest] object Slicing {
 
   /**
    * Implicit to support <code>Aggregating</code> nature of <code>String</code>.

--- a/scalatest/src/main/scala/org/scalatest/enablers/Sortable.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Sortable.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.Equality
 import org.scalactic.ArrayWrapper

--- a/scalatest/src/main/scala/org/scalatest/enablers/Writability.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Writability.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.enablers
+package org.scalatest.enablers
 
 import org.scalactic.Equality
 import org.scalactic.ArrayWrapper

--- a/scalatest/src/main/scala/org/scalatest/enablers/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/package.scala
@@ -17,37 +17,8 @@ package org.scalatest
 
 package object enablers {
 
-  @deprecated("Please use org.scalactic.enablers.Collecting instead.")
-  type Collecting[E, C] = org.scalactic.enablers.Collecting[E, C]
-
-  @deprecated("Please use org.scalactic.enablers.Definition instead.")
-  type Definition[-T] = org.scalactic.enablers.Definition[T]
-
   type EvidenceThat[T] = org.scalactic.enablers.EvidenceThat[T] // TODO, just change all these
 
-  @deprecated("Please use org.scalactic.enablers.Emptiness instead.")
-  type Emptiness[-T] = org.scalactic.enablers.Emptiness[T]
-
-  @deprecated("Please use org.scalactic.enablers.Existence instead.")
-  type Existence[-S] = org.scalactic.enablers.Existence[S]
-
-  @deprecated("Please use org.scalactic.enablers.Length instead.")
-  type Length[T] = org.scalactic.enablers.Length[T]
-
-  @deprecated("Please use org.scalactic.enablers.Messaging instead.")
-  type Messaging[T] = org.scalactic.enablers.Messaging[T]
-
-  @deprecated("Please use org.scalactic.enablers.Readability instead.")
-  type Readability[-T] = org.scalactic.enablers.Readability[T]
-
-  @deprecated("Please use org.scalactic.enablers.Size instead.")
-  type Size[T] = org.scalactic.enablers.Size[T]
-
-  @deprecated("Please use org.scalactic.enablers.Sortable instead.")
-  type Sortable[-S] = org.scalactic.enablers.Sortable[S]
-
-  @deprecated("Please use org.scalactic.enablers.Writability instead.")
-  type Writability[-T] = org.scalactic.enablers.Writability[T]
 }
 
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FeatureSpecLike extends FeatureSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FlatSpecLike extends FlatSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FreeSpecLike extends FreeSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FunSpecLike extends FunSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait FunSuiteLike extends FunSuiteRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait PropSpecLike extends PropSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
@@ -15,4 +15,5 @@
  */
 package org.scalatest.fixture
 
+//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses
 trait WordSpecLike extends WordSpecRegistration with ClassicTests

--- a/scalatest/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -1376,6 +1376,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
     def be(tripleEqualsInvocation: TripleEqualsInvocation[_]): Matcher[T] =
       outerInstance.and(MatcherWords.not.be(tripleEqualsInvocation))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -1385,6 +1386,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(symbol: Symbol): Matcher[T with AnyRef] = outerInstance.and(MatcherWords.not.be(symbol))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>odd</code> is a <a href="BeMatcher.html"><code>BeMatcher</code></a>:
@@ -1406,6 +1408,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      */
     def be[U](bePropertyMatcher: BePropertyMatcher[U]): Matcher[T with AnyRef with U] = outerInstance.and(MatcherWords.not.be(bePropertyMatcher))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -1415,6 +1418,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication): Matcher[T with AnyRef] = outerInstance.and(MatcherWords.not.be(resultOfAWordApplication))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>validMarks</code> is an <a href="AMatcher.html"><code>AMatcher</code></a>:
@@ -1436,6 +1440,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      */
     def be[U <: AnyRef](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U]): Matcher[T with U] = outerInstance.and(MatcherWords.not.be(resultOfAWordApplication))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -1445,6 +1450,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication): Matcher[T with AnyRef] = outerInstance.and(MatcherWords.not.be(resultOfAnWordApplication))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>directory</code> is a <a href="BePropertyMatcher.html"><code>BePropertyMatcher</code></a>:
@@ -2679,6 +2685,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
     def be(tripleEqualsInvocation: TripleEqualsInvocation[_]): Matcher[T] =
       outerInstance.or(MatcherWords.not.be(tripleEqualsInvocation))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -2688,6 +2695,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(symbol: Symbol): Matcher[T with AnyRef] = outerInstance.or(MatcherWords.not.be(symbol))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>odd</code> is a <a href="BeMatcher.html"><code>BeMatcher</code></a>:
@@ -2709,6 +2717,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      */
     def be[U](bePropertyMatcher: BePropertyMatcher[U]): Matcher[T with AnyRef with U] = outerInstance.or(MatcherWords.not.be(bePropertyMatcher))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -2718,6 +2727,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication): Matcher[T with AnyRef] = outerInstance.or(MatcherWords.not.be(resultOfAWordApplication))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>validMarks</code> is an <a href="AMatcher.html"><code>AMatcher</code></a>:
@@ -2739,6 +2749,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      */
     def be[U <: AnyRef](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U]): Matcher[T with U] = outerInstance.or(MatcherWords.not.be(resultOfAWordApplication))
 
+    // SKIP-SCALATESTJS-START
     /**
      * This method enables the following syntax:
      *
@@ -2748,6 +2759,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      */
     def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication): Matcher[T with AnyRef] = outerInstance.or(MatcherWords.not.be(resultOfAnWordApplication))
+    // SKIP-SCALATESTJS-END
 
     /**
      * This method enables the following syntax, where <code>apple</code> is a <a href="BePropertyMatcher.html"><code>BePropertyMatcher</code></a>:

--- a/scalatest/src/main/scala/org/scalatest/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/package.scala
@@ -20,6 +20,8 @@ package org
  */
 package object scalatest {
 
+  // SKIP-SCALATESTJS-START
+
   private val defaultShell = ShellImpl()
 
   /**
@@ -66,6 +68,8 @@ package object scalatest {
    * Returns a copy of this <code>Shell</code> with <code>statsPassed</code> configuration parameter set to <code>false</code>.
    */
   lazy val nostats: Shell = defaultShell.nostats
+
+  // SKIP-SCALATESTJS-END
 
   /**
    * <p>

--- a/scalatest/src/main/scala/org/scalatest/words/BeEqualEqualWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/BeEqualEqualWord.scala
@@ -19,7 +19,9 @@ import org.scalactic.Prettifier
 import org.scalatest.{Suite, Resources}
 import org.scalatest.matchers.{MatchResult, Matcher}
 import org.scalatest.Assertions.areEqualComparingArraysStructurally
+// SKIP-SCALATESTJS-START
 import org.scalatest.MatchersHelper.matchSymbolToPredicateMethod
+// SKIP-SCALATESTJS-END
 
 /**
  * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="Matchers.html"><code>Matchers</code></a> for an overview of

--- a/scalatest/src/main/scala/org/scalatest/words/ContainWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ContainWord.scala
@@ -27,7 +27,7 @@ import org.scalatest.enablers.KeyMapping
 import org.scalatest.enablers.ValueMapping
 import org.scalatest.exceptions.NotAllowedException
 import org.scalatest.exceptions.StackDepthExceptionHelper.getStackDepthFun
-import org.scalactic.enablers.Collecting
+import org.scalatest.enablers.Collecting
 
 /**
  * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of


### PR DESCRIPTION
- Moved old enablers back into org.scalatest package.
- Necessary changes to get scalactic.js and scalatest.js tests passing.