### PR TITLE
GenContainTests2 Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -121,7 +121,7 @@ class ListShouldContainOnlySpec extends Spec {
                 case _ => a == b
               }
           }
-        List(Book("Peace", 1000), Book("War", 1100)) should contain only (BookTitled("Peace"), BookTitled("War"))
+        Vector(Book("Peace", 1000), Book("War", 1100)) should contain only (BookTitled("Peace"), BookTitled("War"))
       }
     }
 


### PR DESCRIPTION
Fixed broken genContainTests2 by using Vector for the use case test so that it won't get translated to Map/JavaMap in generated tests.