### PR TITLE
Fix ~ 50 typos

### DIFF
--- a/scalactic/src/main/scala/org/scalactic/Accumulation.scala
+++ b/scalactic/src/main/scala/org/scalactic/Accumulation.scala
@@ -54,7 +54,7 @@ trait Accumulation {
   import scala.language.{higherKinds, implicitConversions}
 
   /**
-   * Implicitly converts an accumulating <code>Or</code> to an instance of <a href="Accumulation$$Acumulatable.html"><code>Accumulatable</code></a>, which
+   * Implicitly converts an accumulating <code>Or</code> to an instance of <a href="Accumulation$$Accumulatable.html"><code>Accumulatable</code></a>, which
    * enables <code>zip</code> and <code>when</code> methods to be invoked on it.
    *
    * <p>
@@ -1739,7 +1739,7 @@ object Accumulation extends Accumulation {
     /**
      * Given a <code>Good</code> accumulating <code>Or</code>, applies the given validation functions to the <code>Good</code> value and returns
      * either the same <code>Good</code>, if all validations resulted in <code>Pass</code>, else returns a <code>Bad</code> containing every
-     * error reported by validation <code>Fail</code> results; Given a <code>Bad</code> accumualting <code>Or</code>, returns the same <code>Bad</code>.
+     * error reported by validation <code>Fail</code> results; Given a <code>Bad</code> accumulating<code>Or</code>, returns the same <code>Bad</code>.
      *
      * <p>
      * For more information and examples, see the <a href="Or.html#usingWhen">Using <code>when</code></a>

--- a/scalactic/src/main/scala/org/scalactic/Chain.scala
+++ b/scalactic/src/main/scala/org/scalactic/Chain.scala
@@ -105,7 +105,7 @@ import scala.annotation.unchecked.{ uncheckedVariance => uV }
  *
  * <p>
  * <code>Chain</code> does <em>not</em> currently define any methods corresponding to <code>Seq</code> methods that could result in
- * an empty <code>Seq</code>. However, an implicit converison from <code>Chain</code> to <code>List</code>
+ * an empty <code>Seq</code>. However, an implicit conversion from <code>Chain</code> to <code>List</code>
  * is defined in the <code>Chain</code> companion object that will be applied if you attempt to call one of the missing methods. As a
  * result, you can invoke <code>filter</code> on an <code>Chain</code>, even though <code>filter</code> could result
  * in an empty sequence&mdash;but the result type will be <code>List</code> instead of <code>Chain</code>:
@@ -537,7 +537,7 @@ final class Chain[+T] private (underlying: List[T]) extends PartialFunction[Int,
    * if all the nested <code>GenTraversableOnce</code>s were empty, you'd end up with an empty <code>Chain</code>.
    * </p>
    *
-   * @tparm B the type of the elements of each nested <code>Chain</code>
+   * @tparam B the type of the elements of each nested <code>Chain</code>
    * @return a new <code>Chain</code> resulting from concatenating all nested <code>Chain</code>s.
    */
   final def flatten[B](implicit ev: T <:< Chain[B]): Chain[B] = flatMap(ev)
@@ -1528,7 +1528,7 @@ final class Chain[+T] private (underlying: List[T]) extends PartialFunction[Int,
    * </p>
    *
    * <p>
-   * Another way to express this is that <code>chainX</code> <code>union</code> <code>everyY</code> computes the order-presevring multi-set union
+   * Another way to express this is that <code>chainX</code> <code>union</code> <code>everyY</code> computes the order-preserving multi-set union
    * of <code>chainX</code> and <code>everyY</code>. This <code>union</code> method is hence a counter-part of <code>diff</code> and <code>intersect</code> that
    * also work on multi-sets.
    * </p>
@@ -1546,7 +1546,7 @@ final class Chain[+T] private (underlying: List[T]) extends PartialFunction[Int,
    * </p>
    *
    * <p>
-   * Another way to express this is that <code>chainX</code> <code>union</code> <code>chainY</code> computes the order-presevring multi-set union
+   * Another way to express this is that <code>chainX</code> <code>union</code> <code>chainY</code> computes the order-preserving multi-set union
    * of <code>chainX</code> and <code>chainY</code>. This <code>union</code> method is hence a counter-part of <code>diff</code> and <code>intersect</code> that
    * also work on multi-sets.
    * </p>
@@ -1564,7 +1564,7 @@ final class Chain[+T] private (underlying: List[T]) extends PartialFunction[Int,
    * </p>
    *
    * <p>
-   * Another way to express this is that <code>chainX</code> <code>union</code> <code>ys</code> computes the order-presevring multi-set union
+   * Another way to express this is that <code>chainX</code> <code>union</code> <code>ys</code> computes the order-preserving multi-set union
    * of <code>chainX</code> and <code>ys</code>. This <code>union</code> method is hence a counter-part of <code>diff</code> and <code>intersect</code> that
    * also work on multi-sets.
    * </p>
@@ -1619,8 +1619,8 @@ final class Chain[+T] private (underlying: List[T]) extends PartialFunction[Int,
    * elements in pairs. If one of the two collections is shorter than the other, placeholder elements will be used to extend the
    * shorter collection to the length of the longer.
    *
-   * @tparm O the type of the second half of the returned pairs
-   * @tparm U the type of the first half of the returned pairs
+   * @tparam O the type of the second half of the returned pairs
+   * @tparam U the type of the first half of the returned pairs
    * @param other the <code>Iterable</code> providing the second half of each result pair
    * @param thisElem the element to be used to fill up the result if this <code>Chain</code> is shorter than <code>that</code> <code>Iterable</code>.
    * @param thatElem the element to be used to fill up the result if <code>that</code> <code>Iterable</code> is shorter than this <code>Chain</code>.

--- a/scalactic/src/main/scala/org/scalactic/CheckedEquality.scala
+++ b/scalactic/src/main/scala/org/scalactic/CheckedEquality.scala
@@ -36,7 +36,7 @@ import EqualityPolicy._
  * If <code>TripleEquals</code> is mixed in or imported, the <code>===</code> can be used with any two types
  * and still compile. If <code>TypeCheckedTripleEquals</code> is mixed in or imported, however, only types in 
  * a subtype or supertype relationship with each other (including when both types are exactly the same) will compile.
- * <code>ConversionCheckedTripleEquals</code> is slightly more accomodating, because in addition to compiling any
+ * <code>ConversionCheckedTripleEquals</code> is slightly more accommodating, because in addition to compiling any
  * use of <code>===</code> that will compile under <code>TypeCheckedTripleEquals</code>, it will also compile
  * type types that would be rejected by <code>TypeCheckedTripleEquals</code>, so long as an implicit
  * conversion (in either direction) from one type to another is available.

--- a/scalactic/src/main/scala/org/scalactic/ConversionCheckedTripleEquals.scala
+++ b/scalactic/src/main/scala/org/scalactic/ConversionCheckedTripleEquals.scala
@@ -36,7 +36,7 @@ import EqualityPolicy._
  * If <code>TripleEquals</code> is mixed in or imported, the <code>===</code> can be used with any two types
  * and still compile. If <code>TypeCheckedTripleEquals</code> is mixed in or imported, however, only types in 
  * a subtype or supertype relationship with each other (including when both types are exactly the same) will compile.
- * <code>ConversionCheckedTripleEquals</code> is slightly more accomodating, because in addition to compiling any
+ * <code>ConversionCheckedTripleEquals</code> is slightly more accommodating, because in addition to compiling any
  * use of <code>===</code> that will compile under <code>TypeCheckedTripleEquals</code>, it will also compile
  * type types that would be rejected by <code>TypeCheckedTripleEquals</code>, so long as an implicit
  * conversion (in either direction) from one type to another is available.

--- a/scalactic/src/main/scala/org/scalactic/CooperatingNumeric.scala
+++ b/scalactic/src/main/scala/org/scalactic/CooperatingNumeric.scala
@@ -38,7 +38,7 @@ object CooperatingNumeric {
     override def toString: String = "CooperatingNumeric[Float]"
   }
   private object CooperatingDouble extends CooperatingNumeric[Double] {
-    override def toString: String = "CooperatingNumeric[Doubl]"
+    override def toString: String = "CooperatingNumeric[Double]"
   }
   private object CooperatingBigInt extends CooperatingNumeric[BigInt] {
     override def toString: String = "CooperatingNumeric[BigInt]"

--- a/scalactic/src/main/scala/org/scalactic/EnabledEquality.scala
+++ b/scalactic/src/main/scala/org/scalactic/EnabledEquality.scala
@@ -36,7 +36,7 @@ import EqualityPolicy._
  * If <code>TripleEquals</code> is mixed in or imported, the <code>===</code> can be used with any two types
  * and still compile. If <code>TypeCheckedTripleEquals</code> is mixed in or imported, however, only types in 
  * a subtype or supertype relationship with each other (including when both types are exactly the same) will compile.
- * <code>ConversionCheckedTripleEquals</code> is slightly more accomodating, because in addition to compiling any
+ * <code>ConversionCheckedTripleEquals</code> is slightly more accommodating, because in addition to compiling any
  * use of <code>===</code> that will compile under <code>TypeCheckedTripleEquals</code>, it will also compile
  * type types that would be rejected by <code>TypeCheckedTripleEquals</code>, so long as an implicit
  * conversion (in either direction) from one type to another is available.

--- a/scalactic/src/main/scala/org/scalactic/EquaPath.scala
+++ b/scalactic/src/main/scala/org/scalactic/EquaPath.scala
@@ -1776,7 +1776,7 @@ class EquaPath[T](val equality: HashingEquality[T]) { thisEquaPath =>
     def takeRight(n: Int): thisEquaPath.FastEquaSet = new FastEquaSet(underlying.takeRight(n))
     def to[Col[_]](implicit cbf: CanBuildFrom[Nothing, thisEquaPath.EquaBox, Col[thisEquaPath.EquaBox @uV]]): Col[thisEquaPath.EquaBox @uV] = underlying.to[Col]
     def toArray: Array[T] = {
-      // A workaround becauase underlying.map(_.value).toArray does not work due to this weird error message:
+      // A workaround because underlying.map(_.value).toArray does not work due to this weird error message:
       // No ClassTag available for T
       val arr: Array[Any] = new Array[Any](underlying.size)
       underlying.map(_.value).copyToArray(arr)

--- a/scalactic/src/main/scala/org/scalactic/EqualityPolicy.scala
+++ b/scalactic/src/main/scala/org/scalactic/EqualityPolicy.scala
@@ -298,7 +298,7 @@ trait EqualityPolicy {
    * result in <code>Boolean</code> and enforce no type constraint.
    *
    * <p>
-   * This method is overridden and made implicit by subtrait <a href="TripleEquals.html"><code>TripleEquals</code></a> and overriden as non-implicit by the other
+   * This method is overridden and made implicit by subtrait <a href="TripleEquals.html"><code>TripleEquals</code></a> and overridden as non-implicit by the other
    * subtraits in this package.
    * </p>
    *
@@ -316,7 +316,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is overridden and made implicit by subtraits <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a> and
-   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>, and overriden as
+   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>, and overridden as
    * non-implicit by the other subtraits in this package.
    * </p>
    *
@@ -338,7 +338,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is overridden and made implicit by subtrait <a href="TripleEquals.html"><code>TripleEquals</code></a>
-   * and overriden as non-implicit by the other subtraits in this package.
+   * and overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equalityOfA an <code>Equality[A]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -364,7 +364,7 @@ trait EqualityPolicy {
    * This method is overridden and made implicit by subtrait
    * <a href="LowPriorityTypeCheckedConstraint.html"><code>LowPriorityTypeCheckedConstraint</code></a> (extended by
    * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equivalenceOfB an <code>Equivalence[B]</code> type class to which the <code>Constraint.areEqual</code> method
@@ -381,7 +381,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is used to enable the <a href="Explicitly.html"><code>Explicitly</code></a> DSL for
-   * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalance[B]</code>, but
+   * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalence[B]</code>, but
    * taking an implicit function that provides evidence that <code>A</code> is a subtype of </code>B</code>.
    * </p>
    *
@@ -394,7 +394,7 @@ trait EqualityPolicy {
    * This method is overridden and made implicit by subtraits
    * <a href="LowPriorityTypeCheckedConstraint.html"><code>LowPriorityTypeCheckedConstraint</code></a> (extended by
    * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equivalenceOfB an <code>Equivalence[B]</code> type class to which the <code>Constraint.areEqual</code> method
@@ -417,7 +417,7 @@ trait EqualityPolicy {
    * <p>
    * This method is overridden and made implicit by subtrait
    * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equalityOfA an <code>Equivalence[A]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -433,7 +433,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is used to enable the <a href="Explicitly.html"><code>Explicitly</code></a> DSL for
-   * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalance[B]</code>, but
+   * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalence[B]</code>, but
    * taking an implicit function that provides evidence that <code>A</code> is a subtype of </code>B</code>. For example, under <code>TypeCheckedTripleEquals</code>,
    * this method (as an implicit method), would be used to compile this statement:
    * </p>
@@ -451,7 +451,7 @@ trait EqualityPolicy {
    * <p>
    * This method is overridden and made implicit by subtrait
    * <a href="TypeCheckedTripleEquals.html"><code>TypeCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equalityOfA an <code>Equivalence[A]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -479,7 +479,7 @@ trait EqualityPolicy {
    * This method is overridden and made implicit by subtrait
    * <a href="LowPriorityConversionCheckedConstraint.html"><code>LowPriorityConversionCheckedConstraint</code></a> (extended by
    * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equalityOfB an <code>Equivalence[B]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -495,7 +495,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is used to enable the <a href="Explicitly.html"><code>Explicitly</code></a> DSL for
-   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalance[B]</code>, but
+   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalence[B]</code>, but
    * taking an implicit function that converts from <code>A</code> to </code>B</code>.
    * </p>
    *
@@ -508,7 +508,7 @@ trait EqualityPolicy {
    * This method is overridden and made implicit by subtraits
    * <a href="LowPriorityConversionCheckedConstraint.html"><code>LowPriorityConversionCheckedConstraint</code></a> (extended by
    * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equalityOfB an <code>Equivalence[B]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -530,7 +530,7 @@ trait EqualityPolicy {
    * <p>
    * This method is overridden and made implicit by subtrait
    * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equivalenceOfA an <code>Equivalence[A]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.
@@ -546,7 +546,7 @@ trait EqualityPolicy {
    *
    * <p>
    * This method is used to enable the <a href="Explicitly.html"><code>Explicitly</code></a> DSL for
-   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalance[A]</code>, but
+   * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a> by requiring an explicit <code>Equivalence[A]</code>, but
    * taking an implicit function that converts from <code>B</code> to </code>A</code>. For example, under <code>ConversionCheckedTripleEquals</code>,
    * this method (as an implicit method), would be used to compile this statement:
    * </p>
@@ -564,7 +564,7 @@ trait EqualityPolicy {
    * <p>
    * This method is overridden and made implicit by subtrait
    * <a href="ConversionCheckedTripleEquals.html"><code>ConversionCheckedTripleEquals</code></a>) and
-   * overriden as non-implicit by the other subtraits in this package.
+   * overridden as non-implicit by the other subtraits in this package.
    * </p>
    *
    * @param equivalenceOfA an <code>Equivalence[A]</code> type class to which the <code>Constraint.areEqual</code> method will delegate to determine equality.

--- a/scalactic/src/main/scala/org/scalactic/Equivalence.scala
+++ b/scalactic/src/main/scala/org/scalactic/Equivalence.scala
@@ -27,7 +27,7 @@ package org.scalactic
  * and ScalaTest's <code>should</code> <code>===</code> syntax of <code>Matchers</code> trait. 
  * </p>
  *
- * <a name="equivalanceLaws"></a>
+ * <a name="equivalenceLaws"></a>
  * <h2>Equivalence laws</h2>
  *
  * <p>

--- a/scalactic/src/main/scala/org/scalactic/Every.scala
+++ b/scalactic/src/main/scala/org/scalactic/Every.scala
@@ -94,7 +94,7 @@ import scala.annotation.unchecked.{ uncheckedVariance => uV }
  *
  * <p>
  * <code>Every</code> does <em>not</em> currently define any methods corresponding to <code>Seq</code> methods that could result in
- * an empty <code>Seq</code>. However, an implicit converison from <code>Every</code> to <code>collection.immutable.IndexedSeq</code>
+ * an empty <code>Seq</code>. However, an implicit conversion from <code>Every</code> to <code>collection.immutable.IndexedSeq</code>
  * is defined in the <code>Every</code> companion object that will be applied if you attempt to call one of the missing methods. As a
  * result, you can invoke <code>filter</code> on an <code>Every</code>, even though <code>filter</code> could result
  * in an empty sequence&mdash;but the result type will be <code>collection.immutable.IndexedSeq</code> instead of <code>Every</code>:
@@ -453,7 +453,7 @@ sealed abstract class Every[+T] protected (underlying: Vector[T]) extends Partia
    * if all the nested <code>GenTraversableOnce</code>s were empty, you'd end up with an empty <code>Every</code>.
    * </p>
    *
-   * @tparm B the type of the elements of each nested <code>Every</code>
+   * @tparam B the type of the elements of each nested <code>Every</code>
    * @return a new <code>Every</code> resulting from concatenating all nested <code>Every</code>s.
    */
   final def flatten[B](implicit ev: T <:< Every[B]): Every[B] = flatMap(ev)
@@ -1449,8 +1449,8 @@ sealed abstract class Every[+T] protected (underlying: Vector[T]) extends Partia
    * elements in pairs. If one of the two collections is shorter than the other, placeholder elements will be used to extend the
    * shorter collection to the length of the longer.
    *
-   * @tparm O the type of the second half of the returned pairs
-   * @tparm U the type of the first half of the returned pairs
+   * @tparam O the type of the second half of the returned pairs
+   * @tparam U the type of the first half of the returned pairs
    * @param other the <code>Iterable</code> providing the second half of each result pair
    * @param thisElem the element to be used to fill up the result if this <code>Every</code> is shorter than <code>that</code> <code>Iterable</code>.
    * @param thatElem the element to be used to fill up the result if <code>that</code> <code>Iterable</code> is shorter than this <code>Every</code>.

--- a/scalactic/src/main/scala/org/scalactic/HashingEquality.scala
+++ b/scalactic/src/main/scala/org/scalactic/HashingEquality.scala
@@ -18,7 +18,7 @@ package org.scalactic
 /**
  * An <code>Equality[T]</code> that offers a <code>hashCodeFor</code> method that
  * can provide an <code>Int</code> hash code for a given <code>T</code> instance, whose
- * contract is constrainted by that of <code>areEqual</code>.
+ * contract is constrained by that of <code>areEqual</code>.
  *
  * <p>
  * The general contract of <code>hashCodeFor</code> is:

--- a/scalactic/src/main/scala/org/scalactic/LowPriorityCheckedEqualityConstraints.scala
+++ b/scalactic/src/main/scala/org/scalactic/LowPriorityCheckedEqualityConstraints.scala
@@ -22,7 +22,7 @@ import EqualityPolicy._
  * is not applicable.
  *
  * <p>
- * The purpose of this trait is to make the <code>===</code> operator symetric. In other words, a <code>===</code> invocation
+ * The purpose of this trait is to make the <code>===</code> operator symmetric. In other words, a <code>===</code> invocation
  * will be allowed if subtype relationship exists in either direction. For example, in the following expression, the left hand
  * side is a subtype of the right hand side:
  * </p>

--- a/scalactic/src/main/scala/org/scalactic/LowPriorityEnabledEqualityConstraints.scala
+++ b/scalactic/src/main/scala/org/scalactic/LowPriorityEnabledEqualityConstraints.scala
@@ -36,7 +36,7 @@ import EqualityPolicy._
  * If <code>TripleEquals</code> is mixed in or imported, the <code>===</code> can be used with any two types
  * and still compile. If <code>TypeCheckedTripleEquals</code> is mixed in or imported, however, only types in 
  * a subtype or supertype relationship with each other (including when both types are exactly the same) will compile.
- * <code>ConversionCheckedTripleEquals</code> is slightly more accomodating, because in addition to compiling any
+ * <code>ConversionCheckedTripleEquals</code> is slightly more accommodating, because in addition to compiling any
  * use of <code>===</code> that will compile under <code>TypeCheckedTripleEquals</code>, it will also compile
  * type types that would be rejected by <code>TypeCheckedTripleEquals</code>, so long as an implicit
  * conversion (in either direction) from one type to another is available.

--- a/scalactic/src/main/scala/org/scalactic/Or.scala
+++ b/scalactic/src/main/scala/org/scalactic/Or.scala
@@ -384,7 +384,7 @@ import scala.collection.mutable.Builder
  * <h2>Other ways to accumulate errors</h2>
 
  * <p>
- * The <code>Accumlation</code> trait also enables other ways of accumulating errors.
+ * The <code>Accumulation</code> trait also enables other ways of accumulating errors.
  * </p>
  *
  * <a name="usingCombined"></a>
@@ -430,7 +430,7 @@ import scala.collection.mutable.Builder
  *
  * <p>
  * You can also zip two accumulating <code>Or</code>s together. If both are <code>Good</code>, you'll get a 
- * <code>Good</code> tuple containin both original <code>Good</code> values. Otherwise, you'll get a <code>Bad</code>
+ * <code>Good</code> tuple containing both original <code>Good</code> values. Otherwise, you'll get a <code>Bad</code>
  * containing every error message. Here are some examples:
  * </p>
  *
@@ -449,7 +449,7 @@ import scala.collection.mutable.Builder
  * <h3>Using <code>when</code></h3>
  *
  * <p>
- * In addition, given an accumlating <code>Or</code>, you can pass one or more <em>validation functions</em> to <code>when</code> on the <code>Or</code>
+ * In addition, given an accumulating <code>Or</code>, you can pass one or more <em>validation functions</em> to <code>when</code> on the <code>Or</code>
  * to submit that <code>Or</code> to further scrutiny. A validation function accepts a <code>Good</code> type and returns a <code>Validation[E]</code>,
  * where <code>E</code> is the type in the <code>Every</code> in the <code>Bad</code> type. For an <code>Int</code> <code>Or</code> <code>One[ErrorMessage]</code>, for example
  * the validation function type would be <code>Int</code> <code>=&gt;</code> <code>Validation[ErrorMessage]</code>. Here are a few examples:
@@ -465,7 +465,7 @@ import scala.collection.mutable.Builder
  * 
  * <p>
  * If the <code>Or</code> on which you call <code>when</code> is already <code>Bad</code>, you get the same (<code>Bad</code>) <code>Or</code> back, because
- * no <code>Good</code> value exists to pass to the valiation functions:
+ * no <code>Good</code> value exists to pass to the validation functions:
  * </p>
  * 
  * <pre class="stHighlight">
@@ -745,7 +745,7 @@ sealed abstract class Or[+G,+B] {
    * containing the <code>Bad</code> value, if this is a <code>Bad</code>.
    *
    * <p>
-   * Note that values effectively &ldquo;switch sides&rdquo; when convering an <code>Or</code> to an <code>Either</code>. If the type of the
+   * Note that values effectively &ldquo;switch sides&rdquo; when converting an <code>Or</code> to an <code>Either</code>. If the type of the
    * <code>Or</code> on which you invoke <code>toEither</code> is <code>Or[Int, ErrorMessage]</code> for example, the result will be an
    * <code>Either[ErrorMessage, Int]</code>. The reason is that the convention for <code>Either</code> is that <code>Left</code> is used for &ldquo;bad&rdquo;
    * values and <code>Right</code> is used for &ldquo;good&rdquo; ones.

--- a/scalactic/src/main/scala/org/scalactic/PrettyMethods.scala
+++ b/scalactic/src/main/scala/org/scalactic/PrettyMethods.scala
@@ -26,7 +26,7 @@ trait PrettyMethods {
    *
    * <p>
    * This class exists so that instances of <code>PrettifierConfig</code> can be made implicit instead
-   * of <code>Prettifer</code>. Because <code>Prettifier</code> is a <code>Any =&gt; String</code>, 
+   * of <code>Prettifier</code>. Because <code>Prettifier</code> is a <code>Any =&gt; String</code>,
    * making it implicit could result in unintentional applications.
    * </p>
    *

--- a/scalactic/src/main/scala/org/scalactic/Snapshots.scala
+++ b/scalactic/src/main/scala/org/scalactic/Snapshots.scala
@@ -30,7 +30,7 @@ import reflect.macros.Context
 final case class Snapshot(name: String, value: Any) {
 
   /**
-   * Overriden <code>toString</code> to print in {name} = {value} format.
+   * Overridden <code>toString</code> to print in {name} = {value} format.
    *
    * @return string in {name} = {value} format
    */

--- a/scalactic/src/main/scala/org/scalactic/SortedEquaPath.scala
+++ b/scalactic/src/main/scala/org/scalactic/SortedEquaPath.scala
@@ -754,7 +754,7 @@ class SortedEquaPath[T](override val equality: OrderingEquality[T]) extends Equa
     def takeRight(n: Int): thisEquaPath.TreeEquaSet = new TreeEquaSet(underlying.takeRight(n))
     def to[Col[_]](implicit cbf: CanBuildFrom[Nothing, thisEquaPath.EquaBox, Col[thisEquaPath.EquaBox @uV]]): Col[thisEquaPath.EquaBox @uV] = underlying.to[Col]
     def toArray: Array[T] = {
-      // A workaround becauase underlying.map(_.value).toArray does not work due to this weird error message:
+      // A workaround because underlying.map(_.value).toArray does not work due to this weird error message:
       // No ClassTag available for T
       val arr: Array[Any] = new Array[Any](underlying.size)
       underlying.map(_.value).copyToArray(arr)

--- a/scalactic/src/main/scala/org/scalactic/TraversableEqualityConstraints.scala
+++ b/scalactic/src/main/scala/org/scalactic/TraversableEqualityConstraints.scala
@@ -101,7 +101,7 @@ package org.scalactic
  * 
  * @author Bill Venners
  */
-@deprecated("TraversableEqualityConstraints has been deprecated and will be removed in a future version of ScalaTest. You should be able to just remove all mentions of TraversableEqualityConstriants, as the contraints it provided have been added to the Constraint companion object.")
+@deprecated("TraversableEqualityConstraints has been deprecated and will be removed in a future version of ScalaTest. You should be able to just remove all mentions of TraversableEqualityConstraints, as the constraints it provided have been added to the Constraint companion object.")
 trait TraversableEqualityConstraints extends SeqEqualityConstraints with SetEqualityConstraints with MapEqualityConstraints
 
 /**
@@ -109,5 +109,5 @@ trait TraversableEqualityConstraints extends SeqEqualityConstraints with SetEqua
  * an alternative to mixing it in. One use case is to import <code>TraversableEqualityConstraints</code> members so you can use
  * them in the Scala interpreter.
  */
-@deprecated("TraversableEqualityConstraints has been deprecated and will be removed in a future version of ScalaTest. You should be able to just remove all mentions of TraversableEqualityConstriants, as the contraints it provided have been added to the Constraint companion object.")
+@deprecated("TraversableEqualityConstraints has been deprecated and will be removed in a future version of ScalaTest. You should be able to just remove all mentions of TraversableEqualityConstraints, as the constraints it provided have been added to the Constraint companion object.")
 object TraversableEqualityConstraints extends TraversableEqualityConstraints

--- a/scalactic/src/main/scala/org/scalactic/TypeCheckedTripleEquals.scala
+++ b/scalactic/src/main/scala/org/scalactic/TypeCheckedTripleEquals.scala
@@ -36,7 +36,7 @@ import EqualityPolicy._
  * If <code>TripleEquals</code> is mixed in or imported, the <code>===</code> can be used with any two types
  * and still compile. If <code>TypeCheckedTripleEquals</code> is mixed in or imported, however, only types in 
  * a subtype or supertype relationship with each other (including when both types are exactly the same) will compile.
- * <code>ConversionCheckedTripleEquals</code> is slightly more accomodating, because in addition to compiling any
+ * <code>ConversionCheckedTripleEquals</code> is slightly more accommodating, because in addition to compiling any
  * use of <code>===</code> that will compile under <code>TypeCheckedTripleEquals</code>, it will also compile
  * type types that would be rejected by <code>TypeCheckedTripleEquals</code>, so long as an implicit
  * conversion (in either direction) from one type to another is available.

--- a/scalactic/src/main/scala/org/scalactic/Validation.scala
+++ b/scalactic/src/main/scala/org/scalactic/Validation.scala
@@ -47,7 +47,7 @@ package org.scalactic
  *
  * <p>
  * <code>Validation</code>s can also be used to accumulate error using <code>when</code>, a method that's made available by trait <code>Accumulation</code> on
- * accumualting <code>Or</code>s (<code>Or</code>s whose <code>Bad</code> type is an <code>Every[T]</code>). Here are some examples:
+ * accumulating <code>Or</code>s (<code>Or</code>s whose <code>Bad</code> type is an <code>Every[T]</code>). Here are some examples:
  * </p>
  *
  * <pre class="stHighlight">

--- a/scalactic/src/main/scala/org/scalactic/algebra/Applicative.scala
+++ b/scalactic/src/main/scala/org/scalactic/algebra/Applicative.scala
@@ -25,7 +25,7 @@ import scala.language.higherKinds
  * and <code>applying</code> methods that obey laws of <em>homomorphism</em> and <em>interchange</em>.
  *
  * <p>
- * The <em>homomorhphism law</em> states that given a value, <code>a</code>, of type <code>A</code> and
+ * The <em>homomorphism law</em> states that given a value, <code>a</code>, of type <code>A</code> and
  * a function, <code>f</code>, of type <code>A =&gt; B</code> (and implicit <code>Applicative.adapters</code> imported): 
  * </p>
  *

--- a/scalactic/src/main/scala/org/scalactic/enablers/ContainingConstraint.scala
+++ b/scalactic/src/main/scala/org/scalactic/enablers/ContainingConstraint.scala
@@ -66,7 +66,7 @@ import annotation.implicitNotFound
  * </pre>
  * 
  * <p>
- * The above assertion could never succceed, because an option cannot contain more than
+ * The above assertion could never succeed, because an option cannot contain more than
  * one value. By default the above statement does not compile, because <code>contain</code> <code>allOf</code>
  * is enabled by <code>Aggregating</code>, and ScalaTest provides no implicit <code>Aggregating</code> instance
  * for type <code>scala.Option</code>.

--- a/scalactic/src/main/scala/org/scalactic/enablers/SequencingConstraint.scala
+++ b/scalactic/src/main/scala/org/scalactic/enablers/SequencingConstraint.scala
@@ -26,7 +26,7 @@ import annotation.implicitNotFound
  * Typeclass that enables for sequencing certain <code>contain</code> syntax in the ScalaTest matchers DSL.
  *
  * <p>
- * An <code>Sequencing[A]</code> provides access to the "sequenching nature" of type <code>A</code> in such
+ * An <code>Sequencing[A]</code> provides access to the "sequencing nature" of type <code>A</code> in such
  * a way that relevant <code>contain</code> matcher syntax can be used with type <code>A</code>. An <code>A</code>
  * can be any type of <em>sequencing</em>&#8212;an object that in some way brings together other objects in order.
  * ScalaTest provides implicit implementations for several types out of the box in the
@@ -75,7 +75,7 @@ trait SequencingConstraint[-S, R] {
    * Implements <code>contain</code> <code>inOrderOnly</code> syntax for sequences of type <code>S</code>.
    *
    * @param sequence an sequence about which an assertion is being made
-   * @param eles the only elements that should be contained, in order of appearence in <code>eles</code>, in the passed sequence
+   * @param eles the only elements that should be contained, in order of appearance in <code>eles</code>, in the passed sequence
    * @return true if the passed sequence contains only the passed elements in (iteration) order
    */
   def containsInOrderOnly(sequence: S, eles: Seq[R]): Boolean


### PR DESCRIPTION
These commands were used to produce a single file to spellcheck,

  $ cat $(find -name *.scala) >> all-scala.txt

  $ cat all-scala.txt |tr '<>()[].,$/@=&#%+:"`' ' '|tr ' ' '\n'|
      sort|uniq > scala-single.txt