### PR TITLE
Updated ConfigMapWrapperSuite to use a ConfigMap constructor

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
@@ -19,7 +19,7 @@ import SavesConfigMapSuite.theConfigMap
 import java.util.UUID
 
 @WrapWith(classOf[ConfigMapWrapperSuite])
-class SavesConfigMapSuite(configMap: Map[String, Any]) extends FunSuite {
+class SavesConfigMapSuite(configMap: ConfigMap) extends FunSuite {
   theConfigMap = Some(configMap)
   test("one test") {}
   test("two test") {}


### PR DESCRIPTION
The documentation for ConfigMapWrapperSuite indicates that the test suite should have a single argument in its constructor of type ConfigMap.  However, it was in fact looking for a constructor of type Map[_, _].  I've updated the code to look for a ConfigMap constructor and if not found, to fall back to using the Map[_, _] constructor if present.
