### PR TITLE
Use UTF-8 in HTML output instead of the platform default encoding.

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -197,8 +197,8 @@ private[scalatest] class HtmlReporter(
   
   private def makeSuiteFile(suiteResult: SuiteResult) {
     val name = getSuiteFileName(suiteResult)
-    
-    val pw = new PrintWriter(new BufferedOutputStream(new FileOutputStream(new File(targetDir, name + ".html")), BufferSize))
+
+    val pw = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(new File(targetDir, name + ".html")), BufferSize), "UTF-8"))
     try {
       pw.println {
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + 
@@ -434,7 +434,7 @@ private[scalatest] class HtmlReporter(
   }
   
   private def makeIndexFile(completeMessageFun: => String, completeInMessageFun: String => String, duration: Option[Long]) {
-    val pw = new PrintWriter(new BufferedOutputStream(new FileOutputStream(new File(targetDir, "index.html")), BufferSize))
+    val pw = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(new File(targetDir, "index.html")), BufferSize), "UTF-8"))
     try {
       pw.println {
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +


### PR DESCRIPTION
Previously, HtmlReporter would use the platform default encoding for generation of the HTML report files. This is usually UTF-8 on linux/unix systems (including Mac), and cp1250/iso8859 on Windows. However, since the default can be configured, it may be any value.  This changes HtmlReporter to use UTF-8 in all cases, since that is the encoding listed in the HTML headers in the output.

Thanks to @m-yamaguchi for reporting this issue (https://github.com/scalatest/scalatest/issues/350).