### PR TITLE
Fix a number of Travis build problems.

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -139,6 +139,7 @@ object ScalatestBuild extends Build {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
           "org.scala-lang.modules" %% "scala-xml" % "1.0.2",
+          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
           scalacheckDependency("optional")
         )
       case _ =>

--- a/scalatest-test/src/test/scala/org/scalatest/DispatchReporterSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DispatchReporterSpec.scala
@@ -45,7 +45,7 @@ class DispatchReporterSpec extends FunSpec {
     describe("when slowpoke detection is enabled") {
       def fireTestStarting(): (EventRecordingReporter, DispatchReporter) = {
         val erp = new EventRecordingReporter
-        val dispatch = new DispatchReporter(List(erp, NoisyReporter), Console.err, true, 1, 1)
+        val dispatch = new DispatchReporter(List(erp, SilentReporter), Console.err, true, 1, 1)
         dispatch(
           TestStarting(
             ordinal = TestStartingOrdinal,


### PR DESCRIPTION
This PR fixes a number of Travis test failures:

1. Tests that are failing with "MODE=RegularTests4" and Scala 2.11, which happen because certain tests require the scala parser library, which was modularized in Scala 2.11.  This PR adds the scala parser library dependency for scala versions >= 2.11.

2. Tests that are failing because the Travis maximum log size (4MB) is being exceeded, which can happen in DisplatchReporterSpec when a DispatchReporter is used in combination with NoisyReporter and "eventually".  This PR changes DispatcherReporterSpec to use a SilentReporter.