### PR TITLE
Update version to 2.2.6 and set up OSGi importPackages so that the appropriate packages are imported optionally.

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -12,8 +12,8 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.4
   val buildScalaVersion = "2.11.2"
 
-  val releaseVersion = "2.3.0-SNAP1"
-  val githubTag = "release-2.3.0-SNAP1-for-scala-2.11-and-2.10" // for scaladoc source urls
+  val releaseVersion = "2.2.6"
+  val githubTag = "release-2.2.6-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =
     "https://github.com/scalatest/scalatest/tree/"+ githubTag +
@@ -236,6 +236,14 @@ object ScalatestBuild extends Build {
         "org.scalactic",
         "org.scalautils"
       ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
+      ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "ScalaTest",
         "Bundle-Description" -> "ScalaTest is an open-source test framework for the Java Platform designed to increase your productivity by letting you write fewer lines of test code that more clearly reveal your intent.",
@@ -273,6 +281,14 @@ object ScalatestBuild extends Build {
       OsgiKeys.exportPackage := Seq(
         "org.scalactic",
         "org.scalautils"
+      ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
       ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "Scalactic",


### PR DESCRIPTION
This change sets up the OSGi importPackages key in the scalatest.scala build file. This change imports everything except "scala.*" as "resolution:=optional", which allows unused testing frameworks, and package to be ignored during OSGi bundle loading. For example, the bundle will still load even if you don't have requirements to use frameworks like mockito, or jmock for your application.

Also, since Scala 2.11, scala-xml and scala-parser-combinators are split out from the main library, currently at version 1.0.4 (not at 2.11.x). As a result, those needed to be added to the Seq value separately, in order to specifically indicate that they are in the "[1.0..1.1)" version range. 

If this wasn't explicitly done, the "scala.\*" package name in the "[2.11..2.12)" version range would get in the way. That's because OSGi was looking for the "scala-xml" and "parser-combinator" package versions to be at 2.11, but instead the manifests for 1.0.4 export those packages (scala.xml.\* and scala.util.parsing.\*) at the "[1.0..1.1)" version, not at the "[2.11..2.12)" version. This was causing the bundles not to load, since those components were not being found at the expected, exported versions.

BTW, bndlib (called by the sbt-osgi plugin to generate the manifest property values) is smart enough to know how to deal with the packages "scala.xml.\*" and "scala.util.parsing.\*" being more specific than "scala.*". It's nice enough to generate the manifest entries just the way we want them to be.
