### PR TITLE
ScalaCheck 1.12.4 & Private StackDepthExceptionHelper

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -21,9 +21,9 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.5
   val buildScalaVersion = "2.11.7"
 
-  val releaseVersion = "3.0.0-M6"
+  val releaseVersion = "3.0.0-M7"
 
-  val githubTag = "release-3.0.0-M6-for-scala-2.11-and-2.10" // for scaladoc source urls
+  val githubTag = "release-3.0.0-M7-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =
     "https://github.com/scalatest/scalatest/tree/"+ githubTag +

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -132,7 +132,7 @@ object ScalatestBuild extends Build {
   )
 
   def scalacheckDependency(config: String) =
-    "org.scalacheck" %% "scalacheck" % "1.12.3" % config
+    "org.scalacheck" %% "scalacheck" % "1.12.4" % config
 
   def crossBuildLibraryDependencies(theScalaVersion: String) =
     CrossVersion.partialVersion(theScalaVersion) match {
@@ -362,6 +362,7 @@ object ScalatestBuild extends Build {
       projectTitle := "Scalactic Test.js",
       organization := "org.scalactic",
       jsDependencies += RuntimeDOM % "test",
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.4" % "test",
       //scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,
       //postLinkJSEnv := NodeJSEnv(executable = "node").value,
@@ -477,7 +478,7 @@ object ScalatestBuild extends Build {
         </dependency>,
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + scalatestAll.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       libraryDependencies ++= scalatestJSLibraryDependencies,
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.3",
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.4" % "optional",
       jsDependencies += RuntimeDOM % "test",
       sourceGenerators in Compile += {
         Def.task {
@@ -550,6 +551,7 @@ object ScalatestBuild extends Build {
       organization := "org.scalatest",
       libraryDependencies ++= crossBuildLibraryDependencies(scalaVersion.value),
       libraryDependencies ++= scalatestJSLibraryDependencies,
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.4" % "test",
       jsDependencies += RuntimeDOM % "test",
       //scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,

--- a/scalatest.js/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/scalatest.js/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -37,6 +37,4 @@ private[scalatest] object StackDepthExceptionHelper {
     }
     else None
   }
-
-  val macroCodeStackDepth: Int = 9
 }

--- a/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
@@ -26,9 +26,9 @@ import org.scalatest.words.{TypeCheckWord, CompileWord}
 private[scalatest] object CompileMacro {
 
   // SKIP-SCALATESTJS-START
-  private[scalatest] val stackDepth = 0
+  val stackDepth = 0
   // SKIP-SCALATESTJS-END
-  //SCALATESTJS-ONLY private[scalatest] val stackDepth = 9
+  //SCALATESTJS-ONLY val stackDepth = 9
 
   // extract the code string from the AST
   def getCodeStringFromCodeExpression(c: Context)(methodName: String, code: c.Expr[String]): String = {
@@ -63,7 +63,7 @@ private[scalatest] object CompileMacro {
       // If reach here, type check passes, let's generate code to throw TestFailedException
       val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(codeStr))
       reify {
-        throw new exceptions.TestFailedException(messageExpr.splice, StackDepthExceptionHelper.macroCodeStackDepth)
+        throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
       }
     } catch {
       case e: TypecheckException =>
@@ -75,7 +75,7 @@ private[scalatest] object CompileMacro {
         // parse error, generate code to throw TestFailedException
         val messageExpr = c.literal(Resources.expectedTypeErrorButGotParseError(e.getMessage, codeStr))
         reify {
-          throw new exceptions.TestFailedException(messageExpr.splice, StackDepthExceptionHelper.macroCodeStackDepth)
+          throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
         }
     }
   }
@@ -92,7 +92,7 @@ private[scalatest] object CompileMacro {
       // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
       val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
       reify {
-        throw new exceptions.TestFailedException(messageExpr.splice, StackDepthExceptionHelper.macroCodeStackDepth)
+        throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
       }
     } catch {
       case e: TypecheckException =>
@@ -126,13 +126,13 @@ private[scalatest] object CompileMacro {
         // type check error, compiles fails, generate code to throw TestFailedException
         val messageExpr = c.literal(Resources.expectedNoErrorButGotTypeError(e.getMessage, codeStr))
         reify {
-          throw new exceptions.TestFailedException(messageExpr.splice, StackDepthExceptionHelper.macroCodeStackDepth)
+          throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
         }
       case e: ParseException =>
         // parse error, compiles fails, generate code to throw TestFailedException
         val messageExpr = c.literal(Resources.expectedNoErrorButGotParseError(e.getMessage, codeStr))
         reify {
-          throw new exceptions.TestFailedException(messageExpr.splice, StackDepthExceptionHelper.macroCodeStackDepth)
+          throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
         }
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -95,7 +95,7 @@ Conductor from conduct method: Stack depth should be 3 or 4. Both of which are t
 [scalatest] 	at org.scalatest.FunSuite$class.runTest(FunSuite.scala:1028)
 [scalatest] 	at org.scalatest.concurrent.ConductorSuite.runTest(ConductorSuite.scala:23)
 */
-object StackDepthExceptionHelper {
+private[scalatest] object StackDepthExceptionHelper {
 
   def getStackDepth(stackTrace: Array[StackTraceElement], fileName: String, methodName: String, adjustment: Int = 0): Int = {
     val stackTraceList = stackTrace.toList

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -146,6 +146,4 @@ object StackDepthExceptionHelper {
     }
     else None
   }
-
-  val macroCodeStackDepth: Int = 0
 }


### PR DESCRIPTION
-Updated to use 1.12.4 (changes from 3.0.x branch)
-Fixed private[scalatest] StackDepthExceptionHelper inaccessible problem when used with CompileMacro.