### PR TITLE
Length/Size Macro Fix

### DIFF
--- a/src/main/scala/org/scalactic/Bool.scala
+++ b/src/main/scala/org/scalactic/Bool.scala
@@ -261,7 +261,7 @@ object Bool {
    * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
    * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
    */
-  def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Long): Bool =
+  def lengthSizeMacroBool(left: Any, operator: String, actual: Any, expected: Any): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 
   /**
@@ -1062,7 +1062,7 @@ private[scalactic] class IsInstanceOfMacroBool(left: Any, operator: String, clas
  * @param actual the actual length or size of <code>left</code>
  * @param expected the expected length or size of <code>left</code>
  */
-private[scalactic] class LengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Long) extends Bool {
+private[scalactic] class LengthSizeMacroBool(left: Any, operator: String, actual: Any, expected: Any) extends Bool {
 
   /**
    * the <code>Boolean</code> value of this <code>Bool</code>.

--- a/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -113,13 +113,13 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
   def wasInstanceOf(left: Any, className: String): String =
     FailureMessages("wasInstanceOf", left, UnquotedString(className))
 
-  def hadLengthInsteadOfExpectedLength(left: Any, actual: Long, expected: Long): String =
+  def hadLengthInsteadOfExpectedLength(left: Any, actual: Any, expected: Any): String =
     FailureMessages("hadLengthInsteadOfExpectedLength", left, actual, expected)
 
   def hadLength(left: Any, actual: Long): String =
     FailureMessages("hadLength", left, actual)
 
-  def hadSizeInsteadOfExpectedSize(left: Any, actual: Long, expected: Long): String =
+  def hadSizeInsteadOfExpectedSize(left: Any, actual: Any, expected: Any): String =
     FailureMessages("hadSizeInsteadOfExpectedSize", left, actual, expected)
 
   def hadSize(left: Any, actual: Long): String =
@@ -159,6 +159,15 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
 
     def contains[E1 >: E](elem: E1): Boolean = elem == element
   }
+
+  class FloatLengthSize(value: Float) {
+
+    val length: Float = value
+
+    val size: Float = value
+  }
+
+  val floatLengthSize = new FloatLengthSize(2.0f)
 
   describe("The require(boolean) method") {
 
@@ -1004,6 +1013,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == hadLength(l1, 3))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      require(floatLengthSize.length == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[IllegalArgumentException] {
+        require(floatLengthSize.length == 1.0f)
+      }
+      assert(e.getMessage == hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       require(s1.size == 12)
     }
@@ -1046,6 +1066,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         require(!(l1.size == 3))
       }
       assert(e.getMessage == hadSize(l1, 3))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      require(floatLengthSize.size == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[IllegalArgumentException] {
+        require(floatLengthSize.size == 1.0f)
+      }
+      assert(e.getMessage == hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f))
     }
 
     it("should do nothing when is used to check l1.exists(_ == 3)") {
@@ -2078,6 +2109,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == hadLength(l1, 3) + ", dude")
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      require(floatLengthSize.length == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[IllegalArgumentException] {
+        require(floatLengthSize.length == 1.0f, ", dude")
+      }
+      assert(e.getMessage == hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f) + ", dude")
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       require(s1.size == 12, ", dude")
     }
@@ -2120,6 +2162,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         require(!(l1.size == 3), ", dude")
       }
       assert(e.getMessage == hadSize(l1, 3) + ", dude")
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      require(floatLengthSize.size == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[IllegalArgumentException] {
+        require(floatLengthSize.size == 1.0f, ", dude")
+      }
+      assert(e.getMessage == hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f) + ", dude")
     }
 
     it("should do nothing when is used to check l1.exists(_ == 3)") {
@@ -3112,6 +3165,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == hadLength(l1, 3))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      requireState(floatLengthSize.length == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[IllegalStateException] {
+        requireState(floatLengthSize.length == 1.0f)
+      }
+      assert(e.getMessage == hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       requireState(s1.size == 12)
     }
@@ -3154,6 +3218,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         requireState(!(l1.size == 3))
       }
       assert(e.getMessage == hadSize(l1, 3))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      requireState(floatLengthSize.size == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[IllegalStateException] {
+        requireState(floatLengthSize.size == 1.0f)
+      }
+      assert(e.getMessage == hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f))
     }
 
     it("should do nothing when is used to check l1.exists(_ == 3)") {
@@ -4186,6 +4261,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       assert(e.getMessage == hadLength(l1, 3) + ", dude")
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      requireState(floatLengthSize.length == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[IllegalStateException] {
+        requireState(floatLengthSize.length == 1.0f, ", dude")
+      }
+      assert(e.getMessage == hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f) + ", dude")
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       requireState(s1.size == 12, ", dude")
     }
@@ -4228,6 +4314,17 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
         requireState(!(l1.size == 3), ", dude")
       }
       assert(e.getMessage == hadSize(l1, 3) + ", dude")
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      requireState(floatLengthSize.size == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[IllegalStateException] {
+        requireState(floatLengthSize.size == 1.0f, ", dude")
+      }
+      assert(e.getMessage == hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f) + ", dude")
     }
 
     it("should do nothing when is used to check l1.exists(_ == 3)") {

--- a/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -255,13 +255,13 @@ class AssertionsSpec extends FunSpec {
   def wasInstanceOf(left: Any, className: String) =
     quoteString(left) + " was instance of " + className
 
-  def hadLengthInsteadOfExpectedLength(left: Any, actual: Long, expected: Long): String =
+  def hadLengthInsteadOfExpectedLength(left: Any, actual: Any, expected: Any): String =
     FailureMessages("hadLengthInsteadOfExpectedLength", left, actual, expected)
 
   def hadLength(left: Any, actual: Long): String =
     FailureMessages("hadLength", left, actual)
 
-  def hadSizeInsteadOfExpectedSize(left: Any, actual: Long, expected: Long): String =
+  def hadSizeInsteadOfExpectedSize(left: Any, actual: Any, expected: Any): String =
     FailureMessages("hadSizeInsteadOfExpectedSize", left, actual, expected)
 
   def hadSize(left: Any, actual: Long): String =
@@ -305,6 +305,15 @@ class AssertionsSpec extends FunSpec {
   private def neverRuns1(f: => Unit): Boolean = true
   private def neverRuns2(f: => Unit)(a: Int): Boolean = true
   private def neverRuns3[T](f: => Unit)(a: T): Boolean = true
+
+  class FloatLengthSize(value: Float) {
+
+    val length: Float = value
+
+    val size: Float = value
+  }
+
+  val floatLengthSize = new FloatLengthSize(2.0f)
   
   describe("The assert(boolean) method") {
     val a = 3
@@ -1410,6 +1419,19 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      assert(floatLengthSize.length == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[TestFailedException] {
+        assert(floatLengthSize.length == 1.0f)
+      }
+      assert(e.message == Some(hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f)))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       assert(s1.size == 12)
     }
@@ -1458,6 +1480,19 @@ class AssertionsSpec extends FunSpec {
         assert(!(l1.size == 3))
       }
       assert(e.message == Some(hadSize(l1, 3)))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      assert(floatLengthSize.size == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[TestFailedException] {
+        assert(floatLengthSize.size == 1.0f)
+      }
+      assert(e.message == Some(hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f)))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
@@ -2730,6 +2765,19 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      assert(floatLengthSize.length == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[TestFailedException] {
+        assert(floatLengthSize.length == 1.0f, ", dude")
+      }
+      assert(e.message == Some(hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f) + ", dude"))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       assert(s1.size == 12, ", dude")
     }
@@ -2778,6 +2826,19 @@ class AssertionsSpec extends FunSpec {
         assert(!(l1.size == 3), ", dude")
       }
       assert(e.message == Some(hadSize(l1, 3) + ", dude"))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      assert(floatLengthSize.size == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[TestFailedException] {
+        assert(floatLengthSize.size == 1.0f, ", dude")
+      }
+      assert(e.message == Some(hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f) + ", dude"))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
@@ -4044,6 +4105,19 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      assume(floatLengthSize.length == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[TestCanceledException] {
+        assume(floatLengthSize.length == 1.0f)
+      }
+      assert(e.message == Some(hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f)))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       assume(s1.size == 12)
     }
@@ -4092,6 +4166,19 @@ class AssertionsSpec extends FunSpec {
         assume(!(l1.size == 3))
       }
       assert(e.message == Some(hadSize(l1, 3)))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      assume(floatLengthSize.size == 2.0f)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[TestCanceledException] {
+        assume(floatLengthSize.size == 1.0f)
+      }
+      assert(e.message == Some(hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f)))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
@@ -5364,6 +5451,19 @@ class AssertionsSpec extends FunSpec {
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check floatLengthSize.length == 2.0f") {
+      assume(floatLengthSize.length == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.length == 1.0f") {
+      val e = intercept[TestCanceledException] {
+        assume(floatLengthSize.length == 1.0f, ", dude")
+      }
+      assert(e.message == Some(hadLengthInsteadOfExpectedLength(floatLengthSize, 2.0f, 1.0f) + ", dude"))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check s1.size == 9") {
       assume(s1.size == 12, ", dude")
     }
@@ -5412,6 +5512,19 @@ class AssertionsSpec extends FunSpec {
         assume(!(l1.size == 3), ", dude")
       }
       assert(e.message == Some(hadSize(l1, 3) + ", dude"))
+      assert(e.failedCodeFileName == (Some(fileName)))
+      assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check floatLengthSize.size == 2.0f") {
+      assume(floatLengthSize.size == 2.0f, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check floatLengthSize.size == 1.0f") {
+      val e = intercept[TestCanceledException] {
+        assume(floatLengthSize.size == 1.0f, ", dude")
+      }
+      assert(e.message == Some(hadSizeInsteadOfExpectedSize(floatLengthSize, 2.0f, 1.0f) + ", dude"))
       assert(e.failedCodeFileName == (Some(fileName)))
       assert(e.failedCodeLineNumber == (Some(thisLineNumber - 4)))
     }


### PR DESCRIPTION
Fixed length/size problem in assert/assume/require/requireState macro when used with custom length or size method that returns non-integral type.

Note: This fix should be cherry-pick into 3.0.x branch if possible, else we should submit a different PR for 3.0.x.