### PR TITLE
Fix isNestedMethod() detection to include a corner case

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/Spec.scala
+++ b/scalatest/src/main/scala/org/scalatest/Spec.scala
@@ -1420,7 +1420,7 @@ private[scalatest] object Spec {
     
     val isOuterMethod = m.getName.endsWith("$$outer")
     
-    val isNestedMethod = m.getName.matches(".+\\$\\$.+\\$[1-9]+")
+    val isNestedMethod = m.getName.matches(".+\\$\\$.+\\$[1-9][0-9]*")
 
     //val isOuterMethod = m.getName.endsWith("$$$outer")
     // def maybe(b: Boolean) = if (b) "" else "!"

--- a/scalatest/src/main/scala/org/scalatest/fixture/Spec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/Spec.scala
@@ -261,7 +261,7 @@ private[scalatest] object Spec {
     
     val isOuterMethod = m.getName.endsWith("$$outer")
     
-    val isNestedMethod = m.getName.matches(".+\\$\\$.+\\$[1-9]+")
+    val isNestedMethod = m.getName.matches(".+\\$\\$.+\\$[1-9][0-9]*")
 
     // def maybe(b: Boolean) = if (b) "" else "!"
     // println("m.getName: " + m.getName + ": " + maybe(isInstanceMethod) + "isInstanceMethod, " + maybe(hasNoParams) + "hasNoParams, " + maybe(includesEncodedSpace) + "includesEncodedSpace")


### PR DESCRIPTION
Nested methods can end with a number including 0. For example,
consider a block like

    class ExampleSpec extends Spec {
      object `An example` {
          def `test 1` {
            def helper() = ...
          }

          def `test 2` {
            def helper() = ...
          }

          ...

          def `test 10` {
            def helper() = ...
          }
        }
      }

The `helper` methods will be turned into something like:

    `ExampleSpec$An$u0020example$$helper$1`
    `ExampleSpec$An$u0020example$$helper$2`
    ...
    `ExampleSpec$An$u0020example$$helper$10`

But that tenth helper method will currently be counted as a test and executed.
(This extra execution is most obvious when the helper method throws an exception.)