### PR TITLE
Fix Scalacheck Fork Problem

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -10,7 +10,7 @@ object ScalatestBuild extends Build {
 
   val buildScalaVersion = "2.11.2"
 
-  val releaseVersion = "2.2.5"
+  val releaseVersion = "2.2.6-SNAP1"
   val githubTag = "release-2.2.5-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =
@@ -123,10 +123,10 @@ object ScalatestBuild extends Build {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
           "org.scala-lang.modules" %% "scala-xml" % "1.0.2",
-          "org.scalacheck" %% "scalacheck" % "1.12.1" % "optional"
+          "org.scalacheck" %% "scalacheck" % "1.12.4" % "optional"
         )
       case _ =>
-        Seq("org.scalacheck" %% "scalacheck" % "1.12.1" % "optional")
+        Seq("org.scalacheck" %% "scalacheck" % "1.12.4" % "optional")
     }
 
   def scalaLibraries(theScalaVersion: String) =
@@ -185,7 +185,8 @@ object ScalatestBuild extends Build {
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gencompcls", "GenCompatibleClasses.scala")(GenCompatibleClasses.genMain),
      sourceGenerators in Compile <+=
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genversions", "GenVersions.scala")(GenVersions.genScalaTestVersions),
-     testOptions in Test := Seq(Tests.Argument("-l", "org.scalatest.tags.Slow",
+     testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest,
+                                               "-l", "org.scalatest.tags.Slow",
                                                "-m", "org.scalatest",
                                                "-m", "org.scalactic",
                                                "-m", "org.scalatest.fixture",

--- a/src/main/scala/org/scalatest/prop/Checkers.scala
+++ b/src/main/scala/org/scalatest/prop/Checkers.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest.prop
 
+import org.scalacheck.util.Pretty
 import org.scalatest._
 import org.scalatest.Suite
 import org.scalacheck.Arbitrary
@@ -398,10 +399,12 @@ object Checkers extends Checkers {
           )
 
         case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
-              
+
+          val prettyArgsStr = prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs))
+
           throw new GeneratorDrivenPropertyCheckFailedException(
-            sde => FailureMessages("propertyException", UnquotedString(sde.getClass.getSimpleName)) + "\n" + 
-              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" + 
+            sde => FailureMessages("propertyException", UnquotedString(sde.getClass.getSimpleName)) + "\n" +
+              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
               "  " + FailureMessages("propertyFailed", result.succeeded) + "\n" +
               (
                 sde match {
@@ -409,21 +412,23 @@ object Checkers extends Checkers {
                     "  " + FailureMessages("thrownExceptionsLocation", UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
                   case _ => ""
                 }
-              ) +
-              "  " + FailureMessages("occurredOnValues") + "\n" + 
-              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs)) + "\n" +
-              "  )" + 
+                ) +
+              "  " + FailureMessages("occurredOnValues") + "\n" +
+              prettyArgsStr + "\n" +
+              "  )" +
               getLabelDisplay(scalaCheckLabels),
             None,
             getStackDepthFun(stackDepthFileName, stackDepthMethodName),
             None,
             FailureMessages("propertyFailed", result.succeeded),
-            scalaCheckArgs,
+            scalaCheckArgs.map(_.arg),
             None,
             scalaCheckLabels.toList
           )
 
         case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
+
+          val prettyArgsStr = prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs))
 
           throw new GeneratorDrivenPropertyCheckFailedException(
             sde => FailureMessages("propertyException", UnquotedString(e.getClass.getSimpleName)) + "\n" +
@@ -434,16 +439,16 @@ object Checkers extends Checkers {
                     "  " + FailureMessages("thrownExceptionsLocation", UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
                   case _ => ""
                 }
-              ) +
+                ) +
               "  " + FailureMessages("occurredOnValues") + "\n" +
-              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs)) + "\n" +
-              "  )" + 
+              prettyArgsStr + "\n" +
+              "  )" +
               getLabelDisplay(scalaCheckLabels),
             Some(e),
             getStackDepthFun(stackDepthFileName, stackDepthMethodName),
             None,
             FailureMessages("propertyException", UnquotedString(e.getClass.getName)),
-            scalaCheckArgs,
+            scalaCheckArgs.map(_.arg),
             None,
             scalaCheckLabels.toList
           )

--- a/src/main/scala/org/scalatest/prop/Checkers.scala
+++ b/src/main/scala/org/scalatest/prop/Checkers.scala
@@ -15,7 +15,6 @@
  */
 package org.scalatest.prop
 
-import org.scalacheck.util.Pretty
 import org.scalatest._
 import org.scalatest.Suite
 import org.scalacheck.Arbitrary
@@ -400,8 +399,6 @@ object Checkers extends Checkers {
 
         case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
 
-          val prettyArgsStr = prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs))
-
           throw new GeneratorDrivenPropertyCheckFailedException(
             sde => FailureMessages("propertyException", UnquotedString(sde.getClass.getSimpleName)) + "\n" +
               ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
@@ -414,21 +411,19 @@ object Checkers extends Checkers {
                 }
                 ) +
               "  " + FailureMessages("occurredOnValues") + "\n" +
-              prettyArgsStr + "\n" +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs)) + "\n" +
               "  )" +
               getLabelDisplay(scalaCheckLabels),
             None,
             getStackDepthFun(stackDepthFileName, stackDepthMethodName),
             None,
             FailureMessages("propertyFailed", result.succeeded),
-            scalaCheckArgs.map(_.arg),
+            scalaCheckArgs,
             None,
             scalaCheckLabels.toList
           )
 
         case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
-
-          val prettyArgsStr = prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs))
 
           throw new GeneratorDrivenPropertyCheckFailedException(
             sde => FailureMessages("propertyException", UnquotedString(e.getClass.getSimpleName)) + "\n" +
@@ -441,14 +436,14 @@ object Checkers extends Checkers {
                 }
                 ) +
               "  " + FailureMessages("occurredOnValues") + "\n" +
-              prettyArgsStr + "\n" +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs)) + "\n" +
               "  )" +
               getLabelDisplay(scalaCheckLabels),
             Some(e),
             getStackDepthFun(stackDepthFileName, stackDepthMethodName),
             None,
             FailureMessages("propertyException", UnquotedString(e.getClass.getName)),
-            scalaCheckArgs.map(_.arg),
+            scalaCheckArgs,
             None,
             scalaCheckLabels.toList
           )


### PR DESCRIPTION
Fixed scalacheck problem when used in SBT fork mode.

Note: This fix should be cherry-pick into 3.0.x branch.