### PR TITLE
Implicit Numeric Widening Error Fix for 2.2.x

### DIFF
--- a/src/main/scala/org/scalactic/Bool.scala
+++ b/src/main/scala/org/scalactic/Bool.scala
@@ -265,6 +265,45 @@ object Bool {
     new LengthSizeMacroBool(left, operator, actual, expected)
 
   /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
+  def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Long): Bool =
+    new LengthSizeMacroBool(left, operator, actual, expected)
+
+  /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
+  def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Int): Bool =
+    new LengthSizeMacroBool(left, operator, actual, expected)
+
+  /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
+  def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Int): Bool =
+    new LengthSizeMacroBool(left, operator, actual, expected)
+
+  /**
    * Create exists macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
    * represented by <code>exists</code> method call.
    *

--- a/src/main/scala/org/scalactic/Bool.scala
+++ b/src/main/scala/org/scalactic/Bool.scala
@@ -261,46 +261,7 @@ object Bool {
    * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
    * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
    */
-  def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Long): Bool =
-    new LengthSizeMacroBool(left, operator, actual, expected)
-
-  /**
-   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
-   * represented by <code>length</code> and <code>size</code> method call,
-   *
-   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
-   * @param operator the operator (method name) of the <code>Boolean</code> expression
-   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
-   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
-   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
-   */
-  def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Long): Bool =
-    new LengthSizeMacroBool(left, operator, actual, expected)
-
-  /**
-   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
-   * represented by <code>length</code> and <code>size</code> method call,
-   *
-   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
-   * @param operator the operator (method name) of the <code>Boolean</code> expression
-   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
-   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
-   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
-   */
-  def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Int): Bool =
-    new LengthSizeMacroBool(left, operator, actual, expected)
-
-  /**
-   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
-   * represented by <code>length</code> and <code>size</code> method call,
-   *
-   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
-   * @param operator the operator (method name) of the <code>Boolean</code> expression
-   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
-   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
-   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
-   */
-  def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Int): Bool =
+  def lengthSizeMacroBool(left: Any, operator: String, actual: Any, expected: Any): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 
   /**
@@ -1101,7 +1062,7 @@ private[scalactic] class IsInstanceOfMacroBool(left: Any, operator: String, clas
  * @param actual the actual length or size of <code>left</code>
  * @param expected the expected length or size of <code>left</code>
  */
-private[scalactic] class LengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Long) extends Bool {
+private[scalactic] class LengthSizeMacroBool(left: Any, operator: String, actual: Any, expected: Any) extends Bool {
 
   /**
    * the <code>Boolean</code> value of this <code>Bool</code>.

--- a/src/main/scala/org/scalactic/MacroOwnerRepair.scala
+++ b/src/main/scala/org/scalactic/MacroOwnerRepair.scala
@@ -31,7 +31,7 @@ private[org] class MacroOwnerRepair[C <: reflect.macros.Context with Singleton](
 
     // Proactively typecheck the tree. This will assign symbols to
     // DefTrees introduced by the macro.
-    val typed = c.typeCheck(expr.tree).asInstanceOf[symtab.Tree]
+    val typed = c.typeCheck(c.universe.atPos(c.macroApplication.pos)(expr.tree)).asInstanceOf[symtab.Tree]
 
     // The current owner at the call site. Symbols owned by this may need
     // to be transplanted.


### PR DESCRIPTION
Back port macro implicit numeric widening error from 3.0.x branch.