### PR TITLE
SBT 0.13.9 & Missing Scaladocs

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/scalactic/src/main/scala/org/scalactic/Bool.scala
+++ b/scalactic/src/main/scala/org/scalactic/Bool.scala
@@ -260,12 +260,42 @@ object Bool {
   def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Long): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 
+  /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
   def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Long): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 
+  /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
   def lengthSizeMacroBool(left: Any, operator: String, actual: Long, expected: Int): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 
+  /**
+   * Create macro <code>Bool</code> that is used by <code>BooleanMacro</code> to wrap a recognized <code>Boolean</code> expression
+   * represented by <code>length</code> and <code>size</code> method call,
+   *
+   * @param left the left-hand-side (LHS) of the <code>Boolean</code> expression
+   * @param operator the operator (method name) of the <code>Boolean</code> expression
+   * @param actual the actual value returned from <code>length</code> or <code>size</code> method call
+   * @param expected the expected value returned from <code>length</code> or <code>size</code> method call
+   * @return a <code>Bool</code> instance that represents a <code>length</code> or <code>size</code> method call
+   */
   def lengthSizeMacroBool(left: Any, operator: String, actual: Int, expected: Int): Bool =
     new LengthSizeMacroBool(left, operator, actual, expected)
 


### PR DESCRIPTION
Bump up to use sbt 0.13.9 and added missing scaladoc in Bool.scala.