### PR TITLE
Add optional OSGI imports to scalatest.scala project file

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -21,7 +21,7 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.4
   val buildScalaVersion = "2.11.6"
 
-  val releaseVersion = "3.0.0-SNAPSHOT"
+  val releaseVersion = "3.0.0-SNAP4"
   val githubTag = "release-3.0.0-SNAP4-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -21,7 +21,7 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.4
   val buildScalaVersion = "2.11.6"
 
-  val releaseVersion = "3.0.0-SNAP4"
+  val releaseVersion = "3.0.0-SNAPSHOT"
   val githubTag = "release-3.0.0-SNAP4-for-scala-2.11-and-2.10" // for scaladoc source urls
 
   val docSourceUrl =
@@ -295,6 +295,14 @@ object ScalatestBuild extends Build {
         "org.scalactic.anyvals",
         "org.scalautils"
       ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
+      ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "Scalactic",
         "Bundle-Description" -> "Scalactic is an open-source library for Scala projects.",
@@ -423,6 +431,14 @@ object ScalatestBuild extends Build {
         "org.scalactic.algebra",
         "org.scalautils"
       ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
+      ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "ScalaTest",
         "Bundle-Description" -> "ScalaTest is an open-source test framework for the Java Platform designed to increase your productivity by letting you write fewer lines of test code that more clearly reveal your intent.",
@@ -517,6 +533,14 @@ object ScalatestBuild extends Build {
         "org.scalactic.algebra",
         "org.scalautils"
       ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
+      ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "ScalaTest",
         "Bundle-Description" -> "ScalaTest is an open-source test framework for the Java Platform designed to increase your productivity by letting you write fewer lines of test code that more clearly reveal your intent.",
@@ -597,6 +621,14 @@ object ScalatestBuild extends Build {
         "org.scalactic.anyvals",
         "org.scalautils"
       ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
+      ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "ScalaTest",
         "Bundle-Description" -> "ScalaTest is an open-source test framework for the Java Platform designed to increase your productivity by letting you write fewer lines of test code that more clearly reveal your intent.",
@@ -653,6 +685,14 @@ object ScalatestBuild extends Build {
         "org.scalactic",
         "org.scalactic.anyvals",
         "org.scalautils"
+      ),
+      OsgiKeys.importPackage := Seq(
+        "org.scalatest.*",
+        "org.scalactic.*",
+        "scala.util.parsing.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.xml.*;version=\"$<range;[==,=+);$<replace;1.0.4;-;.>>\"",
+        "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+        "*;resolution:=optional"
       ),
       OsgiKeys.additionalHeaders:= Map(
         "Bundle-Name" -> "ScalaTest",


### PR DESCRIPTION
This adds the resolution:=optional qualifier to imported packages that should be listed as optional in the artifact bundle META-INF/MANIFEST.MF file. If this is not done, you need to add maven (or sbt) dependencies for optional packages in artifacts that may never be used.
