### PR TITLE
Replace deprecated use of 'evaluating' in examples

### DIFF
--- a/project/GenTable.scala
+++ b/project/GenTable.scala
@@ -771,14 +771,14 @@ import scala.annotation.tailrec
  * </pre>
  * 
  * <p>
- * Given this table, you could check that all invalid combinations produce <code>IllegalArgumentException</code>, like this:
+ * Given this table, you could check that all invalid combinations throw <code>IllegalArgumentException</code>, like this:
  * </p>
  *
  * <pre class="stHighlight">
  * forAll (invalidCombos) { (n: Int, d: Int) =>
- *   evaluating {
+ *   an [IllegalArgumentException] should be thrownBy {
  *     new Fraction(n, d)
- *   } should produce [IllegalArgumentException]
+ *   }
  * }
  * </pre>
  *

--- a/scalatest/src/main/scala/org/scalatest/PropSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/PropSpec.scala
@@ -52,9 +52,9 @@ import Suite.autoTagClassAnnotations
  *     }
  *   }
  * 
- *   property("invoking head on an empty set should produce NoSuchElementException") {
+ *   property("invoking head on an empty set should throw a NoSuchElementException") {
  *     forAll(examples) { set =&gt;
- *       evaluating { set.head } should produce [NoSuchElementException]
+ *       a [NoSuchElementException] should be thrownBy { set.head }
  *     }
  *   }
  * }
@@ -78,7 +78,7 @@ import Suite.autoTagClassAnnotations
  * <pre class="stREPL">
  * <span class="stGreen">SetSpec:
  * - an empty Set should have size 0
- * - invoking head on an empty Set should produce NoSuchElementException</span>
+ * - invoking head on an empty Set should throw a NoSuchElementException</span>
  * </pre>
  *
  * <p>
@@ -160,9 +160,9 @@ import Suite.autoTagClassAnnotations
  *     }
  *   }
  * 
- *   property("invoking head on an empty set should produce NoSuchElementException") {
+ *   property("invoking head on an empty set should throw a NoSuchElementException") {
  *     forAll(examples) { set =>
- *       evaluating { set.head } should produce [NoSuchElementException]
+ *       a [NoSuchElementException] should be thrownBy { set.head }
  *     }
  *   }
  * }
@@ -183,7 +183,7 @@ import Suite.autoTagClassAnnotations
  * <pre class="stREPL">
  * <span class="stGreen">SetSuite:</span>
  * <span class="stYellow">- an empty Set should have size 0 !!! IGNORED !!!</span>
- * <span class="stGreen">- invoking head on an empty Set should produce NoSuchElementException</span>
+ * <span class="stGreen">- invoking head on an empty Set should throw a NoSuchElementException</span>
  * </pre>
  *
  * <a name="informers"></a><h2>Informers</h2></a>
@@ -474,9 +474,9 @@ import Suite.autoTagClassAnnotations
  * 
  *   property("an empty Set should have size 0") (pending)
  * 
- *   property("invoking head on an empty set should produce NoSuchElementException") {
+ *   property("invoking head on an empty set should throw a NoSuchElementException") {
  *     forAll(examples) { set =&gt;
- *       evaluating { set.head } should produce [NoSuchElementException]
+ *       a [NoSuchElementException] should be thrownBy { set.head }
  *     }
  *   }
  * }
@@ -499,7 +499,7 @@ import Suite.autoTagClassAnnotations
  * <pre class="stREPL">
  * <span class="stGreen">SetSuite:</span>
  * <span class="stYellow">- An empty Set should have size 0 (pending)</span>
- * <span class="stGreen">- Invoking head on an empty Set should produce NoSuchElementException</span>
+ * <span class="stGreen">- Invoking head on an empty Set should throw a NoSuchElementException</span>
  * </pre>
  * 
  * <p>
@@ -575,11 +575,11 @@ import Suite.autoTagClassAnnotations
  *     }
  *   }
  * 
- *   property("invoking head on an empty set should produce NoSuchElementException",
+ *   property("invoking head on an empty set should throw a NoSuchElementException",
  *       SlowTest, DbTest) {
  * 
  *     forAll(examples) { set =&gt;
- *       evaluating { set.head } should produce [NoSuchElementException]
+ *       a [NoSuchElementException] should be thrownBy { set.head }
  *     }
  *   }
  * }
@@ -748,7 +748,7 @@ import Suite.autoTagClassAnnotations
  * <table style="border-collapse: collapse; border: 1px solid black">
  * <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black">&nbsp;</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><code>BitSet</code></th><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><code>HashSet</code></th><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><code>TreeSet</code></th></tr>
  * <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: right">An empty Set should have size 0</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td></td></tr>
- * <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: right">Invoking head on an empty set should produce NoSuchElementException</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td></td></tr>
+ * <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: right">Invoking head on an empty set should throw a NoSuchElementException</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><span class="stGreen">pass</span></td></td></tr>
  * </table>
  *
  * <p>
@@ -837,10 +837,10 @@ import Suite.autoTagClassAnnotations
  *     }
  *   }
  * 
- *   property("invoking head on an empty set should produce NoSuchElementException") {
+ *   property("invoking head on an empty set should throw a NoSuchElementException") {
  *     new EmptySetExamples {
  *       forAll(examples) { set =&gt;
- *         evaluating { set.head } should produce [NoSuchElementException]
+ *         a [NoSuchElementException] should be thrownBy { set.head }
  *       }
  *     }
  *   }

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -286,8 +286,8 @@ import Suite.getMethodForTestName
  *     Set.empty.size should equal (0)
  *   }
  *
- *   def &#96;test: invoking head on an empty Set should produce NoSuchElementException&#96; {
- *     evaluating { Set.empty.head } should produce [NoSuchElementException]
+ *   def &#96;test: invoking head on an empty Set should throw a NoSuchElementException&#96; {
+ *     a [NoSuchElementException] should be thrownBy { Set.empty.head }
  *   }
  * }
  * </pre>

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyChecks.scala
@@ -72,7 +72,7 @@ package prop
  *
  * <p>
  * And you could use a table-driven property check to test that all combinations of invalid values passed to the <code>Fraction</code> constructor
- * produce the expected <code>IllegalArgumentException</code>, like this:
+ * throw the expected <code>IllegalArgumentException</code>, like this:
  * </p>
  *
  * <pre class="stHighlight">
@@ -87,9 +87,9 @@ package prop
  *   )
  *
  * forAll (invalidCombos) { (n: Int, d: Int) =&gt;
- *   evaluating {
+ *   an [IllegalArgumentException] should be thrownBy {
  *     new Fraction(n, d)
- *   } should produce [IllegalArgumentException]
+ *   }
  * }
  * </pre>
  *


### PR DESCRIPTION
The `evaluating {...} should produce [...]` syntax is deprecated,

  warning:
    method evaluating in trait Matchers is deprecated:
    Please use 'an [Exception] should be thrownBy { ... }' syntax instead

Update the API documentation examples to follow this advice.