### PR TITLE
Fact Enhancement Step 3

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
@@ -115,6 +115,18 @@ class ExpectationsSpec extends FunSpec with Expectations {
         "No(expected 5, but got 6)"
       )
     }
+    it("should use vertical diagrammed style of message and prefix Unary_! instance with !") {
+      val fact = (expectResult(3) { 3 } && !expectResult(4) { 4 }) || expectResult(5) { 6 }
+      assert(fact.factMessage ==
+        "No(" + NEWLINE +
+        "  Yes(expected 3, and got 3) &&" + NEWLINE +
+        "  No(" + NEWLINE +
+        "    !Yes(expected 4, and got 4)" + NEWLINE +
+        "  )" + NEWLINE +
+        ") ||" + NEWLINE +
+        "No(expected 5, but got 6)"
+      )
+    }
   }
 
   describe("The expectThrows method") {

--- a/scalatest-test/src/test/scala/org/scalatest/FactSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/FactSpec.scala
@@ -34,6 +34,8 @@ No(4 did not equal 3)
 */
 class FactSpec extends FreeSpec with Matchers with PrettyMethods with ExpectationHavePropertyMatchers {
 
+  val NEWLINE = scala.compat.Platform.EOL
+
   "A Fact" - {
     // As if we said expectResult(3) { 1 + 1 }
     val noFact: Expectation = No("Expected 3, but got 2", "3 did not equal 2", "expected 3, but got 2", "3 did not equal 2")
@@ -380,6 +382,22 @@ class FactSpec extends FreeSpec with Matchers with PrettyMethods with Expectatio
         fact.rawMidSentenceSimplifiedFactMessage should be (Resources.rawBothParensCommaAnd)
         fact.isLeaf should be (false)
       }*/
+    }
+
+    "toString method" - {
+
+      "should display midSentenceFactMessage enclosed with opening and closing bracket" in {
+        val yes = Yes("fact message", "simplified fact message", "mid-sentence fact message", "simplified mid-sentence fact message")
+        yes.toString shouldBe "Yes(mid-sentence fact message)"
+
+        val no = No("fact message", "simplified fact message", "mid-sentence fact message", "simplified mid-sentence fact message")
+        no.toString shouldBe "No(mid-sentence fact message)"
+      }
+
+      "should prefix new line to midSentenceFactMessage in toString when the midSentenceFactMessage contains \\n" in {
+        val fact = Yes("fact message", "simplified fact message", "line 1\nline 2\nline 3", "simplified mid-sentence fact message")
+        fact.toString shouldBe "Yes(" + NEWLINE + "line 1\nline 2\nline 3" + NEWLINE + ")"
+      }
     }
   }
 

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -87,7 +87,13 @@ sealed abstract class Fact {
   private def makeString(raw: String, args: IndexedSeq[Any]): String =
     Resources.formatString(raw, args.map(Prettifier.default).toArray)
 
-  override def toString: String = stringPrefix + "(" + midSentenceFactMessage + ")"
+  private val NEWLINE = scala.compat.Platform.EOL
+
+  override def toString: String =
+    if (midSentenceFactMessage.contains("\n"))
+      stringPrefix + "(" + NEWLINE + midSentenceFactMessage + NEWLINE + ")"
+    else
+      stringPrefix + "(" + midSentenceFactMessage + ")"
 }
 
 object Fact {

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -709,7 +709,9 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
         Resources.formatString(raw, Array(left, right))
 
       case unaryNot: Unary_! =>
-        ""
+        (if (unaryNot.isYes) "Yes(" else "No(") + NEWLINE +
+        ("  " * (level + 1)) + "!" + diagramToString(unaryNot.underlying, level) + NEWLINE +
+        ("  " * level) + ")"
 
       case other => fact.toString
     }

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -94,6 +94,43 @@ sealed abstract class Fact {
       stringPrefix + "(" + NEWLINE + midSentenceFactMessage + NEWLINE + ")"
     else
       stringPrefix + "(" + midSentenceFactMessage + ")"
+
+  private[scalatest] def rawFactDiagram(level: Int, operator: String): String = {
+    val padding = "  " * level
+    padding + "{0} " + operator + NEWLINE +
+      padding + "{1}"
+  }
+
+  private def rawNestedFactDiagram(isTrue: Boolean, level: Int, operator: String): String = {
+    val padding = "  " * level
+    padding + (if (isTrue) "Yes(" else "No(") + NEWLINE +
+      rawFactDiagram(level + 1, operator) + NEWLINE +
+      padding + ")"
+  }
+
+  private[scalatest] def factDiagram(level: Int): String = {
+    import Fact.{Binary_&&, Binary_||, Unary_!}
+    this match {
+      case binaryDoubleAmpersand: Binary_&& =>
+        val raw = rawNestedFactDiagram(this.isYes, level, "&&")
+        val left = binaryDoubleAmpersand.leftFactDiagram(level)
+        val right = binaryDoubleAmpersand.rightFactDiagram(level)
+        Resources.formatString(raw, Array(left, right))
+
+      case binaryDoublePipe: Binary_|| =>
+        val raw = rawNestedFactDiagram(this.isYes, level, "||")
+        val left = binaryDoublePipe.leftFactDiagram(level)
+        val right = binaryDoublePipe.rightFactDiagram(level)
+        Resources.formatString(raw, Array(left, right))
+
+      case unaryNot: Unary_! =>
+        (if (unaryNot.isYes) "Yes(" else "No(") + NEWLINE +
+          ("  " * (level + 1)) + "!" + unaryNot.underlying.factDiagram(level) + NEWLINE +
+          ("  " * level) + ")"
+
+      case other => toString
+    }
+  }
 }
 
 object Fact {
@@ -685,44 +722,7 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
     override def unary_!(): org.scalatest.Fact = underlying
   }
 
-  private val NEWLINE = scala.compat.Platform.EOL
-
-  private def rawDiagram(level: Int, operator: String): String = {
-    val padding = "  " * level
-    padding + "{0} " + operator + NEWLINE +
-    padding + "{1}"
-  }
-
-  private def rawNestedDiagram(isTrue: Boolean, level: Int, operator: String): String = {
-    val padding = "  " * level
-    padding + (if (isTrue) "Yes(" else "No(") + NEWLINE +
-    rawDiagram(level + 1, operator) + NEWLINE +
-    padding + ")"
-  }
-
-  private def diagramToString(fact: Fact, level: Int): String =
-    fact match {
-      case binaryDoubleAmpersand: Binary_&& =>
-        val raw = rawNestedDiagram(fact.isYes, level, "&&")
-        val left = diagramToString(binaryDoubleAmpersand.left, level + 1)
-        val right = diagramToString(binaryDoubleAmpersand.right, level + 1)
-        Resources.formatString(raw, Array(left, right))
-
-      case binaryDoublePipe: Binary_|| =>
-        val raw = rawNestedDiagram(fact.isYes, level, "||")
-        val left = diagramToString(binaryDoublePipe.left, level + 1)
-        val right = diagramToString(binaryDoublePipe.right, level + 1)
-        Resources.formatString(raw, Array(left, right))
-
-      case unaryNot: Unary_! =>
-        (if (unaryNot.isYes) "Yes(" else "No(") + NEWLINE +
-        ("  " * (level + 1)) + "!" + diagramToString(unaryNot.underlying, level) + NEWLINE +
-        ("  " * level) + ")"
-
-      case other => fact.toString
-    }
-
-  class Binary_&&(private[scalatest] val left: Fact, private[scalatest] val right: Fact) extends Fact {
+  class Binary_&&(left: Fact, right: Fact) extends Fact {
 
     require(left.isYes)
 
@@ -731,7 +731,7 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
         Resources.rawCommaBut
       }
       else
-        rawDiagram(0, "&&")
+        rawFactDiagram(0, "&&")
     }
     val rawSimplifiedFactMessage: String = {
       Resources.rawCommaBut
@@ -750,7 +750,7 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
         ) // Simplify if combining
       }
       else {
-        Vector(UnquotedString(diagramToString(left, 0)), UnquotedString(diagramToString(right, 0)))
+        Vector(UnquotedString(left.factDiagram(0)), UnquotedString(right.factDiagram(0)))
       }
     }
     val simplifiedFactMessageArgs: IndexedSeq[Any] = {
@@ -767,13 +767,17 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
     val prettifier: Prettifier = left.prettifier
 
     def isYes: Boolean = left.isYes && right.isYes
+
+    private[scalatest] def leftFactDiagram(level: Int): String = left.factDiagram(level + 1)
+
+    private[scalatest] def rightFactDiagram(level: Int): String = right.factDiagram(level + 1)
   }
 
   object Binary_&& {
     def apply(left: Fact, right: => Fact): Fact = new Binary_&&(left, right)
   }
 
-  class Binary_||(private[scalatest] val left: Fact, private[scalatest] val right: Fact) extends Fact {
+  class Binary_||(left: Fact, right: Fact) extends Fact {
 
     require(left.isNo)
 
@@ -782,7 +786,7 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
         Resources.rawCommaAnd
       }
       else
-        rawDiagram(0, "||")
+        rawFactDiagram(0, "||")
     }
     val rawSimplifiedFactMessage: String = {
       Resources.rawCommaAnd
@@ -798,7 +802,7 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
         Vector(FactMessage(left), MidSentenceFactMessage(right))
       }
       else {
-        Vector(UnquotedString(diagramToString(left, 0)), UnquotedString(diagramToString(right, 0)))
+        Vector(UnquotedString(left.factDiagram(0)), UnquotedString(right.factDiagram(0)))
       }
     }
     val simplifiedFactMessageArgs: IndexedSeq[Any] = {
@@ -815,6 +819,10 @@ factMessage is the simplified one, if need be, and simplifiedFactMessage is a si
     val prettifier: Prettifier = left.prettifier
 
     def isYes: Boolean = left.isYes || right.isYes
+
+    private[scalatest] def leftFactDiagram(level: Int): String = left.factDiagram(level + 1)
+
+    private[scalatest] def rightFactDiagram(level: Int): String = right.factDiagram(level + 1)
   }
 
   object Binary_|| {


### PR DESCRIPTION
-Display Unary_! correct in fact diagram.
-Enhanced Fact.toString to prefix and prepend midSentenceFactMessage with new line character when midSentenceFactMessage itself contains '\n' character.
-Refactored diagramToString method into Fact as factDiagram method, which eliminate the needs to mark left and right of Binary_&& and Binary_|| as private[scalatest].