### PR TITLE
Fact and Expectations Step 5

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
@@ -98,7 +98,7 @@ class ExpectationsSpec extends FunSpec with Expectations {
         ")"
       )
     }
-    it("should give a basic message for a binary expression with 2 leafs") {
+    it("should give a basic message for a && binary expression with 2 leafs") {
       val fact1 = expectResult(3) { 3 } && expectResult(3) { 4 }
       assert(fact1.isNo)
       assert(fact1.factMessage  == "3 equaled 3, but 3 did not equal 4")
@@ -121,7 +121,30 @@ class ExpectationsSpec extends FunSpec with Expectations {
         ")"
       )
     }
-    it("should use vertical diagrammed style of message when one of component in a binary expression is not a leaf") {
+    it("should give a basic message for a & binary expression with 2 leafs") {
+      val fact1 = expectResult(3) { 3 } & expectResult(3) { 4 }
+      assert(fact1.isNo)
+      assert(fact1.factMessage  == "3 equaled 3, but 3 did not equal 4")
+      assert(fact1.toString ==
+        "No(" + NEWLINE +
+          "  Yes(expected 3, and got 3) &" + NEWLINE +
+          "  No(expected 3, but got 4)" + NEWLINE +
+          ")"
+      )
+
+      val fact2 = expectResult(3) { 3 } & !expectResult(4) { 4 }
+      assert(fact2.isNo)
+      assert(fact2.factMessage  == "3 equaled 3, but 4 equaled 4")
+      assert(fact2.toString ==
+        "No(" + NEWLINE +
+          "  Yes(expected 3, and got 3) &" + NEWLINE +
+          "  No(" + NEWLINE +
+          "    !Yes(expected 4, and got 4)" + NEWLINE +
+          "  )" + NEWLINE +
+          ")"
+      )
+    }
+    it("should use vertical diagrammed style of message when one of component in && and || binary expression is not a leaf") {
       val fact = (expectResult(3) { 3 } && expectResult(3) { 4 }) || expectResult(5) { 6 }
       assert(fact.factMessage ==
         "No(" + NEWLINE +
@@ -140,6 +163,27 @@ class ExpectationsSpec extends FunSpec with Expectations {
         "  ) ||" + NEWLINE +
         "  No(expected 5, but got 6)" + NEWLINE +
         ")"
+      )
+    }
+    it("should use vertical diagrammed style of message when one of component in & and | binary expression is not a leaf") {
+      val fact = (expectResult(3) { 3 } & expectResult(3) { 4 }) | expectResult(5) { 6 }
+      assert(fact.factMessage ==
+        "No(" + NEWLINE +
+          "  No(" + NEWLINE +
+          "    Yes(expected 3, and got 3) &" + NEWLINE +
+          "    No(expected 3, but got 4)" + NEWLINE +
+          "  ) |" + NEWLINE +
+          "  No(expected 5, but got 6)" + NEWLINE +
+          ")"
+      )
+      assert(fact.toString ==
+        "No(" + NEWLINE +
+          "  No(" + NEWLINE +
+          "    Yes(expected 3, and got 3) &" + NEWLINE +
+          "    No(expected 3, but got 4)" + NEWLINE +
+          "  ) |" + NEWLINE +
+          "  No(expected 5, but got 6)" + NEWLINE +
+          ")"
       )
     }
     it("should use vertical diagrammed style of message and prefix Unary_! instance with !") {

--- a/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
@@ -354,4 +354,74 @@ class ExpectationsSpec extends FunSpec with Expectations {
       assert(fact.factMessage == "1 did not equal 2")
     }
   }
+
+  describe("expectDoesNotCompile method") {
+
+    describe("when work with string literal") {
+
+      it("should return Yes with correct fact message when type check failed") {
+        val fact = expectDoesNotCompile("val a: String = 1")
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.didNotCompile("val a: String = 1"))
+      }
+
+      it("should return No with correct fact message when parse and type check passed") {
+        val fact = expectDoesNotCompile("val a = 1")
+        assert(fact.isInstanceOf[Fact.No])
+        assert(fact.factMessage == Resources.expectedCompileErrorButGotNone("val a = 1"))
+      }
+
+      it("should return Yes with correct fact messsage when parse failed") {
+        val fact = expectDoesNotCompile("println(\"test)")
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.didNotCompile("println(\"test)"))
+      }
+
+    }
+
+    describe("when used with triple quotes string literal with stripMargin") {
+
+      it("should return Yes with correct fact message when type check failed") {
+        val fact = expectDoesNotCompile(
+          """
+            |val a: String = 2
+            |""".stripMargin
+        )
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.didNotCompile(
+          """
+            |val a: String = 2
+            |""".stripMargin
+        ))
+      }
+
+      it("should return No with correct fact message when parse and type check passed") {
+        val fact = expectDoesNotCompile(
+          """
+            |val a = 1
+            |""".stripMargin
+        )
+        assert(fact.isInstanceOf[Fact.No])
+        assert(fact.factMessage == Resources.expectedCompileErrorButGotNone(
+          """
+            |val a = 1
+            |""".stripMargin
+        ))
+      }
+
+      it("should return Yes with correct fact message when parse failed ") {
+        val fact = expectDoesNotCompile(
+          """
+            |println(\"test)
+            |""".stripMargin
+        )
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.didNotCompile(
+          """
+            |println(\"test)
+            |""".stripMargin
+        ))
+      }
+    }
+  }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
@@ -424,4 +424,81 @@ class ExpectationsSpec extends FunSpec with Expectations {
       }
     }
   }
+
+  describe("expectCompiles method") {
+
+    describe("when work with string literal") {
+
+      it("should return Yes with correct fact message when type check passed") {
+        val fact = expectCompiles("val a = 1")
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.compiledSuccessfully("val a = 1"))
+      }
+
+      it("should return No with correct fact message when type check failed") {
+        val fact = expectCompiles("val a: String = 2")
+        assert(fact.isInstanceOf[Fact.No])
+        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+          """type mismatch;
+            | found   : Int(2)
+            | required: String""".stripMargin, "val a: String = 2"))
+      }
+
+      it("should return No with correct fact message when parse failed") {
+        val fact = expectCompiles("println(\"test)")
+        assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("unclosed string literal", "println(\"test)"))
+      }
+    }
+
+    describe("when used with triple quotes string literal with stripMargin") {
+
+      it("should return Fact with correct fact message when type check passed") {
+        val fact =
+          expectCompiles(
+            """
+              |val a = 1
+              |""".stripMargin
+          )
+        assert(fact.isInstanceOf[Fact.Yes])
+        assert(fact.factMessage == Resources.compiledSuccessfully(
+          """
+            |val a = 1
+            |""".stripMargin
+        ))
+      }
+
+      it("should return No with correct fact message when type check failed") {
+        val fact =
+          expectCompiles(
+            """
+              |val a: String = 2
+              |""".stripMargin
+          )
+        assert(fact.isInstanceOf[Fact.No])
+        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+          """type mismatch;
+            | found   : Int(2)
+            | required: String""".stripMargin,
+          """
+            |val a: String = 2
+            |""".stripMargin))
+      }
+
+      it("should return No with correct fact message when parse failed") {
+        val fact =
+          expectCompiles(
+            """
+              |println("test)
+              |""".stripMargin
+          )
+        assert(fact.isInstanceOf[Fact.No])
+        assert(fact.factMessage == Resources.expectedNoErrorButGotParseError(
+          "unclosed string literal",
+          """
+            |println("test)
+            |""".stripMargin
+        ))
+      }
+    }
+  }
 }

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -665,6 +665,7 @@ nonEmptyMatchPatternCase=No code is allowed to the right of rocket symbols (=>) 
 expectedTypeErrorButGotNone=Expected a type error, but got none for code: {0}
 expectedCompileErrorButGotNone=Expected a compiler error, but got none for code: {0}
 didNotCompile={0} did not compile
+compiledSuccessfully={0} compiled successfully
 expectedTypeErrorButGotParseError=Expected a type error, but got the following parse error: "{0}", for code: {1}
 expectedNoErrorButGotTypeError=Expected no compiler error, but got the following type error: "{0}", for code: {1}
 expectedNoErrorButGotParseError=Expected no compiler error, but got the following parse error: "{0}", for code: {1}

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -664,6 +664,7 @@ nonEmptyMatchPatternCase=No code is allowed to the right of rocket symbols (=>) 
 
 expectedTypeErrorButGotNone=Expected a type error, but got none for code: {0}
 expectedCompileErrorButGotNone=Expected a compiler error, but got none for code: {0}
+didNotCompile={0} did not compile
 expectedTypeErrorButGotParseError=Expected a type error, but got the following parse error: "{0}", for code: {1}
 expectedNoErrorButGotTypeError=Expected no compiler error, but got the following type error: "{0}", for code: {1}
 expectedNoErrorButGotParseError=Expected no compiler error, but got the following parse error: "{0}", for code: {1}

--- a/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
@@ -108,6 +108,66 @@ private[scalatest] object CompileMacro {
     }
   }
 
+  // parse and type check a code snippet, generate code to return Fact (Yes or No).
+  def expectDoesNotCompileImpl(c: Context)(code: c.Expr[String]): c.Expr[Fact] = {
+    import c.universe._
+
+    // extract code snippet
+    val codeStr = getCodeStringFromCodeExpression(c)("assertDoesNotCompile", code)
+
+    try {
+      c.typeCheck(c.parse("{ "+codeStr+" }"))  // parse and type check code snippet
+      // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
+      val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
+      reify {
+        Fact.No(
+          messageExpr.splice,
+          messageExpr.splice,
+          messageExpr.splice,
+          messageExpr.splice,
+          Vector.empty,
+          Vector.empty,
+          Vector.empty,
+          Vector.empty
+        )
+        //throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
+      }
+    } catch {
+      case e: TypecheckException =>
+        val messageExpr = c.literal(Resources.didNotCompile(codeStr))
+        reify {
+          // type check error, code snippet does not compile as expected, generate code to return Succeeded
+          Fact.Yes(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )
+          //Succeeded
+        }
+      case e: ParseException =>
+        val messageExpr = c.literal(Resources.didNotCompile(codeStr))
+        reify {
+          // parse error, code snippet does not compile as expected, generate code to return Succeeded
+          Fact.Yes(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )
+          //Succeeded
+        }
+    }
+  }
+
   // parse and type check a code snippet, generate code to throw TestFailedException when either parse or type check fails.
   def assertCompilesImpl(c: Context)(code: c.Expr[String]): c.Expr[Assertion] = {
     import c.universe._

--- a/scalatest/src/main/scala/org/scalatest/Expectations.scala
+++ b/scalatest/src/main/scala/org/scalatest/Expectations.scala
@@ -139,28 +139,8 @@ trait Expectations {
   import language.experimental.macros
 
   def expect(expression: Boolean): Fact = macro ExpectationsMacro.expect
-    /*if (expression)
-      Yes(
-        "Expectation was true",
-        "Expectation was true",
-        "expectation was true",
-        "expectation was true",
-        Vector.empty,
-        Vector.empty,
-        Vector.empty,
-        Vector.empty
-      )
-    else
-      No(
-        "Expectation was false",
-        "Expectation was false",
-        "expectation was false",
-        "expectation was false",
-        Vector.empty,
-        Vector.empty,
-        Vector.empty,
-        Vector.empty
-      )*/
+
+  def expectDoesNotCompile(code: String): Fact = macro CompileMacro.expectDoesNotCompileImpl
 }
 
 object Expectations extends Expectations

--- a/scalatest/src/main/scala/org/scalatest/Expectations.scala
+++ b/scalatest/src/main/scala/org/scalatest/Expectations.scala
@@ -141,6 +141,8 @@ trait Expectations {
   def expect(expression: Boolean): Fact = macro ExpectationsMacro.expect
 
   def expectDoesNotCompile(code: String): Fact = macro CompileMacro.expectDoesNotCompileImpl
+
+  def expectCompiles(code: String): Fact = macro CompileMacro.expectCompilesImpl
 }
 
 object Expectations extends Expectations

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -700,6 +700,8 @@ object Fact {
 
   class Binary_&(left: Fact, right: Fact) extends Fact {
 
+    private[scalatest] def operatorName: String = "&"
+
     val rawFactMessage: String = {
       if (left.isLeaf && right.isLeaf) {
         if (left.isYes && right.isNo)
@@ -746,7 +748,7 @@ object Fact {
     override def factDiagram(level: Int): String = {
       val padding = "  " * level
       padding + stringPrefix + "(" + NEWLINE +
-        left.factDiagram(level + 1) + " &&" + NEWLINE +
+        left.factDiagram(level + 1) + " " + operatorName + NEWLINE +
         right.factDiagram(level + 1) + NEWLINE +
         padding + ")"
     }
@@ -758,6 +760,7 @@ object Fact {
 
   class Binary_&&(left: Fact, right: Fact) extends Binary_&(left, right) {
     require(left.isYes)
+    override private[scalatest] def operatorName: String = "&&"
   }
 
   object Binary_&& {
@@ -765,6 +768,8 @@ object Fact {
   }
 
   class Binary_|(left: Fact, right: Fact) extends Fact {
+
+    private[scalatest] def operatorName: String = "|"
 
     val rawFactMessage: String = {
       if (left.isLeaf && right.isLeaf) {
@@ -802,7 +807,7 @@ object Fact {
     override def factDiagram(level: Int): String = {
       val padding = "  " * level
       padding + stringPrefix + "(" + NEWLINE +
-      left.factDiagram(level + 1) + " ||" + NEWLINE +
+      left.factDiagram(level + 1) + " " + operatorName + NEWLINE +
       right.factDiagram(level + 1) + NEWLINE +
       padding + ")"
     }
@@ -814,6 +819,7 @@ object Fact {
 
   class Binary_||(left: Fact, right: Fact) extends Binary_|(left, right) {
     require(left.isNo)
+    override private[scalatest] def operatorName: String = "||"
   }
 
   object Binary_|| {


### PR DESCRIPTION
-Fixed wrong symbol was used in factDiagram for Binary_& and Binary_|.
-Added expectDoesNotCompile to Expections.
-Added expectCompiles to Expectations.