### PR TITLE
Further Scala-js Broken Tests Fix

### DIFF
--- a/project/GenTable.scala
+++ b/project/GenTable.scala
@@ -325,7 +325,7 @@ class TableFor$n$[$alphaUpper$](val heading: ($strings$), rows: ($alphaUpper$)*)
           // SKIP-SCALATESTJS-START
           val stackDepth = 2
           // SKIP-SCALATESTJS-END
-          //SCALATESTJS-ONLY val stackDepth = 0
+          //SCALATESTJS-ONLY val stackDepth = 1
 
           throw new TableDrivenPropertyCheckFailedException(
             sde => FailureMessages.propertyException(UnquotedString(ex.getClass.getSimpleName)) +

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -44,12 +44,17 @@ sealed abstract class Fact {
 
   final def toBoolean: Boolean = isYes
 
-  final def toAssertion: Assertion =
+  final def toAssertion: Assertion = {
+    // SKIP-SCALATESTJS-START
+    val stackDepth = 5
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepth = 10
     if (isYes) {
       if (!isVacuousYes) Succeeded
-      else throw new TestCanceledException(factMessage, 5)
+      else throw new TestCanceledException(factMessage, stackDepth)
     }
-    else throw new TestFailedException(factMessage, 5)
+    else throw new TestFailedException(factMessage, stackDepth)
+  }
 
   // This is called internally by implicit conversions, which has different stack depth
   private[scalatest] final def internalToAssertion: Assertion =

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
@@ -299,8 +299,14 @@ trait Futures extends PatienceConfiguration {
      * @return
      */
     final def isReadyWithin(timeout: Span)(implicit config: PatienceConfig): Boolean = {
+
+      // SKIP-SCALATESTJS-START
+      val stackDepthAdjustment = 3
+      // SKIP-SCALATESTJS-END
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+
       try {
-        futureValueImpl("isReadyWithin")(PatienceConfig(timeout, config.interval))
+        futureValueImpl("isReadyWithin", stackDepthAdjustment)(PatienceConfig(timeout, config.interval))
         true
       }
       catch {
@@ -344,8 +350,13 @@ trait Futures extends PatienceConfiguration {
      * @throws TestFailedException if the future is cancelled, expires, or is still not ready after
      *     the specified timeout has been exceeded
      */
-    final def futureValue(timeout: Timeout, interval: Interval): T =
-      futureValueImpl("futureValue")(PatienceConfig(timeout.value, interval.value))
+    final def futureValue(timeout: Timeout, interval: Interval): T = {
+      // SKIP-SCALATESTJS-START
+      val stackDepthAdjustment = 3
+      // SKIP-SCALATESTJS-END
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      futureValueImpl("futureValue", stackDepthAdjustment)(PatienceConfig(timeout.value, interval.value))
+    }
 
     /**
      * Returns the result of this <code>FutureConcept</code>, once it is ready, or throws either the
@@ -384,8 +395,13 @@ trait Futures extends PatienceConfiguration {
      * @throws TestFailedException if the future is cancelled, expires, or is still not ready after
      *     the specified timeout has been exceeded
      */
-    final def futureValue(timeout: Timeout)(implicit config: PatienceConfig): T =
-      futureValueImpl("futureValue")(PatienceConfig(timeout.value, config.interval))
+    final def futureValue(timeout: Timeout)(implicit config: PatienceConfig): T = {
+      // SKIP-SCALATESTJS-START
+      val stackDepthAdjustment = 3
+      // SKIP-SCALATESTJS-END
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      futureValueImpl("futureValue", stackDepthAdjustment)(PatienceConfig(timeout.value, config.interval))
+    }
 
     /**
      * Returns the result of this <code>FutureConcept</code>, once it is ready, or throws either the
@@ -424,8 +440,13 @@ trait Futures extends PatienceConfiguration {
      * @throws TestFailedException if the future is cancelled, expires, or is still not ready after
      *     the specified timeout has been exceeded
      */
-    final def futureValue(interval: Interval)(implicit config: PatienceConfig): T =
-      futureValueImpl("futureValue")(PatienceConfig(config.timeout, interval.value))
+    final def futureValue(interval: Interval)(implicit config: PatienceConfig): T = {
+      // SKIP-SCALATESTJS-START
+      val stackDepthAdjustment = 3
+      // SKIP-SCALATESTJS-END
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      futureValueImpl("futureValue", stackDepthAdjustment)(PatienceConfig(config.timeout, interval.value))
+    }
 
     /**
      * Returns the result of this <code>FutureConcept</code>, once it is ready, or throws either the
@@ -464,15 +485,15 @@ trait Futures extends PatienceConfiguration {
      * @throws TestFailedException if the future is cancelled, expires, or is still not ready after
      *     the specified timeout has been exceeded
      */
-    def futureValue(implicit config: PatienceConfig): T =
-      futureValueImpl("futureValue")(config)
-
-    private[concurrent] def futureValueImpl(methodName: String)(implicit config: PatienceConfig): T = {
-
+    def futureValue(implicit config: PatienceConfig): T = {
       // SKIP-SCALATESTJS-START
-      val stackDepthAdjustment = 3 + jsAdjustment
+      val stackDepthAdjustment = 3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepthAdjustment = 1 + jsAdjustment
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      futureValueImpl("futureValue", stackDepthAdjustment)(config)
+    }
+
+    private[concurrent] def futureValueImpl(methodName: String, stackDepthAdjustment: Int)(implicit config: PatienceConfig): T = {
 
       val startNanos = System.nanoTime
 
@@ -577,7 +598,11 @@ trait Futures extends PatienceConfiguration {
    * @return the result of invoking the <code>fun</code> parameter
    */
   final def whenReady[T, U](future: FutureConcept[T], timeout: Timeout, interval: Interval)(fun: T => U)(implicit config: PatienceConfig): U = {
-    val result = future.futureValueImpl("whenReady")(PatienceConfig(timeout.value, interval.value))
+    // SKIP-SCALATESTJS-START
+    val stackDepthAdjustment = 3
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepthAdjustment = 1
+    val result = future.futureValueImpl("whenReady", stackDepthAdjustment)(PatienceConfig(timeout.value, interval.value))
     fun(result)
   }
     // whenReady(future)(fun)(PatienceConfig(timeout.value, interval.value))
@@ -611,7 +636,11 @@ trait Futures extends PatienceConfiguration {
    * @return the result of invoking the <code>fun</code> parameter
    */
   final def whenReady[T, U](future: FutureConcept[T], timeout: Timeout)(fun: T => U)(implicit config: PatienceConfig): U = {
-    val result = future.futureValueImpl("whenReady")(PatienceConfig(timeout.value, config.interval))
+    // SKIP-SCALATESTJS-START
+    val stackDepthAdjustment = 3
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepthAdjustment = 1
+    val result = future.futureValueImpl("whenReady", stackDepthAdjustment)(PatienceConfig(timeout.value, config.interval))
     fun(result)
   }
     // whenReady(future)(fun)(PatienceConfig(timeout.value, config.interval))
@@ -636,7 +665,11 @@ trait Futures extends PatienceConfiguration {
    * @return the result of invoking the <code>fun</code> parameter
    */
   final def whenReady[T, U](future: FutureConcept[T], interval: Interval)(fun: T => U)(implicit config: PatienceConfig): U = {
-    val result = future.futureValueImpl("whenReady")(PatienceConfig(config.timeout, interval.value))
+    // SKIP-SCALATESTJS-START
+    val stackDepthAdjustment = 3
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepthAdjustment = 1
+    val result = future.futureValueImpl("whenReady", stackDepthAdjustment)(PatienceConfig(config.timeout, interval.value))
     fun(result)
   }
     // whenReady(future)(fun)(PatienceConfig(config.timeout, interval.value))
@@ -669,7 +702,11 @@ trait Futures extends PatienceConfiguration {
    * @return the result of invoking the <code>fun</code> parameter
    */
   final def whenReady[T, U](future: FutureConcept[T])(fun: T => U)(implicit config: PatienceConfig): U = {
-    val result = future.futureValueImpl("whenReady")(config)
+    // SKIP-SCALATESTJS-START
+    val stackDepthAdjustment = 3
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepthAdjustment = 1
+    val result = future.futureValueImpl("whenReady", stackDepthAdjustment)(config)
     fun(result)
   }
 }

--- a/scalatest/src/main/scala/org/scalatest/concurrent/JavaFutures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/JavaFutures.scala
@@ -77,7 +77,7 @@ trait JavaFutures extends Futures {
       def isCanceled: Boolean = javaFuture.isCancelled // Two ll's in Canceled. The verbosity of Java strikes again!
       // TODO: Catch TimeoutException and wrap that in a TFE with ScalaTest's TimeoutException I think.
       // def awaitAtMost(span: Span): T = javaFuture.get(span.totalNanos, TimeUnit.NANOSECONDS)
-      override private[concurrent] def futureValueImpl(methodName: String)(implicit config: PatienceConfig): T = {
+      override private[concurrent] def futureValueImpl(methodName: String, stackDepthAdjustment: Int)(implicit config: PatienceConfig): T = {
         val adjustment =
           if (methodName == "whenReady")
             3

--- a/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
@@ -344,6 +344,7 @@ trait Checkers extends Configuration {
    * @throws TestFailedException if a test case is discovered for which the property doesn't hold.
    */
   def check(p: Prop, prms: Test.Parameters): Assertion = {
+    println("here11")
     Checkers.doCheck(p, prms, "Checkers.scala", "check")
   }
 
@@ -355,7 +356,8 @@ trait Checkers extends Configuration {
    */
   def check(p: Prop, configParams: PropertyCheckConfigParam*)(implicit config: PropertyCheckConfigurable): Assertion = {
     val params = getParams(configParams, config)
-    check(p, params)
+    //check(p, params)
+    Checkers.doCheck(p, params, "Checkers.scala", "check")
   }
 }
 
@@ -400,6 +402,11 @@ object Checkers extends Checkers {
 
         case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
 
+          // SKIP-SCALATESTJS-START
+          val stackDepth = 0
+          // SKIP-SCALATESTJS-END
+          //SCALATESTJS-ONLY val stackDepth = 1
+
           throw new GeneratorDrivenPropertyCheckFailedException(
             sde => FailureMessages.propertyException(UnquotedString(sde.getClass.getSimpleName)) + "\n" +
               ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" + 
@@ -416,7 +423,7 @@ object Checkers extends Checkers {
               "  )" + 
               getLabelDisplay(scalaCheckLabels),
             None,
-            getStackDepthFun(stackDepthFileName, stackDepthMethodName),
+            getStackDepthFun(stackDepthFileName, stackDepthMethodName, stackDepth),
             None,
             FailureMessages.propertyFailed(result.succeeded),
             scalaCheckArgs,


### PR DESCRIPTION
Fixed failing tests (under scala-js) in FactSpec, ScalaFuturesSpec, TableDrivenPropertyCheckFailedExceptionSpec and CheckersSuite.