### PR TITLE
Async Tests + Scala-js Stack Depth Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFeatureSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFeatureSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        scenario("test 1") {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        scenario("test 2") {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        scenario("test 3") {
+          Future {
+            pending
+          }
+        }
+
+        scenario("test 4") {
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        scenario("test 1") {
+          assert(a == 1)
+        }
+
+        scenario("test 2") {
+          assert(a == 2)
+        }
+
+        scenario("test 3") {
+          pending
+        }
+
+        scenario("test 4") {
+          cancel
+        }
+
+        ignore("test 5") {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        scenario("test 1") {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        scenario("test 2") {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        scenario("test 3") {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        scenario("test 1") {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        scenario("test 2") {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        scenario("test 3") {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFeatureSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFeatureSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        scenario("test 1") {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        scenario("test 2") {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        scenario("test 3") {
+          Future {
+            pending
+          }
+        }
+
+        scenario("test 4") {
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        scenario("test 1") {
+          assert(a == 1)
+        }
+
+        scenario("test 2") {
+          assert(a == 2)
+        }
+
+        scenario("test 3") {
+          pending
+        }
+
+        scenario("test 4") {
+          cancel
+        }
+
+        ignore("test 5") {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        scenario("test 1") {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        scenario("test 2") {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        scenario("test 3") {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        scenario("test 1") {
+          SleepHelper.sleep(3000)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        scenario("test 2") {
+          assert(count == 1)
+          SleepHelper.sleep(5000)
+          count = 2
+          Succeeded
+        }
+
+        scenario("test 3") {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFlatSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFlatSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        it should "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it should "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it should "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        it should "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        it should "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        it should "test 1" in {
+          assert(a == 1)
+        }
+
+        it should "test 2" in {
+          assert(a == 2)
+        }
+
+        it should "test 3" in {
+          pending
+        }
+
+        it should "test 4" in {
+          cancel
+        }
+
+        it should "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        it should "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it should "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it should "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        it should "test 1" in {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it should "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it should "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import org.scalatest.SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFlatSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFlatSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFlatSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        it should "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it should "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it should "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        it should "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        it should "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        it should "test 1" in {
+          assert(a == 1)
+        }
+
+        it should "test 2" in {
+          assert(a == 2)
+        }
+
+        it should "test 3" in {
+          pending
+        }
+
+        it should "test 4" in {
+          cancel
+        }
+
+        it should "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        it should "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it should "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it should "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        it should "test 1" in {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it should "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it should "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFreeSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFreeSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          assert(a == 1)
+        }
+
+        "test 2" in {
+          assert(a == 2)
+        }
+
+        "test 3" in {
+          pending
+        }
+
+        "test 4" in {
+          cancel
+        }
+
+        "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFreeSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFreeSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFreeSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          assert(a == 1)
+        }
+
+        "test 2" in {
+          assert(a == 2)
+        }
+
+        "test 3" in {
+          pending
+        }
+
+        "test 4" in {
+          cancel
+        }
+
+        "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
@@ -16,10 +16,23 @@
 package org.scalatest
 
 import SharedHelpers.EventRecordingReporter
-import scala.concurrent.Future
+import scala.concurrent.{Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
-class AsyncFunSpecSpec extends FunSpec {
+class AsyncFunSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
 
   describe("AsyncFunSpec") {
 
@@ -30,7 +43,7 @@ class AsyncFunSpecSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         val a = 1
 
@@ -66,13 +79,13 @@ class AsyncFunSpecSpec extends FunSpec {
 
         it("test 6") {
           Future {
-            expect(a == 1)
+            assert(a == 1)
           }
         }
 
         it("test 7") {
           Future {
-            expect(a == 22)
+            assert(a == 22)
           }
         }
 
@@ -82,25 +95,24 @@ class AsyncFunSpecSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val spec = new ExampleSpec
       val status = spec.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-      assert(rep.testStartingEventsReceived.length == 6)
-      assert(rep.testSucceededEventsReceived.length == 2)
-      assert(rep.testSucceededEventsReceived(0).testName == "test 1")
-      assert(rep.testSucceededEventsReceived(1).testName == "test 6")
-      assert(rep.testFailedEventsReceived.length == 2)
-      assert { 
-        val zero = rep.testFailedEventsReceived(0).testName
-        val one = rep.testFailedEventsReceived(1).testName
-        (zero == "test 2" && one == "test 7") || (zero == "test 7" && one == "test 2")
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 6)
+        assert(rep.testSucceededEventsReceived.length == 2)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testSucceededEventsReceived(1).testName == "test 6")
+        assert(rep.testFailedEventsReceived.length == 2)
+        assert {
+          val zero = rep.testFailedEventsReceived(0).testName
+          val one = rep.testFailedEventsReceived(1).testName
+          (zero == "test 2" && one == "test 7") || (zero == "test 7" && one == "test 2")
+        }
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
       }
-      assert(rep.testPendingEventsReceived.length == 1)
-      assert(rep.testPendingEventsReceived(0).testName == "test 3")
-      assert(rep.testCanceledEventsReceived.length == 1)
-      assert(rep.testCanceledEventsReceived(0).testName == "test 4")
-      assert(rep.testIgnoredEventsReceived.length == 1)
-      assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
     }
 
     it("can be used for tests that did not return Future") {
@@ -110,7 +122,7 @@ class AsyncFunSpecSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         val a = 1
 
@@ -149,25 +161,24 @@ class AsyncFunSpecSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val spec = new ExampleSpec
       val status = spec.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-      assert(rep.testStartingEventsReceived.length == 6)
-      assert(rep.testSucceededEventsReceived.length == 2)
-      assert(rep.testSucceededEventsReceived(0).testName == "test 1")
-      assert(rep.testSucceededEventsReceived(1).testName == "test 6")
-      assert(rep.testFailedEventsReceived.length == 2)
-      assert { 
-        val zero = rep.testFailedEventsReceived(0).testName
-        val one = rep.testFailedEventsReceived(1).testName
-        (zero == "test 2" && one == "test 7") || (zero == "test 7" && one == "test 2")
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 6)
+        assert(rep.testSucceededEventsReceived.length == 2)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testSucceededEventsReceived(1).testName == "test 6")
+        assert(rep.testFailedEventsReceived.length == 2)
+        assert {
+          val zero = rep.testFailedEventsReceived(0).testName
+          val one = rep.testFailedEventsReceived(1).testName
+          (zero == "test 2" && one == "test 7") || (zero == "test 7" && one == "test 2")
+        }
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
       }
-      assert(rep.testPendingEventsReceived.length == 1)
-      assert(rep.testPendingEventsReceived(0).testName == "test 3")
-      assert(rep.testCanceledEventsReceived.length == 1)
-      assert(rep.testCanceledEventsReceived(0).testName == "test 4")
-      assert(rep.testIgnoredEventsReceived.length == 1)
-      assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
     }
 
     it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
@@ -181,13 +192,14 @@ class AsyncFunSpecSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         it("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
             count = 1
+            Succeeded
           }
         }
 
@@ -196,6 +208,7 @@ class AsyncFunSpecSpec extends FunSpec {
             assert(count == 1)
             SleepHelper.sleep(50)
             count = 2
+            Succeeded
           }
         }
 
@@ -212,13 +225,10 @@ class AsyncFunSpecSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-
-      assert(rep.testStartingEventsReceived.length == 3)
-      assert(rep.testSucceededEventsReceived.length == 3)
-
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
     }
 
     it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
@@ -232,18 +242,20 @@ class AsyncFunSpecSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         it("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
+          Succeeded
         }
 
         it("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
+          Succeeded
         }
 
         it("test 3") {
@@ -257,13 +269,10 @@ class AsyncFunSpecSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-
-      assert(rep.testStartingEventsReceived.length == 3)
-      assert(rep.testSucceededEventsReceived.length == 3)
-
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
     }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
@@ -16,10 +16,23 @@
 package org.scalatest
 
 import org.scalatest.SharedHelpers.EventRecordingReporter
-import scala.concurrent.Future
+import scala.concurrent.{Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
-class AsyncFunSuiteSpec extends FunSpec {
+class AsyncFunSuiteSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSuiteSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
 
   describe("AsyncFunSuite") {
 
@@ -30,7 +43,7 @@ class AsyncFunSuiteSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         val a = 1
 
@@ -70,20 +83,19 @@ class AsyncFunSuiteSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSuite
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-      assert(rep.testStartingEventsReceived.length == 4)
-      assert(rep.testSucceededEventsReceived.length == 1)
-      assert(rep.testSucceededEventsReceived(0).testName == "test 1")
-      assert(rep.testFailedEventsReceived.length == 1)
-      assert(rep.testFailedEventsReceived(0).testName == "test 2")
-      assert(rep.testPendingEventsReceived.length == 1)
-      assert(rep.testPendingEventsReceived(0).testName == "test 3")
-      assert(rep.testCanceledEventsReceived.length == 1)
-      assert(rep.testCanceledEventsReceived(0).testName == "test 4")
-      assert(rep.testIgnoredEventsReceived.length == 1)
-      assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
     }
 
     it("can be used for tests that did not return Future") {
@@ -93,7 +105,7 @@ class AsyncFunSuiteSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         val a = 1
 
@@ -123,20 +135,19 @@ class AsyncFunSuiteSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSuite
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-      assert(rep.testStartingEventsReceived.length == 4)
-      assert(rep.testSucceededEventsReceived.length == 1)
-      assert(rep.testSucceededEventsReceived(0).testName == "test 1")
-      assert(rep.testFailedEventsReceived.length == 1)
-      assert(rep.testFailedEventsReceived(0).testName == "test 2")
-      assert(rep.testPendingEventsReceived.length == 1)
-      assert(rep.testPendingEventsReceived(0).testName == "test 3")
-      assert(rep.testCanceledEventsReceived.length == 1)
-      assert(rep.testCanceledEventsReceived(0).testName == "test 4")
-      assert(rep.testIgnoredEventsReceived.length == 1)
-      assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
     }
 
     it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
@@ -150,13 +161,14 @@ class AsyncFunSuiteSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         test("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
             count = 1
+            Succeeded
           }
         }
 
@@ -165,6 +177,7 @@ class AsyncFunSuiteSpec extends FunSpec {
             assert(count == 1)
             SleepHelper.sleep(50)
             count = 2
+            Succeeded
           }
         }
 
@@ -181,13 +194,10 @@ class AsyncFunSuiteSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSuite
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-
-      assert(rep.testStartingEventsReceived.length == 3)
-      assert(rep.testSucceededEventsReceived.length == 3)
-
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
     }
 
     it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
@@ -201,18 +211,20 @@ class AsyncFunSuiteSpec extends FunSpec {
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS-END
-        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
         test("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
+          Succeeded
         }
 
         test("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
+          Succeeded
         }
 
         test("test 3") {
@@ -226,13 +238,10 @@ class AsyncFunSuiteSpec extends FunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSuite
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS-END
-
-      assert(rep.testStartingEventsReceived.length == 3)
-      assert(rep.testSucceededEventsReceived.length == 3)
-
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
     }
 
   }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncPropSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncPropSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        property("test 1") {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        property("test 2") {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        property("test 3") {
+          Future {
+            pending
+          }
+        }
+
+        property("test 4") {
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        property("test 1") {
+          assert(a == 1)
+        }
+
+        property("test 2") {
+          assert(a == 2)
+        }
+
+        property("test 3") {
+          pending
+        }
+
+        property("test 4") {
+          cancel
+        }
+
+        ignore("test 5") {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        property("test 1") {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        property("test 2") {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        property("test 3") {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        property("test 1") {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        property("test 2") {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        property("test 3") {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncPropSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncPropSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncPropSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        property("test 1") {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        property("test 2") {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        property("test 3") {
+          Future {
+            pending
+          }
+        }
+
+        property("test 4") {
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        property("test 1") {
+          assert(a == 1)
+        }
+
+        property("test 2") {
+          assert(a == 2)
+        }
+
+        property("test 3") {
+          pending
+        }
+
+        property("test 4") {
+          cancel
+        }
+
+        ignore("test 5") {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        property("test 1") {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        property("test 2") {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        property("test 3") {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        property("test 1") {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        property("test 2") {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        property("test 3") {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncWordSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncWordSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          assert(a == 1)
+        }
+
+        "test 2" in {
+          assert(a == 2)
+        }
+
+        "test 3" in {
+          pending
+        }
+
+        "test 4" in {
+          cancel
+        }
+
+        "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncWordSpecSpec2 extends AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncWordSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncWordSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in {
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in {
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore {
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        val a = 1
+
+        "test 1" in {
+          assert(a == 1)
+        }
+
+        "test 2" in {
+          assert(a == 2)
+        }
+
+        "test 3" in {
+          pending
+        }
+
+        "test 4" in {
+          cancel
+        }
+
+        "test 5" ignore {
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in {
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in {
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        "test 1" in {
+          SleepHelper.sleep(3000)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in {
+          assert(count == 1)
+          SleepHelper.sleep(5000)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in {
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFeatureSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFeatureSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        scenario("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        scenario("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        scenario("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        scenario("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        scenario("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        scenario("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        scenario("test 3") { fixture =>
+          pending
+        }
+
+        scenario("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        scenario("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        scenario("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        scenario("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        scenario("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        scenario("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        scenario("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFeatureSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFeatureSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        scenario("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        scenario("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        scenario("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        scenario("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        scenario("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        scenario("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        scenario("test 3") { fixture =>
+          pending
+        }
+
+        scenario("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "Scenario: test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "Scenario: test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "Scenario: test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "Scenario: test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "Scenario: test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        scenario("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        scenario("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        scenario("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFeatureSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        scenario("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        scenario("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        scenario("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFlatSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFlatSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it should "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it should "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it should "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        it should "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        it should "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it should "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        it should "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        it should "test 3" in { fixture =>
+          pending
+        }
+
+        it should "test 4" in { fixture =>
+          cancel
+        }
+
+        it should "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it should "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it should "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it should "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it should "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it should "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it should "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFlatSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFlatSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it should "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it should "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it should "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        it should "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        it should "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it should "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        it should "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        it should "test 3" in { fixture =>
+          pending
+        }
+
+        it should "test 4" in { fixture =>
+          cancel
+        }
+
+        it should "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "should test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "should test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "should test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "should test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "should test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it should "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it should "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it should "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFlatSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it should "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it should "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it should "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFreeSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFreeSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        "test 3" in { fixture =>
+          pending
+        }
+
+        "test 4" in { fixture =>
+          cancel
+        }
+
+        "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFreeSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFreeSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        "test 3" in { fixture =>
+          pending
+        }
+
+        "test 4" in { fixture =>
+          cancel
+        }
+
+        "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFreeSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFunSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFunSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        it("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFunSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        it("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        it("test 3") { fixture =>
+          pending
+        }
+
+        it("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFunSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFunSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFunSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncFunSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        it("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        it("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        it("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncFunSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        it("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        it("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        it("test 3") { fixture =>
+          pending
+        }
+
+        it("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFunSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        it("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        it("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncFunSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        it("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        it("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        it("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSuiteLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFunSuiteLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSuite extends AsyncFunSuiteLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        test("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        test("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        test("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        test("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSuite
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSuite extends AsyncFunSuiteLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        test("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        test("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        test("test 3") { fixture =>
+          pending
+        }
+
+        test("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSuite
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSuite extends AsyncFunSuiteLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        test("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        test("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        test("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSuite
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSuite extends AsyncFunSuiteLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        test("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        test("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        test("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSuite
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import scala.concurrent.{Promise, Future}
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSuiteSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncFunSuite") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSuite extends AsyncFunSuite {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        test("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        test("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        test("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        test("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSuite
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSuite extends AsyncFunSuite {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        test("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        test("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        test("test 3") { fixture =>
+          pending
+        }
+
+        test("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSuite
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSuite extends AsyncFunSuite {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        test("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        test("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        test("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSuite
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSuite extends AsyncFunSuite {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        test("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        test("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        test("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSuite
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSuite
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncPropSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncPropSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        property("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        property("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        property("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        property("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        property("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        property("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        property("test 3") { fixture =>
+          pending
+        }
+
+        property("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        property("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        property("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        property("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        property("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        property("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        property("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncPropSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncPropSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        property("test 1") { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        property("test 2") { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        property("test 3") { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        property("test 4") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        ignore("test 5") { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        property("test 1") { fixture =>
+          assert(a == 1)
+        }
+
+        property("test 2") { fixture =>
+          assert(a == 2)
+        }
+
+        property("test 3") { fixture =>
+          pending
+        }
+
+        property("test 4") { fixture =>
+          cancel
+        }
+
+        ignore("test 5") { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        property("test 1") { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        property("test 2") { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        property("test 3") { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncPropSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        property("test 1") { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        property("test 2") { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        property("test 3") { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncWordSpecLikeSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncWordSpecLike") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        "test 3" in { fixture =>
+          pending
+        }
+
+        "test 4" in { fixture =>
+          cancel
+        }
+
+        "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpecLike {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.fixture
+
+import org.scalatest._
+import SharedHelpers.EventRecordingReporter
+import scala.concurrent.{Promise, Future}
+import org.scalatest.concurrent.SleepHelper
+
+class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
+
+  // SKIP-SCALATESTJS-START
+  implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  // SKIP-SCALATESTJS-END
+  //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncWordSpecSpec2
+
+  def toFuture(status: Status): Future[Boolean] = {
+    val promise = Promise[Boolean]
+    status.whenCompleted { s => promise.success(s) }
+    promise.future
+  }
+
+  describe("AsyncWordSpec") {
+
+    it("can be used for tests that return Future") {
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          Future {
+            assert(a == 1)
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(a == 2)
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            pending
+          }
+        }
+
+        "test 4" in { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        "test 5" ignore { fixture =>
+          Future {
+            cancel
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("can be used for tests that did not return Future") {
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        val a = 1
+
+        "test 1" in { fixture =>
+          assert(a == 1)
+        }
+
+        "test 2" in { fixture =>
+          assert(a == 2)
+        }
+
+        "test 3" in { fixture =>
+          pending
+        }
+
+        "test 4" in { fixture =>
+          cancel
+        }
+
+        "test 5" ignore { fixture =>
+          cancel
+        }
+
+        override def newInstance = new ExampleSpec
+      }
+
+      val rep = new EventRecordingReporter
+      val spec = new ExampleSpec
+      val status = spec.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+    }
+
+    it("should run tests that return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          Future {
+            SleepHelper.sleep(30)
+            assert(count == 0)
+            count = 1
+            Succeeded
+          }
+        }
+
+        "test 2" in { fixture =>
+          Future {
+            assert(count == 1)
+            SleepHelper.sleep(50)
+            count = 2
+            Succeeded
+          }
+        }
+
+        "test 3" in { fixture =>
+          Future {
+            assert(count == 2)
+          }
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+    it("should run tests that does not return Future in serial when oneAfterAnotherAsync is set to true") {
+
+      @volatile var count = 0
+
+      class ExampleSpec extends AsyncWordSpec {
+
+        override protected val oneAfterAnotherAsync: Boolean = true
+
+        // SKIP-SCALATESTJS-START
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+        type FixtureParam = String
+        def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
+          test("testing")
+
+        "test 1" in { fixture =>
+          SleepHelper.sleep(30)
+          assert(count == 0)
+          count = 1
+          Succeeded
+        }
+
+        "test 2" in { fixture =>
+          assert(count == 1)
+          SleepHelper.sleep(50)
+          count = 2
+          Succeeded
+        }
+
+        "test 3" in { fixture =>
+          assert(count == 2)
+        }
+
+        override def newInstance = new ExampleSpec
+
+      }
+
+      val rep = new EventRecordingReporter
+      val suite = new ExampleSpec
+      val status = suite.run(None, Args(reporter = rep))
+      toFuture(status).map { s =>
+        assert(rep.testStartingEventsReceived.length == 3)
+        assert(rep.testSucceededEventsReceived.length == 3)
+      }
+    }
+
+  }
+
+}

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -290,45 +290,14 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
                   reportTestIgnored(theSuite, args.reporter, args.tracker, testName, testTextWithOptionalPrefix, getIndentedTextForTest(testTextWithOptionalPrefix, testLeaf.indentationLevel, true), theTest.location)
                 }
                 else {
-                  // Right here, if one after another async, register the last one to run at the end of the previous one?
-                  // Then for my status, I can't get it from runTest. runTest won't run until later. So I need
-                  // somehow to connect it to the, oh, registration function? So maybe this is a new method on
-                  // Status? Because that's what I need to be able to do, something like:
-                  //
-                  //   lastPreviousStatus thenRun { runTest(testName, args) }
-                  //
-                  // where the signature of thenRun would be
-                  //
-                  //   def thenRun(f: => Status): Status
-                  //
-                  // So the code here would end up being:
-                  //
-                  //   statusList += 
-                  //     if (!oneAfterAnotherAsync || statusList.isEmpty) {
-                  //       statusList += runTest(testName, args) // If oneAfterAnotherAsync, first time just go for it
-                  //     }
-                  //     else {
-                  //       statusList.last thenRun { runTest(testName, args) } // Only if oneAfterAnotherAsync, after first Status
-                  //     }
                   statusList += {
                     if (!oneAfterAnotherAsync || statusList.isEmpty) {
-                      println("!!!!! GOT TO FIRST ONE !!!!: statusList = " + statusList)
                       runTest(testName, args) // If oneAfterAnotherAsync, first time just go for it
                     }
                     else {
-println("!!!!! GOT TO TOP !!!!: statusList = " + statusList)
-                      statusList.last thenRun { println("###### GOT INSIDE #######: statusList = " + statusList); runTest(testName, args) } // Only if oneAfterAnotherAsync, after first Status
+                      statusList.last thenRun runTest(testName, args)  // Only if oneAfterAnotherAsync, after first Status
                     }
                   }
-                  //statusList += runTest(testName, args)
-/*
-                  val testStatus = runTest(testName, args)
-                  // SKIP-SCALATESTJS-START
-                  if (oneAfterAnotherAsync)
-                    testStatus.waitUntilCompleted()
-                  // SKIP-SCALATESTJS-END
-                  statusList += testStatus
-*/
                 }
 
             case infoLeaf @ InfoLeaf(_, message, payload, location) =>

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -57,12 +57,17 @@ sealed abstract class Fact {
   }
 
   // This is called internally by implicit conversions, which has different stack depth
-  private[scalatest] final def internalToAssertion: Assertion =
+  private[scalatest] final def internalToAssertion: Assertion = {
+    // SKIP-SCALATESTJS-START
+    val stackDepth = 3
+    // SKIP-SCALATESTJS-END
+    //SCALATESTJS-ONLY val stackDepth = 12
     if (isYes) {
       if (!isVacuousYes) Succeeded
-      else throw new TestCanceledException(factMessage, 3)
+      else throw new TestCanceledException(factMessage, stackDepth)
     }
-    else throw new TestFailedException(factMessage, 3)
+    else throw new TestFailedException(factMessage, stackDepth)
+  }
 
   /**
    * Get a simplified version of this Fact, sub type will be simplified and all messages field will be substituted with its counter-part.

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
@@ -134,7 +134,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 6
-    //SCALATESTJS-ONLY val stackDepthAdjustment = -4
+    //SCALATESTJS-ONLY val stackDepthAdjustment = -5
     engine.registerTest(Resources.scenario(specText.trim), Transformer(testFun _), Resources.scenarioCannotAppearInsideAnotherScenario, "FeatureSpecLike.scala", "scenario", stackDepth, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
@@ -162,7 +162,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 6
-    //SCALATESTJS-ONLY val stackDepthAdjustment = -5
+    //SCALATESTJS-ONLY val stackDepthAdjustment = -6
     engine.registerIgnoredTest(Resources.scenario(specText), Transformer(testFun _), Resources.ignoreCannotAppearInsideAScenario, "FeatureSpecLike.scala", "ignore", stackDepth, stackDepthAdjustment, None, testTags: _*)
   }
   

--- a/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
@@ -1636,7 +1636,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
     val stackDepthAdjustment = -3
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 6
-    //SCALATESTJS-ONLY val stackDepthAdjustment = -5
+    //SCALATESTJS-ONLY val stackDepthAdjustment = -6
     engine.registerIgnoredTest(specText, Transformer(testFun), Resources.ignoreCannotAppearInsideAnInOrAnIs, "FlatSpecLike.scala", methodName, stackDepth, stackDepthAdjustment, None, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
@@ -166,7 +166,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
     val stackDepthAdjustment = -3
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 6
-    //SCALATESTJS-ONLY val stackDepthAdjustment = -5
+    //SCALATESTJS-ONLY val stackDepthAdjustment = -6
     engine.registerIgnoredTest(specText, Transformer(testFun), Resources.ignoreCannotAppearInsideAnIn, "FreeSpecLike.scala", methodName, stackDepth, stackDepthAdjustment, None, testTags: _*)
   }
 


### PR DESCRIPTION
-Added async tests using scala-js queue, and some cleanup of debugging println.
-Fixed stack depth broken tests in FeatureSpecSpec, FlatSpecSpec and FreeSpecSpec under scala-js.