### PR TITLE
thrownBy Stack Depth Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesSpec.scala
@@ -246,7 +246,43 @@ class SeveredStackTracesSpec extends FunSpec with Matchers with SeveredStackTrac
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy {}") {
+      try {
+        a [IllegalArgumentException] should be thrownBy {}
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) => // s should equal ("SeveredStackTracesSpec.scala:" + (baseLineNumber + 204))
+              if (s != ("SeveredStackTracesSpec.scala:" + (thisLineNumber - 6))) {
+                fail("s was: " + s, e)
+              }
+              checkFileNameAndLineNumber(e, s)
+            case None => fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
+      try {
+        a [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) =>
+              s should equal ("SeveredStackTracesSpec.scala:" + (thisLineNumber - 6))
+              checkFileNameAndLineNumber(e, s)
+            case None => fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") {
       try {
         an [IllegalArgumentException] should be thrownBy {}
       }
@@ -265,7 +301,7 @@ class SeveredStackTracesSpec extends FunSpec with Matchers with SeveredStackTrac
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
       try {
         an [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
       }

--- a/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionSpec.scala
@@ -220,7 +220,40 @@ class TestFailedExceptionSpec extends FunSpec with Matchers {
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy {}") {
+      try {
+        a [IllegalArgumentException] should be thrownBy {}
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) => // s should equal ("TestFailedExceptionSpec.scala:" + (baseLineNumber + 204))
+              if (s != ("TestFailedExceptionSpec.scala:" + (thisLineNumber - 6))) {
+                fail("s was: " + s, e)
+              }
+            case None => fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
+      try {
+        a [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) => s should equal ("TestFailedExceptionSpec.scala:" + (thisLineNumber - 5))
+            case None => fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") {
       try {
         an [IllegalArgumentException] should be thrownBy {}
       }
@@ -238,7 +271,7 @@ class TestFailedExceptionSpec extends FunSpec with Matchers {
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
       try {
         an [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
       }

--- a/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionWithImportSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionWithImportSpec.scala
@@ -221,7 +221,40 @@ class TestFailedExceptionWithImportSpec extends FunSpec {
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy {}") {
+      try {
+        a [IllegalArgumentException] should be thrownBy {}
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) =>
+              if (s != ("TestFailedExceptionWithImportSpec.scala:" + (thisLineNumber - 6))) {
+                fail("s was: " + s, e)
+              }
+            case None => fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy {} didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on a [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
+      try {
+        a [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
+      }
+      catch {
+        case e: TestFailedException =>
+          e.failedCodeFileNameAndLineNumberString match {
+            case Some(s) => s should equal ("TestFailedExceptionWithImportSpec.scala:" + (thisLineNumber - 5))
+            case None => fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a file name and line number string", e)
+          }
+        case e: Throwable =>
+          fail("a [IllegalArgumentException] should be thrownBy { throw new RuntimeException } didn't produce a TestFailedException", e)
+      }
+    }
+
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy {}") {
       try {
         an [IllegalArgumentException] should be thrownBy {}
       }
@@ -239,7 +272,7 @@ class TestFailedExceptionWithImportSpec extends FunSpec {
       }
     }
 
-    ignore("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") { // TODO: Fix thrownBy off-by-one problem
+    it("should give the proper line on an [IllegalArgumentException] should be thrownBy { throw new RuntimeException }") {
       try {
         an [IllegalArgumentException] should be thrownBy { if (false) () else throw new RuntimeException }
       }

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfBeWordForAType.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfBeWordForAType.scala
@@ -40,7 +40,7 @@ final class ResultOfBeWordForAType[T](clazz: Class[T]) {
    */
   def thrownBy(fun: => Any): Assertion = {
     // SKIP-SCALATESTJS-START
-    val stackDepth = 1
+    val stackDepth = 0
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 10
     try {

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfBeWordForAnType.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfBeWordForAnType.scala
@@ -40,7 +40,7 @@ final class ResultOfBeWordForAnType[T](clazz: Class[T]) {
    */
   def thrownBy(fun: => Unit): Assertion = {
     // SKIP-SCALATESTJS-START
-    val stackDepth = 1
+    val stackDepth = 0
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val stackDepth = 10
     try {


### PR DESCRIPTION
Reenabled previously ignored stack depth tests in SeveredStackTracesSpec, TestFailedExceptionSpec and TestFailedExceptionWithImportSpec, and fixed them accordingly.