### PR TITLE
Async Traits Adjustment

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
@@ -65,6 +65,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -118,6 +119,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -172,8 +174,6 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +214,6 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
         scenario("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFeatureSpecLikeSpec2
-
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -72,6 +70,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -126,6 +125,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -184,8 +184,6 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -228,8 +226,6 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
         scenario("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
@@ -65,6 +65,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -118,6 +119,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -172,8 +174,6 @@ class AsyncFeatureSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +214,6 @@ class AsyncFeatureSpecSpec extends FunSpec {
         scenario("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFeatureSpecSpec2
-
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -227,8 +223,6 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
         scenario("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
@@ -65,6 +65,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -118,6 +119,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
         }
 
         override def newInstance = new ExampleSpec
+
       }
 
       val rep = new EventRecordingReporter
@@ -172,8 +174,6 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +214,6 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
         it should "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFlatSpecLikeSpec2
-
   describe("AsyncFlatSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
         it should "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
@@ -172,8 +172,6 @@ class AsyncFlatSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFlatSpecSpec extends FunSpec {
         it should "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFlatSpecSpec2
-
   describe("AsyncFlatSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
         it should "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
@@ -172,8 +172,6 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFreeSpecLikeSpec2
-
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -227,8 +223,6 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
@@ -172,8 +172,6 @@ class AsyncFreeSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFreeSpecSpec extends FunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFreeSpecSpec2
-
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
@@ -172,8 +172,6 @@ class AsyncFunSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFunSpecLikeSpec extends FunSpec {
         it("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSpecLikeSpec2
-
   describe("AsyncFunSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
         it("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
@@ -203,8 +203,6 @@ class AsyncFunSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -245,8 +243,6 @@ class AsyncFunSpecSpec extends FunSpec {
         it("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSpecSpec2
-
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return a Future under parallel async test execution") {
@@ -214,8 +212,6 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -257,8 +253,6 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
         it("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
@@ -172,8 +172,6 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
         test("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSuiteLikeSpec2
-
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
         test("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
@@ -172,8 +172,6 @@ class AsyncFunSuiteSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncFunSuiteSpec extends FunSpec {
         test("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
@@ -19,14 +19,12 @@ import org.scalatest.SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
-class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelAsyncTestExecution {
+class AsyncFunSuiteSpec2 extends AsyncFunSpec {
 
   // SKIP-SCALATESTJS-START
   implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-
-  override def newInstance = new AsyncFunSuiteSpec2
 
   describe("AsyncFunSuite") {
 
@@ -183,8 +181,6 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelAsyncTestExecution {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelAsyncTestExecution {
         test("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
@@ -19,12 +19,14 @@ import org.scalatest.SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
-class AsyncFunSuiteSpec2 extends AsyncFunSpec {
+class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelAsyncTestExecution {
 
   // SKIP-SCALATESTJS-START
   implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+  override def newInstance = new AsyncFunSuiteSpec2
 
   describe("AsyncFunSuite") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
@@ -172,8 +172,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
         property("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncPropSpecLikeSpec2
-
   describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
         property("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
@@ -172,8 +172,6 @@ class AsyncPropSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncPropSpecSpec extends FunSpec {
         property("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncPropSpecSpec2
-
   describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
         property("test 3") {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
@@ -172,8 +172,6 @@ class AsyncWordSpecLikeSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncWordSpecLikeSpec extends FunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
@@ -26,8 +26,6 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncWordSpecLikeSpec2
-
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
@@ -172,8 +172,6 @@ class AsyncWordSpecSpec extends FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -214,8 +212,6 @@ class AsyncWordSpecSpec extends FunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
@@ -26,8 +26,6 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncWordSpecSpec2
-
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -183,8 +181,6 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -226,8 +222,6 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
         scenario("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFeatureSpecLikeSpec2
-
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         scenario("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
@@ -185,8 +185,6 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
         scenario("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFeatureSpecSpec2
-
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
         scenario("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
            }
          }
 
-         override def newInstance = new ExampleSpec
-
        }
 
        val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
          it should "test 3" in { fixture =>
            assert(count == 2)
          }
-
-         override def newInstance = new ExampleSpec
 
        }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFlatSpecLikeSpec2
-
   describe("AsyncFlatSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         it should "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
@@ -185,8 +185,6 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
         it should "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFlatSpecSpec2
-
   describe("AsyncFlatSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
         it should "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFreeSpecLikeSpec2
-
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,9 +239,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
-
+        
       }
 
       val rep = new EventRecordingReporter

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
@@ -93,7 +93,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with ParallelAsyncTestExecution {
 
         // SKIP-SCALATESTJS-START
         implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -185,8 +185,6 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFreeSpecSpec2
-
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
         it("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSpecLikeSpec2
-
   describe("AsyncFunSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         it("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
@@ -185,8 +185,6 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
         it("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSpecSpec2
-
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
         it("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
         test("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSuiteLikeSpec2
-
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
         test("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
@@ -185,8 +185,6 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
         test("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
@@ -27,8 +27,6 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncFunSuiteSpec2
-
   describe("AsyncFunSuite") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSuite
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
         test("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSuite
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
         property("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncPropSpecLikeSpec2
-
   describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         property("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
@@ -185,8 +185,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
         property("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncPropSpecSpec2
-
   describe("AsyncPropSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
         property("test 3") { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
@@ -185,8 +185,6 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
@@ -27,8 +27,6 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncWordSpecLikeSpec2
-
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
@@ -185,8 +185,6 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -231,8 +229,6 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
@@ -27,8 +27,6 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
   // SKIP-SCALATESTJS-END
   //SCALATESTJS-ONLY implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  override def newInstance = new AsyncWordSpecSpec2
-
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -196,8 +194,6 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        override def newInstance = new ExampleSpec
-
       }
 
       val rep = new EventRecordingReporter
@@ -243,8 +239,6 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
         "test 3" in { fixture =>
           assert(count == 2)
         }
-
-        override def newInstance = new ExampleSpec
 
       }
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
@@ -48,7 +48,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
-trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: => Future[Assertion]): () => AsyncOutcome =
     () => {
@@ -202,33 +202,24 @@ trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with As
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
-
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new NoArgAsyncTest {
-              val name = testData.name
-              def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new NoArgAsyncTest {
+            val name = testData.name
+            def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
@@ -48,7 +48,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
-trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: => Future[Assertion]): () => AsyncOutcome =
     () => {
@@ -1667,33 +1667,25 @@ trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with Shoul
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
-
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new NoArgAsyncTest {
-              val name = testData.name
-              def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+    // Therefore, in test-specific instance, so run the test.
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new NoArgAsyncTest {
+            val name = testData.name
+            def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
-trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: => Future[Assertion]): () => AsyncOutcome =
     () => {
@@ -390,33 +390,24 @@ trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with Async
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
-
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new NoArgAsyncTest {
-              val name = testData.name
-              def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new NoArgAsyncTest {
+            val name = testData.name
+            def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
@@ -44,7 +44,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
-trait AsyncFunSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFunSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: => Future[Assertion]): () => AsyncOutcome =
     () => {
@@ -419,33 +419,24 @@ trait AsyncFunSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncC
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
-
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new NoArgAsyncTest {
-              val name = testData.name
-              def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new NoArgAsyncTest {
+            val name = testData.name
+            def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
@@ -45,7 +45,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
-trait AsyncWordSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncWordSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: => Future[Assertion]): () => AsyncOutcome =
     () => {
@@ -1052,33 +1052,24 @@ one error found
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
-
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new NoArgAsyncTest {
-              val name = testData.name
-              def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new NoArgAsyncTest {
+            val name = testData.name
+            def apply(): Future[Outcome] = { theTest.testFun().toFutureOutcome }
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/ParallelAsyncTestExecution.scala
+++ b/scalatest/src/main/scala/org/scalatest/ParallelAsyncTestExecution.scala
@@ -19,7 +19,7 @@ import events.Event
 import org.scalatest.time.Span
 import tools.{DistributedTestRunnerSuite, TestSortingReporter}
 
-trait ParallelAsyncTestExecution { this: AsyncSuite =>
+trait ParallelAsyncTestExecution extends ParallelTestExecution { this: AsyncSuite =>
   protected[scalatest] override val parallelAsyncTestExecution = true
 }
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
@@ -49,7 +49,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
-trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -233,36 +233,27 @@ trait AsyncFeatureSpecLike extends AsyncSuite with AsyncTestRegistration with As
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
@@ -49,7 +49,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
-trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -2092,36 +2092,27 @@ trait AsyncFlatSpecLike extends AsyncSuite with AsyncTestRegistration with Shoul
    * @throws NullArgumentException if <code>testName</code> or <code>args</code> is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
-trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -504,36 +504,27 @@ trait AsyncFreeSpecLike extends AsyncSuite with AsyncTestRegistration with Async
    * @throws NullArgumentException if <code>testName</code> or <code><args/code> is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
@@ -43,7 +43,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
-trait AsyncFunSuiteLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncFunSuiteLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -204,36 +204,27 @@ trait AsyncFunSuiteLike extends AsyncSuite with AsyncTestRegistration with Async
    * @throws NullArgumentException if <code>testName</code> or <code>args</code> is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncPropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncPropSpecLike.scala
@@ -43,7 +43,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
-trait AsyncPropSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncPropSpecLike extends AsyncSuite with AsyncTestRegistration with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -182,36 +182,27 @@ trait AsyncPropSpecLike extends AsyncSuite with AsyncTestRegistration with Async
    * @throws NullArgumentException if any of <code>testName</code> or <code>args</code> is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
@@ -51,7 +51,7 @@ import scala.concurrent.Future
  */
 //SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
-trait AsyncWordSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility with OneInstancePerTest { thisSuite =>
+trait AsyncWordSpecLike extends AsyncSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with AsyncCompatibility { thisSuite =>
 
   override private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[Assertion]): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
@@ -1179,36 +1179,27 @@ trait AsyncWordSpecLike extends AsyncSuite with AsyncTestRegistration with Shoul
    * @throws NullArgumentException if any of <code>testName</code> or <code>args</code> is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
+    def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
+      val theConfigMap = args.configMap
+      val testData = testDataFor(testName, theConfigMap)
+      FutureOutcome(
+        withAsyncFixture(
+          new OneArgAsyncTest {
+            val name = testData.name
 
-    if (args.runTestInNewInstance) {
-      // In initial instance, so create a new test-specific instance for this test and invoke run on it.
-      val oneInstance = newInstance
-      oneInstance.run(Some(testName), args)
-    }
-    else {
-      // Therefore, in test-specific instance, so run the test.
-      def invokeWithAsyncFixture(theTest: TestLeaf): AsyncOutcome = {
-        val theConfigMap = args.configMap
-        val testData = testDataFor(testName, theConfigMap)
-        FutureOutcome(
-          withAsyncFixture(
-            new OneArgAsyncTest {
-              val name = testData.name
+            def apply(fixture: FixtureParam): Future[Outcome] =
+              theTest.testFun(fixture).toFutureOutcome
 
-              def apply(fixture: FixtureParam): Future[Outcome] =
-                theTest.testFun(fixture).toFutureOutcome
-
-              val configMap = testData.configMap
-              val scopes = testData.scopes
-              val text = testData.text
-              val tags = testData.tags
-            }
-          )
+            val configMap = testData.configMap
+            val scopes = testData.scopes
+            val text = testData.text
+            val tags = testData.tags
+          }
         )
-      }
-
-      runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
+      )
     }
+
+    runTestImpl(thisSuite, testName, args, true, invokeWithAsyncFixture)
   }
 
   /**


### PR DESCRIPTION
-Make async traits to not extend OneInstancePerTest.
-Fixed sbt console output mixed up problem when used with ParallelTestExecution.