### PR TITLE
Privatize Fact, Expectations and WillMatchers

### DIFF
--- a/project/GenMatchers.scala
+++ b/project/GenMatchers.scala
@@ -134,7 +134,7 @@ object GenMatchers {
     junitDir.mkdirs()
 
     translateFile(targetDir, "MustMatchers.scala", "scalatest/src/main/scala/org/scalatest/Matchers.scala", scalaVersion, scalaJS, translateShouldToMust)
-    translateFile(targetDir, "WillMatchers.scala", "scalatest/src/main/scala/org/scalatest/Matchers.scala", scalaVersion, scalaJS, translateShouldToWill)
+    /*translateFile(targetDir, "WillMatchers.scala", "scalatest/src/main/scala/org/scalatest/Matchers.scala", scalaVersion, scalaJS, translateShouldToWill)
     translateFile(targetDir, "FactNoExceptionWord.scala", "scalatest/src/main/scala/org/scalatest/words/NoExceptionWord.scala", scalaVersion, scalaJS, translateShouldToWill)
     translateFile(targetDir, "FactResultOfATypeInvocation.scala", "scalatest/src/main/scala/org/scalatest/words/ResultOfATypeInvocation.scala", scalaVersion, scalaJS,
       (line: String) => translateShouldToWill(line.replaceAll("PleaseUseNoExceptionShouldSyntaxInstead", "STAY_AS_PLEASEUSNOTEXCEPTIONSHOULDSYNTAXINSTEAD"))
@@ -149,7 +149,7 @@ object GenMatchers {
     translateFile(targetDir, "FactResultOfBeWordForNoException.scala", "scalatest/src/main/scala/org/scalatest/words/ResultOfBeWordForNoException.scala", scalaVersion, scalaJS, translateShouldToWill)
     translateFile(targetDir, "FactResultOfContainWord.scala", "scalatest/src/main/scala/org/scalatest/words/ResultOfContainWord.scala", scalaVersion, scalaJS, translateShouldToWill)
     translateFile(targetDir, "FactResultOfNotWordForAny.scala", "scalatest/src/main/scala/org/scalatest/words/ResultOfNotWordForAny.scala", scalaVersion, scalaJS, translateShouldToWill)
-    translateFile(targetDir, "FactMatcherWords.scala", "scalatest/src/main/scala/org/scalatest/words/MatcherWords.scala", scalaVersion, scalaJS, translateShouldToWill)
+    translateFile(targetDir, "FactMatcherWords.scala", "scalatest/src/main/scala/org/scalatest/words/MatcherWords.scala", scalaVersion, scalaJS, translateShouldToWill)*/
   }
 
   def genMain(targetDir: File, version: String, scalaVersion: String) {

--- a/scalatest/src/main/scala/org/scalatest/AsyncCompatibility.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncCompatibility.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
 
-trait AsyncCompatibility extends AsyncRegistrationPolicy {
+private[scalatest] trait AsyncCompatibility extends AsyncRegistrationPolicy {
 
   implicit override def convertAnyToFutureAssertion(o: Any): Future[Assertion] = Future.successful(Succeeded) // How happy is that?
   implicit override def convertFutureTToFutureAssertion[T](o: Future[T]): Future[Assertion] =

--- a/scalatest/src/main/scala/org/scalatest/AsyncRegistrationPolicy.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncRegistrationPolicy.scala
@@ -18,7 +18,7 @@ package org.scalatest
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 
-trait AsyncRegistrationPolicy {
+private[scalatest] trait AsyncRegistrationPolicy {
 
   implicit def executionContext: ExecutionContext
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncSafety.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncSafety.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
 
-trait AsyncSafety extends AsyncRegistrationPolicy {
+private[scalatest] trait AsyncSafety extends AsyncRegistrationPolicy {
 
   override def convertAnyToFutureAssertion(o: Any): Future[Assertion] = Future.successful(Succeeded) // How happy is that?
   override def convertFutureTToFutureAssertion[T](o: Future[T]): Future[Assertion] =

--- a/scalatest/src/main/scala/org/scalatest/Compatibility.scala
+++ b/scalatest/src/main/scala/org/scalatest/Compatibility.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-trait Compatibility extends RegistrationPolicy {
+private[scalatest] trait Compatibility extends RegistrationPolicy {
   implicit override def convertAnyToAssertion(a: Any): Assertion = Succeeded
   implicit override def convertExpectationToAssertion(e: Expectation): Assertion = e.internalToAssertion
 }

--- a/scalatest/src/main/scala/org/scalatest/Expectations.scala
+++ b/scalatest/src/main/scala/org/scalatest/Expectations.scala
@@ -21,7 +21,7 @@ import org.scalactic.Bool
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 
-trait Expectations {
+private[scalatest] trait Expectations {
   
   // TODO: Need to make this and assertResult use custom equality I think.
   def expectResult(expected: Any)(actual: Any): Fact = {
@@ -149,5 +149,5 @@ trait Expectations {
   def expectTypeError(code: String): Fact = macro CompileMacro.expectTypeErrorImpl
 }
 
-object Expectations extends Expectations
+private[scalatest] object Expectations extends Expectations
 

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -20,7 +20,7 @@ import org.scalatest.exceptions.StackDepthExceptionHelper
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestCanceledException
 
-sealed abstract class Fact {
+private[scalatest] sealed abstract class Fact {
 
   val rawFactMessage: String
   val rawSimplifiedFactMessage: String
@@ -140,7 +140,7 @@ sealed abstract class Fact {
   override def toString: String = factDiagram(0)
 }
 
-object Fact {
+private[scalatest] object Fact {
 
   case class Leaf(
     rawFactMessage: String,

--- a/scalatest/src/main/scala/org/scalatest/RegistrationPolicy.scala
+++ b/scalatest/src/main/scala/org/scalatest/RegistrationPolicy.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-trait RegistrationPolicy {
+private[scalatest] trait RegistrationPolicy {
 
   // Made implicit in Compatibility, non-implicit in Safety
   def convertAnyToAssertion(a: Any): Assertion

--- a/scalatest/src/main/scala/org/scalatest/Safety.scala
+++ b/scalatest/src/main/scala/org/scalatest/Safety.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-trait Safety extends RegistrationPolicy {
+private[scalatest] trait Safety extends RegistrationPolicy {
   override def convertAnyToAssertion(a: Any): Assertion = Succeeded
   implicit override def convertExpectationToAssertion(e: Expectation): Assertion = e.internalToAssertion
 }

--- a/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
@@ -18,7 +18,8 @@ package org.scalatest.matchers
 import org.scalatest.{UnquotedString, Suite, FailureMessages, Resources}
 import org.scalactic.Prettifier
 import org.scalatest.MatchersHelper._
-import org.scalatest.words.{FactResultOfAnTypeInvocation, ResultOfAnTypeInvocation, FactResultOfATypeInvocation, ResultOfATypeInvocation}
+import org.scalatest.words.{ResultOfAnTypeInvocation, ResultOfATypeInvocation}
+//import org.scalatest.words.{FactResultOfAnTypeInvocation, FactResultOfATypeInvocation}
 
 /**
  * <code>TypeMatcherHelper</code> is called by <code>TypeMatcherMacro</code> to support <code>a [Type]</code> and <code>an [Type]</code> syntax.
@@ -200,7 +201,7 @@ object TypeMatcherHelper {
    * @param left the left-hand-side (LHS) to be checked for the type
    * @param aType an instance of <code>ResultOfATypeInvocation</code>
    */
-  def expectATypeWillBeTrue(left: Any, aType: FactResultOfATypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
+  /*def expectATypeWillBeTrue(left: Any, aType: FactResultOfATypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
     val clazz = aType.clazz
     if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
       org.scalatest.Fact.No(
@@ -217,7 +218,7 @@ object TypeMatcherHelper {
         else
           FailureMessages.wasNotAnInstanceOf(left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))
       )
-  }
+  }*/
 
   /**
    * Based on <code>shouldBeTrue</code> value, check if the given <code>left</code> is an instance of the type as described in the given <code>ResultOfAnTypeInvocation</code>.
@@ -247,7 +248,7 @@ object TypeMatcherHelper {
    * @param left the left-hand-side (LHS) to be checked for the type
    * @param anType an instance of <code>ResultOfAnTypeInvocation</code>
    */
-  def expectAnTypeWillBeTrue(left: Any, anType: FactResultOfAnTypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
+  /*def expectAnTypeWillBeTrue(left: Any, anType: FactResultOfAnTypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
     val clazz = anType.clazz
     if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
       org.scalatest.Fact.No(
@@ -264,6 +265,6 @@ object TypeMatcherHelper {
         else
           FailureMessages.wasNotAnInstanceOf(left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))
       )
-  }
+  }*/
 
 }

--- a/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
@@ -16,7 +16,8 @@
 package org.scalatest.matchers
 
 import scala.reflect.macros.Context
-import org.scalatest.words.{ResultOfAnTypeInvocation, FactResultOfAnTypeInvocation, MatcherWords, ResultOfATypeInvocation, FactResultOfATypeInvocation}
+import org.scalatest.words.{ResultOfAnTypeInvocation, MatcherWords, ResultOfATypeInvocation}
+//import org.scalatest.words.{FactResultOfAnTypeInvocation, FactResultOfATypeInvocation}
 import org.scalatest.{UnquotedString, Resources, Suite, FailureMessages, Assertions}
 import org.scalactic.Prettifier
 
@@ -375,7 +376,7 @@ private[scalatest] object TypeMatcherMacro {
   def mustBeAnTypeImpl(context: Context)(anType: context.Expr[ResultOfAnTypeInvocation[_]]): context.Expr[org.scalatest.Assertion] =
     assertTypeImpl(context)(anType.tree, "mustBe an", "assertAnType")
 
-  def expectTypeImpl(context: Context)(tree: context.Tree, beMethodName: String, assertMethodName: String): context.Expr[org.scalatest.Fact] = {
+  /*def expectTypeImpl(context: Context)(tree: context.Tree, beMethodName: String, assertMethodName: String): context.Expr[org.scalatest.Fact] = {
     import context.universe._
 
     // check type parameter
@@ -416,7 +417,7 @@ private[scalatest] object TypeMatcherMacro {
     expectTypeImpl(context)(aType.tree, "willBe a", "expectAType")
 
   def willBeAnTypeImpl(context: Context)(anType: context.Expr[FactResultOfAnTypeInvocation[_]]): context.Expr[org.scalatest.Fact] =
-    expectTypeImpl(context)(anType.tree, "willBe an", "expectAnType")
+    expectTypeImpl(context)(anType.tree, "willBe an", "expectAnType")*/
 
   def assertTypeShouldBeTrueImpl(context: Context)(tree: context.Tree, beMethodName: String, assertMethodName: String): context.Expr[org.scalatest.Assertion] = {
     import context.universe._
@@ -463,7 +464,7 @@ private[scalatest] object TypeMatcherMacro {
   def assertAnTypeShouldBeTrueImpl(context: Context)(anType: context.Expr[ResultOfAnTypeInvocation[_]]): context.Expr[org.scalatest.Assertion] =
     assertTypeShouldBeTrueImpl(context)(anType.tree, "should not be an", "assertAnTypeShouldBeTrue")
 
-  def expectTypeWillBeTrueImpl(context: Context)(tree: context.Tree, beMethodName: String, expectMethodName: String): context.Expr[org.scalatest.Fact] = {
+  /*def expectTypeWillBeTrueImpl(context: Context)(tree: context.Tree, beMethodName: String, expectMethodName: String): context.Expr[org.scalatest.Fact] = {
     import context.universe._
 
     // check type parameter
@@ -506,6 +507,6 @@ private[scalatest] object TypeMatcherMacro {
 
   // Do checking on type parameter and generate AST to call TypeMatcherHelper.assertAnTypeShouldBeTrue
   def expectAnTypeWillBeTrueImpl(context: Context)(anType: context.Expr[FactResultOfAnTypeInvocation[_]]): context.Expr[org.scalatest.Fact] =
-    expectTypeWillBeTrueImpl(context)(anType.tree, "will not be an", "expectAnTypeWillBeTrue")
+    expectTypeWillBeTrueImpl(context)(anType.tree, "will not be an", "expectAnTypeWillBeTrue")*/
 
 }


### PR DESCRIPTION
Marked Fact, Expectations, Compatibility, Safety, RegistrationPolicy, AsyncCompatibilty, AsyncSafety and AsyncRegistrationPolicy as private[scalatest], and comment out code to generate WillMatchers, and code that use the generated WillMatchers code.