### PR TITLE
Back to Unit: Step 1

### DIFF
--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -1,0 +1,89 @@
+/*
+* Copyright 2001-2011 Artima, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import java.io.{FileWriter, BufferedWriter, File}
+
+import scala.io.Source
+
+object GenSafeStyles {
+
+  def translateLine(traitName: String)(line: String): String =
+    line.replaceAllLiterally("with TestRegistration", "with SafeTestRegistration")
+        .replaceAllLiterally("=> Unit/*Assertion*/", "=> Assertion")
+        .replaceAllLiterally(traitName, "Safe" + traitName)
+        .replaceAllLiterally("Resources.concurrentSafe" + traitName + "Mod", "Resources.concurrent" + traitName + "Mod")
+        .replaceAllLiterally("final override val styleName: String = \"org.scalatest.Safe" + traitName + "\"", "final override val styleName: String = \"org.scalatest." + traitName + "\"")
+        .replaceAllLiterally("@Finders(Array(\"org.scalatest.finders.Safe" + traitName + "Finder\"))", "@Finders(Array(\"org.scalatest.finders." + traitName + "Finder\"))")
+
+  def translateFile(targetDir: File, fileName: String, sourceFileName: String, scalaVersion: String, scalaJS: Boolean, translateFun: String => String): Unit = {
+    val outputFile = new File(targetDir, fileName)
+    val outputWriter = new BufferedWriter(new FileWriter(outputFile))
+    try {
+      val lines = Source.fromFile(new File(sourceFileName)).getLines.toList
+      var skipMode = false
+      for (line <- lines) {
+        val mustLine: String =
+          if (scalaJS) {
+            if (line.trim == "// SKIP-SCALATESTJS-START") {
+              skipMode = true
+              ""
+            }
+            else if (line.trim == "// SKIP-SCALATESTJS-END") {
+              skipMode = false
+              ""
+            }
+            else if (!skipMode) {
+              if (line.trim.startsWith("//SCALATESTJS-ONLY "))
+                translateFun(line.substring(line.indexOf("//SCALATESTJS-ONLY ") + 19))
+              else
+                translateFun(line)
+            }
+            else
+              ""
+          }
+          else
+            translateFun(line)
+
+        outputWriter.write(mustLine)
+        outputWriter.newLine()
+      }
+    }
+    finally {
+      outputWriter.flush()
+      outputWriter.close()
+      println("Generated " + outputFile.getAbsolutePath)
+    }
+  }
+
+  def genMainImpl(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Unit = {
+    targetDir.mkdirs()
+    val safeDir = new File(targetDir, "safe")
+    safeDir.mkdirs()
+
+    translateFile(safeDir, "SafeTestRegistration.scala", "scalatest/src/main/scala/org/scalatest/TestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration"))
+    translateFile(safeDir, "SafeFunSuiteLike.scala", "scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala", scalaVersion, scalaJS, translateLine("FunSuite"))
+    translateFile(safeDir, "SafeFunSuite.scala", "scalatest/src/main/scala/org/scalatest/FunSuite.scala", scalaVersion, scalaJS, translateLine("FunSuite"))
+  }
+
+  def genMain(targetDir: File, version: String, scalaVersion: String) {
+    genMainImpl(targetDir, version, scalaVersion, false)
+  }
+
+  def genMainForScalaJS(targetDir: File, version: String, scalaVersion: String) {
+    genMainImpl(targetDir, version, scalaVersion, true)
+  }
+
+}

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -415,6 +415,7 @@ object ScalatestBuild extends Build {
      genCodeTask,
      genFactoriesTask,
      genCompatibleClassesTask,
+     genSafeStylesTask,
      sourceGenerators in Compile <+=
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gengen", "GenGen.scala")(GenGen.genMain),
      sourceGenerators in Compile <+=
@@ -427,6 +428,8 @@ object ScalatestBuild extends Build {
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gencompcls", "GenCompatibleClasses.scala")(GenCompatibleClasses.genMain),
      sourceGenerators in Compile <+=
          (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genversions", "GenVersions.scala")(GenVersions.genScalaTestVersions),
+     sourceGenerators in Compile <+=
+       (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gensafestyles", "GenSafeStyles.scala")(GenSafeStyles.genMain),
      scalatestDocSourcesSetting,
      sourceGenerators in Compile += {
        Def.task{
@@ -517,6 +520,7 @@ object ScalatestBuild extends Build {
         }.taskValue
       },
       genFactoriesTask,
+      genSafeStylesTask,
       sourceGenerators in Compile <+=
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genfactories", "GenFactories.scala")(GenFactories.genMainJS),
       sourceGenerators in Compile <+=
@@ -525,6 +529,8 @@ object ScalatestBuild extends Build {
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gentables", "GenTable.scala")(GenTable.genMainForScalaJS),
       sourceGenerators in Compile <+=
         (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("genmatchers", "MustMatchers.scala")(GenMatchers.genMainForScalaJS),
+      sourceGenerators in Compile <+=
+        (baseDirectory, sourceManaged in Compile, version, scalaVersion) map genFiles("gensafestyles", "GenSafeStyles.scala")(GenSafeStyles.genMainForScalaJS),
       /*genMustMatchersTask,
       genGenTask,
       genTablesTask,
@@ -1072,6 +1078,11 @@ object ScalatestBuild extends Build {
     GenTable.genMain(new File(mainTargetDir, "scala/gentables"), theVersion, theScalaVersion)
     GenMatchers.genMain(new File(mainTargetDir, "scala/genmatchers"), theVersion, theScalaVersion)
     GenFactories.genMain(new File(mainTargetDir, "scala/genfactories"), theVersion, theScalaVersion)
+  }
+
+  val genSafeStyles = TaskKey[Unit]("gensafestyles", "Generate safe style traits.")
+  val genSafeStylesTask = genSafeStyles <<= (sourceManaged in Compile, sourceManaged in Test, version, scalaVersion) map { (mainTargetDir: File, testTargetDir: File, theVersion: String, theScalaVersion: String) =>
+    GenSafeStyles.genMain(new File(mainTargetDir, "scala/gensafestyles"), theVersion, theScalaVersion)
   }
 
   //

--- a/scalatest-test/src/test/scala/org/scalatest/SafeFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/SafeFunSuiteSpec.scala
@@ -1,0 +1,1254 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import SharedHelpers._
+import org.scalatest.events._
+import Suite.CHOSEN_STYLES
+import org.scalatest.exceptions.DuplicateTestNameException
+import org.scalatest.exceptions.NotAllowedException
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.exceptions.TestRegistrationClosedException
+import org.scalactic.exceptions.NullArgumentException
+
+class SafeFunSuiteSpec extends FunSpec {
+
+  describe("A FunSuite") {
+
+    it("should return the test names in registration order from testNames") {
+
+      val a = new SafeFunSuite {
+        test("test this") {}
+        test("test that") {}
+      }
+
+      assertResult(List("test this", "test that")) {
+        a.testNames.iterator.toList
+      }
+
+      val b = new SafeFunSuite {}
+
+      assertResult(List[String]()) {
+        b.testNames.iterator.toList
+      }
+
+      val c = new SafeFunSuite {
+        test("test that") {}
+        test("test this") {}
+      }
+
+      assertResult(List("test that", "test this")) {
+        c.testNames.iterator.toList
+      }
+    }
+
+    it("should throw NotAllowedException if a duplicate test name registration is attempted") {
+
+      intercept[DuplicateTestNameException] {
+        new SafeFunSuite {
+          test("test this") {}
+          test("test this") {}
+        }
+      }
+      intercept[DuplicateTestNameException] {
+        new SafeFunSuite {
+          test("test this") {}
+          ignore("test this") {}
+        }
+      }
+      intercept[DuplicateTestNameException] {
+        new SafeFunSuite {
+          ignore("test this") {}
+          ignore("test this") {}
+        }
+      }
+      intercept[DuplicateTestNameException] {
+        new SafeFunSuite {
+          ignore("test this") {}
+          test("test this") {}
+        }
+      }
+    }
+
+    it("should throw NotAllowedException if test registration is attempted after run has been invoked on a suite") {
+      class InvokedWhenNotRunningSuite extends SafeFunSuite {
+        var fromMethodTestExecuted = false
+        var fromConstructorTestExecuted = false
+        test("from constructor") {
+          fromConstructorTestExecuted = true
+        }
+        def tryToRegisterATest() {
+          test("from method") {
+            fromMethodTestExecuted = true
+          }
+        }
+      }
+      val suite = new InvokedWhenNotRunningSuite
+      suite.run(None, Args(SilentReporter))
+      assert(suite.fromConstructorTestExecuted)
+      assert(!suite.fromMethodTestExecuted)
+      intercept[TestRegistrationClosedException] {
+        suite.tryToRegisterATest()
+      }
+      suite.run(None, Args(SilentReporter))
+      assert(!suite.fromMethodTestExecuted)
+      /*
+            class InvokedWhenRunningSuite extends FunSuite {
+              var fromMethodTestExecuted = false
+              var fromConstructorTestExecuted = false
+              test("from constructor") {
+                tryToRegisterATest()
+                fromConstructorTestExecuted = true
+              }
+              def tryToRegisterATest() {
+                test("from method") {
+                  fromMethodTestExecuted = true
+                }
+              }
+            }
+            val a = new InvokedWhenNotRunningSuite
+            a.run()
+            intercept[TestFailedException] {
+              new InvokedWhenRunningSuite
+            } */
+    }
+
+    it("should invoke withFixture from runTest") {
+      val a = new SafeFunSuite {
+        var withFixtureWasInvoked = false
+        var testWasInvoked = false
+        override def withFixture(test: NoArgTest): Outcome = {
+          withFixtureWasInvoked = true
+          super.withFixture(test)
+        }
+        test("something") {
+          testWasInvoked = true
+        }
+      }
+
+      import scala.language.reflectiveCalls
+
+      a.run(None, Args(SilentReporter))
+      assert(a.withFixtureWasInvoked)
+      assert(a.testWasInvoked)
+    }
+    it("should pass the correct test name in the NoArgTest passed to withFixture") {
+      val a = new SafeFunSuite {
+        var correctTestNameWasPassed = false
+        override def withFixture(test: NoArgTest): Outcome = {
+          correctTestNameWasPassed = test.name == "something"
+          super.withFixture(test)
+        }
+        test("something") {}
+      }
+
+      import scala.language.reflectiveCalls
+
+      a.run(None, Args(SilentReporter))
+      assert(a.correctTestNameWasPassed)
+    }
+    it("should pass the correct config map in the NoArgTest passed to withFixture") {
+      val a = new SafeFunSuite {
+        var correctConfigMapWasPassed = false
+        override def withFixture(test: NoArgTest): Outcome = {
+          correctConfigMapWasPassed = (test.configMap == ConfigMap("hi" -> 7))
+          super.withFixture(test)
+        }
+        test("something") {}
+      }
+
+      import scala.language.reflectiveCalls
+
+      a.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap("hi" -> 7), None, new Tracker(), Set.empty))
+      assert(a.correctConfigMapWasPassed)
+    }
+
+    describe("(with info calls)") {
+      it("should, when the info appears in the body before a test, report the info before the test") {
+        val msg = "hi there, dude"
+        val testName = "test name"
+        class MySuite extends SafeFunSuite {
+          info(msg)
+          test(testName) {}
+        }
+        val (infoProvidedIndex, testStartingIndex, testSucceededIndex) =
+          getIndexesForInformerEventOrderTests(new MySuite, testName, msg)
+        assert(infoProvidedIndex < testStartingIndex)
+        assert(testStartingIndex < testSucceededIndex)
+      }
+      it("should, when the info appears in the body after a test, report the info after the test runs") {
+        val msg = "hi there, dude"
+        val testName = "test name"
+        class MySuite extends SafeFunSuite {
+          test(testName) {}
+          info(msg)
+        }
+        val (infoProvidedIndex, testStartingIndex, testSucceededIndex) =
+          getIndexesForInformerEventOrderTests(new MySuite, testName, msg)
+        assert(testStartingIndex < testSucceededIndex)
+        assert(testSucceededIndex < infoProvidedIndex)
+      }
+      it("should print to stdout when info is called by a method invoked after the suite has been executed") {
+        class MySuite extends SafeFunSuite {
+          callInfo() // This should work fine
+          def callInfo() {
+            info("howdy")
+          }
+          test("howdy also") {
+            callInfo() // This should work fine
+          }
+        }
+        val suite = new MySuite
+        val myRep = new EventRecordingReporter
+        suite.run(None, Args(myRep))
+        suite.callInfo() // TODO: Actually test that it prints to stdout
+      }
+    }
+    it("should run tests registered via the testsFor syntax") {
+      trait SharedFunSuiteTests { this: SafeFunSuite =>
+        def nonEmptyStack(s: String)(i: Int) {
+          test("I am shared") {}
+        }
+      }
+      class MySuite extends SafeFunSuite with SharedFunSuiteTests {
+        testsFor(nonEmptyStack("hi")(1))
+      }
+      val suite = new MySuite
+      val reporter = new EventRecordingReporter
+      suite.run(None, Args(reporter))
+
+      val indexedList = reporter.eventsReceived
+
+      val testStartingOption = indexedList.find(_.isInstanceOf[TestStarting])
+      assert(testStartingOption.isDefined)
+      assert(testStartingOption.get.asInstanceOf[TestStarting].testName === "I am shared")
+    }
+    it("should throw NullArgumentException if a null test tag is provided") {
+      // test
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          test("hi", null) {}
+        }
+      }
+      val caught = intercept[NullArgumentException] {
+        new SafeFunSuite {
+          test("hi", mytags.SlowAsMolasses, null) {}
+        }
+      }
+      assert(caught.getMessage == "a test tag was null")
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          test("hi", mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) {}
+        }
+      }
+
+      // ignore
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          ignore("hi", null) {}
+        }
+      }
+      val caught2 = intercept[NullArgumentException] {
+        new SafeFunSuite {
+          ignore("hi", mytags.SlowAsMolasses, null) {}
+        }
+      }
+      assert(caught2.getMessage == "a test tag was null")
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          ignore("hi", mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) {}
+        }
+      }
+
+      // registerTest
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerTest("hi", null) {}
+        }
+      }
+      val caught3 = intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerTest("hi", mytags.SlowAsMolasses, null) {}
+        }
+      }
+      assert(caught3.getMessage == "a test tag was null")
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerTest("hi", mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) {}
+        }
+      }
+
+      // registerIgnoredTest
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerIgnoredTest("hi", null) {}
+        }
+      }
+      val caught4 = intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerIgnoredTest("hi", mytags.SlowAsMolasses, null) {}
+        }
+      }
+      assert(caught4.getMessage == "a test tag was null")
+      intercept[NullArgumentException] {
+        new SafeFunSuite {
+          registerIgnoredTest("hi", mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) {}
+        }
+      }
+    }
+
+    class TestWasCalledSuite extends SafeFunSuite {
+      var theTestThisCalled = false
+      var theTestThatCalled = false
+      test("this") { theTestThisCalled = true }
+      test("that") { theTestThatCalled = true }
+    }
+
+    it("should execute all tests when run is called with testName None") {
+
+      val b = new TestWasCalledSuite
+      b.run(None, Args(SilentReporter))
+      assert(b.theTestThisCalled)
+      assert(b.theTestThatCalled)
+    }
+
+    it("should execute one test when run is called with a defined testName") {
+
+      val a = new TestWasCalledSuite
+      a.run(Some("this"), Args(SilentReporter))
+      assert(a.theTestThisCalled)
+      assert(!a.theTestThatCalled)
+    }
+
+    it("should report as ignored, and not run, tests marked ignored") {
+
+      val a = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this") { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repA = new TestIgnoredTrackingReporter
+      a.run(None, Args(repA))
+      assert(!repA.testIgnoredReceived)
+      assert(a.theTestThisCalled)
+      assert(a.theTestThatCalled)
+
+      val b = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        ignore("test this") { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+
+      val repB = new TestIgnoredTrackingReporter
+      b.run(None, Args(repB))
+      assert(repB.testIgnoredReceived)
+      assert(repB.lastEvent.isDefined)
+      assert(repB.lastEvent.get.testName endsWith "test this")
+      assert(!b.theTestThisCalled)
+      assert(b.theTestThatCalled)
+
+      val c = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this") { theTestThisCalled = true }
+        ignore("test that") { theTestThatCalled = true }
+      }
+
+      val repC = new TestIgnoredTrackingReporter
+      c.run(None, Args(repC))
+      assert(repC.testIgnoredReceived)
+      assert(repC.lastEvent.isDefined)
+      assert(repC.lastEvent.get.testName endsWith "test that", repC.lastEvent.get.testName)
+      assert(c.theTestThisCalled)
+      assert(!c.theTestThatCalled)
+
+      // The order I want is order of appearance in the file.
+      // Will try and implement that tomorrow. Subtypes will be able to change the order.
+      val d = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        ignore("test this") { theTestThisCalled = true }
+        ignore("test that") { theTestThatCalled = true }
+      }
+
+      val repD = new TestIgnoredTrackingReporter
+      d.run(None, Args(repD))
+      assert(repD.testIgnoredReceived)
+      assert(repD.lastEvent.isDefined)
+      assert(repD.lastEvent.get.testName endsWith "test that") // last because should be in order of appearance
+      assert(!d.theTestThisCalled)
+      assert(!d.theTestThatCalled)
+    }
+
+    it("should ignore a test marked as ignored if run is invoked with that testName") {
+      val e = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        ignore("test this") { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repE = new TestIgnoredTrackingReporter
+      e.run(Some("test this"), Args(repE))
+      assert(repE.testIgnoredReceived)
+      assert(!e.theTestThisCalled)
+      assert(!e.theTestThatCalled)
+    }
+
+    it("should exclude a test with a tag included in the tagsToExclude set even if run is invoked with that testName") {
+      val e = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repE = new TestIgnoredTrackingReporter
+      e.run(Some("test this"), Args(repE, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repE.testIgnoredReceived)
+      assert(!e.theTestThisCalled)
+      assert(!e.theTestThatCalled)
+    }
+
+    it("should exclude a registered test with a tag included in the tagsToExclude set even if run is invoked with that testName") {
+      val e = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        registerTest("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repE = new TestIgnoredTrackingReporter
+      e.run(Some("test this"), Args(repE, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repE.testIgnoredReceived)
+      assert(!e.theTestThisCalled)
+      assert(!e.theTestThatCalled)
+    }
+
+    it("should run only those tests selected by the tags to include and exclude sets") {
+
+      // Nothing is excluded
+      val a = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repA = new TestIgnoredTrackingReporter
+      a.run(None, Args(repA))
+      assert(!repA.testIgnoredReceived)
+      assert(a.theTestThisCalled)
+      assert(a.theTestThatCalled)
+
+      // SlowAsMolasses is included, one test should be excluded
+      val b = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        test("test that") { theTestThatCalled = true }
+      }
+      val repB = new TestIgnoredTrackingReporter
+      b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repB.testIgnoredReceived)
+      assert(b.theTestThisCalled)
+      assert(!b.theTestThatCalled)
+
+      // SlowAsMolasses is included, and both tests should be included
+      val c = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        test("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+      }
+      val repC = new TestIgnoredTrackingReporter
+      c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repC.testIgnoredReceived)
+      assert(c.theTestThisCalled)
+      assert(c.theTestThatCalled)
+
+      // SlowAsMolasses is included. both tests should be included but one ignored
+      val d = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        ignore("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+      }
+      val repD = new TestIgnoredTrackingReporter
+      d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(repD.testIgnoredReceived)
+      assert(!d.theTestThisCalled)
+      assert(d.theTestThatCalled)
+
+      // SlowAsMolasses included, FastAsLight excluded
+      val e = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        test("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        test("test the other") { theTestTheOtherCalled = true }
+      }
+      val repE = new TestIgnoredTrackingReporter
+      e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repE.testIgnoredReceived)
+      assert(!e.theTestThisCalled)
+      assert(e.theTestThatCalled)
+      assert(!e.theTestTheOtherCalled)
+
+      // An Ignored test that was both included and excluded should not generate a TestIgnored event
+      val f = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        ignore("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        test("test the other") { theTestTheOtherCalled = true }
+      }
+      val repF = new TestIgnoredTrackingReporter
+      f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repF.testIgnoredReceived)
+      assert(!f.theTestThisCalled)
+      assert(f.theTestThatCalled)
+      assert(!f.theTestTheOtherCalled)
+
+      // An Ignored test that was not included should not generate a TestIgnored event
+      val g = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        test("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        ignore("test the other") { theTestTheOtherCalled = true }
+      }
+      val repG = new TestIgnoredTrackingReporter
+      g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repG.testIgnoredReceived)
+      assert(!g.theTestThisCalled)
+      assert(g.theTestThatCalled)
+      assert(!g.theTestTheOtherCalled)
+
+      // No tagsToInclude set, FastAsLight excluded
+      val h = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        test("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        test("test the other") { theTestTheOtherCalled = true }
+      }
+      val repH = new TestIgnoredTrackingReporter
+      h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repH.testIgnoredReceived)
+      assert(!h.theTestThisCalled)
+      assert(h.theTestThatCalled)
+      assert(h.theTestTheOtherCalled)
+
+      // No tagsToInclude set, SlowAsMolasses excluded
+      val i = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        test("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        test("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        test("test the other") { theTestTheOtherCalled = true }
+      }
+      val repI = new TestIgnoredTrackingReporter
+      i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repI.testIgnoredReceived)
+      assert(!i.theTestThisCalled)
+      assert(!i.theTestThatCalled)
+      assert(i.theTestTheOtherCalled)
+
+      // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
+      val j = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        ignore("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        ignore("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        test("test the other") { theTestTheOtherCalled = true }
+      }
+      val repJ = new TestIgnoredTrackingReporter
+      j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repI.testIgnoredReceived)
+      assert(!j.theTestThisCalled)
+      assert(!j.theTestThatCalled)
+      assert(j.theTestTheOtherCalled)
+
+      // Same as previous, except Ignore specifically mentioned in excludes set
+      val k = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        ignore("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        ignore("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        ignore("test the other") { theTestTheOtherCalled = true }
+      }
+      val repK = new TestIgnoredTrackingReporter
+      k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(repK.testIgnoredReceived)
+      assert(!k.theTestThisCalled)
+      assert(!k.theTestThatCalled)
+      assert(!k.theTestTheOtherCalled)
+    }
+
+    it("should run only those registered tests selected by the tags to include and exclude sets") {
+
+      // Nothing is excluded
+      val a = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        registerTest("test that") { theTestThatCalled = true }
+      }
+
+      import scala.language.reflectiveCalls
+
+      val repA = new TestIgnoredTrackingReporter
+      a.run(None, Args(repA))
+      assert(!repA.testIgnoredReceived)
+      assert(a.theTestThisCalled)
+      assert(a.theTestThatCalled)
+
+      // SlowAsMolasses is included, one test should be excluded
+      val b = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        registerTest("test that") { theTestThatCalled = true }
+      }
+      val repB = new TestIgnoredTrackingReporter
+      b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repB.testIgnoredReceived)
+      assert(b.theTestThisCalled)
+      assert(!b.theTestThatCalled)
+
+      // SlowAsMolasses is included, and both tests should be included
+      val c = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+      }
+      val repC = new TestIgnoredTrackingReporter
+      c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repC.testIgnoredReceived)
+      assert(c.theTestThisCalled)
+      assert(c.theTestThatCalled)
+
+      // SlowAsMolasses is included. both tests should be included but one ignored
+      val d = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        registerIgnoredTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+      }
+      val repD = new TestIgnoredTrackingReporter
+      d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(repD.testIgnoredReceived)
+      assert(!d.theTestThisCalled)
+      assert(d.theTestThatCalled)
+
+      // SlowAsMolasses included, FastAsLight excluded
+      val e = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repE = new TestIgnoredTrackingReporter
+      e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repE.testIgnoredReceived)
+      assert(!e.theTestThisCalled)
+      assert(e.theTestThatCalled)
+      assert(!e.theTestTheOtherCalled)
+
+      // An Ignored test that was both included and excluded should not generate a TestIgnored event
+      val f = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerIgnoredTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repF = new TestIgnoredTrackingReporter
+      f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repF.testIgnoredReceived)
+      assert(!f.theTestThisCalled)
+      assert(f.theTestThatCalled)
+      assert(!f.theTestTheOtherCalled)
+
+      // An Ignored test that was not included should not generate a TestIgnored event
+      val g = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerIgnoredTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repG = new TestIgnoredTrackingReporter
+      g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
+        ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repG.testIgnoredReceived)
+      assert(!g.theTestThisCalled)
+      assert(g.theTestThatCalled)
+      assert(!g.theTestTheOtherCalled)
+
+      // No tagsToInclude set, FastAsLight excluded
+      val h = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repH = new TestIgnoredTrackingReporter
+      h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repH.testIgnoredReceived)
+      assert(!h.theTestThisCalled)
+      assert(h.theTestThatCalled)
+      assert(h.theTestTheOtherCalled)
+
+      // No tagsToInclude set, SlowAsMolasses excluded
+      val i = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repI = new TestIgnoredTrackingReporter
+      i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repI.testIgnoredReceived)
+      assert(!i.theTestThisCalled)
+      assert(!i.theTestThatCalled)
+      assert(i.theTestTheOtherCalled)
+
+      // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
+      val j = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerIgnoredTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerIgnoredTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repJ = new TestIgnoredTrackingReporter
+      j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(!repI.testIgnoredReceived)
+      assert(!j.theTestThisCalled)
+      assert(!j.theTestThatCalled)
+      assert(j.theTestTheOtherCalled)
+
+      // Same as previous, except Ignore specifically mentioned in excludes set
+      val k = new SafeFunSuite {
+        var theTestThisCalled = false
+        var theTestThatCalled = false
+        var theTestTheOtherCalled = false
+        registerIgnoredTest("test this", mytags.SlowAsMolasses, mytags.FastAsLight) { theTestThisCalled = true }
+        registerIgnoredTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true }
+        registerIgnoredTest("test the other") { theTestTheOtherCalled = true }
+      }
+      val repK = new TestIgnoredTrackingReporter
+      k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
+      assert(repK.testIgnoredReceived)
+      assert(!k.theTestThisCalled)
+      assert(!k.theTestThatCalled)
+      assert(!k.theTestTheOtherCalled)
+    }
+
+    it("should return the correct test count from its expectedTestCount method") {
+
+      val a = new SafeFunSuite {
+        test("test this") {}
+        test("test that") {}
+      }
+      assert(a.expectedTestCount(Filter()) == 2)
+
+      val b = new SafeFunSuite {
+        ignore("test this") {}
+        test("test that") {}
+      }
+      assert(b.expectedTestCount(Filter()) == 1)
+
+      val c = new SafeFunSuite {
+        test("test this", mytags.FastAsLight) {}
+        test("test that") {}
+      }
+      assert(c.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(c.expectedTestCount(Filter(None, Set("org.scalatest.FastAsLight"))) == 1)
+
+      val d = new SafeFunSuite {
+        test("test this", mytags.FastAsLight, mytags.SlowAsMolasses) {}
+        test("test that", mytags.SlowAsMolasses) {}
+        test("test the other thing") {}
+      }
+      assert(d.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(d.expectedTestCount(Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight"))) == 1)
+      assert(d.expectedTestCount(Filter(None, Set("org.scalatest.SlowAsMolasses"))) == 1)
+      assert(d.expectedTestCount(Filter()) == 3)
+
+      val e = new SafeFunSuite {
+        test("test this", mytags.FastAsLight, mytags.SlowAsMolasses) {}
+        test("test that", mytags.SlowAsMolasses) {}
+        ignore("test the other thing") {}
+      }
+      assert(e.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(e.expectedTestCount(Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight"))) == 1)
+      assert(e.expectedTestCount(Filter(None, Set("org.scalatest.SlowAsMolasses"))) == 0)
+      assert(e.expectedTestCount(Filter()) == 2)
+
+      val f = new Suites(a, b, c, d, e)
+      assert(f.expectedTestCount(Filter()) == 10)
+    }
+    it("should return the correct test count from its expectedTestCount method when uses registerTest and registerIgnoredTest to register test") {
+
+      val a = new SafeFunSuite {
+        registerTest("test this") {}
+        registerTest("test that") {}
+      }
+      assert(a.expectedTestCount(Filter()) == 2)
+
+      val b = new SafeFunSuite {
+        registerIgnoredTest("test this") {}
+        registerTest("test that") {}
+      }
+      assert(b.expectedTestCount(Filter()) == 1)
+
+      val c = new SafeFunSuite {
+        registerTest("test this", mytags.FastAsLight) {}
+        registerTest("test that") {}
+      }
+      assert(c.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(c.expectedTestCount(Filter(None, Set("org.scalatest.FastAsLight"))) == 1)
+
+      val d = new SafeFunSuite {
+        registerTest("test this", mytags.FastAsLight, mytags.SlowAsMolasses) {}
+        registerTest("test that", mytags.SlowAsMolasses) {}
+        registerTest("test the other thing") {}
+      }
+      assert(d.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(d.expectedTestCount(Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight"))) == 1)
+      assert(d.expectedTestCount(Filter(None, Set("org.scalatest.SlowAsMolasses"))) == 1)
+      assert(d.expectedTestCount(Filter()) == 3)
+
+      val e = new SafeFunSuite {
+        registerTest("test this", mytags.FastAsLight, mytags.SlowAsMolasses) {}
+        registerTest("test that", mytags.SlowAsMolasses) {}
+        registerIgnoredTest("test the other thing") {}
+      }
+      assert(e.expectedTestCount(Filter(Some(Set("org.scalatest.FastAsLight")), Set())) == 1)
+      assert(e.expectedTestCount(Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight"))) == 1)
+      assert(e.expectedTestCount(Filter(None, Set("org.scalatest.SlowAsMolasses"))) == 0)
+      assert(e.expectedTestCount(Filter()) == 2)
+
+      val f = new Suites(a, b, c, d, e)
+      assert(f.expectedTestCount(Filter()) == 10)
+    }
+    it("should generate a TestPending message when the test body is (pending)") {
+      val a = new SafeFunSuite {
+
+        test("should do this") (pending)
+
+        test("should do that") {
+          assert(2 + 2 === 4)
+        }
+
+        test("should do something else") {
+          assert(2 + 2 === 4)
+          pending
+        }
+      }
+      val rep = new EventRecordingReporter
+      a.run(None, Args(rep))
+      val tp = rep.testPendingEventsReceived
+      assert(tp.size === 2)
+    }
+    it("should generate a test failure if a Throwable, or an Error other than direct Error subtypes " +
+      "known in JDK 1.5, excluding AssertionError") {
+      val a = new SafeFunSuite {
+        test("throws AssertionError") { throw new AssertionError }
+        test("throws plain old Error") { throw new Error }
+        test("throws Throwable") { throw new Throwable }
+      }
+      val rep = new EventRecordingReporter
+      a.run(None, Args(rep))
+      val tf = rep.testFailedEventsReceived
+      assert(tf.size === 3)
+    }
+    // SKIP-SCALATESTJS-START
+    it("should propagate out Errors that are direct subtypes of Error in JDK 1.5, other than " +
+      "AssertionError, causing Suites and Runs to abort.") {
+      val a = new SafeFunSuite {
+        test("throws AssertionError") { throw new OutOfMemoryError }
+      }
+      intercept[OutOfMemoryError] {
+        a.run(None, Args(SilentReporter))
+      }
+    }
+    // SKIP-SCALATESTJS-END
+    describe("(when a nesting rule has been violated)") {
+
+      it("should, if they call a nested it from within an it clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          test("should blow up") {
+            test("should never run") {
+              assert(1 === 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+      it("should, if they call a nested it with tags from within an it clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          test("should blow up") {
+            test("should never run", mytags.SlowAsMolasses) {
+              assert(1 == 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+      it("should, if they call a nested registerTest with tags from within a registerTest clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          registerTest("should blow up") {
+            registerTest("should never run", mytags.SlowAsMolasses) {
+              assert(1 == 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+      it("should, if they call a nested ignore from within an it clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          test("should blow up") {
+            ignore("should never run") {
+              assert(1 === 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+      it("should, if they call a nested ignore with tags from within an it clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          test("should blow up") {
+            ignore("should never run", mytags.SlowAsMolasses) {
+              assert(1 == 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+      it("should, if they call a nested registerIgnoredTest with tags from within a registerTest clause, result in a TestFailedException when running the test") {
+
+        class MySuite extends SafeFunSuite {
+          registerTest("should blow up") {
+            registerIgnoredTest("should never run", mytags.SlowAsMolasses) {
+              assert(1 == 1)
+            }
+          }
+        }
+
+        val spec = new MySuite
+        ensureTestFailedEventReceived(spec, "should blow up")
+      }
+    }
+
+    it("should throw IllegalArgumentException if passed a testName that doesn't exist") {
+      class MySuite extends SafeFunSuite {
+        test("one") {}
+        test("two") {}
+      }
+      val suite = new MySuite
+      intercept[IllegalArgumentException] {
+        suite.run(Some("three"), Args(SilentReporter))
+      }
+    }
+
+    it("should throw a NotAllowedException if chosenStyles is defined and does not include FunSuite") {
+
+      class SimpleSuite extends SafeFunSuite {
+        test("one") {}
+        test("two") {}
+        test("three") {}
+      }
+
+      val simpleSuite = new SimpleSuite()
+      simpleSuite.run(None, Args(SilentReporter))
+      simpleSuite.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap(CHOSEN_STYLES -> Set("org.scalatest.FunSuite")), None, new Tracker, Set.empty))
+      val caught =
+        intercept[NotAllowedException] {
+          simpleSuite.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap(CHOSEN_STYLES -> Set("org.scalatest.FunSpec")), None, new Tracker, Set.empty))
+        }
+      import OptionValues._
+      assert(caught.message.value === Resources.notTheChosenStyle("org.scalatest.FunSuite", "org.scalatest.FunSpec"))
+      val caught2 =
+        intercept[NotAllowedException] {
+          simpleSuite.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap(CHOSEN_STYLES -> Set("org.scalatest.FunSpec", "org.scalatest.FreeSpec")), None, new Tracker, Set.empty))
+        }
+      assert(caught2.message.value === Resources.notOneOfTheChosenStyles("org.scalatest.FunSuite", Suite.makeListForHumans(Vector("org.scalatest.FunSpec", "org.scalatest.FreeSpec"))))
+      val caught3 =
+        intercept[NotAllowedException] {
+          simpleSuite.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap(CHOSEN_STYLES -> Set("org.scalatest.FunSpec", "org.scalatest.FreeSpec", "org.scalatest.FlatSpec")), None, new Tracker, Set.empty))
+        }
+      assert(caught3.message.value === Resources.notOneOfTheChosenStyles("org.scalatest.FunSuite", Suite.makeListForHumans(Vector("org.scalatest.FunSpec", "org.scalatest.FreeSpec", "org.scalatest.FlatSpec"))))
+    }
+
+    describe("registerTest and registerIgnoredTest method") {
+
+      it("should allow test registration and ignored test registration") {
+        class TestSpec extends SafeFunSuite {
+          val a = 1
+          registerTest("test 1") {
+            val e = intercept[TestFailedException] {
+              assert(a == 2)
+            }
+            assert(e.message == Some("1 did not equal 2"))
+            assert(e.failedCodeFileName == Some("SafeFunSuiteSpec.scala"))
+            assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
+          }
+          registerTest("test 2") {
+            assert(a == 2)
+          }
+          registerTest("test 3") {
+            pending
+          }
+          registerTest("test 4") {
+            cancel
+          }
+          registerIgnoredTest("test 5") {
+            assert(a == 2)
+          }
+        }
+
+        val rep = new EventRecordingReporter
+        val s = new TestSpec
+        s.run(None, Args(rep))
+
+        assert(rep.testStartingEventsReceived.length == 4)
+        assert(rep.testSucceededEventsReceived.length == 1)
+        assert(rep.testSucceededEventsReceived(0).testName == "test 1")
+        assert(rep.testFailedEventsReceived.length == 1)
+        assert(rep.testFailedEventsReceived(0).testName == "test 2")
+        assert(rep.testPendingEventsReceived.length == 1)
+        assert(rep.testPendingEventsReceived(0).testName == "test 3")
+        assert(rep.testCanceledEventsReceived.length == 1)
+        assert(rep.testCanceledEventsReceived(0).testName == "test 4")
+        assert(rep.testIgnoredEventsReceived.length == 1)
+        assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
+      }
+
+      it("should generate TestRegistrationClosedException with correct stack depth info when has a registerTest nested inside a registerTest") {
+        class TestSpec extends SafeFunSuite {
+          var registrationClosedThrown = false
+          registerTest("a scenario") {
+            registerTest("nested scenario") {
+              assert(1 == 2)
+            }
+          }
+          override def withFixture(test: NoArgTest): Outcome = {
+            val outcome = test.apply()
+            outcome match {
+              case Exceptional(ex: TestRegistrationClosedException) =>
+                registrationClosedThrown = true
+              case _ =>
+            }
+            outcome
+          }
+        }
+        val rep = new EventRecordingReporter
+        val s = new TestSpec
+        s.run(None, Args(rep))
+        assert(s.registrationClosedThrown == true)
+        val testFailedEvents = rep.testFailedEventsReceived
+        assert(testFailedEvents.size === 1)
+        assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
+        val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
+        assert("SafeFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
+        assert(trce.message == Some("Test cannot be nested inside another test."))
+      }
+
+      it("should generate TestRegistrationClosedException with correct stack depth info when has an registerIgnoredTest nested inside a registerTest") {
+        class TestSpec extends SafeFunSuite {
+          var registrationClosedThrown = false
+          registerTest("a scenario") {
+            registerIgnoredTest("nested scenario") {
+              assert(1 == 2)
+            }
+          }
+          override def withFixture(test: NoArgTest): Outcome = {
+            val outcome = test.apply()
+            outcome match {
+              case Exceptional(ex: TestRegistrationClosedException) =>
+                registrationClosedThrown = true
+              case _ =>
+            }
+            outcome
+          }
+        }
+        val rep = new EventRecordingReporter
+        val s = new TestSpec
+        s.run(None, Args(rep))
+        assert(s.registrationClosedThrown == true)
+        val testFailedEvents = rep.testFailedEventsReceived
+        assert(testFailedEvents.size === 1)
+        assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
+        val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
+        assert("SafeFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
+        assert(trce.message == Some("Test cannot be nested inside another test."))
+      }
+    }
+
+    ignore("should support expectations") { // Unignore after we uncomment the expectation implicits in RegistrationPolicy
+    class TestSpec extends SafeFunSuite with Expectations {
+      test("fail scenario") {
+        expect(1 === 2)
+      }
+      test("nested fail scenario") {
+        expect(1 === 2)
+      }
+    }
+      val rep = new EventRecordingReporter
+      val s1 = new TestSpec
+      s1.run(None, Args(rep))
+      assert(rep.testFailedEventsReceived.size === 2)
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "SafeFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "SafeFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
+    }
+  }
+
+  describe("when failure happens") {
+    it("should fire TestFailed event with correct stack depth info when test failed") {
+      class TestSpec extends SafeFunSuite {
+        test("fail scenario") {
+          assert(1 === 2)
+        }
+      }
+      val rep = new EventRecordingReporter
+      val s1 = new TestSpec
+      s1.run(None, Args(rep))
+      assert(rep.testFailedEventsReceived.size === 1)
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "SafeFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
+    }
+
+    it("should generate TestRegistrationClosedException with correct stack depth info when has a test nested inside a test") {
+      class TestSpec extends SafeFunSuite {
+        var registrationClosedThrown = false
+        test("a scenario") {
+          test("nested scenario") {
+            assert(1 == 2)
+          }
+        }
+        override def withFixture(test: NoArgTest): Outcome = {
+          val outcome = test.apply()
+          outcome match {
+            case Exceptional(ex: TestRegistrationClosedException) =>
+              registrationClosedThrown = true
+            case _ =>
+          }
+          outcome
+        }
+      }
+      val rep = new EventRecordingReporter
+      val s = new TestSpec
+      s.run(None, Args(rep))
+      assert(s.registrationClosedThrown == true)
+      val testFailedEvents = rep.testFailedEventsReceived
+      assert(testFailedEvents.size === 1)
+      assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
+      val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
+      assert("SafeFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
+      assert(trce.message == Some("A test clause may not appear inside another test clause."))
+    }
+
+    it("should generate TestRegistrationClosedException with correct stack depth info when has an ignore nested inside a test") {
+      class TestSpec extends SafeFunSuite {
+        var registrationClosedThrown = false
+        test("a scenario") {
+          ignore("nested scenario") {
+            assert(1 == 2)
+          }
+        }
+        override def withFixture(test: NoArgTest): Outcome = {
+          val outcome = test.apply()
+          outcome match {
+            case Exceptional(ex: TestRegistrationClosedException) =>
+              registrationClosedThrown = true
+            case _ =>
+          }
+          outcome
+        }
+      }
+      val rep = new EventRecordingReporter
+      val s = new TestSpec
+      s.run(None, Args(rep))
+      assert(s.registrationClosedThrown == true)
+      val testFailedEvents = rep.testFailedEventsReceived
+      assert(testFailedEvents.size === 1)
+      assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
+      val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
+      assert("SafeFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
+      assert(trce.message == Some("An ignore clause may not appear inside a test clause."))
+    }
+  }
+}

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
@@ -94,7 +94,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS-END
@@ -102,7 +102,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
     engine.registerTest(Resources.scenario(testText.trim), Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "FeatureSpecLike.scala", "registerTest", 4, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -128,7 +128,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def scenario(specText: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def scenario(specText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -156,7 +156,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def ignore(specText: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def ignore(specText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -172,7 +172,7 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
    * (defined with <code>it</code>). This trait's implementation of this method will register the
    * description string and immediately invoke the passed function.
    */
-  protected def feature(description: String)(fun: => Unit) {
+  protected def feature(description: String)(fun: => Unit/*Assertion*/) {
 
     // SKIP-SCALATESTJS-START
     val stackDepth = 4

--- a/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
@@ -94,7 +94,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS-END
@@ -102,7 +102,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "FlatSpecLike.scala", "registerTest", 4, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -129,7 +129,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, methodName: String, testTags: List[Tag], testFun: () => Assertion) {
+  private def registerTestToRun(specText: String, methodName: String, testTags: List[Tag], testFun: () => Unit)/*Assertion*/ {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
@@ -267,7 +267,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + name.trim, "in", tags, testFun _)
     }
 
@@ -311,7 +311,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "ignore", testFun _)
     }
   }
@@ -379,7 +379,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + name.trim, "in", List(), testFun _)
     }
 
@@ -421,7 +421,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "ignore", testFun _)
     }
 
@@ -673,7 +673,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "in", testFun _)
     }
 
@@ -770,7 +770,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "in", testFun _)
     }
 
@@ -982,7 +982,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + name.trim, "in", tags, testFun _)
     }
 
@@ -1026,7 +1026,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "ignore", testFun _)
     }
   }
@@ -1094,7 +1094,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + name.trim, "in", List(), testFun _)
     }
 
@@ -1136,7 +1136,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "ignore", testFun _)
     }
 
@@ -1395,7 +1395,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + rest.trim, "in", List(), testFun _)
     }
     
@@ -1416,7 +1416,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", testFun _)
     }
   }
@@ -1493,7 +1493,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, testFun _)
     }
 
@@ -1516,7 +1516,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", testFun _)
     }
   }
@@ -1630,7 +1630,7 @@ trait FlatSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Assertion) {
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3

--- a/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
@@ -96,7 +96,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -104,7 +104,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "FreeSpecLike.scala", "registerTest", 5, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -131,7 +131,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Assertion) {
+  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
@@ -160,7 +160,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Assertion) {
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
@@ -198,7 +198,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(specText, tags, "in", testFun _)
     }
 
@@ -238,7 +238,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(specText, tags, "ignore", testFun _)
     }
   }       
@@ -258,7 +258,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
      * implementation of this method will register the text (passed to the contructor of <code>FreeSpecStringWrapper</code>
      * and immediately invoke the passed function.
      */
-    def - (fun: => Unit) {
+    def - (fun: => Unit/*Assertion*/) {
 
       // SKIP-SCALATESTJS-START
       val stackDepth = 3
@@ -295,7 +295,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def in(f: => Assertion) {
+    def in(f: => Unit/*Assertion*/) {
       registerTestToRun(string, List(), "in", f _)
     }
 
@@ -315,7 +315,7 @@ trait FreeSpecLike extends Suite with TestRegistration with Informing with Notif
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def ignore(f: => Assertion) {
+    def ignore(f: => Unit/*Assertion*/) {
       registerTestToIgnore(string, List(), "ignore", f _)
     }
 

--- a/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
@@ -93,7 +93,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -101,7 +101,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, sourceFileName, "registerTest", 5, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -155,7 +155,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
      * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
      * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
      */
-    def apply(specText: String, testTags: Tag*)(testFun: => Assertion) {
+    def apply(specText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
       // SKIP-SCALATESTJS-START
       val stackDepth = 3
       val stackDepthAdjustment = -2
@@ -273,7 +273,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
      * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
      * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
      */
-    def apply(specText: String, testTags: Tag*)(testFun: => Assertion) {
+    def apply(specText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
       engine.registerTest(specText, Transformer(testFun _), Resources.theyCannotAppearInsideAnotherItOrThey, sourceFileName, "apply", 3, -2, None, None, None, testTags: _*)
     }
 
@@ -357,7 +357,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def ignore(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def ignore(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -373,7 +373,7 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
    * (defined with <code>it</code>). This trait's implementation of this method will register the
    * description string and immediately invoke the passed function.
    */
-  protected def describe(description: String)(fun: => Unit) {
+  protected def describe(description: String)(fun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val errorStackDepth = 4

--- a/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
@@ -87,7 +87,7 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS-END
@@ -95,7 +95,7 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "FunSuite.scala", "registerTest", 4, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -3
     // SKIP-SCALATESTJS-END
@@ -117,7 +117,7 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
    */
-  protected def test(testName: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def test(testName: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -142,7 +142,7 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
    * @throws DuplicateTestNameException if a test with the same name has been registered previously
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    */
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def ignore(testName: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3

--- a/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
@@ -87,7 +87,7 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS-END
@@ -95,7 +95,7 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "PropSpecLike.scala", "registerTest", 4, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -117,7 +117,7 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
    */
-  protected def property(testName: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def property(testName: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -142,7 +142,7 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
    * @throws DuplicateTestNameException if a test with the same name has been registered previously
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    */
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Assertion) {
+  protected def ignore(testName: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -2

--- a/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
@@ -27,7 +27,7 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerTest(testText: String, testTags: Tag*)(testFun: => Unit)
+  def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/)
 
   /**
    * Register an ignored test, note that an ignored test will not be executed, but it will cause a <code>TestIgnored</code>
@@ -37,5 +37,5 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit)
+  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/)
 }

--- a/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
@@ -27,7 +27,7 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion)
+  def registerTest(testText: String, testTags: Tag*)(testFun: => Unit)
 
   /**
    * Register an ignored test, note that an ignored test will not be executed, but it will cause a <code>TestIgnored</code>
@@ -37,5 +37,5 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion)
+  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit)
 }

--- a/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
@@ -91,7 +91,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS-END
@@ -99,7 +99,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
     engine.registerTest(testText, Transformer(testFun _), Resources.testCannotBeNestedInsideAnotherTest, "WordSpecLike.scala", "registerTest", 4, stackDepthAdjustment, None, None, None, testTags: _*)
   }
 
-  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Assertion) {
+  final def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS-END
@@ -126,7 +126,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Assertion) {
+  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
@@ -155,7 +155,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Assertion) {
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Unit/*Assertion*/) {
     // SKIP-SCALATESTJS-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
@@ -165,7 +165,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
     engine.registerIgnoredTest(specText, Transformer(testFun), Resources.ignoreCannotAppearInsideAnIn, "WordSpecLike.scala", methodName, stackDepth, stackDepthAdjustment, None, testTags: _*)
   }
 
-  private def registerBranch(description: String, childPrefix: Option[String], verb: String, methodName:String, stackDepth: Int, adjustment: Int, fun: () => Unit) {
+  private def registerBranch(description: String, childPrefix: Option[String], verb: String, methodName:String, stackDepth: Int, adjustment: Int, fun: () => Unit/*Assertion*/) {
     def getStackDepth: Int =
       verb match {
         // SKIP-SCALATESTJS-START
@@ -209,7 +209,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
     }
   }
   
-  private def registerShorthandBranch(childPrefix: Option[String], notAllowMessage: => String, methodName:String, stackDepth: Int, adjustment: Int, fun: () => Unit) {
+  private def registerShorthandBranch(childPrefix: Option[String], notAllowMessage: => String, methodName:String, stackDepth: Int, adjustment: Int, fun: () => Unit/*Assertion*/) {
 
     // SKIP-SCALATESTJS-START
     val notAllowStackDepth = 2
@@ -273,7 +273,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def in(testFun: => Assertion) {
+    def in(testFun: => Unit/*Assertion*/) {
       registerTestToRun(specText, tags, "in", testFun _)
     }
 
@@ -313,7 +313,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Assertion) {
+    def ignore(testFun: => Unit/*Assertion*/) {
       registerTestToIgnore(specText, tags, "ignore", testFun _)
     }
   }       
@@ -351,7 +351,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def in(f: => Assertion) {
+    def in(f: => Unit/*Assertion*/) {
       registerTestToRun(string, List(), "in", f _)
     }
 
@@ -371,7 +371,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def ignore(f: => Assertion) {
+    def ignore(f: => Unit/*Assertion*/) {
       registerTestToIgnore(string, List(), "ignore", f _)
     }
 
@@ -432,7 +432,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def when(f: => Unit) {
+    def when(f: => Unit/*Assertion*/) {
       // SKIP-SCALATESTJS-START
       val stackDepth = 4
       // SKIP-SCALATESTJS-END
@@ -478,7 +478,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def that(f: => Unit) {
+    def that(f: => Unit/*Assertion*/) {
       // SKIP-SCALATESTJS-START
       val stackDepth = 4
       // SKIP-SCALATESTJS-END
@@ -502,7 +502,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def which(f: => Unit) {
+    def which(f: => Unit/*Assertion*/) {
       // SKIP-SCALATESTJS-START
       val stackDepth = 4
       // SKIP-SCALATESTJS-END
@@ -615,7 +615,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * methods.  For more information, see the <a href="WordSpec.html#AfterWords">main documentation</code></a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def apply(f: => Unit) = new ResultOfAfterWordApplication(text, f _)
+    def apply(f: => Unit/*Assertion*/) = new ResultOfAfterWordApplication(text, f _)
   }
 
   /**
@@ -714,7 +714,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def should(right: => Unit) {
+    def should(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("should"), Resources.itMustAppearAfterTopLevelSubject, "should", stackDepth, -2, right _)
     }
     
@@ -737,7 +737,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def must(right: => Unit) {
+    def must(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("must"), Resources.itMustAppearAfterTopLevelSubject, "must", stackDepth, -2, right _)
     }
     
@@ -760,7 +760,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def can(right: => Unit) {
+    def can(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("can"), Resources.itMustAppearAfterTopLevelSubject, "can", stackDepth, -2, right _)
     }
     
@@ -783,7 +783,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def when(right: => Unit) {
+    def when(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("when"), Resources.itMustAppearAfterTopLevelSubject, "when", stackDepth, -2, right _)
     }
   }
@@ -849,7 +849,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def should(right: => Unit) {
+    def should(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("should"), Resources.theyMustAppearAfterTopLevelSubject, "should", stackDepth, -2, right _)
     }
     
@@ -872,7 +872,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def must(right: => Unit) {
+    def must(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("must"), Resources.theyMustAppearAfterTopLevelSubject, "must", stackDepth, -2, right _)
     }
     
@@ -895,7 +895,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def can(right: => Unit) {
+    def can(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("can"), Resources.theyMustAppearAfterTopLevelSubject, "can", stackDepth, -2, right _)
     }
     
@@ -918,7 +918,7 @@ trait WordSpecLike extends Suite with TestRegistration with ShouldVerb with Must
      * for <code>WordSpec</code>.
      * </p>
      */
-    def when(right: => Unit) {
+    def when(right: => Unit/*Assertion*/) {
       registerShorthandBranch(Some("when"), Resources.theyMustAppearAfterTopLevelSubject, "when", stackDepth, -2, right _)
     }
   }
@@ -995,7 +995,7 @@ one error found
    */
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
     new StringVerbBlockRegistration {
-      def apply(left: String, verb: String, f: () => Unit) = registerBranch(left, Some(verb), verb, "apply", 6, -2, f)
+      def apply(left: String, verb: String, f: () => Unit/*Assertion*/) = registerBranch(left, Some(verb), verb, "apply", 6, -2, f)
     }
 
   /**
@@ -1020,7 +1020,7 @@ one error found
    * subject and executes the block.
    * </p>
    */
-  protected implicit val subjectWithAfterWordRegistrationFunction: (String, String, ResultOfAfterWordApplication) => Unit = {
+  protected implicit val subjectWithAfterWordRegistrationFunction: (String, String, ResultOfAfterWordApplication) => Unit/*Assertion*/ = {
     (left, verb, resultOfAfterWordApplication) => {
       val afterWordFunction =
         () => {


### PR DESCRIPTION
Changed style traits under org.scalatest package to use Unit, and generated SafeTestRegistration, SafeFunSuiteLike and SafeFunSuite.