### PR TITLE
Safety Test Compile Error Quick Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.SharedHelpers.EventRecordingReporter
 import org.scalatest.events.InfoProvided
 import scala.concurrent.Promise
 
-class BeforeAndAfterEachAllSuite extends FunSuite with Safety {
+class BeforeAndAfterEachAllSuite extends FunSuite {
 
   // SKIP-SCALATESTJS-START
   implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalatest.SharedHelpers.SilentReporter
 import org.scalatest.SharedHelpers.EventRecordingReporter
 
-class RandomAsyncTestExecutionSpec extends AsyncFunSuite with Safety /* with RandomTestOrder*/ { thisOuterSuite =>
+class RandomAsyncTestExecutionSpec extends AsyncFunSuite /* with RandomTestOrder*/ { thisOuterSuite =>
   
   // SKIP-SCALATESTJS-START
   implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
Removed Safety usage in BeforeAndAfterEachAllSuite and RandomAsyncTestExecutionSpec, as Safety is already been removed.