### PR TITLE
Runnable Examples-js

### DIFF
--- a/project/GenExamplesJS.scala
+++ b/project/GenExamplesJS.scala
@@ -87,7 +87,13 @@ object GenExamplesJS {
         "cpuall",
         "diskall",
         "slowall",
-        "networkall"
+        "networkall",
+        "noargasynctest",
+        "beforeandafterall",
+        "loanfixture",
+        "noargtest",
+        "oneargtest",
+        "beforeandafterallconfigmap"
       )
     )
   }

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -949,13 +949,13 @@ object ScalatestBuild extends Build {
   lazy val examples = Project("examples", file("examples"), delegates = scalatest :: Nil)
     .settings(
       scalaVersion := buildScalaVersion,
-      libraryDependencies += scalacheckDependency("compile")
+      libraryDependencies += scalacheckDependency("test")
     ).dependsOn(scalacticMacro, scalactic, scalatest)
 
   lazy val examplesJS = Project("examplesJS", file("examples.js"), delegates = scalatest :: Nil)
     .settings(
       scalaVersion := buildScalaVersion,
-      libraryDependencies += scalacheckDependency("compile"),
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
       sourceGenerators in Test += {
         Def.task {
           GenExamplesJS.genScala((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)


### PR DESCRIPTION
Make examples.js runnable by not copying examples that use java.io.File when generating examples.js.
