### PR TITLE
Make the eventually construct understand failed assumptions

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
@@ -19,6 +19,7 @@ import org.scalatest._
 import Eventually._
 import SharedHelpers.thisLineNumber
 import time.{Millisecond, Span, Millis}
+import org.scalatest.exceptions.TestCanceledException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestPendingException
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
@@ -196,6 +197,18 @@ class EventuallySpec extends FunSpec with Matchers with OptionValues with Severe
         eventually {
           count += 1
           pending
+        }
+      }
+      count should equal (1)
+    }
+    
+    it("should allow TestCanceledException, which does not normally cause a test to fail, through immediately when thrown") {
+
+      var count = 0
+      intercept[TestCanceledException] {
+        eventually {
+          count += 1
+          assume(1 + 1 == 3, "well that's odd")
         }
       }
       count should equal (1)

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Eventually.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Eventually.scala
@@ -16,7 +16,7 @@
 package org.scalatest.concurrent
 
 import org.scalatest._
-import exceptions.{TestFailedDueToTimeoutException, TestFailedException, TestPendingException}
+import exceptions.{TestCanceledException, TestFailedDueToTimeoutException, TestFailedException, TestPendingException}
 import org.scalatest.exceptions.StackDepthExceptionHelper.getStackDepthFun
 import org.scalatest.Suite.anExceptionThatShouldCauseAnAbort
 import scala.annotation.tailrec
@@ -395,6 +395,7 @@ trait Eventually extends PatienceConfiguration {
       }
       catch {
         case tpe: TestPendingException => throw tpe
+        case tce: TestCanceledException => throw tce
         case e: Throwable if !anExceptionThatShouldCauseAnAbort(e) => Left(e)
       }
     }


### PR DESCRIPTION
When an `assume` fails, it throws a `TestCanceledException` to cancel the test. `eventually` should understand this and rethrow the exception instead of retrying.

See the new test for an example of what I'm talking about.