### PR TITLE
Scala-js Stack Depth Fix

### DIFF
--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -722,7 +722,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
 
   /**
@@ -765,7 +765,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
 
   /**
@@ -809,7 +809,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
 
   /**
@@ -854,7 +854,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
 
   /**
@@ -900,7 +900,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
 
   /**
@@ -947,7 +947,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
         }
         val prop = Prop.forAll(propF)
         val params = getParams(configParams, config)
-        asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "apply")
+        asserting.check(prop, params)
     }
   }
 """
@@ -991,7 +991,7 @@ $arbShrinks$,
       }
       val prop = Prop.forAll(propF)
       val params = getParams(Seq(), config)
-      asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "forAll")
+      asserting.check(prop, params)
   }
 
   /**
@@ -1032,7 +1032,7 @@ $arbShrinks$,
       }
       val prop = Prop.forAll(propF)
       val params = getParams(configParams, config)
-      asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "forAll", Some(List($argNameNames$)))
+      asserting.check(prop, params, Some(List($argNameNames$)))
   }
 
   /**
@@ -1080,7 +1080,7 @@ $shrinks$,
       }
       val prop = Prop.forAll($genArgs$)(propF)
       val params = getParams(configParams, config)
-      asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "forAll")
+      asserting.check(prop, params)
   }
 
   /**
@@ -1131,7 +1131,7 @@ $tupleBusters$
       }
       val prop = Prop.forAll($genArgs$)(propF)
       val params = getParams(configParams, config)
-      asserting.check(prop, params, "GeneratorDrivenPropertyChecks.scala", "forAll", Some(List($argNameNames$)))
+      asserting.check(prop, params, Some(List($argNameNames$)))
   }
 """
 

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CheckersSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CheckersSuite.scala
@@ -218,7 +218,11 @@ class CheckersSpec extends FunSpec with Checkers {
     expectFileNameLineNumber(ex5, "CheckersSuite.scala", thisLineNumber - 1)
     val ex6 = intercept[GeneratorDrivenPropertyCheckFailedException] { check((a: List[Int], b: List[Int], c: List[Int], d: List[Int], e: List[Int], f: List[Int]) => a.size + b.size + c.size == (a ::: b ::: c ::: d ::: e ::: f).size + 1) }
     expectFileNameLineNumber(ex6, "CheckersSuite.scala", thisLineNumber - 1)
-    
+    val ex7 = intercept[GeneratorDrivenPropertyCheckFailedException] { check(Prop.forAll((n: Int) => n + 0 == n + 1)) }
+    expectFileNameLineNumber(ex7, "CheckersSuite.scala", thisLineNumber - 1)
+    val ex8 = intercept[GeneratorDrivenPropertyCheckFailedException] { check(Prop.forAll((n: Int) => n + 0 == n + 1), new Test.Parameters.Default { override val minSuccessfulTests = 5 }) }
+    expectFileNameLineNumber(ex8, "CheckersSuite.scala", thisLineNumber - 1)
+
     try {
       check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size + 1)
     }
@@ -226,11 +230,6 @@ class CheckersSpec extends FunSpec with Checkers {
       case ex: GeneratorDrivenPropertyCheckFailedException =>
         expectFileNameLineNumber(ex, "CheckersSuite.scala", thisLineNumber - 4)
     }
-    
-    val ex7 = intercept[GeneratorDrivenPropertyCheckFailedException] { check(Prop.forAll((n: Int) => n + 0 == n + 1)) }
-    expectFileNameLineNumber(ex7, "CheckersSuite.scala", thisLineNumber - 1)
-    val ex8 = intercept[GeneratorDrivenPropertyCheckFailedException] { check(Prop.forAll((n: Int) => n + 0 == n + 1), new Test.Parameters.Default { override val minSuccessfulTests = 5 }) }
-    expectFileNameLineNumber(ex8, "CheckersSuite.scala", thisLineNumber - 1)
   }
 
   //

--- a/scalatest/src/main/scala/org/scalatest/Inspectors.scala
+++ b/scalatest/src/main/scala/org/scalatest/Inspectors.scala
@@ -208,7 +208,7 @@ trait Inspectors {
   // SKIP-SCALATESTJS-START
   val stackDepthAdjustment = 2
   // SKIP-SCALATESTJS-END
-  //SCALATESTJS-ONLY val stackDepthAdjustment = 1
+  //SCALATESTJS-ONLY val stackDepthAdjustment = 0
 
   /**
    * Ensure that all elements in a given collection pass the given inspection function, where "pass" means returning normally from the function (<em>i.e.</em>,

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
@@ -303,7 +303,7 @@ trait Futures extends PatienceConfiguration {
       // SKIP-SCALATESTJS-START
       val stackDepthAdjustment = 3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 1
 
       try {
         futureValueImpl("isReadyWithin", stackDepthAdjustment)(PatienceConfig(timeout, config.interval))
@@ -489,7 +489,7 @@ trait Futures extends PatienceConfiguration {
       // SKIP-SCALATESTJS-START
       val stackDepthAdjustment = 3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepthAdjustment = 0
+      //SCALATESTJS-ONLY val stackDepthAdjustment = 1
       futureValueImpl("futureValue", stackDepthAdjustment)(config)
     }
 

--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -32,7 +32,7 @@ import org.scalatest.exceptions.StackDepthException
 
 trait CheckerAsserting[T] {
   type Result
-  def check(p: Prop, prms: Test.Parameters, stackDepthFileName: String, stackDepthMethodName: String, argNames: Option[List[String]] = None): Result
+  def check(p: Prop, prms: Test.Parameters, argNames: Option[List[String]] = None): Result
 }
 
 abstract class UnitCheckerAsserting {
@@ -41,7 +41,9 @@ abstract class UnitCheckerAsserting {
 
     import CheckerAsserting._
 
-    def check(p: Prop, prms: Test.Parameters, stackDepthFileName: String, stackDepthMethodName: String, argNames: Option[List[String]] = None): Result = {
+    private val sourceFileName: String = "CheckerAsserting.scala"
+
+    def check(p: Prop, prms: Test.Parameters, argNames: Option[List[String]] = None): Result = {
 
       val result = Test.check(prms, p)
       if (!result.passed) {
@@ -64,16 +66,13 @@ abstract class UnitCheckerAsserting {
               args,
               labels,
               None,
-              getStackDepthFun(stackDepthFileName, stackDepthMethodName)
+              getStackDepthFun(sourceFileName, "check")
             )
 
           case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
 
-            // SKIP-SCALATESTJS-START
-            val stackDepth = 2
-            // SKIP-SCALATESTJS-END
-            //SCALATESTJS-ONLY val stackDepth = 1
-
+            val stackDepth = 1
+            
             indicateFailure(
               sde => FailureMessages.propertyException(UnquotedString(sde.getClass.getSimpleName)) + "\n" +
               ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
@@ -93,7 +92,7 @@ abstract class UnitCheckerAsserting {
               scalaCheckArgs,
               scalaCheckLabels.toList,
               None,
-              getStackDepthFun(stackDepthFileName, stackDepthMethodName, stackDepth)
+              getStackDepthFun(sourceFileName, "check", stackDepth)
             )
 
           case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
@@ -116,7 +115,7 @@ abstract class UnitCheckerAsserting {
               scalaCheckArgs,
               scalaCheckLabels.toList,
               Some(e),
-              getStackDepthFun(stackDepthFileName, stackDepthMethodName)
+              getStackDepthFun(sourceFileName, "check")
             )
         }
       } else indicateSuccess(FailureMessages.propertyCheckSucceeded)

--- a/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
@@ -162,8 +162,8 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(Resources.scenario(specText), Transformer(testFun), Resources.ignoreCannotAppearInsideAScenario, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
     def apply(testFun: () => Any /* Assertion */): Unit = {
@@ -171,8 +171,8 @@ trait FeatureSpecLike extends Suite with TestRegistration with Informing with No
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(Resources.scenario(specText), Transformer(new NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideAScenario, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
@@ -385,8 +385,8 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 8
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -9
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(specText, Transformer(testFun), Resources.ignoreCannotAppearInsideAnItOrAThey, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
     def apply(testFun: () => Any /* Assertion */): Unit = {
@@ -394,8 +394,8 @@ trait FunSpecLike extends Suite with TestRegistration with Informing with Notify
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 8
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -9
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(specText, Transformer(new NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideAnItOrAThey, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
@@ -163,8 +163,8 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(testName, Transformer(testFun), Resources.ignoreCannotAppearInsideATest, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
 
@@ -173,8 +173,8 @@ trait FunSuiteLike extends Suite with TestRegistration with Informing with Notif
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(testName, Transformer(new NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideATest, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
@@ -152,8 +152,8 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(testName, Transformer(testFun), Resources.ignoreCannotAppearInsideAProperty, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
     def apply(testFun: () => Any /* Assertion */) {
@@ -161,8 +161,8 @@ trait PropSpecLike extends Suite with TestRegistration with Informing with Notif
       val stackDepth = 3
       val stackDepthAdjustment = -3
       // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY val stackDepth = 6
-      //SCALATESTJS-ONLY val stackDepthAdjustment = -7
+      //SCALATESTJS-ONLY val stackDepth = 5
+      //SCALATESTJS-ONLY val stackDepthAdjustment = -6
       engine.registerIgnoredTest(testName, Transformer(new NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideAProperty, sourceFileName, "apply", stackDepth, stackDepthAdjustment, None, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
@@ -244,7 +244,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1), params)
   }
 
   /**
@@ -262,7 +262,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2), params)
   }
 
   /**
@@ -281,7 +281,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3), params)
   }
 
   /**
@@ -301,7 +301,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4), params)
   }
 
   /**
@@ -322,7 +322,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4, a5, s5, pp5), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4, a5, s5, pp5), params)
   }
 
   /**
@@ -344,7 +344,7 @@ trait Checkers extends Configuration {
       asserting: CheckerAsserting[ASSERTION]
     ): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4, a5, s5, pp5, a6, s6, pp6), params, "Checkers.scala", "check")
+    asserting.check(Prop.forAll(f)(p, a1, s1, pp1, a2, s2, pp2, a3, s3, pp3, a4, s4, pp4, a5, s5, pp5, a6, s6, pp6), params)
   }
 
   /**
@@ -355,7 +355,7 @@ trait Checkers extends Configuration {
    * @throws TestFailedException if a test case is discovered for which the property doesn't hold.
    */
   def check[ASSERTION](p: Prop, prms: Test.Parameters)(implicit asserting: CheckerAsserting[ASSERTION]): asserting.Result = {
-    asserting.check(p, prms, "Checkers.scala", "check")
+    asserting.check(p, prms)
   }
 
   /**
@@ -366,7 +366,7 @@ trait Checkers extends Configuration {
    */
   def check[ASSERTION](p: Prop, configParams: PropertyCheckConfigParam*)(implicit config: PropertyCheckConfigurable, asserting: CheckerAsserting[ASSERTION]): asserting.Result = {
     val params = getParams(configParams, config)
-    asserting.check(p, params, "Checkers.scala", "check")
+    asserting.check(p, params)
   }
 }
 


### PR DESCRIPTION
-Fixed failing tests under scala-js.
-Removed filename and methodName argument from CheckerAsserting's check method.