### PR TITLE
Async Style Traits Info/Note/Markup/Alert scala-js Tests Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
@@ -518,6 +518,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           scenario("test 1") {
             info("hi there")
@@ -546,6 +548,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -597,6 +601,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           note(
             "hi there"
@@ -621,6 +627,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           scenario("test 1") {
             note("hi there")
@@ -642,6 +650,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -686,6 +696,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           alert(
             "hi there"
@@ -710,6 +722,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           scenario("test 1") {
             alert("hi there")
@@ -731,6 +745,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -775,6 +791,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           markup(
             "hi there"
@@ -798,6 +816,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -827,6 +847,8 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
@@ -456,6 +456,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send an InfoProvided event for an info in feature body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           info(
             "hi there"
@@ -479,6 +481,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -508,6 +512,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -559,6 +565,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in feature body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           note(
             "hi there"
@@ -583,6 +591,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           scenario("test 1") {
             note("hi there")
@@ -604,6 +614,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -648,6 +660,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in feature body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           alert(
             "hi there"
@@ -672,6 +686,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           scenario("test 1") {
             alert("hi there")
@@ -693,6 +709,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -737,6 +755,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in feature body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         feature("test feature") {
           markup(
             "hi there"
@@ -760,6 +780,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {
@@ -789,6 +811,8 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         feature("test feature") {
           scenario("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
@@ -460,6 +460,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFlatSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           info("hi there")
           succeed
@@ -486,6 +488,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -535,6 +539,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFlatSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           note("hi there")
           succeed
@@ -554,6 +560,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFlatSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -596,6 +604,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFlatSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           alert("hi there")
           succeed
@@ -615,6 +625,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFlatSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -657,6 +669,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFlatSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           markup("hi there")
           succeed
@@ -683,6 +697,8 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
@@ -458,6 +458,8 @@ class AsyncFlatSpecSpec extends FunSpec {
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFlatSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           info("hi there")
           succeed
@@ -484,6 +486,8 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -533,6 +537,8 @@ class AsyncFlatSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFlatSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           note("hi there")
           succeed
@@ -552,6 +558,8 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -594,6 +602,8 @@ class AsyncFlatSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFlatSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           alert("hi there")
           succeed
@@ -613,6 +623,8 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {
@@ -655,6 +667,8 @@ class AsyncFlatSpecSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFlatSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should "test 1" in {
           markup("hi there")
           succeed
@@ -681,6 +695,8 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should "test 1" in {
           Future {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
@@ -458,6 +458,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           info(
             "hi there"
@@ -481,6 +483,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -510,6 +514,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -561,6 +567,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           note(
             "hi there"
@@ -585,6 +593,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           "test 1" in {
             note("hi there")
@@ -606,6 +616,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -650,6 +662,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           alert(
             "hi there"
@@ -674,6 +688,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           "test 1" in {
             alert("hi there")
@@ -695,6 +711,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -739,6 +757,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           markup(
             "hi there"
@@ -762,6 +782,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -791,6 +813,8 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
@@ -458,6 +458,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           info(
             "hi there"
@@ -481,6 +483,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -510,6 +514,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -561,6 +567,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           note(
             "hi there"
@@ -585,6 +593,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           "test 1" in {
             note("hi there")
@@ -606,6 +616,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -650,6 +662,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           alert(
             "hi there"
@@ -674,6 +688,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           "test 1" in {
             alert("hi there")
@@ -695,6 +711,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -739,6 +757,8 @@ class AsyncFreeSpecSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFreeSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" - {
           markup(
             "hi there"
@@ -762,6 +782,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {
@@ -791,6 +813,8 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" - {
           "test 1" in {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
@@ -458,6 +458,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           info(
             "hi there"
@@ -481,6 +483,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -510,6 +514,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -561,6 +567,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           note(
             "hi there"
@@ -585,6 +593,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           it("test 1") {
             note("hi there")
@@ -606,6 +616,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -650,6 +662,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           alert(
             "hi there"
@@ -674,6 +688,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           it("test 1") {
             alert("hi there")
@@ -695,6 +711,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -739,6 +757,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFunSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           markup(
             "hi there"
@@ -762,6 +782,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -791,6 +813,8 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
@@ -493,6 +493,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           info(
             "hi there"
@@ -516,6 +518,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -545,6 +549,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -596,6 +602,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           note(
             "hi there"
@@ -620,6 +628,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           it("test 1") {
             note("hi there")
@@ -641,6 +651,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -685,6 +697,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           alert(
             "hi there"
@@ -709,6 +723,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           it("test 1") {
             alert("hi there")
@@ -730,6 +746,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -774,6 +792,8 @@ class AsyncFunSpecSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFunSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         describe("test feature") {
           markup(
             "hi there"
@@ -797,6 +817,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {
@@ -826,6 +848,8 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         describe("test feature") {
           it("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
@@ -458,6 +458,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSuiteLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           info("hi there")
           succeed
@@ -484,6 +486,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -533,6 +537,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSuiteLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           note("hi there")
           succeed
@@ -552,6 +558,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -594,6 +602,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSuiteLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           alert("hi there")
           succeed
@@ -613,6 +623,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -655,6 +667,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSuiteLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           markup("hi there")
           succeed
@@ -681,6 +695,8 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
@@ -459,6 +459,8 @@ class AsyncFunSuiteSpec extends FunSpec {
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSuite  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           info("hi there")
           succeed
@@ -485,6 +487,8 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -534,6 +538,8 @@ class AsyncFunSuiteSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSuite  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           note("hi there")
           succeed
@@ -553,6 +559,8 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -595,6 +603,8 @@ class AsyncFunSuiteSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSuite  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           alert("hi there")
           succeed
@@ -614,6 +624,8 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {
@@ -656,6 +668,8 @@ class AsyncFunSuiteSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSuite  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         test("test 1") {
           markup("hi there")
           succeed
@@ -682,6 +696,8 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         test("test 1") {
           Future {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
@@ -458,6 +458,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           info(
             "hi there"
@@ -481,6 +483,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -510,6 +514,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -561,6 +567,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           note(
             "hi there"
@@ -585,6 +593,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           "test 1" in {
             note("hi there")
@@ -606,6 +616,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -650,6 +662,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           alert(
             "hi there"
@@ -674,6 +688,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           "test 1" in {
             alert("hi there")
@@ -695,6 +711,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -739,6 +757,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncWordSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           markup(
             "hi there"
@@ -762,6 +782,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -791,6 +813,8 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
@@ -457,6 +457,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           info(
             "hi there"
@@ -480,6 +482,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -509,6 +513,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -560,6 +566,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           note(
             "hi there"
@@ -584,6 +592,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           "test 1" in {
             note("hi there")
@@ -605,6 +615,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -649,6 +661,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           alert(
             "hi there"
@@ -673,6 +687,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           "test 1" in {
             alert("hi there")
@@ -694,6 +710,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -738,6 +756,8 @@ class AsyncWordSpecSpec extends FunSpec {
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncWordSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         "test feature" should {
           markup(
             "hi there"
@@ -761,6 +781,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {
@@ -790,6 +812,8 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         "test feature" should {
           "test 1" in {

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
@@ -500,6 +500,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send an InfoProvided event for an info in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -527,6 +529,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -560,6 +564,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -596,6 +602,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -619,6 +627,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -648,6 +658,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send a NoteProvided event for a note in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -673,6 +685,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -702,6 +716,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -725,6 +741,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -754,6 +772,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send an AlertProvided event for an alert in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -779,6 +799,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -808,6 +830,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFeatureSpecLike  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +855,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in feature body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -859,6 +885,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -892,6 +920,8 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
@@ -500,6 +500,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send an InfoProvided event for an info in feature body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -527,6 +529,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -560,6 +564,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -596,6 +602,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -619,6 +627,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in feature body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -648,6 +658,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send a NoteProvided event for a note in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -673,6 +685,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -702,6 +716,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -725,6 +741,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in feature body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -754,6 +772,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send an AlertProvided event for an alert in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -779,6 +799,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -808,6 +830,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFeatureSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +855,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in feature body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -859,6 +885,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -892,6 +920,8 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFeatureSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
@@ -500,6 +500,8 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      it("should send an InfoProvided event for an info in test body") {
        class MySuite extends AsyncFlatSpecLike  {
 
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -530,6 +532,8 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send an InfoProvided event for an info in Future returned by scenario body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -563,6 +567,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a NoteProvided event for a note in main spec body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -585,6 +592,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a NoteProvided event for a note in test body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -607,6 +617,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a NoteProvided event for a note in Future returned by test body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -631,6 +644,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send an AlertProvided event for an alert in main spec body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -653,6 +669,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send an AlertProvided event for an alert in test body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -675,6 +694,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send an AlertProvided event for an alert in Future returned by test body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -699,6 +721,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a MarkupProvided event for a markup in main spec body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -721,6 +746,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a MarkupProvided event for a markup in test body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")
@@ -750,6 +778,9 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
        class MySuite extends AsyncFlatSpecLike  {
+
+         //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
          type FixtureParam = String
          def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
            test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
@@ -476,6 +476,8 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFlatSpec  {
 
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -499,6 +501,8 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -530,6 +534,8 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
 
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
@@ -563,6 +569,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -585,6 +594,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -607,6 +619,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -631,6 +646,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -653,6 +671,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -675,6 +696,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -699,6 +723,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -721,6 +748,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -750,6 +780,9 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
       class MySuite extends AsyncFlatSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
@@ -497,6 +497,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +526,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +560,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +596,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +621,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +650,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +677,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +706,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +731,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +760,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +787,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +816,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +841,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +870,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +904,9 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFreeSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
@@ -475,6 +475,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +529,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +563,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +599,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +624,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +653,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +680,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +709,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +734,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +763,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +790,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +819,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +844,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +873,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +907,9 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFreeSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
@@ -475,6 +475,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +529,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +563,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +599,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +624,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +653,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +680,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +709,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +734,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +763,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +790,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +819,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +844,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +873,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +907,9 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
@@ -475,6 +475,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +529,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +563,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +599,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +624,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +653,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +680,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +709,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +734,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +763,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +790,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +819,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +844,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +873,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +907,9 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
@@ -475,6 +475,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -526,6 +532,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -557,6 +566,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -579,6 +591,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -601,6 +616,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -625,6 +643,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -647,6 +668,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -669,6 +693,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -693,6 +720,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -715,6 +745,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -744,6 +777,9 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSuiteLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
@@ -475,6 +475,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -526,6 +532,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -557,6 +566,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -579,6 +591,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -601,6 +616,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -625,6 +643,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -647,6 +668,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -669,6 +693,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -693,6 +720,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -715,6 +745,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -744,6 +777,9 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncFunSuite  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
@@ -475,6 +475,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +529,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +563,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +599,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +624,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +653,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +680,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +709,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +734,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +763,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +790,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +819,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +844,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +873,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +907,9 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncWordSpecLike  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
@@ -475,6 +475,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -497,6 +500,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in scope body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -523,6 +529,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -554,6 +563,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -587,6 +599,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in main spec body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -609,6 +624,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in scope body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -635,6 +653,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -659,6 +680,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -685,6 +709,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in main spec body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -707,6 +734,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in scope body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -733,6 +763,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -757,6 +790,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -783,6 +819,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in main spec body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -805,6 +844,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in scope body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -831,6 +873,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")
@@ -862,6 +907,9 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
       class MySuite extends AsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
         type FixtureParam = String
         def withAsyncFixture(test: OneArgAsyncTest): Future[Outcome] =
           test("testing")


### PR DESCRIPTION
Fixed failing scala-js tests for async style traits.