### PR TITLE
Immediate Note & Alert in SBT

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -1732,10 +1732,12 @@ class FrameworkSuite extends FunSuite {
       val task = tasks(0)
       val logger = new TestLogger
       task.execute(testEventHandler, Array(logger))
-      assert(logger.infoReceived.length == 3)
+
+      //assert(logger.infoReceived.length == 3)
+      assert(logger.infoReceived.length == 1)
       assert(logger.infoReceived(0) == "SampleSuite:")
-      assert(logger.infoReceived(1) == "  + This is an alert! ")
-      assert(logger.infoReceived(2) == "  + This is an update! ")
+      //assert(logger.infoReceived(1) == "  + This is an alert! ")
+      //assert(logger.infoReceived(2) == "  + This is an update! ")
     }
     finally {
       runner.done()

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -610,6 +610,12 @@ class Framework extends SbtFramework {
         logger.info(fragment.toPossiblyColoredText(logger.ansiCodesSupported && presentInColor))
       }
     }
+
+    protected def printPossiblyInColorImmediately(fragment: Fragment) {
+      loggers.foreach { logger =>
+        println(fragment.toPossiblyColoredText(logger.ansiCodesSupported && presentInColor))
+      }
+    }
     
     override def apply(event: Event) {
       event match {
@@ -619,18 +625,33 @@ class Framework extends SbtFramework {
           }
         case _ =>
       }
-      fragmentsForEvent(
-        event,
-        presentUnformatted,
-        presentAllDurations,
-        presentShortStackTraces,
-        presentFullStackTraces,
-        presentReminder,
-        presentReminderWithShortStackTraces,
-        presentReminderWithFullStackTraces,
-        presentReminderWithoutCanceledTests,
-        reminderEventsBuf
-      ) foreach printPossiblyInColor
+
+      if (event.isInstanceOf[NotificationEvent])
+        fragmentsForEvent(
+          event,
+          presentUnformatted,
+          presentAllDurations,
+          presentShortStackTraces,
+          presentFullStackTraces,
+          presentReminder,
+          presentReminderWithShortStackTraces,
+          presentReminderWithFullStackTraces,
+          presentReminderWithoutCanceledTests,
+          reminderEventsBuf
+        ) foreach printPossiblyInColorImmediately
+      else
+        fragmentsForEvent(
+          event,
+          presentUnformatted,
+          presentAllDurations,
+          presentShortStackTraces,
+          presentFullStackTraces,
+          presentReminder,
+          presentReminderWithShortStackTraces,
+          presentReminderWithFullStackTraces,
+          presentReminderWithoutCanceledTests,
+          reminderEventsBuf
+        ) foreach printPossiblyInColor
     }
 
     def dispose() = ()


### PR DESCRIPTION
Make note and alert to print directly to standard output immediately without waiting for the suite to complete.