### PR TITLE
Scala-js 0.6.7

### DIFF
--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -207,8 +207,7 @@ object GenScalaTestJS {
         "TimeLimitedTests.scala",       // skipped because js is single-threaded and does not share memory, there's no practical way to interrupt in js.
         "DeprecatedTimeLimitedTests.scala",       // skipped because js is single-threaded and does not share memory, there's no practical way to interrupt in js.
         "Timeouts.scala",               // skipped because js is single-threaded and does not share memory, there's no practical way to interrupt in js.
-        "TimeoutTask.scala"/*,            // skipped because timeout is not supported.,
-        "SerialExecutionContext.scala"*/  // skipped because we can't block in js, should use QueueExecutionContext provided by scala-js itself.
+        "TimeoutTask.scala"            // skipped because timeout is not supported.,
       )
     ) ++
     copyDir("scalatest/src/main/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
@@ -272,7 +271,8 @@ object GenScalaTestJS {
         "TestThreadsStartingCounterSpec.scala",   // skipped because depends on Conductors
         "TimeLimitedTestsSpec.scala",   // skipped because TimeLimitedTests not supported.
         "DeprecatedTimeLimitedTestsSpec.scala",   // skipped because DeprecatedTimeLimitedTests not supported.
-        "TimeoutsSpec.scala"            // skipped because Timeouts not supported.
+        "TimeoutsSpec.scala",            // skipped because Timeouts not supported.
+        "TimeLimitsSpec.scala"  // TODO next: try rebuild
       )) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/enablers", "org/scalatest/enablers", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/events/examples", "org/scalatest/events/examples", targetDir, List.empty) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.7")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -184,7 +184,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.5"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.7"
     )
 
   def scalatestTestOptions =
@@ -391,6 +391,9 @@ object ScalatestBuild extends Build {
       organization := "org.scalactic",
       jsDependencies += RuntimeDOM % "test",
       libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
+      scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
+      //jsEnv := NodeJSEnv(executable = "node").value,
+      //jsEnv := PhantomJSEnv().value,
       //scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,
       //postLinkJSEnv := NodeJSEnv(executable = "node").value,
@@ -601,6 +604,9 @@ object ScalatestBuild extends Build {
       libraryDependencies ++= scalatestJSLibraryDependencies,
       libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
       jsDependencies += RuntimeDOM % "test",
+      scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
+      //jsEnv := NodeJSEnv(executable = "node").value,
+      //jsEnv := PhantomJSEnv().value,
       //scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,
       //postLinkJSEnv := NodeJSEnv(executable = "node").value,


### PR DESCRIPTION
Bump up to use scala-js 0.6.7, note that it still has many stack depth related tests failed.