### PR TITLE
Don't call wait(0, 0) in AsyncAssertions.awaitImpl

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/concurrent/AsyncAssertions.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/AsyncAssertions.scala
@@ -381,6 +381,7 @@ trait AsyncAssertions extends PatienceConfiguration {
       if (Thread.currentThread != creatingThread)
         throw new NotAllowedException(Resources.awaitMustBeCalledOnCreatingThread, 2)
 
+      val minWaitTime = Span(1, Nanoseconds)
       val startTime: Long = System.nanoTime
       val endTime: Long = startTime + timeout.totalNanos
       def timedOut: Boolean = endTime < System.nanoTime
@@ -388,7 +389,7 @@ trait AsyncAssertions extends PatienceConfiguration {
         while (dismissedCount < dismissals && !timedOut && thrown.isEmpty) {
           val timeLeft: Span = {
             val diff = endTime - System.nanoTime
-            if (diff > 0) Span(diff, Nanoseconds) else Span.Zero
+            if (diff > 0) Span(diff, Nanoseconds) else minWaitTime
           }
           wait(timeLeft.millisPart, timeLeft.nanosPart)
         }


### PR DESCRIPTION
`wait(0, 0)` and `wait(0)` will wait forever until notified. `awaitImpl` should not call `wait` with 0 otherwise it will block forever and never timeout if `notifyAll` is not called.

This patch fixes `awaitImpl` by always calling `wait` with non-zero values.
