### PR TITLE
Fix EndWith regex failures

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/words/EndWithWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/EndWithWordSpec.scala
@@ -19,23 +19,23 @@ import org.scalatest._
 import Matchers._
 
 class EndWithWordSpec extends FreeSpec with FileMocks {
-  
+
   "EndWithWord " - {
-    
+
     "should have pretty toString" in {
       endWith.toString should be ("endWith")
     }
-    
+
     "apply(String) method returns Matcher" - {
-      
+
       val mt = endWith ("er")
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith (\"er\")")
       }
-      
+
       val mr = mt("Programmer")
-      
+
       "should have correct MatcherResult" in {
         mr should have (
           'matches (true),
@@ -50,12 +50,12 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("Programmer", "er")),
           'negatedFailureMessageArgs(Vector("Programmer", "er")),
           'midSentenceFailureMessageArgs(Vector("Programmer", "er")),
-          'midSentenceNegatedFailureMessageArgs(Vector("Programmer", "er"))    
+          'midSentenceNegatedFailureMessageArgs(Vector("Programmer", "er"))
         )
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr should have (
           'matches (false),
@@ -70,22 +70,22 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("Programmer", "er")),
           'negatedFailureMessageArgs(Vector("Programmer", "er")),
           'midSentenceFailureMessageArgs(Vector("Programmer", "er")),
-          'midSentenceNegatedFailureMessageArgs(Vector("Programmer", "er"))    
+          'midSentenceNegatedFailureMessageArgs(Vector("Programmer", "er"))
         )
       }
     }
-    
+
     "regex(String) method returns Matcher" - {
-      
+
       val decimal = """(-)?(\d+)(\.\d*)?"""
       val mt = endWith regex decimal
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"" + decimal + "\"")
       }
-      
+
       val mr = mt("b2.7")
-      
+
       "should have correct MatcherResult" in {
         mr should have (
           'matches (true),
@@ -100,12 +100,12 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
           'negatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
           'midSentenceFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))    
+          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))
         )
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr should have (
           'matches (false),
@@ -120,75 +120,75 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
           'negatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
           'midSentenceFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))    
+          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))
         )
       }
     }
-    
+
     "regex(Regex) method returns Matcher" - {
-      
+
       val decimal = """(-)?(\d+)(\.\d*)?"""
       val mt = endWith regex decimal.r
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"" + decimal + "\"")
       }
-      
-      val mr = mt("b2.7")
-      
+
+      val mr = mt("a1.6b2.7")
+
       "should have correct MatcherResult" in {
         mr should have (
           'matches (true),
-          'failureMessage ("\"b2.7\" did not end with a substring that matched the regular expression " + decimal),
-          'negatedFailureMessage ("\"b2.7\" ended with a substring that matched the regular expression " + decimal),
-          'midSentenceFailureMessage ("\"b2.7\" did not end with a substring that matched the regular expression " + decimal),
-          'midSentenceNegatedFailureMessage ("\"b2.7\" ended with a substring that matched the regular expression " + decimal),
+          'failureMessage ("\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal),
+          'negatedFailureMessage ("\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal),
+          'midSentenceFailureMessage ("\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal),
+          'midSentenceNegatedFailureMessage ("\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal),
           'rawFailureMessage ("{0} did not end with a substring that matched the regular expression {1}"),
           'rawNegatedFailureMessage ("{0} ended with a substring that matched the regular expression {1}"),
           'rawMidSentenceFailureMessage ("{0} did not end with a substring that matched the regular expression {1}"),
           'rawMidSentenceNegatedFailureMessage ("{0} ended with a substring that matched the regular expression {1}"),
-          'failureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'negatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))    
+          'failureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'negatedFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'midSentenceFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'midSentenceNegatedFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal)))
         )
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr should have (
           'matches (false),
-          'failureMessage ("\"b2.7\" ended with a substring that matched the regular expression " + decimal),
-          'negatedFailureMessage ("\"b2.7\" did not end with a substring that matched the regular expression " + decimal),
-          'midSentenceFailureMessage ("\"b2.7\" ended with a substring that matched the regular expression " + decimal),
-          'midSentenceNegatedFailureMessage ("\"b2.7\" did not end with a substring that matched the regular expression " + decimal),
+          'failureMessage ("\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal),
+          'negatedFailureMessage ("\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal),
+          'midSentenceFailureMessage ("\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal),
+          'midSentenceNegatedFailureMessage ("\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal),
           'rawFailureMessage ("{0} ended with a substring that matched the regular expression {1}"),
           'rawNegatedFailureMessage ("{0} did not end with a substring that matched the regular expression {1}"),
           'rawMidSentenceFailureMessage ("{0} ended with a substring that matched the regular expression {1}"),
           'rawMidSentenceNegatedFailureMessage ("{0} did not end with a substring that matched the regular expression {1}"),
-          'failureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'negatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceFailureMessageArgs(Vector("b2.7", UnquotedString(decimal))),
-          'midSentenceNegatedFailureMessageArgs(Vector("b2.7", UnquotedString(decimal)))    
+          'failureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'negatedFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'midSentenceFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal))),
+          'midSentenceNegatedFailureMessageArgs(Vector("a1.6b2.7", UnquotedString(decimal)))
         )
       }
     }
-    
+
     "regex(a(b*)c withGroup bb) method returns Matcher" - {
-      
+
       val bb = "bb"
-      
+
       val mt = endWith regex ("""a(b*)c""" withGroup bb)
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"a(b*)c\" withGroup (\"" + bb + "\")")
       }
-      
+
       val mr1 = mt("abbc")
-      
+
       "when apply with \"abbc\"" - {
-      
+
         "should have correct MatcherResult" in {
           mr1 should have (
             'matches (true),
@@ -203,12 +203,12 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))),
             'negatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
             'midSentenceFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb")))
           )
         }
-      
+
         val nmr = mr1.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr should have (
             'matches (false),
@@ -223,18 +223,18 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
             'negatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))),
             'midSentenceFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb")))
           )
         }
-        
+
       }
-      
+
       val mr2 = mt("abbbc")
-        
+
       "when apply with \"abbbc\"" - {
-          
+
         "should have correct MatcherResult" in {
-            
+
           mr2 should have (
             'matches (false),
             'failureMessage ("\"abbbc\" ended with a substring that matched the regular expression a(b*)c, but \"bbb\" did not match group bb"),
@@ -248,13 +248,13 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))),
             'negatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
             'midSentenceFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb")))
           )
-            
+
         }
-          
+
         val nmr = mr2.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr should have (
             'matches (true),
@@ -269,16 +269,16 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
             'negatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))),
             'midSentenceFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb")))
           )
         }
-          
+
       }
-      
+
       val mr3 = mt("ABBC")
-      
+
       "when apply with \"ABBC\"" - {
-        
+
         "should have correct MatcherResult" in {
           mr3 should have (
             'matches (false),
@@ -293,12 +293,12 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
             'negatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
             'midSentenceFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c")))
           )
         }
-        
+
         val nmr = mr3.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr should have (
             'matches (true),
@@ -313,24 +313,24 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
             'failureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
             'negatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
             'midSentenceFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c"))),
-            'midSentenceNegatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c")))    
+            'midSentenceNegatedFailureMessageArgs(Vector("ABBC", UnquotedString("a(b*)c")))
           )
         }
       }
     }
-    
+
     "regex(a(b*)(c*) withGroup bb) method returns Matcher" - {
       val bb = "bb"
       val cc = "cc"
-      
+
       val mt = endWith regex ("""a(b*)(c*)""" withGroups (bb, cc))
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"a(b*)(c*)\" withGroups (\"" + bb + "\", \"" + cc + "\")")
       }
-      
+
       val mr = mt("abbccc")
-      
+
       "should have correct MatcherResult" in {
         mr should have (
           'matches (false),
@@ -345,12 +345,12 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)),
           'negatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))),
           'midSentenceFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)),
-          'midSentenceNegatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc")))    
+          'midSentenceNegatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc")))
         )
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr should have (
           'matches (true),
@@ -365,7 +365,7 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           'failureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))),
           'negatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)),
           'midSentenceFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))),
-          'midSentenceNegatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1))    
+          'midSentenceNegatedFailureMessageArgs(Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1))
         )
       }
     }

--- a/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
@@ -61,7 +61,7 @@ private[scalatest] object MatchersHelper {
   // 1           0            1                      Some(G)
   // 1           1            0                      Some(M)
   // 1           1            1                      Some(M) prefer a Scala style one of a Java style, such as when using BeanProperty annotation
-  // 
+  //
   def accessProperty(objectWithProperty: AnyRef, propertySymbol: Symbol, isBooleanProperty: Boolean): Option[Any] = {
 
     // If 'title passed, propertyName would be "title"
@@ -152,7 +152,7 @@ private[scalatest] object MatchersHelper {
     // should not look for anything in the first 2 elements, caller stack element is at 3rd/4th
     // also, it solves the problem when the suite file that mixin in Matchers has the [suiteFileName]:newTestFailedException appears in the top 2 elements
     // this approach should be better than adding && _.getMethodName == newTestFailedException we used previously.
-    val elements = temp.getStackTrace.drop(2) 
+    val elements = temp.getStackTrace.drop(2)
     // TODO: Perhaps we should add org.scalatest.enablers also here later?
     // TODO: Probably need a MatchersHelper.scala here also
     val stackDepth = elements.indexWhere(st => st.getFileName != "Matchers.scala" && st.getFileName != "MustMatchers.scala" && !st.getClassName.startsWith("org.scalatest.words.")) + 2 // the first 2 elements dropped previously
@@ -228,7 +228,7 @@ private[scalatest] object MatchersHelper {
             FailureMessages.hasNeitherAnOrAnMethod(left, UnquotedString(methodNameToInvoke), UnquotedString(methodNameToInvokeWithIs))
           else
             FailureMessages.hasNeitherAOrAnMethod(left, UnquotedString(methodNameToInvoke), UnquotedString(methodNameToInvokeWithIs)),
-          None, 
+          None,
           stackDepth
         )
 
@@ -250,12 +250,12 @@ private[scalatest] object MatchersHelper {
   }
   // SKIP-SCALATESTJS-END
 
-  def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String], 
+  def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String],
                                  didNotMatchMessage: => String, matchMessage: => String, notGroupAtIndexMessage:  => String, notGroupMessage: => String,
                                  andGroupMessage: => String): MatchResult = {
     if (groups.size == 0 || !matches)
       MatchResult(
-        matches, 
+        matches,
         didNotMatchMessage,
         matchMessage,
         Vector(left, UnquotedString(regex.toString))
@@ -263,54 +263,55 @@ private[scalatest] object MatchersHelper {
     else {
       val count = pMatcher.groupCount
       val failed = // Find the first group that fails
-        groups.zipWithIndex.find { case (group, idx) => 
+        groups.zipWithIndex.find { case (group, idx) =>
           val groupIdx = idx + 1
           !(groupIdx <= count && pMatcher.group(groupIdx) == group)
         }
       failed match {
         case Some((group, idx)) =>
           MatchResult(
-            false, 
+            false,
             if (groups.size > 1) notGroupAtIndexMessage else notGroupMessage,
             andGroupMessage,
-            if (groups.size > 1) Vector(left, UnquotedString(regex.toString), pMatcher.group(idx + 1), UnquotedString(group), idx) else Vector(left, UnquotedString(regex.toString), pMatcher.group(1), UnquotedString(group)), 
+            if (groups.size > 1) Vector(left, UnquotedString(regex.toString), pMatcher.group(idx + 1), UnquotedString(group), idx) else Vector(left, UnquotedString(regex.toString), pMatcher.group(1), UnquotedString(group)),
             Vector(left, UnquotedString(regex.toString), UnquotedString(groups.mkString(", ")))
           )
-        case None => 
+        case None =>
           // None of group failed
           MatchResult(
-            true, 
+            true,
             notGroupMessage,
             andGroupMessage,
-            Vector(left, UnquotedString(regex.toString), pMatcher.group(1),  UnquotedString(groups.mkString(", "))), 
+            Vector(left, UnquotedString(regex.toString), pMatcher.group(1),  UnquotedString(groups.mkString(", "))),
             Vector(left, UnquotedString(regex.toString), UnquotedString(groups.mkString(", ")))
           )
       }
     }
   }
-  
+
   def fullyMatchRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.matches
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotFullyMatchRegex, Resources.rawFullyMatchedRegex, Resources.rawFullyMatchedRegexButNotGroupAtIndex,
                                Resources.rawFullyMatchedRegexButNotGroup, Resources.rawFullyMatchedRegexAndGroup)
   }
-  
+
   def startWithRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.lookingAt
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotStartWithRegex, Resources.rawStartedWithRegex, Resources.rawStartedWithRegexButNotGroupAtIndex,
       Resources.rawStartedWithRegexButNotGroup, Resources.rawStartedWithRegexAndGroup)
   }
-  
+
   def endWithRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
-    val found = pMatcher.find
-    val matches = found && pMatcher.end == left.length
+    while (!pMatcher.hitEnd) { pMatcher.find }
+    val matches = pMatcher.hitEnd && (pMatcher.end == left.length)
+
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotEndWithRegex, Resources.rawEndedWithRegex, Resources.rawEndedWithRegexButNotGroupAtIndex,
                                Resources.rawEndedWithRegexButNotGroup, Resources.rawEndedWithRegexAndGroup)
   }
-  
+
   def includeRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.find

--- a/scalatest/src/main/scala/org/scalatest/words/EndWithWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/EndWithWord.scala
@@ -61,18 +61,18 @@ final class EndWithWord {
    * </pre>
    */
   def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  
+
   /**
    * This method enables the following syntax:
    *
    * <pre class="stHighlight">
-   * string should not { endWith regex ("a(b*)c" withGroup "bb") } 
+   * string should not { endWith regex ("a(b*)c" withGroup "bb") }
    *                             ^
    * </pre>
-   */	
-  def regex(regexWithGroups: RegexWithGroups) = 
+   */
+  def regex(regexWithGroups: RegexWithGroups) =
     new Matcher[String] {
-      def apply(left: String): MatchResult = 
+      def apply(left: String): MatchResult =
         endWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       override def toString: String = "endWith regex " + Prettifier.default(regexWithGroups)
     }
@@ -89,9 +89,10 @@ final class EndWithWord {
   def regex(rightRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult = {
-        val allMatches = rightRegex.findAllIn(left)
+        val pMatcher = rightRegex.pattern.matcher(left)
+        while (!pMatcher.hitEnd) { pMatcher.find }
         MatchResult(
-          allMatches.hasNext && (allMatches.end == left.length),
+          pMatcher.hitEnd && (pMatcher.end == left.length),
           Resources.rawDidNotEndWithRegex,
           Resources.rawEndedWithRegex,
           Vector(left, UnquotedString(rightRegex.toString))
@@ -99,7 +100,7 @@ final class EndWithWord {
       }
       override def toString: String = "endWith regex \"" + Prettifier.default(rightRegex) + "\""
     }
-  
+
   /**
    * Overrides toString to return "endWith"
    */


### PR DESCRIPTION
Was using `endWith` in scalatest and found the following bug:

`scala> "ab20" should endWith regex ("\d+")

scala> "a10b20" should endWith regex ("\d+")
org.scalatest.exceptions.TestFailedException: "a10b20" did not end with a substring that matched the regular expression \d+
  at org.scalatest.MatchersHelper$.newTestFailedException(MatchersHelper.scala:160)
  at org.scalatest.Matchers$ResultOfEndWithWordForString.regex(Matchers.scala:2324)
  at org.scalatest.Matchers$ResultOfEndWithWordForString.regex(Matchers.scala:2295)
  ... 38 elided`

The `endWith` implementation looks like this:
`val allMatches = rightRegex.findAllIn(left)
allMatches.hasNext && (allMatches.end == left.length)`

This fails because `findAllIn` doesn't find all, it returns an iterator so doing allMatches.end just grabs the first match. In the above example, this would grab the chunk that says "10" and only be halfway through the string. This then fails the check `allMatches.end == left.length` since the regex didn't have the chance to search until the end of the string.

My fix is as follows:
`val pMatcher = rightRegex.pattern.matcher(left)
while (!pMatcher.hitEnd) { pMatcher.find }
pMatcher.hitEnd && (pMatcher.end == left.length)`

I use a matcher and iterate through until the end. When we reach the end, THEN we check if the ending indices match up. Unfortunately, I don't think there is a way to reverse regex, it still has to search from beginning to end.

Apologies for all of the white space changes, I have "remove trailing whitespace" on Sublime turned on. Can revert the whitespace changes if desired.
