### PR TITLE
StreamlinedXml fixes

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
@@ -21,7 +21,7 @@ import scala.collection.GenSet
 import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
-import scala.xml.{Node, Text, NodeSeq, PCData}
+import scala.xml._
 
 class StreamlinedXmlEqualitySpec extends Spec with Matchers {
 
@@ -59,6 +59,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       )
 
       <div>{Text("My name is ")}{Text("Harry")}</div> should equal (<div>My name is Harry</div>)
+      <summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer> should equal (<summer><day>Hello Dude!</day></summer>)
       <div>My name is {PCData("Harry")}</div> should equal (<div>My name is Harry</div>)
     }
   }
@@ -100,6 +101,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       (Text("   "): Node) should equal (Text("   "))
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>)
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: Node) should equal (<summer><day>Hello Dude!</day></summer>)
       (<div>My name is {PCData("Harry")}</div>: Node) should equal (<div>My name is Harry</div>)
     }
   }
@@ -141,6 +143,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       (Text("   "): NodeSeq) should equal (Text("   "))
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>)
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: NodeSeq) should equal (<summer><day>Hello Dude!</day></summer>)
       (<div>My name is {PCData("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>)
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
@@ -21,7 +21,7 @@ import scala.collection.GenSet
 import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
-import scala.xml.{Node, Text, NodeSeq}
+import scala.xml.{Node, Text, NodeSeq, PCData}
 
 class StreamlinedXmlEqualitySpec extends Spec with Matchers {
 
@@ -59,6 +59,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       )
 
       <div>{Text("My name is ")}{Text("Harry")}</div> should equal (<div>My name is Harry</div>)
+      <div>My name is {PCData("Harry")}</div> should equal (<div>My name is Harry</div>)
     }
   }
 
@@ -99,6 +100,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       (Text("   "): Node) should equal (Text("   "))
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>)
+      (<div>My name is {PCData("Harry")}</div>: Node) should equal (<div>My name is Harry</div>)
     }
   }
 
@@ -139,6 +141,7 @@ class StreamlinedXmlEqualitySpec extends Spec with Matchers {
       (Text("   "): NodeSeq) should equal (Text("   "))
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>)
+      (<div>My name is {PCData("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>)
     }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
@@ -102,5 +102,25 @@ class StreamlinedXmlNormMethodsSpec extends Spec with Matchers with StreamlinedX
       (Text("   "): NodeSeq).norm shouldBe Text("   ")
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq).norm shouldBe <div>My name is Harry</div>
     }
+
+     def `should keep the order of the nodes while merging adjacent Text` {
+      (<seasons>
+        <spring>
+          <day>One</day>
+          <day>Tow</day>
+        </spring>
+        <summer>
+          <day>Three</day>
+        </summer>
+        <fall>
+          <day>Four</day>
+        </fall>
+        <winter>
+          <day>Five</day>
+          <day>Six</day>
+          <day>Seven</day>
+        </winter>
+      </seasons>: NodeSeq).norm shouldBe <seasons><spring><day>One</day><day>Tow</day></spring><summer><day>Three</day></summer><fall><day>Four</day></fall><winter><day>Five</day><day>Six</day><day>Seven</day></winter></seasons>
+    }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import scala.xml.{Node, Text, NodeSeq}
+import scala.xml.{Node, Text, NodeSeq, PCData}
 
 class StreamlinedXmlNormMethodsSpec extends Spec with Matchers with StreamlinedXmlNormMethods {
 
@@ -43,6 +43,8 @@ class StreamlinedXmlNormMethodsSpec extends Spec with Matchers with StreamlinedX
           </day>
         </summer>.norm shouldBe true
       <div>{Text("My name is ")}{Text("Harry")}</div>.norm shouldBe <div>My name is Harry</div>
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>).norm shouldBe <summer><day>Hello Dude!</day></summer>
+      (<div>My name is {PCData("Harry")}</div>).norm shouldBe <div>My name is Harry</div>
     }
   }
 
@@ -72,6 +74,8 @@ class StreamlinedXmlNormMethodsSpec extends Spec with Matchers with StreamlinedX
         </summer>.norm: Node) shouldBe true
       (Text("   "): Node).norm shouldBe Text("   ")
       (<div>{Text("My name is ")}{Text("Harry")}</div>: Node).norm shouldBe <div>My name is Harry</div>
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: Node).norm shouldBe <summer><day>Hello Dude!</day></summer>
+      (<div>My name is {PCData("Harry")}</div>: Node).norm shouldBe <div>My name is Harry</div>
     }
   }
 
@@ -101,6 +105,8 @@ class StreamlinedXmlNormMethodsSpec extends Spec with Matchers with StreamlinedX
         </summer>.norm: NodeSeq) shouldBe true
       (Text("   "): NodeSeq).norm shouldBe Text("   ")
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq).norm shouldBe <div>My name is Harry</div>
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: Node).norm shouldBe <summer><day>Hello Dude!</day></summer>
+      (<div>My name is {PCData("Harry")}</div>: NodeSeq).norm shouldBe <div>My name is Harry</div>
     }
 
      def `should keep the order of the nodes while merging adjacent Text` {

--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
@@ -21,7 +21,7 @@ import scala.collection.GenSet
 import scala.collection.GenIterable
 import scala.collection.GenTraversable
 import scala.collection.GenTraversableOnce
-import scala.xml.{Elem, Node, Text, NodeSeq}
+import scala.xml.{Elem, Node, Text, NodeSeq, XML, PCData}
 
 class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
 
@@ -57,6 +57,8 @@ class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
       ) (after being streamlined[Elem])
 
       <div>{Text("My name is ")}{Text("Harry")}</div> should equal (<div>My name is Harry</div>) (after being streamlined[Elem])
+      <summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer> should equal (<summer><day>Hello Dude!</day></summer>) (after being streamlined[Elem])
+      <div>My name is {PCData("Harry")}</div> should equal (<div>My name is Harry</div>) (after being streamlined[Elem])
     }
   }
 
@@ -97,6 +99,7 @@ class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
       (Text("   "): Node) should equal (Text("   ")) (after being streamlined[Node])
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>) (after being streamlined[Node])
+      (<div>My name is {PCData("Harry")}</div>: Node) should equal (<div>My name is Harry</div>) (after being streamlined[Node])
     }
   }
 
@@ -137,7 +140,17 @@ class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
       (Text("   "): NodeSeq) should equal (Text("   ")) (after being streamlined[NodeSeq])
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>) (after being streamlined[NodeSeq])
+      (<div>My name is {PCData("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>) (after being streamlined[NodeSeq])
     }
   }
+
+  def `should handle XML entities`(){
+    (<root>{">"}</root>) should equal (XML.loadString("""<root>&gt;</root>""")) (after being streamlined[Elem])
+    (<root>&gt;</root>) should equal (XML.loadString("""<root>&gt;</root>""").head) (after being streamlined[Elem])
+    (<root>foo&quot;</root>) should equal (<root>foo{"""""""}</root>) (after being streamlined[Elem])
+    (<root>foo&quot;</root>) should equal (XML.loadString("""<root>foo&quot;</root>""")) (after being streamlined[Elem])
+    (<root>foo&quot;</root>) should equal (XML.loadString("""<root>foo"</root>""").head) (after being streamlined[Elem])
+  }
+
 }
 

--- a/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
@@ -99,6 +99,7 @@ class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
       (Text("   "): Node) should equal (Text("   ")) (after being streamlined[Node])
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>) (after being streamlined[Node])
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: Node) should equal (<summer><day>Hello Dude!</day></summer>) (after being streamlined[Node])
       (<div>My name is {PCData("Harry")}</div>: Node) should equal (<div>My name is Harry</div>) (after being streamlined[Node])
     }
   }
@@ -140,16 +141,17 @@ class StreamlinedXmlSpec extends Spec with Matchers with StreamlinedXml {
       (Text("   "): NodeSeq) should equal (Text("   ")) (after being streamlined[NodeSeq])
 
       (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>) (after being streamlined[NodeSeq])
+      (<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer>: NodeSeq) should equal (<summer><day>Hello Dude!</day></summer>) (after being streamlined[NodeSeq])
       (<div>My name is {PCData("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>) (after being streamlined[NodeSeq])
     }
   }
 
   def `should handle XML entities`(){
-    (<root>{">"}</root>) should equal (XML.loadString("""<root>&gt;</root>""")) (after being streamlined[Elem])
-    (<root>&gt;</root>) should equal (XML.loadString("""<root>&gt;</root>""").head) (after being streamlined[Elem])
-    (<root>foo&quot;</root>) should equal (<root>foo{"""""""}</root>) (after being streamlined[Elem])
-    (<root>foo&quot;</root>) should equal (XML.loadString("""<root>foo&quot;</root>""")) (after being streamlined[Elem])
-    (<root>foo&quot;</root>) should equal (XML.loadString("""<root>foo"</root>""").head) (after being streamlined[Elem])
+    <root>{">"}</root> should equal (XML.loadString("""<root>&gt;</root>""")) (after being streamlined[Elem])
+    <root>&gt;</root> should equal (XML.loadString("""<root>&gt;</root>""").head) (after being streamlined[Elem])
+    <root>foo&quot;</root> should equal (<root>foo{"""""""}</root>) (after being streamlined[Elem])
+    <root>foo&quot;</root> should equal (XML.loadString("""<root>foo&quot;</root>""")) (after being streamlined[Elem])
+    <root>foo&quot;</root> should equal (XML.loadString("""<root>foo"</root>""").head) (after being streamlined[Elem])
   }
 
 }

--- a/scalatest/src/main/scala/org/scalatest/StreamlinedXml.scala
+++ b/scalatest/src/main/scala/org/scalatest/StreamlinedXml.scala
@@ -164,7 +164,7 @@ trait StreamlinedXml {
       def normalized(nodeSeq: T): T = {
         normalizedXml(nodeSeq) match {
           case NodeSeq.Empty => nodeSeq
-          case normalized if nodeSeq.isInstanceOf[Node] => normalized.head
+          case normalized if normalized.size == 1 => normalized.head
           case normalized => normalized
         }
       }.asInstanceOf[T]

--- a/scalatest/src/main/scala/org/scalatest/StreamlinedXml.scala
+++ b/scalatest/src/main/scala/org/scalatest/StreamlinedXml.scala
@@ -133,33 +133,41 @@ trait StreamlinedXml {
   def streamlined[T <: NodeSeq]: Uniformity[T] = {
 
     def trimTextZappingEmpty(node: Node): Seq[Node] =
-      node match {
-        case Text(text) if (text.trim.isEmpty) => Nil
-        case Text(text) => List(Text(text.trim))
+      node.text.trim match {
+        case "" => NodeSeq.Empty
+        case trimmed => Text(trimmed)
+      }
+
+    def mergeAdjacentTextNodes(children: Seq[Node]) =
+      children.foldRight[List[Node]](Nil) { (ele, acc) =>
+        ele match {
+          case eleTxt if eleTxt.isAtom =>
+            acc match {
+              case accTxt :: tail if accTxt.isAtom =>
+                Text(eleTxt.text + accTxt.text) :: tail
+              case _ => eleTxt :: acc
+            }
+          case _ => ele :: acc
+        }
+      }
+
+    def normalizedXml(nodeSeq: NodeSeq): NodeSeq =
+      mergeAdjacentTextNodes(nodeSeq).flatMap {
         case Elem(pre, lab, md, scp, children @ _*) =>
-          Elem(pre, lab, md, scp, false, (children.flatMap(trimTextZappingEmpty)):_*)
-        case _ => List(node)
+          Elem(pre, lab, md, scp, false, normalizedXml(children): _*)
+        case textNode if textNode.isAtom =>
+          trimTextZappingEmpty(textNode)
+        case x => x
       }
 
     new Uniformity[T] {
-      def normalized(nodeSeq: T): T =
-        nodeSeq match {
-          case Elem(pre, lab, md, scp, children @ _*) =>
-            val mergedTextNodes = // Merge adjacent text nodes
-              children.foldLeft(Nil: List[Node]) { (acc, ele) =>
-                ele match {
-                  case eleTxt: Text =>
-                    acc.headOption match {
-                      case Some(accTxt: Text) =>
-                        Text(accTxt.text + eleTxt.text) :: acc.tail
-                      case _ => ele :: acc
-                    }
-                  case _ => ele :: acc
-                }
-              }
-            Elem(pre, lab, md, scp, false, (mergedTextNodes.flatMap(trimTextZappingEmpty)):_*).asInstanceOf[T]
-          case _ => nodeSeq
+      def normalized(nodeSeq: T): T = {
+        normalizedXml(nodeSeq) match {
+          case NodeSeq.Empty => nodeSeq
+          case normalized if nodeSeq.isInstanceOf[Node] => normalized.head
+          case normalized => normalized
         }
+      }.asInstanceOf[T]
 
       /**
        * Returns true if the passed <code>Any</code> is a <code>Elem</code>.


### PR DESCRIPTION
- Apply adjacent text merge to all child nodes.
```scala
<summer><day>{Text("Hello ")}{Text("Dude!")}</day></summer> should equal (<summer><day>Hello Dude!</day></summer>) (after being streamlined[Elem])
```
The previous test was failing because the adjacent text merge was applied only on children of the root node.

- Handle "scala.xml.PCData" as text
```scala
<div>My name is {PCData("Harry")}</div> should equal (<div>My name is Harry</div>) (after being streamlined[Elem])
```

- Keep nodes order while merging adjacent text.
```scala
(<seasons>
  <spring>
    <day>One</day>
    <day>Tow</day>
  </spring>
  <summer>
    <day>Three</day>
  </summer>
  <fall>
    <day>Four</day>
  </fall>
  <winter>
    <day>Five</day>
    <day>Six</day>
    <day>Seven</day>
  </winter>
</seasons>).norm shouldBe <seasons><spring><day>One</day><day>Tow</day></spring><summer><day>Three</day></summer><fall><day>Four</day></fall><winter><day>Five</day><day>Six</day><day>Seven</day></winter></seasons>
```
The previous test was failling because the adjacent text merge was revesing the order of the nodes.

- fix #461 StreamlinedXml reports false positive with XML entities 
```scala
<root>&gt;</root> should equal (XML.loadString("""<root>&gt;</root>""").head) (after being streamlined[Elem])
```
The previous test was failling because the "&gt;" at left handside is a "scala.xml.EntityRef" and at the right handside is a "scala.xml.Text". So now "scala.xml.EntityRef" is handle as text