### PR TITLE
refs #880 AnnotationHelper to support @WrapWith on traits

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/tools/AnnotationHelperSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/AnnotationHelperSpec.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.tools
+
+import org.scalatest.Args
+import org.scalatest.FunSpec
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.WrapWith
+import org.scalatest.events.Event
+import org.scalatest.exceptions.NotAllowedException
+
+class AnnotationHelperSpec extends FunSpec {
+
+  class MarkerAnnotatedAtClass extends Suite
+
+  class MarkerAnnotatedAtSuper extends Suite
+
+  class Marker1AnnotatedAtTrait extends Suite
+
+  class Marker2AnnotatedAtTrait extends Suite
+
+  class DefaultSuperClass
+
+  @WrapWith(classOf[MarkerAnnotatedAtSuper])
+  class AnnotatedSuperClass
+
+  trait DefaultTrait
+
+  @WrapWith(classOf[Marker1AnnotatedAtTrait])
+  trait AnnotatedTrait1
+
+  @WrapWith(classOf[Marker2AnnotatedAtTrait])
+  trait AnnotatedTrait2a
+
+  @WrapWith(classOf[Marker2AnnotatedAtTrait])
+  trait AnnotatedTrait2b
+
+  trait IndirectAnnotatedTrait extends AnnotatedTrait1
+
+  describe("distinctEq") {
+    it("empty = empty") {
+      assert(AnnotationHelper.distinctEq(Seq()) == Seq())
+    }
+    it("a = a") {
+      val a = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a)) == Seq(a))
+    }
+    it("aa = a") {
+      val a = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, a)) == Seq(a))
+    }
+    it("ab = ab") {
+      val a = new DefaultSuperClass
+      val b = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, b)) == Seq(a, b))
+    }
+    it("aab = ab") {
+      val a = new DefaultSuperClass
+      val b = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, a, b)) == Seq(a, b))
+    }
+    it("abb = ab") {
+      val a = new DefaultSuperClass
+      val b = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, b, b)) == Seq(a, b))
+    }
+    it("aabb = ab") {
+      val a = new DefaultSuperClass
+      val b = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, a, b, b)) == Seq(a, b))
+    }
+    it("abcaba = acb") {
+      val a = new DefaultSuperClass
+      val b = new DefaultSuperClass
+      val c = new DefaultSuperClass
+      assert(AnnotationHelper.distinctEq(Seq(a, b, c, a, b, a)) == Seq(a, b, c))
+    }
+  }
+
+  describe("TestRunner") {
+    @WrapWith(classOf[MarkerAnnotatedAtClass])
+    class Subject extends FunSpec with AnnotatedTrait1 {
+      describe("describe") {
+        it("it") {
+          assert(true === true)
+        }
+      }
+    }
+
+    it("run should throw NotAllowedException when more then one @WrapWith Annotation was found") {
+      val subject = new Subject()
+      intercept[NotAllowedException] {
+        subject.run(None, Args(new Reporter() {
+          def apply(event: Event): Unit = {
+          }
+        }))
+      }
+    }
+  }
+
+  describe("DefaultSuperClass") {
+    class Subject extends DefaultSuperClass
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.isEmpty)
+    }
+  }
+
+  describe("DefaultSuperClass with DefaultTrait") {
+    class Subject extends DefaultSuperClass with DefaultTrait
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.isEmpty)
+    }
+  }
+
+  describe("DefaultSuperClass with AnnotatedTrait1") {
+    class Subject extends DefaultSuperClass with AnnotatedTrait1
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 1)
+      assert(result.head.value === classOf[Marker1AnnotatedAtTrait])
+    }
+  }
+
+  describe("DefaultSuperClass with IndirectAnnotatedTrait") {
+    class Subject extends DefaultSuperClass with IndirectAnnotatedTrait
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 1)
+      assert(result.head.value === classOf[Marker1AnnotatedAtTrait])
+    }
+  }
+
+  describe("DefaultSuperClass with AnnotatedTrait1 with IndirectAnnotatedTrait") {
+    class Subject extends DefaultSuperClass with AnnotatedTrait1 with IndirectAnnotatedTrait
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 1)
+      assert(result.head.value === classOf[Marker1AnnotatedAtTrait])
+    }
+  }
+
+  describe("AnnotatedSuperClass") {
+    class Subject extends AnnotatedSuperClass
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 1)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+    }
+  }
+
+  describe("AnnotatedSuperClass with AnnotatedTrait1") {
+    class Subject extends AnnotatedSuperClass with AnnotatedTrait1
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 2)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+      assert(result.tail.head.value === classOf[Marker1AnnotatedAtTrait])
+    }
+  }
+
+  describe("AnnotatedSuperClass with DefaultTrait") {
+    class Subject extends AnnotatedSuperClass with DefaultTrait
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 1)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+    }
+  }
+
+  describe("AnnotatedSuperClass with DefaultTrait with Annotation") {
+    @WrapWith(classOf[MarkerAnnotatedAtClass])
+    class Subject extends AnnotatedSuperClass with DefaultTrait
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 2)
+      assert(result.head.value === classOf[MarkerAnnotatedAtClass])
+      assert(result.tail.head.value === classOf[MarkerAnnotatedAtSuper])
+    }
+  }
+
+  describe("AnnotatedSuperClass with AnnotatedTrait1 with AnnotatedTrait2a") {
+    class Subject extends AnnotatedSuperClass with AnnotatedTrait1 with AnnotatedTrait2a
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 3)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+      assert(result.tail.head.value === classOf[Marker1AnnotatedAtTrait])
+      assert(result.tail.tail.head.value === classOf[Marker2AnnotatedAtTrait])
+    }
+  }
+
+  describe("AnnotatedSuperClass with AnnotatedTrait1 with AnnotatedTrait2a with AnnotatedTrait2b") {
+    class Subject extends AnnotatedSuperClass with AnnotatedTrait1 with AnnotatedTrait2a with AnnotatedTrait2b
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 4)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+      assert(result.tail.head.value === classOf[Marker1AnnotatedAtTrait])
+      assert(result.tail.tail.head.value === classOf[Marker2AnnotatedAtTrait])
+      assert(result.tail.tail.tail.head.value === classOf[Marker2AnnotatedAtTrait])
+    }
+  }
+
+  describe("AnnotatedSuperClass with MarkerAnnotatedAtSuper on class") {
+    @WrapWith(classOf[MarkerAnnotatedAtSuper])
+    class Subject extends AnnotatedSuperClass
+
+    val result = AnnotationHelper.findAll(classOf[WrapWith], classOf[Subject])
+
+    it("findAll should detect annotations correctly") {
+      assert(result.length == 2)
+      assert(result.head.value === classOf[MarkerAnnotatedAtSuper])
+      assert(result.tail.head.value === classOf[MarkerAnnotatedAtSuper])
+    }
+  }
+}

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -666,6 +666,9 @@ cannotRerun=Test in memory file is not rerunnable: rerun event = {0}, suiteId = 
 
 testCannotBeNestedInsideAnotherTest=Test cannot be nested inside another test.
 
+moreThenOneAnnotationFound=More then one "{0}" Annotation found on class hierarchy of class "{1}"
+notExactlyOneAnnotationFound=Not exactly one "{0}" Annotation found on class hierarchy of class "{1}"
+
 nonEmptyMatchPatternCase=No code is allowed to the right of rocket symbols (=>) in a partial function passed to matchPattern, because matchPattern is intended only for ensuring that an expression matches a pattern. If you want to make further assertions after a successful pattern match, use org.scalatest.Inside instead.
 
 expectedTypeErrorButGotNone=Expected a type error, but got none for code: {0}

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -43,6 +43,7 @@ import Suite.wrapReporterIfNecessary
 import annotation.tailrec
 import collection.GenTraversable
 import collection.mutable.ListBuffer
+import org.scalatest.tools.AnnotationHelper
 
 // SKIP-SCALATESTJS-START
 import Suite.getTopOfClass
@@ -1347,7 +1348,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
     val suiteClass = getClass
     // SKIP-SCALATESTJS-START
     val isAccessible = SuiteDiscoveryHelper.isAccessibleSuite(suiteClass)
-    val hasWrapWithAnnotation = suiteClass.getAnnotation(classOf[WrapWith]) != null
+    val hasWrapWithAnnotation = AnnotationHelper.findWrapWith(suiteClass).isDefined
     if (isAccessible || hasWrapWithAnnotation)
       Some(suiteClass.getName)
     else

--- a/scalatest/src/main/scala/org/scalatest/tools/AnnotationHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/AnnotationHelper.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.tools
+
+import java.lang.annotation.Annotation
+
+import org.scalatest.WrapWith
+import org.scalatest.Resources
+import org.scalatest.exceptions.StackDepthExceptionHelper.getStackDepthFun
+import org.scalatest.exceptions.NotAllowedException
+
+import scala.collection.mutable
+
+/**
+ * A Helper Object to find an Annotation on a given class and all of its superclasses, interfaces and traits.
+ *
+ * @author Dennis Rieks
+ */
+object AnnotationHelper {
+  /**
+   * Builds a new Seq from the given Seq without any duplicate elements.
+   *
+   * In oposite to scala.collection.SeqLike.distinct
+   * this function uses eq and not ==
+   */
+  private[scalatest] def distinctEq[A <: AnyRef](seq: Seq[A]): Seq[A] = {
+    val seen = mutable.MutableList[A]()
+    def addToSeen(a: A): A = {
+      seen += a
+      a
+    }
+    for {
+      a <- seq
+      if !seen.exists(_ eq a)
+    } yield addToSeen(a)
+  }
+
+  /**
+   * Finds all Annotations of the given type for the given class.
+   *
+   * @param anno The type of the Annotation to search for.
+   *
+   * @param clazz the class to search.
+   *
+   * @return a Seq of all found Annotations.
+   */
+  def findAll[A <: Annotation](anno: Class[A], clazz: Class[_]): Seq[A] = {
+    if (Option(clazz).isEmpty) {
+      Seq()
+    } else {
+      distinctEq(Option(clazz.getAnnotation(anno)).toSeq ++
+        findAll(anno, clazz.getSuperclass) ++
+        clazz.getInterfaces.flatMap(findAll(anno, _)))
+    }
+  }
+
+  /**
+   * Find zero or one instance of the given Annotation on the class.
+   *
+   * Returns <code>None<code> when the class is not annotated, or <code>Some(A)<code> when there was only
+   * one instance of the annotation found on the class.
+   *
+   * @throws NotAllowedException when there was more then one annotation found one the class.
+   *
+   * @param anno The type of the Annotation to return.
+   *
+   * @param clazz the class to search.
+   *
+   * @return the found Annotation.
+   */
+  def find[A <: Annotation](anno: Class[A], clazz: Class[_]): Option[A] = {
+    val ret = findAll(anno, clazz)
+    if (ret.length > 1) {
+      throw new NotAllowedException(Resources.moreThenOneAnnotationFound(anno.getName, clazz.getName), getStackDepthFun("AnnotationHelper", "find"))
+    }
+    ret.headOption
+  }
+
+  /**
+   * Returns the instance of the given Annotation found on the class.
+   *
+   * @throws NotAllowedException when there was not exactly one instance of the annotation found one the class.
+   *
+   * @param anno The type of the Annotation to return.
+   *
+   * @param clazz the class to search.
+   *
+   * @return The instance of the Annotation of the given Type
+   */
+  def get[A <: Annotation](anno: Class[A], clazz: Class[_]): A = {
+    val ret = findAll(anno, clazz)
+    if (ret.length != 1) {
+      throw new NotAllowedException(Resources.notExactlyOneAnnotationFound(anno.getName, clazz.getName), getStackDepthFun("AnnotationHelper", "get"))
+    }
+    ret.head
+  }
+
+  /**
+   * Returns the WrapWith Annotation of the given class.
+   *
+   * @throws NotAllowedException when there was more then one annotation found one the class.
+   *
+   * @param anno The type of the Annotation to return.
+   * @param clazz the class to search.
+   *
+   * @return the found Annotation.
+   */
+  def findWrapWith(clazz: Class[_]): Option[WrapWith] = {
+    find(classOf[WrapWith], clazz)
+  }
+}

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -431,10 +431,7 @@ class Framework extends SbtFramework {
       if (accessible || runnable) {
         val suite =
           try {
-            if (accessible)
-              suiteClass.newInstance.asInstanceOf[Suite]
-            else {
-              val wrapWithAnnotation = suiteClass.getAnnotation(classOf[WrapWith])
+            AnnotationHelper.find(classOf[WrapWith], suiteClass).map(wrapWithAnnotation => {
               val suiteClazz = wrapWithAnnotation.value
               val constructorList = suiteClazz.getDeclaredConstructors()
               val constructor = constructorList.find { c =>
@@ -442,7 +439,7 @@ class Framework extends SbtFramework {
                 types.length == 1 && types(0) == classOf[java.lang.Class[_]]
               }
               constructor.get.newInstance(suiteClass).asInstanceOf[Suite]
-            }
+            }).getOrElse(suiteClass.newInstance.asInstanceOf[Suite])
           } catch {
             case t: Throwable => new DeferredAbortedSuite(suiteClass.getName, t)
           }

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -394,11 +394,7 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
             val tracker = new Tracker
             val suiteStartTime = System.currentTimeMillis
 
-            val wrapWithAnnotation = suiteClass.getAnnotation(classOf[WrapWith])
-            val suite = 
-            if (wrapWithAnnotation == null)
-              suiteClass.newInstance.asInstanceOf[Suite]
-            else {
+            val suite = AnnotationHelper.findWrapWith(suiteClass).map(wrapWithAnnotation => {
               val suiteClazz = wrapWithAnnotation.value
               val constructorList = suiteClazz.getDeclaredConstructors()
               val constructor = constructorList.find { c => 
@@ -406,7 +402,7 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
                   types.length == 1 && types(0) == classOf[java.lang.Class[_]]
                 }
               constructor.get.newInstance(suiteClass).asInstanceOf[Suite]
-            }
+            }).getOrElse(suiteClass.newInstance.asInstanceOf[Suite])
 
             val formatter = formatterForSuiteStarting(suite)
 

--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
@@ -210,17 +210,14 @@ private[scalatest] object SuiteDiscoveryHelper {
   }
   
   private[scalatest] def isRunnable(clazz: java.lang.Class[_]): Boolean = {
-    val wrapWithAnnotation = clazz.getAnnotation(classOf[WrapWith])
-    if (wrapWithAnnotation != null) {
+    AnnotationHelper.findWrapWith(clazz).map(wrapWithAnnotation => {
       val wrapperSuiteClazz = wrapWithAnnotation.value
       val constructorList = wrapperSuiteClazz.getDeclaredConstructors()
       constructorList.exists { c => 
         val types = c.getParameterTypes
         types.length == 1 && types(0) == classOf[java.lang.Class[_]]
       }
-    }
-    else
-      false
+    }).getOrElse(false)
   }
   
   private[scalatest] def isRunnable(className: String, loader: ClassLoader): Boolean = {


### PR DESCRIPTION
This PR will add a new AnnotationHelper what is used to find all @WrapWith Annotations, even on traits. We need this to add @WrapWith to a DriverLauncher trait that should start the actual test for different Browsers.
