### PR TITLE
Use the value property of `TagAnnotation` for the tag name.

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/InheritedTagProp.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InheritedTagProp.scala
@@ -89,7 +89,7 @@ class InheritedTagProp extends SuiteProp {
       val resultTags = suite.tags
       assert(resultTags.size == 1)
       resultTags.foreach { case (testName, tagSet) =>
-        assert(tagSet.contains("org.scalatest.tags.CPU"))
+        assert(tagSet.contains("cpu"))
       }
     }
   }
@@ -99,7 +99,7 @@ class InheritedTagProp extends SuiteProp {
       val resultTags = suite.tags
       assert(resultTags.size == 1)
       resultTags.foreach { case (testName, tagSet) =>
-        assert(tagSet.contains("org.scalatest.tags.Disk"))
+        assert(tagSet.contains("disk"))
       }
     }
   }
@@ -109,7 +109,7 @@ class InheritedTagProp extends SuiteProp {
       val resultTags = suite.tags
       assert(resultTags.size == 1)
       resultTags.foreach { case (testName, tagSet) =>
-        assert(tagSet.contains("org.scalatest.tags.Network"))
+        assert(tagSet.contains("network"))
       }
     }
   }
@@ -178,7 +178,7 @@ class InheritedTagProp extends SuiteProp {
     forAll(filteredExamples) { suite =>
       assert(suite.testNames.size == 1)
       val resultTestData = suite.testDataFor(suite.testNames.head)
-      assert(resultTestData.tags.contains("org.scalatest.tags.CPU"))
+      assert(resultTestData.tags.contains("cpu"))
     }
   }
 
@@ -186,7 +186,7 @@ class InheritedTagProp extends SuiteProp {
     forAll(filteredExamples) { suite =>
       assert(suite.testNames.size == 1)
       val resultTestData = suite.testDataFor(suite.testNames.head)
-      assert(resultTestData.tags.contains("org.scalatest.tags.Disk"))
+      assert(resultTestData.tags.contains("disk"))
     }
   }
 
@@ -194,7 +194,7 @@ class InheritedTagProp extends SuiteProp {
     forAll(filteredExamples) { suite =>
       assert(suite.testNames.size == 1)
       val resultTestData = suite.testDataFor(suite.testNames.head)
-      assert(resultTestData.tags.contains("org.scalatest.tags.Network"))
+      assert(resultTestData.tags.contains("network"))
     }
   }
 

--- a/scalatest/src/main/scala/org/scalatest/AnnotatedSuiteToTagNames.scala
+++ b/scalatest/src/main/scala/org/scalatest/AnnotatedSuiteToTagNames.scala
@@ -1,0 +1,29 @@
+package org.scalatest
+
+import java.lang.annotation.Annotation
+
+object AnnotatedSuiteToTagNames {
+  def apply(theSuite: Suite): Set[String] = {
+    val suiteTags = for {
+      a <- theSuite.getClass.getAnnotations
+      tag <- AnnotationClassToTagName(a.annotationType)
+    } yield tag
+
+    suiteTags.toSet
+  }
+}
+
+object AnnotationClassToTagName {
+  def apply(annotationClass: Class[_ <: Annotation]): Option[String] = {
+    if (annotationClass.isAnnotationPresent(classOf[TagAnnotation])) {
+      val tagAnnotation = annotationClass.getAnnotation(classOf[TagAnnotation])
+      val annotationValue = tagAnnotation.value()
+      if (annotationValue.isEmpty)
+        Some(annotationClass.getName)
+      else
+        Some(annotationValue)
+    } else {
+      None
+    }
+  }
+}

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -847,11 +847,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
   
   private[scalatest] def testTags(testName: String, theSuite: Suite): Set[String] = {
     // SKIP-SCALATESTJS-START
-    val suiteTags = for { 
-      a <- theSuite.getClass.getAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+    val suiteTags = AnnotatedSuiteToTagNames(theSuite)
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val suiteTags = Set.empty[String]
     val testTagSet = atomic.get.tagsMap.getOrElse(testName, Set.empty)

--- a/scalatest/src/main/scala/org/scalatest/Engine.scala
+++ b/scalatest/src/main/scala/org/scalatest/Engine.scala
@@ -752,11 +752,7 @@ private[scalatest] sealed abstract class SuperEngine[T](concurrentBundleModMessa
   
   private[scalatest] def testTags(testName: String, theSuite: Suite): Set[String] = {
     // SKIP-SCALATESTJS-START
-    val suiteTags = for { 
-      a <- theSuite.getClass.getAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+    val suiteTags = AnnotatedSuiteToTagNames(theSuite)
     // SKIP-SCALATESTJS-END
     //SCALATESTJS-ONLY val suiteTags = Set.empty[String]
     val testTagSet = atomic.get.tagsMap.getOrElse(testName, Set.empty)

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -2066,11 +2066,7 @@ used for test events like succeeded/failed, etc.
 
   def autoTagClassAnnotations(tags: Map[String, Set[String]], theSuite: Suite) = {
     // SKIP-SCALATESTJS-START
-    val suiteTags = for {
-      a <- theSuite.getClass.getAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+    val suiteTags = AnnotatedSuiteToTagNames(theSuite)
 
     val autoTestTags =
       if (suiteTags.size > 0)

--- a/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
@@ -72,9 +72,8 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
         def getMethodTags(o: AnyRef, methodName: String) =
           for {
             a <- getMethod(o, methodName).getDeclaredAnnotations
-            annotationClass = a.annotationType
-            if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-          } yield annotationClass.getName
+            tag <- AnnotationClassToTagName(a.annotationType)
+          } yield tag
           
         def getScopeClassName(o: AnyRef): String = {
           val className = o.getClass.getName

--- a/scalatest/src/main/scala/org/scalatest/junit/JUnitSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/junit/JUnitSuiteLike.scala
@@ -193,11 +193,7 @@ trait JUnitSuiteLike extends Suite with AssertionsForJUnit { thisSuite =>
    * @return a <code>TestData</code> instance for the specified test, which includes the specified config map
    */
   override def testDataFor(testName: String, theConfigMap: ConfigMap = ConfigMap.empty): TestData = {
-    val suiteTags = for { 
-      a <- this.getClass.getAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+    val suiteTags = AnnotatedSuiteToTagNames(this)
     val testTags: Set[String] = 
       try {
         if (hasIgnoreTag(testName))

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -64,9 +64,8 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
         def getMethodTags(o: AnyRef, methodName: String) =
           for {
             a <- getMethod(o, methodName).getDeclaredAnnotations
-            annotationClass = a.annotationType
-            if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-          } yield annotationClass.getName
+            tag <- AnnotationClassToTagName(a.annotationType)
+          } yield tag
         
         def getScopeClassName(o: AnyRef): String = {
           val className = o.getClass.getName

--- a/scalatest/src/main/scala/org/scalatest/testng/TestNGSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/testng/TestNGSuiteLike.scala
@@ -159,9 +159,8 @@ trait TestNGSuiteLike extends Suite { thisSuite =>
   private def getTags(testName: String) =
     for {
       a <- Suite.getMethodForTestName(thisSuite, testName).getDeclaredAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+      tag <- AnnotationClassToTagName(a.annotationType)
+    } yield tag
 
   override def tags: Map[String, Set[String]] = {
     val testNameSet = testNames
@@ -174,11 +173,7 @@ trait TestNGSuiteLike extends Suite { thisSuite =>
   }
 
   override def testDataFor(testName: String, theConfigMap: ConfigMap = ConfigMap.empty): TestData = {
-    val suiteTags = for {
-      a <- this.getClass.getAnnotations
-      annotationClass = a.annotationType
-      if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
-    } yield annotationClass.getName
+    val suiteTags = AnnotatedSuiteToTagNames(this)
     val testTags: Set[String] =
       try {
         getTags(testName).toSet


### PR DESCRIPTION
`TagAnnotation` has a handy `value` field, but it was ignored when
figuring out tag names. If `value` is set, use it for the tag name.
If it's not set, use the annotation class name instead.

This change is not backwards compatible, but the migration path
should be just changing which tag name you filter on.

* Create helper `AnnotatedSuiteToTagNames` and
  `AnnotationClassToTagName` objects to DRY up the annotation -> tag
  name logic.
* Use the logic in places where were were doing something like:

```
annotationClass = a.annotationType
if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
```