### PR TITLE
Deprecated the checkCorrectType in WebBrowser.scala.

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -1892,6 +1892,7 @@ trait WebBrowser {
   trait ValueElement extends Element {
     val underlying: WebElement
 
+    @deprecated("This method is internal which is not intended to be called by user, we plan to remove it in the future version of ScalaTest, if you did use it, please kindly let us know by contacting us.")
     def checkCorrectType(isA: (WebElement) => Boolean, typeDescription: String)(implicit pos: source.Position): Unit = {
       if(!isA(underlying))
         throw new TestFailedException(


### PR DESCRIPTION
Deprecated the checkCorrectType in WebBrowser.scala.

This fix should be cherry-picked into 3.1.x and subsequently pulled into 3.2.x.