### PR TITLE
Exceptions Clean Up

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/exceptions/DuplicateTestNameException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/DuplicateTestNameException.scala
@@ -28,7 +28,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  * stack trace to find the correct filename and line number of the offending code.)
  *
  * @param testName the test name that was attempted to be registered twice
- * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of code that attempted
+ * @param posOrStackDepthFun either a source position or a function that return the depth in the stack trace of this exception at which the line of code that attempted
  *   to register the test with the duplicate name resides.
  *
  * @throws NullArgumentException if <code>testName</code> is <code>null</code>
@@ -46,6 +46,12 @@ class DuplicateTestNameException(
   
   requireNonNull(testName)
 
+  /**
+    * Constructs a <code>DuplicateTestNameException</code> with given message and source position
+    *
+    * @param message the error message
+    * @param pos the source position
+    */
   def this(
     message: String,
     pos: source.Position
@@ -63,7 +69,12 @@ class DuplicateTestNameException(
   def this(testName: String, failedCodeStackDepth: Int) =
     this(testName, Right((e: StackDepthException) => failedCodeStackDepth))
 
-  // This was probably the olde main constructor
+  /**
+    * Constructs a <code>DuplicateTestNameException</code> with given test name and stack depth function.
+    *
+    * @param testName the test name
+    * @param failedCodeStackDepthFun the depth in the stack trace of this exception at which the line of test code that failed resides.
+    */
   def this(testName: String, failedCodeStackDepthFun: StackDepthException => Int) =
     this(testName, Right(failedCodeStackDepthFun))
 

--- a/scalatest/src/main/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedException.scala
@@ -24,7 +24,7 @@ import org.scalactic.source
  *
  * @param messageFun a function that returns a detail message (not optional) for this <code>GeneratorDrivenPropertyCheckFailedException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>GeneratorDrivenPropertyCheckFailedException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
  * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it.
  * @param args the argument values, if any, that caused the property check to fail.
@@ -48,6 +48,20 @@ class GeneratorDrivenPropertyCheckFailedException(
   messageFun, cause, posOrStackDepthFun, payload, undecoratedMessage, args, namesOfArgs
 ) {
 
+  /**
+    * Constructs a <code>GeneratorDrivenPropertyCheckFailedException</code> with the given message function, cause exception, source position, payload,
+    * undecorated message, argument values, names and labels.
+    *
+    * @param messageFun the message function
+    * @param cause the optional cause
+    * @param pos the source position
+    * @param payload the payload
+    * @param undecoratedMessage the undecorated message
+    * @param args the argument values
+    * @param namesOfArgs the argument names
+    * @param labels the argument labels
+    * @return
+    */
   def this(
     messageFun: StackDepthException => String,
     cause: Option[Throwable],
@@ -59,7 +73,19 @@ class GeneratorDrivenPropertyCheckFailedException(
     labels: List[String]
   ) = this(messageFun, cause, Left(pos), payload, undecoratedMessage, args, namesOfArgs, labels)
 
-  // The olde constructor
+  /**
+    * Constructs a <code>GeneratorDrivenPropertyCheckFailedException</code> with the given message function, cause exception, stack depth function,
+    * payload, undecorated message, argument values, names and labels.
+    *
+    * @param messageFun the message function
+    * @param cause the optional cause
+    * @param failedCodeStackDepthFun the function that returns the depth in the stack trace of this exception at which the line of test code that failed resides
+    * @param payload the payload
+    * @param undecoratedMessage the undecorated message
+    * @param args the argument values
+    * @param namesOfArgs the argument names
+    * @param labels the argument labels
+    */
   def this(
     messageFun: StackDepthException => String,
     cause: Option[Throwable],

--- a/scalatest/src/main/scala/org/scalatest/exceptions/NotAllowedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/NotAllowedException.scala
@@ -28,7 +28,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  *
  * @param message a string that explains the problem
  * @param cause an optional cause
- * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of code that attempted
+ * @param posOrStackDepthFun either a source position or a function that return the depth in the stack trace of this exception at which the line of code that attempted
  *    something not allowed resides.
  *
  * @throws NullArgumentException if either <code>message</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>
@@ -43,12 +43,25 @@ class NotAllowedException(
 
   requireNonNull(message, cause, posOrStackDepthFun)
 
+  /**
+    * Constructs a <code>NotAllowedException</code> with given error message, optional cause and source position.
+    *
+    * @param message the exception's detail message
+    * @param cause the optional cause
+    * @param pos the source position
+    */
   def this(
     message: String,
     cause: Option[Throwable],
     pos: source.Position
   ) = this(message, cause, Left(pos))
 
+  /**
+    * Constructs a <code>NotAllowedException</code> with given error message and source position.
+    *
+    * @param message the exception's detail message
+    * @param pos the source position
+    */
   def this(
     message: String,
     pos: source.Position

--- a/scalatest/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
@@ -46,6 +46,16 @@ abstract class PropertyCheckFailedException(
   optionalArgNames: Option[List[String]]
 ) extends TestFailedException((sde: StackDepthException) => Some(messageFun(sde)), cause, posOrStackDepthFun, payload) {
 
+  def this(
+    messageFun: StackDepthException => String,
+    cause: Option[Throwable],
+    failedCodeStackDepthFun: StackDepthException => Int,
+    payload: Option[Any],
+    undecoratedMessage: String,
+    args: List[Any],
+    optionalArgNames: Option[List[String]]
+  ) = this(messageFun, cause, Right(failedCodeStackDepthFun), payload, undecoratedMessage, args, optionalArgNames)
+
   requireNonNull(
     messageFun, cause, posOrStackDepthFun, undecoratedMessage, args,
     optionalArgNames)

--- a/scalatest/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
@@ -26,7 +26,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  *
  * @param messageFun a function that returns a detail message (not optional) for this <code>PropertyCheckFailedException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>PropertyCheckFailedException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
  * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it.
  * @param args the argument values that caused the property check to fail.
@@ -46,6 +46,18 @@ abstract class PropertyCheckFailedException(
   optionalArgNames: Option[List[String]]
 ) extends TestFailedException((sde: StackDepthException) => Some(messageFun(sde)), cause, posOrStackDepthFun, payload) {
 
+  /**
+    * Constructs a <code>PropertyCheckFailedException</code> with given error message function, optional cause, stack depth function,
+    * optional payload, undecorated message, arguments values and optional argument names.
+    *
+    * @param messageFun a function that returns a detail message (not optional) for this <code>PropertyCheckFailedException</code>
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>PropertyCheckFailedException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
+    * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it.
+    * @param args the argument values that caused the property check to fail.
+    * @param optionalArgNames an optional list of string names for the arguments.
+    */
   def this(
     messageFun: StackDepthException => String,
     cause: Option[Throwable],

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
@@ -29,7 +29,7 @@ import StackDepthExceptionHelper.getStackDepthFun
  *
  * @param messageFun a function that produces an optional detail message for this <code>StackDepthException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>StackDepthException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
  *
  * @throws NullArgumentException if either <code>messageFun</code>, <code>cause</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>, or <code>Some(null)</code>.
  *
@@ -56,6 +56,15 @@ abstract class StackDepthException(
 
   val position: Option[source.Position] = posOrStackDepthFun.left.toOption
 
+  /**
+    * Constructs a <code>StackDepthException</code> with an optional pre-determined <code>message</code>, optional cause, and
+    * a source position.
+    *
+    * @param message an optional detail message for this <code>StackDepthException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>StackDepthException</code> to be thrown.
+    * @param position a source position.
+    *.
+    */
   def this(message: Option[String], cause: Option[Throwable], position: source.Position) =
     this(
       message match {
@@ -67,7 +76,15 @@ abstract class StackDepthException(
       Left(position)
     )
 
-  // I think this was the olde primary constructor
+  /**
+    * Constructs a <code>StackDepthException</code> with message function, optional cause, and
+    * a <code>failedCodeStackDepth</code> function.
+    *
+    * @param messageFun a function that produces an optional detail message for this <code>StackDepthException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>StackDepthException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of test code that failed resides.
+    *.
+    */
   def this(messageFun: StackDepthException => Option[String], cause: Option[Throwable], failedCodeStackDepthFun: StackDepthException => Int) =
     this(
       messageFun,

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedException.scala
@@ -28,7 +28,7 @@ import org.scalactic.source
  *
  * @param messageFun a function that returns a detail message, not optional) for this <code>TableDrivenPropertyCheckFailedException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TableDrivenPropertyCheckFailedException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
  * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it
  * @param args the argument values
@@ -52,6 +52,20 @@ class TableDrivenPropertyCheckFailedException(
   messageFun, cause, posOrStackDepthFun, payload, undecoratedMessage, args, Some(namesOfArgs)
 ) {
 
+  /**
+    * Constructs a <code>TableDrivenPropertyCheckFailedException</code> with given error message function, optional cause, source position,
+    * optional payload, undecorated message, argument values and names, and index of the failing row.
+    *
+    * @param messageFun a function that returns a detail message, not optional) for this <code>TableDrivenPropertyCheckFailedException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TableDrivenPropertyCheckFailedException</code> to be thrown.
+    * @param pos a source position
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
+    * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it
+    * @param args the argument values
+    * @param namesOfArgs a list of string names for the arguments
+    * @param row the index of the table row that failed the property check, causing this exception to be thrown
+    *
+    */
   def this(
     messageFun: StackDepthException => String,
     cause: Option[Throwable],
@@ -63,7 +77,20 @@ class TableDrivenPropertyCheckFailedException(
     row: Int
   ) = this(messageFun, cause, Left(pos), payload, undecoratedMessage, args, namesOfArgs, row)
 
-  // The olde constructor
+  /**
+    * Constructs a <code>TableDrivenPropertyCheckFailedException</code> with given error message function, optional cause, source position,
+    * optional payload, undecorated message, argument values and names, and index of the failing row.
+    *
+    * @param messageFun a function that returns a detail message, not optional) for this <code>TableDrivenPropertyCheckFailedException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TableDrivenPropertyCheckFailedException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that returns the depth in the stack trace of this exception at which the line of test code that failed resides.
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
+    * @param undecoratedMessage just a short message that has no redundancy with args, labels, etc. The regular "message" has everything in it
+    * @param args the argument values
+    * @param namesOfArgs a list of string names for the arguments
+    * @param row the index of the table row that failed the property check, causing this exception to be thrown
+    *
+    */
   def this(
     messageFun: StackDepthException => String,
     cause: Option[Throwable],

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
@@ -154,6 +154,11 @@ class TestCanceledException(
       None
     )
 
+  def this(messageFun: StackDepthException => Option[String],
+           cause: Option[Throwable],
+           failedCodeStackDepthFun: StackDepthException => Int,
+           payload: Option[Any]) = this(messageFun, cause, Right(failedCodeStackDepthFun), payload)
+
   /**
    * Returns an exception of class <code>TestCanceledException</code> with <code>failedExceptionStackDepth</code> set to 0 and
    * all frames above this stack depth severed off. This can be useful when working with tools (such as IDEs) that do not

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
@@ -35,7 +35,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  *
  * @param messageFun a function that return an optional detail message for this <code>TestCanceledException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestCanceledException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that return the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestCanceled</code> event
  *
  * @author Travis Stevens
@@ -48,6 +48,14 @@ class TestCanceledException(
   val payload: Option[Any]
 ) extends StackDepthException(messageFun, cause, posOrStackDepthFun/*, posOrElseStackDepthFun(pos, failedCodeStackDepthFun)*/) with ModifiableMessage[TestCanceledException] with PayloadField with ModifiablePayload[TestCanceledException] {
 
+  /**
+    * Constructs a <code>TestCanceledException</code> with the given error message function, optional cause, source position and optional payload.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestCanceledException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestCanceledException</code> to be thrown.
+    * @param pos a source position
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestCanceled</code> event
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],
@@ -55,6 +63,13 @@ class TestCanceledException(
     payload: Option[Any]
   ) = this(messageFun, cause, Left(pos), payload)
 
+  /**
+    * Constructs a <code>TestCanceledException</code> with the given error message function, optional cause and source position.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestCanceledException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestCanceledException</code> to be thrown.
+    * @param pos a source position
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],
@@ -154,6 +169,14 @@ class TestCanceledException(
       None
     )
 
+  /**
+    * Constructs a <code>TestCanceledException</code> with the given error message function, optional cause, stack depth function and optional payload.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestCanceledException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestCanceledException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of test code that failed resides.
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestCanceled</code> event
+    */
   def this(messageFun: StackDepthException => Option[String],
            cause: Option[Throwable],
            failedCodeStackDepthFun: StackDepthException => Int,

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedDueToTimeoutException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedDueToTimeoutException.scala
@@ -31,7 +31,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  *
  * @param messageFun a function that produces an optional detail message for this <code>TestFailedDueToTimeoutException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedDueToTimeoutException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun either a source position or a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param timeout the timeout that expired
  *
  * @throws NullArgumentException if either <code>messageFun</code>, <code>cause</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>, or <code>Some(null)</code>.
@@ -46,6 +46,14 @@ class TestFailedDueToTimeoutException(
   val timeout: Span
 ) extends TestFailedException(messageFun, cause, posOrStackDepthFun, payload) with TimeoutField {
 
+  /**
+    * Constructs a <code>TestFailedDueToTimeoutException</code> with the given error message function, optional cause, source position and optional payload.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestCanceledException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestCanceledException</code> to be thrown.
+    * @param pos a source position
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestCanceled</code> event
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],
@@ -54,7 +62,15 @@ class TestFailedDueToTimeoutException(
     timeout: Span
   ) = this(messageFun, cause, Left(pos), payload, timeout)
 
-  // The olde constructor
+  /**
+    * Constructs a <code>TestFailedDueToTimeoutException</code> with the given error message function, optional cause, stack depth function, optional payload and timeout.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestFailedDueToTimeoutException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedDueToTimeoutException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of test code that failed resides.
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestCanceled</code> event
+    * @param timeout the timeout that expired
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
@@ -179,6 +179,12 @@ class TestFailedException(
       None
     )
 
+  def this(
+    messageFun: StackDepthException => Option[String],
+    cause: Option[Throwable],
+    failedCodeStackDepthFun: StackDepthException => Int,
+    payload: Option[Any]) = this(messageFun, cause, Right(failedCodeStackDepthFun), payload)
+
   /**
    * Returns an exception of class <code>TestFailedException</code> with <code>failedExceptionStackDepth</code> set to 0 and 
    * all frames above this stack depth severed off. This can be useful when working with tools (such as IDEs) that do not

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
@@ -39,7 +39,7 @@ import org.scalactic.source
  *
  * @param messageFun a function that produces an optional detail message for this <code>TestFailedException</code>.
  * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedException</code> to be thrown.
- * @param failedCodeStackDepthFun a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
+ * @param posOrStackDepthFun a source position or a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
  * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailed</code> event
  *
  * @throws NullArgumentException if either <code>messageFun</code>, <code>cause</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>, or <code>Some(null)</code>.
@@ -53,6 +53,14 @@ class TestFailedException(
   val payload: Option[Any]
 ) extends StackDepthException(messageFun, cause, posOrStackDepthFun) with ModifiableMessage[TestFailedException] with PayloadField with ModifiablePayload[TestFailedException] {
 
+  /**
+    * Constructs a <code>TestFailedException</code> with the given error message function, optional cause, source position and optional payload.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestFailedException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedException</code> to be thrown.
+    * @param pos a source position
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailedException</code> event
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],
@@ -60,6 +68,13 @@ class TestFailedException(
     payload: Option[Any]
   ) = this(messageFun, cause, Left(pos), payload)
 
+  /**
+    * Constructs a <code>TestFailedException</code> with the given error message function, optional cause and source position.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestFailedException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedException</code> to be thrown.
+    * @param pos a source position
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],
@@ -179,6 +194,14 @@ class TestFailedException(
       None
     )
 
+  /**
+    * Constructs a <code>TestFailedException</code> with the given error message function, optional cause, stack depth function and optional payload.
+    *
+    * @param messageFun a function that return an optional detail message for this <code>TestFailedException</code>.
+    * @param cause an optional cause, the <code>Throwable</code> that caused this <code>TestFailedException</code> to be thrown.
+    * @param failedCodeStackDepthFun a function that produces the depth in the stack trace of this exception at which the line of test code that failed resides.
+    * @param payload an optional payload, which ScalaTest will include in a resulting <code>TestFailedException</code> event
+    */
   def this(
     messageFun: StackDepthException => Option[String],
     cause: Option[Throwable],

--- a/scalatest/src/main/scala/org/scalatest/exceptions/TestRegistrationClosedException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/TestRegistrationClosedException.scala
@@ -48,7 +48,7 @@ import StackDepthExceptionHelper.posOrElseStackDepthFun
  * </p>
  *
  * @param message the exception's detail message
- * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of code that attempted
+ * @param posOrStackDepthFun either a source position or a function that return the depth in the stack trace of this exception at which the line of code that attempted
  *   to register the test after registration had been closed.
  *
  * @throws NullArgumentException if either <code>message</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>
@@ -62,6 +62,14 @@ class TestRegistrationClosedException(
 
   requireNonNull(message, posOrStackDepthFun)
 
+  /**
+    * Constructs a <code>TestRegistrationClosedException</code> with a <code>message</code> and a source position.
+    *
+    * @param message the exception's detail message
+    * @param pos the source position.
+    *
+    * @throws NullArgumentException if <code>message</code> or <code>pos</code> is <code>null</code>
+    */
   def this(
     message: String,
     pos: source.Position
@@ -79,7 +87,15 @@ class TestRegistrationClosedException(
   def this(message: String, failedCodeStackDepth: Int) =
     this(message, Right((e: StackDepthException) => failedCodeStackDepth))
 
-  // The olde main constructor
+  /**
+    * Constructs a <code>TestRegistrationClosedException</code> with a <code>message</code> and a pre-determined
+    * and <code>failedCodeStackDepthFun</code>.
+    *
+    * @param message the exception's detail message
+    * @param failedCodeStackDepthFun a function that return the depth in the stack trace of this exception at which the line of code that attempted.
+    *
+    * @throws NullArgumentException if <code>message</code> or <code>failedCodeStackDepthFun</code> is <code>null</code>
+    */
   def this(message: String, failedCodeStackDepthFun: StackDepthException => Int) =
     this(message, Right(failedCodeStackDepthFun))
 


### PR DESCRIPTION
-Added missing old undeprecated constructors in exception classes, to avoid code breaking.
-Cleanup scaladoc in exceptions.