### PR TITLE
s/FunSpec/WordSpec/g in ScalaDoc of AsyncWordSpec (closes #900)

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
@@ -21,12 +21,12 @@ package org.scalatest
  *
  * <table><tr><td class="usage">
  * <strong>Recommended Usage</strong>:
- * <code>AsyncFunSpec</code> is intended to enable users of <a href="FunSpec.html"><code>FunSpec</code></a>
- * to write non-blocking asynchronous tests that are consistent with their traditional <code>FunSpec</code> tests. 
- * <em>Note: <code>AsyncFunSpec</code> is intended for use in special situations where non-blocking asynchronous
- * testing is needed, with class <code>FunSpec</code> used for general needs.</em>
+ * <code>AsyncWordSpec</code> is intended to enable users of <a href="WordSpec.html"><code>WordSpec</code></a>
+ * to write non-blocking asynchronous tests that are consistent with their traditional <code>WordSpec</code> tests.
+ * <em>Note: <code>AsyncWordSpec</code> is intended for use in special situations where non-blocking asynchronous
+ * testing is needed, with class <code>WordSpec</code> used for general needs.</em>
  * </td></tr></table>
- * 
+ *
  * <p>
  * Given a <code>Future</code> returned by the code you are testing,
  * you need not block until the <code>Future</code> completes before
@@ -84,12 +84,12 @@ package org.scalatest
  * <p>
  * In an <code>AsyncWordSpec</code> you write a one (or more) sentence specification for each bit of behavior you wish to
  * specify and test. Each specification sentence has a
- * "subject," which is sometimes called the <em>system under test</em> (or SUT). The 
+ * "subject," which is sometimes called the <em>system under test</em> (or SUT). The
  * subject is entity being specified and tested and also serves as the subject of the sentences you write for each test. A subject
  * can be followed by one of three verbs, <code>should</code>, <code>must</code>, or <code>can</code>, and a block. Here are some
  * examples:
  * </p>
- * 
+ *
  * <pre class="stHighlight">
  * "A Stack" should {
  *   // ...
@@ -101,7 +101,7 @@ package org.scalatest
  *   // ...
  * }
  * </pre>
- * 
+ *
  * <p>
  * You can describe a subject in varying situations by using a <code>when</code> clause. A <code>when</code> clause
  * follows the subject and precedes a block. In the block after the <code>when</code>, you place strings that describe a situation or a state
@@ -121,7 +121,7 @@ package org.scalatest
  *   }
  * }
  * </pre>
- * 
+ *
  * <p>
  * When you are ready to finish a sentence, you write a string followed by <code>in</code> and a block that
  * contains the code of the test.
@@ -226,22 +226,22 @@ package org.scalatest
  * <code>AsyncWordSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
- * execution context is used by <code>AsyncWordSpec</code> to 
+ * execution context is used by <code>AsyncWordSpec</code> to
  * transform the <code>Future[Assertion]</code>s returned by each test
  * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
  * </p>
- * 
+ *
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
  * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
  * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
+ * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM,
  * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
  * </p>
- * 
+ *
  * <p>
  * When ScalaTest's serial execution context is called upon to execute a task, that task is recorded
  * in a queue for later execution. For example, one task that will be placed in this queue is the
@@ -280,7 +280,7 @@ package org.scalatest
  * concurrently execute tests you have competing for threads from the same limited thread pool, the more likely it
  * will be that tests will intermitently fail due to timeouts.
  * </p>
- * 
+ *
  * <p>
  * Using ScalaTest's serial execution context on the JVM will ensure the same thread that produced the <code>Future[Assertion]</code>
  * returned from a test body is also used to execute any tasks given to the execution context while executing the test
@@ -296,8 +296,8 @@ package org.scalatest
  * This thread confinement strategy does mean, however, that when you are using the default execution context on the JVM, you
  * must be sure to <em>never block</em> in the test body waiting for a task to be completed by the
  * execution context. If you block, your test will never complete. This kind of problem will be obvious, because the test will
- * consistently hang every time you run it. (If a test is hanging, and you're not sure which one it is, 
- * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
+ * consistently hang every time you run it. (If a test is hanging, and you're not sure which one it is,
+ * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do
  * want to block in your tests, you may wish to just use a
  * traditional <a href="WordSpec.html"><code>WordSpec</code></a> with
  * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
@@ -343,15 +343,15 @@ package org.scalatest
  * <p>
  * If you want the tests of an <code>AsyncWordSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
- * 
+ *
  * <pre>
  * parallelExecution in Test := true // the default in sbt
  * </pre>
- * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ *
+ * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
  * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
@@ -363,7 +363,7 @@ package org.scalatest
  * you need not worry about synchronizing access to shared mutable state accessed by transformations and callbacks of <code>Future</code>s
  * inside the test.
  * </p>
- * 
+ *
  * <p>
  * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
@@ -375,11 +375,11 @@ package org.scalatest
  * however, even though tests will be started sequentially by one thread, they will be allowed to run concurrently using threads from the
  * execution context's thread pool.
  * </p>
- * 
+ *
  * <p>
  * The latter behavior is essentially what you'll see on Scala.js when you execute a suite that mixes in <code>ParallelTestExecution</code>.
  * Because only one thread exists when running under JavaScript, you can't "enable parallel execution of suites." However, it may
- * still be useful to run tests in parallel on Scala.js, because tests can invoke API calls that are truly asynchronous by calling into 
+ * still be useful to run tests in parallel on Scala.js, because tests can invoke API calls that are truly asynchronous by calling into
  * external APIs that take advantage of non-JavaScript threads. Thus on Scala.js, <code>ParallelTestExecution</code> allows asynchronous
  * tests to run in parallel, even though they must be started sequentially. This may give you better performance when you are using API
  * calls in your Scala.js tests that are truly asynchronous.
@@ -635,7 +635,7 @@ package org.scalatest
  * <p>
  * One of the parameters to <code>AsyncWordSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
- * Information about suites and tests that were run, whether tests succeeded or failed, 
+ * Information about suites and tests that were run, whether tests succeeded or failed,
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AsyncWordSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
@@ -644,7 +644,7 @@ package org.scalatest
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
- * 
+ *
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
  * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncWordSpec</code>
@@ -653,26 +653,26 @@ package org.scalatest
  *
  * <pre class="stHighlight">
  * package org.scalatest.examples.asyncwordspec.info
- * 
+ *
  * import collection.mutable
  * import org.scalatest._
- * 
+ *
  * class SetSpec extends AsyncWordSpec with GivenWhenThen {
- *   
+ *
  *   "A mutable Set" should {
  *     "allow an element to be added" in {
  *       Given("an empty mutable Set")
  *       val set = mutable.Set.empty[String]
- * 
+ *
  *       When("an element is added")
  *       set += "clarity"
- * 
+ *
  *       Then("the Set should have size 1")
  *       assert(set.size === 1)
- * 
+ *
  *       And("the Set should contain the added element")
  *       assert(set.contains("clarity"))
- * 
+ *
  *       info("That's all folks!")
  *       succeed
  *     }
@@ -688,10 +688,10 @@ package org.scalatest
  * scala&gt; org.scalatest.run(new SetSpec)
  * <span class="stGreen">A mutable Set
  * - should allow an element to be added
- *   + Given an empty mutable Set 
- *   + When an element is added 
- *   + Then the Set should have size 1 
- *   + And the Set should contain the added element 
+ *   + Given an empty mutable Set
+ *   + When an element is added
+ *   + Then the Set should have size 1
+ *   + And the Set should contain the added element
  *   + That's all folks!</span>
  * </pre>
  *
@@ -831,7 +831,7 @@ package org.scalatest
  *
  * <p>
  * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
- * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
+ * If you find a test is taking a long time to complete, but you're not sure which test, you can enable
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
  * </p>
@@ -938,9 +938,9 @@ package org.scalatest
  * <a name="taggingTests"></a><h2>Tagging tests</h2>
  *
  * <p>
- * An <code>AsyncFunSpec</code>'s tests may be classified into groups by <em>tagging</em> them with string names.
- * As with any suite, when executing an <code>AsyncFunSpec</code>, groups of tests can
- * optionally be included and/or excluded. To tag an <code>AsyncFunSpec</code>'s tests,
+ * An <code>AsyncWordSpec</code>'s tests may be classified into groups by <em>tagging</em> them with string names.
+ * As with any suite, when executing an <code>AsyncWordSpec</code>, groups of tests can
+ * optionally be included and/or excluded. To tag an <code>AsyncWordSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
  * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
@@ -948,7 +948,7 @@ package org.scalatest
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
  * <code>com.mycompany.tags.DbTest</code>, then you could
- * create a matching tag for <code>AsyncFunSpec</code>s like this:
+ * create a matching tag for <code>AsyncWordSpec</code>s like this:
  * </p>
  *
  * <pre class="stHighlight">
@@ -960,7 +960,7 @@ package org.scalatest
  * </pre>
  *
  * <p>
- * Given these definitions, you could place <code>AsyncFunSpec</code> tests into groups with tags like this:
+ * Given these definitions, you could place <code>AsyncWordSpec</code> tests into groups with tags like this:
  * </p>
  *
  * <pre class="stHighlight">
@@ -1012,7 +1012,7 @@ package org.scalatest
  *
  * <p>
  * It is recommended, though not required, that you create a corresponding tag annotation when you
- * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFunSpec</code> in
+ * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncWordSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
  * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
@@ -1191,11 +1191,11 @@ package org.scalatest
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSpec</code>.
+ * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncWordSpec</code>.
  * </p>
  *
  * <p>
- * Trait <code>AsyncFunSpec</code>'s <code>runTest</code> method passes a no-arg async test function to
+ * Trait <code>AsyncWordSpec</code>'s <code>runTest</code> method passes a no-arg async test function to
  * <code>withFixture(NoArgAsyncTest)</code>. It is <code>withFixture</code>'s
  * responsibility to invoke that test function. The default implementation of <code>withFixture</code> simply
  * invokes the function and returns the result, like this:
@@ -1587,7 +1587,7 @@ package org.scalatest
  * In this example, the tests required one fixture object, a <code>StringActor</code>. If your tests need multiple fixture objects, you can
  * simply define the <code>FixtureParam</code> type to be a tuple containing the objects or, alternatively, a case class containing
  * the objects.  For more information on the <code>withFixture(OneArgAsyncTest)</code> technique, see
- * the <a href="fixture/AsyncFunSpec.html">documentation for <code>fixture.AsyncFunSpec</code></a>.
+ * the <a href="fixture/AsyncWordSpec.html">documentation for <code>fixture.AsyncWordSpec</code></a>.
  * </p>
  *
  * <a name="beforeAndAfter"></a>
@@ -1838,19 +1838,19 @@ package org.scalatest
  *
  * <pre class="stHighlight">
  * package org.scalatest.examples.asyncwordspec.composingbeforeandaftereach
- * 
+ *
  * import org.scalatest._
  * import org.scalatest.BeforeAndAfterEach
  * import collection.mutable.ListBuffer
  * import scala.concurrent.Future
  * import scala.concurrent.ExecutionContext
- * 
+ *
  * // Defining actor messages
  * sealed abstract class StringOp
  * case object Clear extends StringOp
  * case class Append(value: String) extends StringOp
  * case object GetValue
- * 
+ *
  * class StringBuilderActor { // Simulating an actor
  *   private final val sb = new StringBuilder
  *   def !(op: StringOp): Unit =
@@ -1865,7 +1865,7 @@ package org.scalatest
  *       synchronized { sb.toString }
  *     }
  * }
- * 
+ *
  * class StringBufferActor {
  *   private final val buf = ListBuffer.empty[String]
  *   def !(op: StringOp): Unit =
@@ -1880,36 +1880,36 @@ package org.scalatest
  *       synchronized { buf.toList }
  *     }
  * }
- * 
+ *
  * trait Builder extends BeforeAndAfterEach { this: Suite =&gt;
- * 
+ *
  *   final val builderActor = new StringBuilderActor
- * 
+ *
  *   override def beforeEach() {
  *     builderActor ! Append("ScalaTest is ")
  *     super.beforeEach() // To be stackable, must call super.beforeEach
  *   }
- * 
+ *
  *   override def afterEach() {
  *     try super.afterEach() // To be stackable, must call super.afterEach
  *     finally builderActor ! Clear
  *   }
  * }
- * 
+ *
  * trait Buffer extends BeforeAndAfterEach { this: Suite =&gt;
- * 
+ *
  *   final val bufferActor = new StringBufferActor
- * 
+ *
  *   override def afterEach() {
  *     try super.afterEach() // To be stackable, must call super.afterEach
  *     finally bufferActor ! Clear
  *   }
  * }
- * 
+ *
  * class ExampleSpec extends AsyncWordSpec with Builder with Buffer {
- * 
+ *
  *   "Testing" should {
- * 
+ *
  *     "be easy" in {
  *       builderActor ! Append("easy!")
  *       val futureString = builderActor ? GetValue
@@ -1922,7 +1922,7 @@ package org.scalatest
  *         succeed
  *       }
  *     }
- * 
+ *
  *     "be fun" in {
  *       builderActor ! Append("fun!")
  *       val futureString = builderActor ? GetValue
@@ -1960,10 +1960,10 @@ package org.scalatest
  * <p>
  * Sometimes you may want to run the same test code on different fixture objects. In other words, you may want to write tests that are "shared"
  * by different fixture objects.
- * To accomplish this in an <code>AsyncFunSpec</code>, you first place shared tests in
+ * To accomplish this in an <code>AsyncWordSpec</code>, you first place shared tests in
  * <em>behavior functions</em>. These behavior functions will be
- * invoked during the construction phase of any <code>AsyncFunSpec</code> that uses them, so that the tests they contain will
- * be registered as tests in that <code>AsyncFunSpec</code>.
+ * invoked during the construction phase of any <code>AsyncWordSpec</code> that uses them, so that the tests they contain will
+ * be registered as tests in that <code>AsyncWordSpec</code>.
  * For example, given this <code>StackActor</code> class:
  * </p>
  *
@@ -2032,14 +2032,14 @@ package org.scalatest
  * <em>etc</em>. You may find you have several tests that make sense any time the stack is non-empty. Thus you'd ideally want to run
  * those same tests for three stack fixture objects: a full stack, a stack with a one item, and a stack with one item less than
  * capacity. With shared tests, you can factor these tests out into a behavior function, into which you pass the
- * stack fixture to use when running the tests. So in your <code>AsyncFunSpec</code> for <code>StackActor</code>, you'd invoke the
+ * stack fixture to use when running the tests. So in your <code>AsyncWordSpec</code> for <code>StackActor</code>, you'd invoke the
  * behavior function three times, passing in each of the three stack fixtures so that the shared tests are run for all three fixtures.
  * </p>
  *
  * <p>
  * You can define a behavior function that encapsulates these shared tests inside the <code>AsyncWordSpec</code> that uses them. If they are shared
- * between different <code>AsyncFunSpec</code>s, however, you could also define them in a separate trait that is mixed into
- * each <code>AsyncFunSpec</code> that uses them.
+ * between different <code>AsyncWordSpec</code>s, however, you could also define them in a separate trait that is mixed into
+ * each <code>AsyncWordSpec</code> that uses them.
  * <a name="StackBehaviors">For</a> example, here the <code>nonEmptyStackActor</code> behavior function (in this case, a
  * behavior <em>method</em>) is defined in a trait along with another
  * method containing shared tests for non-full stacks:
@@ -2247,16 +2247,16 @@ package org.scalatest
  * If you register the same tests repeatedly in the same suite, one problem you may encounter is an exception at runtime
  * complaining that multiple tests are being registered with the same test name.
  * Although in an <code>AsyncWordSpec</code>, the <code>when</code>, <code>should</code>, <code>can</code> and <code>must</code> clause is a nesting construct analogous to
- * <code>AsyncFunSpec</code>'s <code>describe</code> clause, you many sometimes need to do a bit of
+ * <code>AsyncWordSpec</code>'s <code>describe</code> clause, you many sometimes need to do a bit of
  * extra work to ensure that the test names are unique.  If a duplicate test name problem shows up in an
- * <code>AsyncFunSpec</code>, you'll need to pass in a prefix or suffix string to add to each test name. You can call
+ * <code>AsyncWordSpec</code>, you'll need to pass in a prefix or suffix string to add to each test name. You can call
  * <code>toString</code> on the shared fixture object, or pass this string
  * the same way you pass any other data needed by the shared tests.
- * This is the approach taken by the previous <code>AsyncFunSpecStackBehaviors</code> example.
+ * This is the approach taken by the previous <code>AsyncWordSpecStackBehaviors</code> example.
  * </p>
  *
  * <p>
- * Given this <code>AsyncFunSpecStackBehaviors</code> trait, calling it with the <code>almostEmptyStackActor</code> fixture, like this:
+ * Given this <code>AsyncWordSpecStackBehaviors</code> trait, calling it with the <code>almostEmptyStackActor</code> fixture, like this:
  * </p>
  *
  * <pre class="stHighlight">


### PR DESCRIPTION
Looks like my Atom editor settings have removed some trailing whitespace, hoping that's OK ...