### PR TITLE
StatefulStatus Enhancement

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/StatefulStatusSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StatefulStatusSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest
 
 import scala.util.{Try, Success}
+import OptionValues._
 
 class StatefulStatusSpec extends fixture.FunSpec {
 
@@ -30,6 +31,8 @@ class StatefulStatusSpec extends fixture.FunSpec {
     def waitUntilCompleted()
     // SKIP-SCALATESTJS-END
     def whenCompleted(f: Try[Boolean] => Unit)
+    def setFailedWith(ex: Throwable): Unit
+    def unreportedException: Option[Throwable]
   }
 
    override protected def withFixture(test: OneArgTest): Outcome = {
@@ -237,6 +240,17 @@ class StatefulStatusSpec extends fixture.FunSpec {
       SharedHelpers.serializeRoundtrip(status)
     }
     // SKIP-SCALATESTJS-END
+
+    it("should not replace previous failed exception if it is already set") { status =>
+      val e1 = new RuntimeException("exception 1")
+      val e2 = new RuntimeException("exception 2")
+
+      status.setFailedWith(e1)
+      assert(status.unreportedException.value.getMessage == "exception 1")
+
+      status.setFailedWith(e2)
+      assert(status.unreportedException.value.getMessage == "exception 1")
+    }
 
   }
 }

--- a/scalatest/src/main/scala/org/scalatest/Status.scala
+++ b/scalatest/src/main/scala/org/scalatest/Status.scala
@@ -544,13 +544,14 @@ private[scalatest] final class ScalaTestStatefulStatus extends Status with Seria
   }
 
   def setFailedWith(ex: Throwable): Unit = {
-    // TODO: Throw an exception if it is a fatal one?
-    // TODO: Throw an exception if already have an exception in here.
     synchronized {
       if (isCompleted)
         throw new IllegalStateException("status is already completed")
       succeeded = false
-      asyncException = Some(ex)
+      if (asyncException.isEmpty)
+        asyncException = Some(ex)
+      else
+        ex.printStackTrace()
     }
   }
 
@@ -673,13 +674,14 @@ final class StatefulStatus extends Status with Serializable {
   }
 
   def setFailedWith(ex: Throwable): Unit = {
-    // TODO: Throw an exception if it is a fatal one?
-    // TODO: Throw an exception if already have an exception in here.
     synchronized {
       if (isCompleted)
         throw new IllegalStateException("status is already completed")
       succeeded = false
-      asyncException = Some(ex)
+      if (asyncException.isEmpty)
+        asyncException = Some(ex)
+      else
+        ex.printStackTrace()
     }
   }
 


### PR DESCRIPTION
Enhanced setFailedWith in StatefulStatus and ScalaTestStateful status to not set the second exception if unreported exception is already set, we'll just print it out to the stack trace in that case.