### PR TITLE
[DO NOT MERGE] Troubleshoot 2.12 Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: scala
 scala:
-  - 2.11.8
-  - 2.10.6
   - 2.12.0-M4
 jdk:
-  - oraclejdk7
-  - openjdk6
   - oraclejdk8
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 jdk:
   - oraclejdk8
 
-sudo: false
+#sudo: false
 
 env:
   #see https://github.com/scalatest/scalatest/pull/245

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -125,6 +125,7 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
                 case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
+                  println("###ScalaTestVersions.BuiltForScalaVersion: " + ScalaTestVersions.BuiltForScalaVersion)
                   if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
                   else


### PR DESCRIPTION
Added a println to troubleshoot test failure in travis, make travis to build only with Scala 2.12.0-M4 and oraclejdk8 only.