### PR TITLE
Travis Scala 2.12 Build Fix [PLEASE DO NOT MERGE YET]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jdk:
 # Current 8u31 is having problem and cause a test failure under Scala 2.12 builds.
 # We should enable this back after https://github.com/travis-ci/travis-ci/issues/3259 is closed.
 #sudo: false
+sudo: required
+dist: trusty
 
 env:
   #see https://github.com/scalatest/scalatest/pull/245

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ jdk:
   - openjdk6
   - oraclejdk8
 
-sudo: false
+# Disable new container infra temporary, until oraclejdk8 version is updated to latest version of jdk8
+# Current 8u31 is having problem and cause a test failure under Scala 2.12 builds.
+# We should enable this back after https://github.com/travis-ci/travis-ci/issues/3259 is closed.
+#sudo: false
 
 env:
   #see https://github.com/scalatest/scalatest/pull/245

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ jdk:
 sudo: required
 dist: trusty
 
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
+
 env:
   #see https://github.com/scalatest/scalatest/pull/245
   #global values should be replaced using http://docs.travis-ci.com/user/encryption-keys/ with valid values


### PR DESCRIPTION
Temporary disable the use of new container infra in travis, because it is currently using outdated 8u31 version that has problem causing a test to fail in Scala 2.12 build.
