### PR TITLE
AsyncEngine Fix

### DIFF
--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -65,6 +65,16 @@ object GenScalaTestJS {
     }
   }
 
+  def copyStartsWithFiles(sourceDirName: String, packageDirName: String, startsWith: String, targetDir: File): Seq[File] = {
+    val packageDir = new File(targetDir, packageDirName)
+    packageDir.mkdirs()
+    val sourceDir = new File(sourceDirName)
+    sourceDir.listFiles.toList.filter(f => f.isFile && f.getName.startsWith(startsWith) && f.getName.endsWith(".scala")).map { sourceFile =>
+      val destFile = new File(packageDir, sourceFile.getName)
+      copyFile(sourceFile, destFile)
+    }
+  }
+
   def copyDir(sourceDirName: String, packageDirName: String, targetDir: File, skipList: List[String]): Seq[File] = {
     val packageDir = new File(targetDir, packageDirName)
     packageDir.mkdirs()
@@ -222,7 +232,8 @@ object GenScalaTestJS {
   }
 
   def genTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
-    //copyFiles("scalatest-test/src/test/scala/org/scalatest", "org/scalatest", List("MatcherStackDepthSpec.scala"), targetDir)
+    //copyStartsWithFiles("scalatest-test/src/test/scala/org/scalatest", "org/scalatest", "Async", targetDir) ++ 
+    //copyFiles("scalatest-test/src/test/scala/org/scalatest", "org/scalatest", List("FutureOutcomeSpec.scala"), targetDir)
     copyDir("scalatest-test/src/test/scala/org/scalatest", "org/scalatest", targetDir,
       List(
         "BigSuiteSuite.scala",

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
@@ -1038,6 +1038,42 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("Feature: a feature Scenario: test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
@@ -847,6 +847,42 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
@@ -866,5 +866,41 @@ class AsyncFeatureSpecSpec extends FunSpec {
       val cause = causeThrowable.asInstanceOf[DuplicateTestNameException]
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("Feature: a feature Scenario: test 1")))
     }
+
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") {
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
@@ -726,6 +726,36 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
       assert(markupProvided.text == "hi there")
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should "test A" in {
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in {
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
@@ -727,6 +727,36 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should "test A" in {
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in {
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
@@ -739,6 +739,36 @@ class AsyncFlatSpecSpec extends FunSpec {
       assert(!e.cause.isDefined)
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should "test A" in {
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in {
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
@@ -726,6 +726,36 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should "test A" in {
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in {
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
@@ -869,6 +869,42 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" - {
+          "scenario A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
@@ -843,6 +843,42 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" - {
+          "scenario A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
@@ -869,6 +869,42 @@ class AsyncFreeSpecSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" - {
+          "scenario A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
@@ -841,5 +841,41 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" - {
+          "scenario A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
@@ -842,6 +842,42 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        describe("feature 1") {
+          it("test A") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
@@ -904,5 +904,41 @@ class AsyncFunSpecSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        describe("feature 1") {
+          it("test A") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
@@ -875,5 +875,41 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        describe("feature 1") {
+          it("test A") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") {
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
@@ -724,6 +724,34 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
       assert(markupProvided.text == "hi there")
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuiteLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        test("test A") {
+          Future { assert(a == 1) }
+        }
+        test("test B") {
+          Future { assert(a == 1) }
+        }
+        test("test C") {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
@@ -752,6 +752,34 @@ class AsyncFunSuiteSpec extends FunSpec {
       assert(!e.cause.isDefined)
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuite {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        test("test A") {
+          Future { assert(a == 1) }
+        }
+        test("test B") {
+          Future { assert(a == 1) }
+        }
+        test("test C") {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
@@ -727,5 +727,33 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuite {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        test("test A") {
+          Future { assert(a == 1) }
+        }
+        test("test B") {
+          Future { assert(a == 1) }
+        }
+        test("test C") {
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
@@ -1062,6 +1062,42 @@ class AsyncWordSpecLikeSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should {
+          "test A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
@@ -842,6 +842,42 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should {
+          "test A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
@@ -1061,6 +1061,42 @@ class AsyncWordSpecSpec extends FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should {
+          "test A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
@@ -842,6 +842,42 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        val a = 1
+        "feature 1" should {
+          "test A" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in {
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in {
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
@@ -939,6 +939,47 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
@@ -955,6 +955,47 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
       assert(markupProvided.text == "hi there")
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") { fixture  =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") { fixture  =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") { fixture  =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
@@ -945,6 +945,47 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFeatureSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        feature("feature 1") {
+          scenario("scenario A") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("feature 2")  {
+          scenario("scenario B") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        feature("group3") {
+          scenario("test C") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
@@ -797,6 +797,41 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        "feature 1" should "test A" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
@@ -829,6 +829,41 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
       assert(!e.cause.isDefined)
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        "feature 1" should "test A" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
@@ -797,6 +797,41 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFlatSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        "feature 1" should "test A" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 2" should "test B" in { fixture =>
+          Future { assert(a == 1) }
+        }
+        "feature 3" should "test C" in { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
@@ -965,6 +965,46 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
+
+        val a = 1
+        "feature 1" - {
+          "scenario A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
@@ -909,6 +909,46 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
+
+        val a = 1
+        "feature 1" - {
+          "scenario A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
@@ -968,6 +968,46 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
+
+        val a = 1
+        "feature 1" - {
+          "scenario A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
@@ -909,6 +909,46 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFreeSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
+
+        val a = 1
+        "feature 1" - {
+          "scenario A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" - {
+          "scenario B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "group3" - {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
@@ -941,6 +941,47 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
       assert(markupProvided.text == "hi there")
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        describe("feature 1") {
+          it("test A") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
@@ -968,6 +968,47 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        describe("feature 1") {
+          it("test A") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
@@ -909,6 +909,47 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        describe("feature 1") {
+          it("test A") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("feature 2") {
+          it("test B") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        describe("group3") {
+          it("test C") { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
@@ -809,6 +809,39 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
       assert(markupProvided.text == "hi there")
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuiteLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        test("test A") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test B") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test C") { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
@@ -785,6 +785,39 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuiteLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        test("test A") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test B") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test C") { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
@@ -791,6 +791,39 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncFunSuite {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        val a = 1
+        test("test A") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test B") { fixture =>
+          Future { assert(a == 1) }
+        }
+        test("test C") { fixture =>
+          Future { assert(a == 1) }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
@@ -1179,6 +1179,46 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
+        val a = 1
+        "feature 1" should {
+          "test A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
@@ -909,6 +909,46 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpecLike {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
+        val a = 1
+        "feature 1" should {
+          "test A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
@@ -1179,6 +1179,46 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
+        val a = 1
+        "feature 1" should {
+          "test A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+
+      // SKIP-SCALATESTJS-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS-END
+      assert(reporter.scopeOpenedEventsReceived.length == 3)
+      assert(reporter.scopeClosedEventsReceived.length == 3)
+      assert(reporter.testStartingEventsReceived.length == 3)
+      assert(reporter.testSucceededEventsReceived.length == 3)
+    }
+
   }
 
 }

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
@@ -909,6 +909,46 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
       }
     }
 
+    it("should allow other execution context to be used") {
+      class TestSpec extends AsyncWordSpec {
+        // SKIP-SCALATESTJS-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
+        val a = 1
+        "feature 1" should {
+          "test A" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 2" should {
+          "test B" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+        "feature 3" should {
+          "test C" in { fixture =>
+            Future { assert(a == 1) }
+          }
+        }
+      }
+      val suite = new TestSpec
+      val reporter = new EventRecordingReporter
+      val status = suite.run(None, Args(reporter))
+      val promise = Promise[EventRecordingReporter]
+      status whenCompleted { _ => promise.success(reporter) }
+      promise.future.map { r =>
+        assert(reporter.scopeOpenedEventsReceived.length == 3)
+        assert(reporter.scopeClosedEventsReceived.length == 3)
+        assert(reporter.testStartingEventsReceived.length == 3)
+        assert(reporter.testSucceededEventsReceived.length == 3)
+      }
+    }
+
   }
 
 }

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -413,6 +413,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
     args: Args,
     includeIcon: Boolean,
     parallelAsyncTestExecution: Boolean,
+    initStatusList: List[Status],
     runTest: (String, Args) => Status
   ): List[Status] = {
 
@@ -420,7 +421,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
 
     def traverseSubNodes(): List[Status] = {
       //branch.subNodes.reverse.flatMap { node =>
-      branch.subNodes.reverse.foldLeft(List.empty[Status]) { case (statusList, node) =>
+      branch.subNodes.reverse.foldLeft(initStatusList) { case (statusList, node) =>
         if (!stopper.stopRequested) {
           node match {
             case testLeaf @ TestLeaf(_, testName, testText, _, _, _, _) =>
@@ -461,7 +462,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
               reportMarkupProvided(theSuite, args.reporter, args.tracker, None, message, markupLeaf.indentationLevel, location, true, includeIcon)
               statusList
 
-            case branch: Branch => statusList ::: runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, runTest)
+            case branch: Branch => runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, statusList, runTest)
           }
         }
         else
@@ -551,7 +552,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
           else
             List.empty
 
-        case None => runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, runTest)
+        case None => runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, List.empty, runTest)
       }
     new CompositeStatus(Set.empty ++ statusList)
   }

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -413,13 +413,14 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
     args: Args,
     includeIcon: Boolean,
     parallelAsyncTestExecution: Boolean,
+    statusList: ListBuffer[Status],
     runTest: (String, Args) => Status
   ): Status = {
 
     import args.stopper
     
     // TODO: Inspect this and make sure it does not need synchronization, and either way, document why.
-    val statusList = new ListBuffer[Status]()
+    //val statusList = new ListBuffer[Status]()
 
     branch match {
 
@@ -472,7 +473,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
             case markupLeaf @ MarkupLeaf(_, message, location) =>
               reportMarkupProvided(theSuite, args.reporter, args.tracker, None, message, markupLeaf.indentationLevel, location, true, includeIcon)
 
-            case branch: Branch => statusList += runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, runTest)
+            case branch: Branch => /*statusList += */runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, statusList, runTest)
           }
         }
       }
@@ -540,7 +541,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
             statusBuffer += runTest(tn, newArgs)
           }
         }
-      case None => statusBuffer += runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, runTest)
+      case None => /*statusBuffer += */runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, statusBuffer, runTest)
     }
     new CompositeStatus(Set.empty ++ statusBuffer)
   }

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -413,33 +413,14 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
     args: Args,
     includeIcon: Boolean,
     parallelAsyncTestExecution: Boolean,
-    statusList: ListBuffer[Status],
     runTest: (String, Args) => Status
-  ): Status = {
+  ): List[Status] = {
 
     import args.stopper
-    
-    // TODO: Inspect this and make sure it does not need synchronization, and either way, document why.
-    //val statusList = new ListBuffer[Status]()
 
-    branch match {
-
-      case desc @ DescriptionBranch(parent, descriptionText, _, lineInFile) =>
-
-        val descriptionTextWithOptionalPrefix = prependChildPrefix(parent, descriptionText)
-        val indentationLevel = desc.indentationLevel
-        reportScopeOpened(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
-        traverseSubNodes()
-        if (desc.pending) 
-          reportScopePending(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
-        else 
-          reportScopeClosed(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
-      case Trunk =>
-        traverseSubNodes()
-    }
-
-    def traverseSubNodes(): Unit = {
-      branch.subNodes.reverse.foreach { node =>
+    def traverseSubNodes(): List[Status] = {
+      //branch.subNodes.reverse.flatMap { node =>
+      branch.subNodes.reverse.foldLeft(List.empty[Status]) { case (statusList, node) =>
         if (!stopper.stopRequested) {
           node match {
             case testLeaf @ TestLeaf(_, testName, testText, _, _, _, _) =>
@@ -449,36 +430,62 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
                   val testTextWithOptionalPrefix = prependChildPrefix(branch, testText)
                   val theTest = atomic.get.testsMap(testName)
                   reportTestIgnored(theSuite, args.reporter, args.tracker, testName, testTextWithOptionalPrefix, getIndentedTextForTest(testTextWithOptionalPrefix, testLeaf.indentationLevel, true), theTest.location)
+                  statusList
                 }
                 else {
-                  statusList += {
+                  statusList ::: List(
                     if (parallelAsyncTestExecution || statusList.isEmpty) {
                       runTest(testName, args) // Even if serial async test execution (i.e., not parallelAsyncTestExection), first time still just go for it
                     }
                     else {
                       statusList.last thenRun runTest(testName, args)  // Only if serial async test execution (i.e., not parallelAsyncTestExecution), after first Status
                     }
-                  }
+                  )
                 }
+              else
+                statusList
 
             case infoLeaf @ InfoLeaf(_, message, payload, location) =>
               reportInfoProvided(theSuite, args.reporter, args.tracker, None, message, payload, infoLeaf.indentationLevel, location, true, includeIcon)
+              statusList
 
             case noteLeaf @ NoteLeaf(_, message, payload, location) =>
               reportNoteProvided(theSuite, args.reporter, args.tracker, None, message, payload, noteLeaf.indentationLevel, location, true, includeIcon)
+              statusList
 
             case alertLeaf @ AlertLeaf(_, message, payload, location) =>
               reportAlertProvided(theSuite, args.reporter, args.tracker, None, message, payload, alertLeaf.indentationLevel, location, true, includeIcon)
+              statusList
 
             case markupLeaf @ MarkupLeaf(_, message, location) =>
               reportMarkupProvided(theSuite, args.reporter, args.tracker, None, message, markupLeaf.indentationLevel, location, true, includeIcon)
+              statusList
 
-            case branch: Branch => /*statusList += */runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, statusList, runTest)
+            case branch: Branch => statusList ::: runTestsInBranch(theSuite, branch, args, includeIcon, parallelAsyncTestExecution, runTest)
           }
         }
+        else
+          statusList
       }
     }
-    new CompositeStatus(Set.empty ++ statusList)
+
+    branch match {
+
+      case desc @ DescriptionBranch(parent, descriptionText, _, lineInFile) =>
+
+        val descriptionTextWithOptionalPrefix = prependChildPrefix(parent, descriptionText)
+        val indentationLevel = desc.indentationLevel
+        reportScopeOpened(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
+        val statusList = traverseSubNodes()
+        if (desc.pending)
+          reportScopePending(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
+        else
+          reportScopeClosed(theSuite, args.reporter, args.tracker, descriptionTextWithOptionalPrefix, indentationLevel, false, lineInFile)
+        statusList
+
+      case Trunk =>
+        traverseSubNodes()
+    }
   }
 
   def prependChildPrefix(branch: Branch, testText: String): String =
@@ -525,25 +532,28 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
     val report = Suite.wrapReporterIfNecessary(theSuite, reporter)
     val newArgs = if (report eq reporter) args else args.copy(reporter = report)
     
-    val statusBuffer = new ListBuffer[Status]()
+    val statusList: List[Status] =
+      // If a testName is passed to run, just run that, else run the tests returned
+      // by testNames.
+      testName match {
+        case Some(tn) =>
+          val (filterTest, ignoreTest) = filter(tn, theSuite.tags, theSuite.suiteId)
+          if (!filterTest) {
+            if (ignoreTest) {
+              val theTest = atomic.get.testsMap(tn)
+              reportTestIgnored(theSuite, report, tracker, tn, tn, getIndentedTextForTest(tn, 1, true), theTest.location)
+              List.empty
+            }
+            else {
+              List(runTest(tn, newArgs))
+            }
+          }
+          else
+            List.empty
 
-    // If a testName is passed to run, just run that, else run the tests returned
-    // by testNames.
-    testName match {
-      case Some(tn) =>
-        val (filterTest, ignoreTest) = filter(tn, theSuite.tags, theSuite.suiteId)
-        if (!filterTest) {
-          if (ignoreTest) {
-            val theTest = atomic.get.testsMap(tn)
-            reportTestIgnored(theSuite, report, tracker, tn, tn, getIndentedTextForTest(tn, 1, true), theTest.location)
-          }
-          else {
-            statusBuffer += runTest(tn, newArgs)
-          }
-        }
-      case None => /*statusBuffer += */runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, statusBuffer, runTest)
-    }
-    new CompositeStatus(Set.empty ++ statusBuffer)
+        case None => runTestsInBranch(theSuite, Trunk, newArgs, includeIcon, parallelAsyncTestExecution, runTest)
+      }
+    new CompositeStatus(Set.empty ++ statusList)
   }
 
   def runImpl(


### PR DESCRIPTION
-Fixed concurrent modification problem when async style traits are used with multiple scopes.
-Get rid of imperative code in AsyncEngine's runTestsInBranch method.