### PR TITLE
Gearing up to 3.0.0-RC4

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, versi
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.0-M4 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.0-M5 clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -21,7 +21,7 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.5
   val buildScalaVersion = "2.11.8"
 
-  val releaseVersion = "3.0.0-RC3"
+  val releaseVersion = "3.0.0-RC4"
 
   val scalacheckVersion = "1.13.1"
 
@@ -611,7 +611,7 @@ object ScalatestBuild extends Build {
       libraryDependencies ++= crossBuildLibraryDependencies(scalaVersion.value),
       libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
       //jsDependencies += RuntimeDOM % "test",
-      //scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
+      scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
       //jsEnv := NodeJSEnv(executable = "node").value,
       //jsEnv := PhantomJSEnv().value,
       scalaJSStage in Global := FastOptStage,
@@ -624,9 +624,9 @@ object ScalatestBuild extends Build {
         Def.task {
           GenScalaTestJS.genTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
         }.taskValue
-      },
+      }/*,
       sourceGenerators in Test <+=
-        (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gengen", "GenGen.scala")(GenGen.genTest)/*,
+        (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("gengen", "GenGen.scala")(GenGen.genTest),
       sourceGenerators in Test <+=
         (baseDirectory, sourceManaged in Test, version, scalaVersion) map genFiles("genmatchers", "GenMustMatchersTests.scala")(GenMustMatchersTests.genTestForScalaJS)*/
     ).dependsOn(scalatestJS % "test", commonTestJS % "test").enablePlugins(ScalaJSPlugin)


### PR DESCRIPTION
Make scala-js tests to run, and bump up to scala 2.12.0-M5 in README.md.