### PR TITLE
Scala 2.12.0-M5 Failed Tests Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.scalatest.ParallelTestExecution
 import org.scalatest.ScreenshotOnFailure
-import org.scalatest.SharedHelpers.SilentReporter
+import org.scalatest.SharedHelpers.{SilentReporter, thisLineNumber}
 import org.scalatest.Suite
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.tagobjects.Slow
@@ -39,7 +39,6 @@ import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar
 import scala.reflect.ClassTag
-
 
 trait InputFieldBehaviour extends JettySpec with Matchers with SpanSugar with WebBrowser with HtmlUnit {
   def inputField[T <: ValueElement](file: String, fn: (String) => T, typeDescription: String, description: String, value1: String, value2: String, lineNumber: Int): Unit = {
@@ -2029,17 +2028,6 @@ class WebBrowserSpec extends JettySpec with Matchers with SpanSugar with WebBrow
       }
       """ should compile
     }
-  }
-  
-  def thisLineNumber = {
-    val st = Thread.currentThread.getStackTrace
-
-    if (!st(2).getMethodName.contains("thisLineNumber"))
-      st(2).getLineNumber
-    else if (!st(3).getMethodName.contains("thisLineNumber"))
-      st(3).getLineNumber
-    else
-      st(4).getLineNumber
   }
 }
 // class ParallelWebBrowserSpec extends WebBrowserSpec with ParallelTestExecution

--- a/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
@@ -136,7 +136,7 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
                 case dtne: DuplicateTestNameException => throw dtne
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
                   if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 7))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -125,7 +125,7 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
                   if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 7))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other


### PR DESCRIPTION
Fixed failing tests when build using Scala 2.12.0-M5.
