### PR TITLE
Improve validity of Junit XML reports

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -459,8 +459,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
     <properties> {
       for (name <- propertyNames(sysprops))
         yield
-          <property name={ name } value = { sysprops.getProperty(name) }>
-          </property>
+          <property name={ name } value = { sysprops.getProperty(name) } />
     }
     </properties>
   }

--- a/scalatest/src/main/scala/org/scalatest/tools/XmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/XmlReporter.scala
@@ -432,8 +432,7 @@ private[scalatest] class XmlReporter(directory: String) extends Reporter {
     <properties> {
       for (name <- propertyNames(sysprops))
         yield
-          <property name={ name } value = { sysprops.getProperty(name) }>
-          </property>
+          <property name={ name } value = { sysprops.getProperty(name) } />
     }
     </properties>
   }


### PR DESCRIPTION
The Junit reports generated by scalatest are considered as invalid
when using for instance these xsd:
https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd

The problem is that we have  `<property ... > </property>` instead of
`<property ... />`.

This is why the Jenkins XUnit plugin does not accept reports from
scalatest. This issue had already been raised (see issue #4 ).

Next step would be to fix org.scala.xml.PrettyPrinter which transforms
`<a .../>` to `<a ...>\n    </a>` when the line is too long. It is
possible that the option "minimizeEmpty" from
https://github.com/scala/scala-xml/pull/90
will completely fix the issue.
