### PR TITLE
Fix GenContainTests1

### DIFF
--- a/project/GenContainBase.scala
+++ b/project/GenContainBase.scala
@@ -180,7 +180,8 @@ class GenContainBase {
       "List\\(" -> "javaList(",
       "listsNil" -> "listsJavaCol",
       "Nil" -> "new java.util.ArrayList",
-      "LinkedjavaList" -> "LinkedList"
+      "LinkedjavaList" -> "LinkedList",
+      "//ADDITIONAL//" -> "import scala.collection.JavaConverters._"
     )
 
   val mapMapping =
@@ -485,7 +486,7 @@ class GenContainBase {
       "ListShould" -> "JavaMapShould",
       //"Entry\\(" -> "org.scalatest.Entry(",
       "new Equality\\[String\\]" -> "new Equality[java.util.Map.Entry[String, String]]",
-      "//ADDITIONAL//" -> (javaMapLowerCased + "\n" + javaMapTrimmed + "\n" + "import org.scalatest.Entry"),
+      "//ADDITIONAL//" -> (javaMapLowerCased + "\n" + javaMapTrimmed + "\n" + "import org.scalatest.Entry" + "\n" + "import scala.collection.JavaConverters._"),
       "def areEqual\\(a: String, b: Any\\): Boolean = a.toUpperCase == b" -> javaMapUpperCasedAreEqual,
       "def areEqual\\(a: List\\[String\\], b: Any\\): Boolean = a.map\\(\\_.toUpperCase\\) == b" -> "def areEqual(a: java.util.Map[String, String], b: Any): Boolean = a.asScala.map(e => upperCase(e)) == b",
       "def areEqual\\(a: String, b: Any\\)" -> "def areEqual(a: java.util.Map.Entry[String, String], b: Any)",

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
@@ -28,6 +28,8 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
@@ -61,8 +63,6 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends FunSpec {
         }
       case _ => value
     }
-
-  //ADDITIONAL//
 
   val fileName: String = "ListShouldContainNoElementsOfLogicalAndSpec.scala"
 

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
@@ -28,6 +28,8 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
@@ -61,8 +63,6 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends FunSpec {
         }
       case _ => value
     }
-
-  //ADDITIONAL//
 
   val fileName: String = "ListShouldContainNoElementsOfLogicalOrSpec.scala"
 

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -28,51 +28,51 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
     }
-  
-  val invertedListOfStringEquality = 
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
-  
+
   val upperCaseStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a.toUpperCase == b
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a.map(_.toUpperCase) == b
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainNoneOfLogicalAndSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum")
     val toList: List[String] = List("to")
-    
+
     describe("when used with (contain noneOf (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain noneOf ("fee", "fie", "foe", "fam") and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -97,7 +97,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -110,7 +110,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf ("fee", "fie", "foe", "fie", "fum") and contain noneOf("fie", "fee", "fam", "foe"))
@@ -118,7 +118,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf ("fie", "fee", "fam", "foe") and contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -127,9 +127,9 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (equal (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -141,7 +141,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
@@ -154,7 +154,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -167,7 +167,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -177,9 +177,9 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) and contain noneOf("fie", "fee", "fam", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -191,7 +191,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))
@@ -204,7 +204,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -217,7 +217,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) and contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -229,7 +229,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
     }
 
     describe("when used with (contain noneOf (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain noneOf("fie", "fee", "fam", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
@@ -241,7 +241,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))
@@ -254,7 +254,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -267,7 +267,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
@@ -277,9 +277,9 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain noneOf (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf("fee", "fie", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -291,7 +291,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))
@@ -299,13 +299,13 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
           fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and (not contain noneOf ("fee", "fie", "fum", "foe")))
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -318,7 +318,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain noneOf ("fee", "fie", "foe", "fie", "fum") and not contain noneOf("fee", "fie", "fum", "foe"))
@@ -326,7 +326,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain noneOf ("fee", "fie", "fum", "foe") and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -335,9 +335,9 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
@@ -349,7 +349,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -362,7 +362,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -375,7 +375,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -385,9 +385,9 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
@@ -399,7 +399,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -412,7 +412,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -425,7 +425,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) and not contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -435,81 +435,81 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
   }
-  
+
   describe("collection of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(1), List(1), List(1))
     val lists: Vector[List[Int]] = Vector(List(1), List(1), List(2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(1), List(1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi"), List("hi"), List("hi"))
     val toLists: Vector[List[String]] = Vector(List("to"), List("to"), List("to"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("when used with (contain noneOf (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain noneOf (3, 2, 8) and contain noneOf (2, 6, 8))
         atLeast (2, lists) should (contain noneOf (3, 2, 5) and contain noneOf (2, 3, 4))
         atMost (2, lists) should (contain noneOf (3, 2, 8) and contain noneOf (2, 3, 4))
         no (lists) should (contain noneOf (1, 2, 8) and contain noneOf (1, 2, 3))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain noneOf (2, 6, 8) and contain noneOf (3, 6, 9))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.containedAtLeastOneOf(prettifier, lists(2), UnquotedString("2, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (contain noneOf (3, 6, 9) and contain noneOf (2, 6, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, FailureMessages.didNotContainAtLeastOneOf(prettifier, lists(2), UnquotedString("3, 6, 9")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, lists(2), UnquotedString("2, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (contain noneOf ("ho", "hello") and contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"ho\", \"hello\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (lists) should (contain noneOf (3, 6, 9) and contain noneOf (2, 6, 8))
         }
         checkMessageStackDepth(e4, allErrMsg(2, FailureMessages.didNotContainAtLeastOneOf(prettifier, lists(2), UnquotedString("3, 6, 9")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, lists(2), UnquotedString("2, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain noneOf (1, 2, 2, 3) and contain noneOf (2, 6, 8))
@@ -517,7 +517,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain noneOf (2, 6, 8) and contain noneOf (1, 2, 2, 3))
         }
@@ -526,65 +526,65 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(1)) and contain noneOf (2, 3, 4))
         atLeast (2, lists) should (be (List(1)) and contain noneOf (2, 3, 4))
         atMost (2, lists) should (be (List(1)) and contain noneOf (2, 3, 4))
         no (lists) should (be (List(8)) and contain noneOf (1, 2, 3))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (be (List(1)) and contain noneOf (3, 6, 9))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was not equal to " + decorateToStringValue(prettifier, List(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (be (List(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (list1s) should (be (List(1)) and contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(1)) and contain noneOf (1, 2, 2, 3))
@@ -594,65 +594,65 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain noneOf (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain noneOf (1, 2, 8) and not contain noneOf (1, 6, 8))
         atLeast (2, lists) should (not contain noneOf (1, 6, 8) and not contain noneOf (1, 3, 8))
         atMost (2, lists) should (not contain noneOf (1, 3, 8) and contain noneOf (1, 6, 8))
         no (lists) should (not contain noneOf (3, 6, 9) and not contain noneOf (5, 7, 9))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain noneOf (1, 6, 8) and not contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.didNotContainAtLeastOneOf(prettifier, List(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not contain noneOf (1, 2, 3) and not contain noneOf (1, 6, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, FailureMessages.containedAtLeastOneOf(prettifier, List(2), UnquotedString("1, 2, 3")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, List(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not contain noneOf ("ho", "hello") and not contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"ho\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not contain noneOf ("hi", "hey", "howdy") and not contain noneOf ("ho", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"hi\", \"hey\", \"howdy\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"ho\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain noneOf (1, 2, 2, 3) and not contain noneOf (1, 6, 8))
@@ -660,7 +660,7 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain noneOf (1, 6, 8) and not contain noneOf (1, 2, 2, 3))
         }
@@ -669,65 +669,65 @@ class ListShouldContainNoneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) and not contain noneOf (1, 2, 3))
         atLeast (2, lists) should (not be (List(3)) and not contain noneOf (1, 6, 8))
         atMost (2, lists) should (not be (List(3)) and contain noneOf (1, 6, 8))
         no (list1s) should (not be (List(1)) and not contain noneOf (3, 6, 9))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not be (List(2)) and not contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was equal to " + decorateToStringValue(prettifier, List(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not be (List(3)) and not contain noneOf (1, 6, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was not equal to " + decorateToStringValue(prettifier, List(3)) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, lists(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) and not contain noneOf ("hi", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain noneOf ("ho", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"ho\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) and not contain noneOf (1, 2, 2, 3))

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -27,52 +27,52 @@ import exceptions.TestFailedException
 class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
-  
+
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
     }
-  
-  val invertedListOfStringEquality = 
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
-  
+
   val upperCaseStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a.toUpperCase == b
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a.map(_.toUpperCase) == b
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainNoneOfLogicalOrSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum")
     val toList: List[String] = List("to")
-    
+
     describe("when used with (contain noneOf (..) or contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain noneOf ("fee", "fie", "foe", "fam") or contain noneOf("fie", "fee", "fam", "foe"))
         fumList should (contain noneOf ("fee", "fie", "foe", "fam") or contain noneOf("fie", "fee", "fum", "foe"))
@@ -93,7 +93,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
@@ -104,7 +104,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf ("fee", "fie", "foe", "fie", "fum") or contain noneOf("fie", "fee", "fam", "foe"))
@@ -112,7 +112,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf ("fie", "fee", "fam", "foe") or contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -121,9 +121,9 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (equal (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
         fumList should (equal (toList) or contain noneOf("fie", "fee", "fam", "foe"))
@@ -133,7 +133,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))
@@ -144,7 +144,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
@@ -155,7 +155,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -165,9 +165,9 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) or contain noneOf("fie", "fee", "fam", "foe"))
         fumList should (be (toList) or contain noneOf("fie", "fee", "fam", "foe"))
@@ -177,7 +177,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))
@@ -188,7 +188,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
@@ -199,7 +199,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) or contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -211,7 +211,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
     }
 
     describe("when used with (contain noneOf (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain noneOf("fie", "fee", "fam", "foe") or be (fumList))
         fumList should (contain noneOf("fie", "fee", "fum", "foe") or be (fumList))
@@ -221,7 +221,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))
@@ -232,7 +232,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
         (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
@@ -243,7 +243,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain noneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
@@ -253,9 +253,9 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain noneOf (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf("fee", "fie", "fum", "foe"))
         fumList should (not contain noneOf ("fee", "fie", "foe", "fam") or not contain noneOf("fee", "fie", "fum", "foe"))
@@ -265,7 +265,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fam\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fam\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))
@@ -276,7 +276,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
@@ -286,7 +286,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain noneOf ("fee", "fie", "foe", "fie", "fum") or not contain noneOf("fee", "fie", "fum", "foe"))
@@ -294,7 +294,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain noneOf ("fee", "fie", "fum", "foe") or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -303,9 +303,9 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
         fumList should (not equal (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
@@ -315,7 +315,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fam\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))
@@ -326,7 +326,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
@@ -337,7 +337,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -347,9 +347,9 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fum"))
         fumList should (not be (fumList) or not contain noneOf("fee", "fie", "foe", "fum"))
@@ -359,7 +359,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -370,7 +370,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
@@ -381,7 +381,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) or not contain noneOf("fee", "fie", "foe", "fie", "fum"))
@@ -391,64 +391,64 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
   }
-  
+
   describe("collection of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(1), List(1), List(1))
     val lists: Vector[List[Int]] = Vector(List(1), List(1), List(2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(1), List(1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi"), List("hi"), List("hi"))
     val toLists: Vector[List[String]] = Vector(List("to"), List("to"), List("to"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("when used with (contain noneOf (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain noneOf (3, 6, 9) or contain noneOf (2, 6, 8))
         all (list1s) should (contain noneOf (1, 2, 3) or contain noneOf (2, 6, 8))
         all (list1s) should (contain noneOf (3, 6, 9) or contain noneOf (1, 2, 3))
-        
+
         atLeast (2, lists) should (contain noneOf (2, 6, 8) or contain noneOf (3, 6, 9))
         atLeast (2, lists) should (contain noneOf (1, 2, 3) or contain noneOf (3, 6, 9))
         atLeast (2, lists) should (contain noneOf (2, 6, 8) or contain noneOf (1, 2, 3))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain noneOf (2, 6, 8) or contain noneOf (2, 3, 5))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.containedAtLeastOneOf(prettifier, lists(2), UnquotedString("2, 6, 8")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, lists(2), UnquotedString("2, 3, 5")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))
         all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))
         all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain noneOf (1, 2, 2, 3) or contain noneOf (2, 6, 8))
@@ -456,7 +456,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain noneOf (2, 6, 8) or contain noneOf (1, 2, 2, 3))
         }
@@ -465,44 +465,44 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(1)) or contain noneOf (2, 6, 8))
         all (list1s) should (be (List(2)) or contain noneOf (2, 6, 8))
         all (list1s) should (be (List(1)) or contain noneOf (1, 2, 3))
-        
+
         val e1 = intercept[TestFailedException] {
           all (list1s) should (be (List(2)) or contain noneOf (1, 2, 3))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was not equal to " + decorateToStringValue(prettifier, List(2)) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, list1s(0), UnquotedString("1, 2, 3")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))
         all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))
         all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(1)) or contain noneOf (1, 2, 2, 3))
@@ -512,44 +512,44 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain noneOf (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain noneOf (1, 2, 3) or not contain noneOf (1, 6, 8))
         all (list1s) should (not contain noneOf (2, 6, 8) or not contain noneOf (1, 6, 8))
         all (list1s) should (not contain noneOf (1, 2, 3) or not contain noneOf (2, 6, 8))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain noneOf (1, 6, 8) or not contain noneOf (1, 3, 5))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.didNotContainAtLeastOneOf(prettifier, lists(2), UnquotedString("1, 6, 8")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, lists(2), UnquotedString("1, 3, 5")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))
         all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))
         all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain noneOf (1, 2, 2, 3) or not contain noneOf (1, 6, 8))
@@ -557,7 +557,7 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.noneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain noneOf (1, 6, 8) or not contain noneOf (1, 2, 2, 3))
         }
@@ -566,44 +566,44 @@ class ListShouldContainNoneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.noneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain noneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) or not contain noneOf (1, 6, 8))
         all (list1s) should (not be (List(1)) or not contain noneOf (1, 6, 8))
         all (list1s) should (not be (List(2)) or not contain noneOf (2, 6, 8))
-        
+
         val e1 = intercept[TestFailedException] {
           all (list1s) should (not be (List(1)) or not contain noneOf (2, 6, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, list1s(0), UnquotedString("2, 6, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))
         all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))
         all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) or not contain noneOf (1, 2, 2, 3))

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
@@ -28,6 +28,8 @@ class ListShouldContainOneElementOfLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
@@ -61,8 +63,6 @@ class ListShouldContainOneElementOfLogicalAndSpec extends FunSpec {
         }
       case _ => value
     }
-
-  //ADDITIONAL//
 
   val fileName: String = "ListShouldContainOneElementOfLogicalAndSpec.scala"
 

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
@@ -28,6 +28,8 @@ class ListShouldContainOneElementOfLogicalOrSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
@@ -61,8 +63,6 @@ class ListShouldContainOneElementOfLogicalOrSpec extends FunSpec {
         }
       case _ => value
     }
-
-  //ADDITIONAL//
 
   val fileName: String = "ListShouldContainOneElementOfLogicalOrSpec.scala"
 

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -27,13 +27,15 @@ import exceptions.TestFailedException
 class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
-  
+
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
     }
-  
-  val invertedListOfStringEquality = 
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
@@ -42,37 +44,35 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a.toUpperCase == b
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a.map(_.toUpperCase) == b
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainOneOfLogicalAndSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum")
     val toList: List[String] = List("to")
-    
+
     describe("when used with (contain oneOf (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -97,7 +97,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -110,7 +110,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf ("fee", "fie", "foe", "fie", "fum") and contain oneOf("fie", "fee", "fum", "foe"))
@@ -118,7 +118,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf ("fie", "fee", "fum", "foe") and contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -127,9 +127,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (equal (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -141,7 +141,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -154,7 +154,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -167,7 +167,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -177,9 +177,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) and contain oneOf("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -191,7 +191,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -204,7 +204,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -217,7 +217,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) and contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -229,7 +229,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
     }
 
     describe("when used with (contain oneOf (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain oneOf("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
@@ -241,7 +241,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))
@@ -254,7 +254,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -267,7 +267,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") and be (fumList))
@@ -277,9 +277,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain oneOf (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
@@ -291,20 +291,20 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))
         val e1 = intercept[TestFailedException] {
           fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))
         }
-        
+
         val e2 = intercept[TestFailedException] {
           fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and (not contain oneOf ("FEE", "FIE", "FOE", "FUM")))
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -317,7 +317,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain oneOf ("fee", "fie", "foe", "fie", "fum") and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
@@ -325,7 +325,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -334,9 +334,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
@@ -348,7 +348,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
@@ -361,7 +361,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -374,7 +374,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -384,9 +384,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) and not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         val e1 = intercept[TestFailedException] {
@@ -398,7 +398,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))
@@ -411,7 +411,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -424,7 +424,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) and not contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -434,25 +434,25 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
   }
-  
+
   describe("collection of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(1), List(1), List(1))
     val lists: Vector[List[Int]] = Vector(List(1), List(1), List(2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(1), List(1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi"), List("hi"), List("hi"))
     val toLists: Vector[List[String]] = Vector(List("to"), List("to"), List("to"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("when used with (contain oneOf (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain oneOf (3, 2, 1) and contain oneOf (1, 3, 4))
         atLeast (2, lists) should (contain oneOf (3, 1, 5) and contain oneOf (1, 3, 4))
@@ -460,67 +460,67 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         no (lists) should (contain oneOf (3, 6, 9) and contain oneOf (3, 4, 5))
         no (nils) should (contain oneOf (1, 2, 8) and contain oneOf (1, 3, 4))
         no (listsNil) should (contain oneOf(3, 8, 5) and contain oneOf (3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain oneOf (1, 6, 8) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("1, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (contain oneOf (1, 2, 8) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("1, 2, 8")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("1, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (nils) should (contain oneOf ("hi", "hello") and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, nils(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (contain oneOf ("hi", "hello") and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"hello\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e5 = intercept[TestFailedException] {
           all (listsNil) should (contain oneOf (1, 3, 4) and contain oneOf (1, 3, Nil))
         }
         checkMessageStackDepth(e5, allErrMsg(2, FailureMessages.didNotContainOneOfElements(prettifier, listsNil(2), UnquotedString("1, 3, 4")), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
-        
+
         val e6 = intercept[TestFailedException] {
           all (lists) should (contain oneOf (1, 2, 8) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e6, allErrMsg(2, FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("1, 2, 8")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("1, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain oneOf (3, 2, 2, 1) and contain oneOf (1, 3, 4))
@@ -528,7 +528,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain oneOf (1, 3, 4) and contain oneOf (3, 2, 2, 1))
         }
@@ -537,9 +537,9 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(1)) and contain oneOf (1, 3, 4))
         atLeast (2, lists) should (be (List(1)) and contain oneOf (1, 3, 4))
@@ -547,67 +547,67 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         no (lists) should (be (List(8)) and contain oneOf (3, 4, 5))
         no (nils) should (be (List(8)) and contain oneOf (1, 3, 4))
         no (listsNil) should (be (List(8)) and contain oneOf (3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (be (List(1)) and contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was not equal to " + decorateToStringValue(prettifier, List(1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (be (List(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, List(1), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (nils) should (be (List("hey")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List()) + " was not equal to " + decorateToStringValue(prettifier, List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi")) and contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, List("hi"), UnquotedString("\"ho\", \"hey\", \"howdy\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e5 = intercept[TestFailedException] {
           all (listsNil) should (be (List(1)) and contain oneOf (1, 3, Nil))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(prettifier, List()) + " was not equal to " + decorateToStringValue(prettifier, List(1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
-        
+
         val e6 = intercept[TestFailedException] {
           all (list1s) should (be (List(1)) and contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, List(1), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(1)) and contain oneOf (3, 2, 2, 1))
@@ -617,65 +617,65 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain oneOf (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain oneOf (3, 2, 8) and not contain oneOf (8, 3, 4))
         atLeast (2, lists) should (not contain oneOf (3, 8, 5) and not contain oneOf (8, 3, 4))
         atMost (2, lists) should (not contain oneOf (3, 6, 8) and contain oneOf (5, 3, 4))
         no (lists) should (not contain oneOf (1, 2, 9) and not contain oneOf (2, 1, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain oneOf (2, 6, 8) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("2, 6, 8")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not contain oneOf (3, 6, 8) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("3, 6, 8")) + ", but " + FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("2, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not contain oneOf ("hi", "hello") and not contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not contain oneOf ("ho", "hey", "howdy") and not contain oneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hey\", \"howdy\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain oneOf (3, 2, 2, 1) and not contain oneOf (8, 3, 4))
@@ -683,7 +683,7 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain oneOf (8, 3, 4) and not contain oneOf (3, 2, 2, 1))
         }
@@ -692,65 +692,65 @@ class ListShouldContainOneOfLogicalAndSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) and not contain oneOf (8, 3, 4))
         atLeast (2, lists) should (not be (List(3)) and not contain oneOf (8, 3, 4))
         atMost (2, lists) should (not be (List(3)) and contain oneOf (5, 3, 4))
         no (list1s) should (not be (List(1)) and not contain oneOf (2, 1, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not be (List(2)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was equal to " + decorateToStringValue(prettifier, List(2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not be (List(3)) and not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(2)) + " was not equal to " + decorateToStringValue(prettifier, List(3)) + ", but " + FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("2, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) and not contain oneOf ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "hello"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"hello\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " +  FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) and not contain oneOf (3, 2, 2, 1))

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -27,52 +27,52 @@ import exceptions.TestFailedException
 class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
-  
+
+  //ADDITIONAL//
+
   val invertedStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a != b
     }
-  
-  val invertedListOfStringEquality = 
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
-  
+
   val upperCaseStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = a.toUpperCase == b
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a.map(_.toUpperCase) == b
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainOneOfLogicalOrSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum")
     val toList: List[String] = List("to")
-    
+
     describe("when used with (contain oneOf (..) or contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf("fie", "fee", "fum", "foe"))
         fumList should (contain oneOf ("fee", "fie", "foe", "fam") or contain oneOf("fie", "fee", "fum", "foe"))
@@ -93,7 +93,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
@@ -104,7 +104,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf ("fee", "fie", "foe", "fie", "fum") or contain oneOf("fie", "fee", "fum", "foe"))
@@ -112,7 +112,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -121,9 +121,9 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (equal (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
         fumList should (equal (toList) or contain oneOf("fie", "fee", "fum", "foe"))
@@ -133,7 +133,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -144,7 +144,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
@@ -155,7 +155,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -165,9 +165,9 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) or contain oneOf("fie", "fee", "fum", "foe"))
         fumList should (be (toList) or contain oneOf("fie", "fee", "fum", "foe"))
@@ -177,7 +177,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))
@@ -188,7 +188,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
@@ -199,7 +199,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) or contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -211,7 +211,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
     }
 
     describe("when used with (contain oneOf (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain oneOf("fie", "fee", "fum", "foe") or be (fumList))
         fumList should (contain oneOf("FEE", "FIE", "FOE", "FUM") or be (fumList))
@@ -221,7 +221,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))
@@ -232,7 +232,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
         (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
@@ -243,7 +243,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain oneOf("fee", "fie", "foe", "fie", "fum") or be (fumList))
@@ -253,9 +253,9 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain oneOf (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
@@ -265,7 +265,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))
@@ -276,7 +276,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
@@ -287,7 +287,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain oneOf ("fee", "fie", "foe", "fie", "fum") or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
@@ -295,7 +295,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
         }
@@ -304,9 +304,9 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         fumList should (not equal (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
@@ -316,7 +316,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))
@@ -327,7 +327,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
@@ -338,7 +338,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -348,9 +348,9 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
         fumList should (not be (fumList) or not contain oneOf("FEE", "FIE", "FOE", "FUM"))
@@ -360,7 +360,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))
@@ -371,7 +371,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
         (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
@@ -382,7 +382,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) or not contain oneOf("fee", "fie", "foe", "fie", "fum"))
@@ -392,64 +392,64 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
   }
-  
+
   describe("collection of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(1), List(1), List(1))
     val lists: Vector[List[Int]] = Vector(List(1), List(1), List(2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(1), List(1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi"), List("hi"), List("hi"))
     val toLists: Vector[List[String]] = Vector(List("to"), List("to"), List("to"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("when used with (contain oneOf (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain oneOf (3, 2, 1) or contain oneOf (1, 3, 4))
         all (list1s) should (contain oneOf (3, 2, 5) or contain oneOf (1, 3, 4))
         all (list1s) should (contain oneOf (3, 2, 1) or contain oneOf (2, 3, 4))
-        
+
         atLeast (2, lists) should (contain oneOf (3, 1, 5) or contain oneOf (1, 3, 4))
         atLeast (2, lists) should (contain oneOf (3, 6, 5) or contain oneOf (1, 3, 4))
         atLeast (2, lists) should (contain oneOf (3, 1, 5) or contain oneOf (8, 3, 4))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain oneOf (6, 7, 8) or contain oneOf (1, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("6, 7, 8")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, lists(2), UnquotedString("1, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))
         all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))
         all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain oneOf (3, 2, 2, 1) or contain oneOf (1, 3, 4))
@@ -457,7 +457,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain oneOf (1, 3, 4) or contain oneOf (3, 2, 2, 1))
         }
@@ -466,44 +466,44 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (be (..) and contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(1)) or contain oneOf (1, 3, 4))
         all (list1s) should (be (List(2)) or contain oneOf (1, 3, 4))
         all (list1s) should (be (List(1)) or contain oneOf (2, 3, 4))
-        
+
         val e1 = intercept[TestFailedException] {
           all (list1s) should (be (List(2)) or contain oneOf (2, 3, 8))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was not equal to " + decorateToStringValue(prettifier, List(2)) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, list1s(0), UnquotedString("2, 3, 8")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))
         all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))
         all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(1)) or contain oneOf (3, 2, 2, 1))
@@ -513,44 +513,44 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not contain oneOf (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain oneOf (3, 2, 8) or not contain oneOf (8, 3, 4))
         all (list1s) should (not contain oneOf (1, 2, 8) or not contain oneOf (8, 3, 4))
         all (list1s) should (not contain oneOf (3, 2, 8) or not contain oneOf (8, 3, 1))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain oneOf (2, 6, 8) or not contain oneOf (2, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("2, 6, 8")) + ", and " + FailureMessages.containedOneOfElements(prettifier, lists(2), UnquotedString("2, 3, 4")), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))
         all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))
         all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain oneOf (3, 2, 2, 1) or not contain oneOf (8, 3, 4))
@@ -558,7 +558,7 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.oneOfDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain oneOf (8, 3, 4) or not contain oneOf (3, 2, 2, 1))
         }
@@ -567,44 +567,44 @@ class ListShouldContainOneOfLogicalOrSpec extends FunSpec {
         e2.message should be (Some(Resources.oneOfDuplicate))
       }
     }
-    
+
     describe("when used with (not be (..) and not contain oneOf (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) or not contain oneOf (8, 3, 4))
         all (list1s) should (not be (List(1)) or not contain oneOf (8, 3, 4))
         all (list1s) should (not be (List(2)) or not contain oneOf (8, 3, 1))
-        
+
         val e1 = intercept[TestFailedException] {
           all (list1s) should (not be (List(1)) or not contain oneOf (2, 3, 1))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List(1)) + " was equal to " + decorateToStringValue(prettifier, List(1)) + ", and " + FailureMessages.containedOneOfElements(prettifier, list1s(0), UnquotedString("2, 3, 1")), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))
         all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))
         all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
         (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        
+
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) or not contain oneOf (3, 2, 2, 1))

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -28,46 +28,46 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
 
-  val invertedListOfStringEquality = 
+  //ADDITIONAL//
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
-  
+
   val upperCaseStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = upperCase(a) == upperCase(b)
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = upperCase(a) == upperCase(b)
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainOnlyLogicalAndSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum", "foe", "fie", "fee")
     val toList: List[String] = List("you", "to", "birthday", "happy")
-    
+
     describe("when used with (contain only (..) and contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain only ("fee", "fie", "foe", "fum") and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -92,7 +92,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -105,7 +105,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only () and contain only ("fie", "fee", "fum", "foe"))
@@ -113,7 +113,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only ("fie", "fee", "fum", "foe") and contain only ())
         }
@@ -121,7 +121,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e2.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and contain only ("fie", "fee", "fum", "foe"))
@@ -129,7 +129,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only ("fie", "fee", "fum", "foe") and contain only ("fee", "fie", "foe", "fie", "fum"))
         }
@@ -149,9 +149,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.didNotContainOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Vector("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (equal (..) and contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -163,7 +163,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
@@ -176,7 +176,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -189,7 +189,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) and contain only ())
@@ -198,7 +198,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (equal (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
@@ -215,9 +215,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Vector("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (be (..) and contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) and contain only ("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -229,7 +229,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))
@@ -242,7 +242,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -255,7 +255,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) and contain only ())
@@ -264,7 +264,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (be (fumList) and contain only ("fee", "fie", "foe", "fie", "fum"))
@@ -283,7 +283,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
     }
 
     describe("when used with (contain only (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain only ("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
@@ -295,7 +295,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))
@@ -308,7 +308,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -321,7 +321,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only () and be (fumList))
@@ -330,7 +330,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (contain only ("fee", "fie", "foe", "fie", "fum") and be (fumList))
@@ -347,9 +347,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Vector("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not contain only xx and not contain only xx)") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain only ("fee", "fie", "foe", "fuu") and not contain only ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -361,7 +361,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))
@@ -374,7 +374,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -387,7 +387,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain only () and not contain only ("fie", "fee", "fuu", "foe"))
@@ -395,7 +395,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain only ("fie", "fee", "fuu", "foe") and not contain only ())
         }
@@ -403,7 +403,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e2.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain only ("fee", "fie", "foe", "fie", "fum") and not contain only ("fie", "fee", "fuu", "foe"))
@@ -411,7 +411,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           fumList should (not contain only ("fie", "fee", "fuu", "foe") and not contain only ("fee", "fie", "foe", "fie", "fum"))
         }
@@ -431,9 +431,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, Vector("happy", "birthday", "to", "you"))) + ", but " + Resources.containedOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, Vector("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) and not contain only ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -445,7 +445,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
@@ -458,7 +458,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -471,7 +471,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) and not contain only ())
@@ -480,7 +480,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not equal (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
@@ -497,9 +497,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, Vector("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not be (..) and not contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) and not contain only ("fie", "fee", "fuu", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -511,7 +511,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))
@@ -524,7 +524,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -537,7 +537,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) and not contain only ())
@@ -546,7 +546,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           fumList should (not be (toList) and not contain only ("fee", "fie", "foe", "fie", "fum"))
@@ -563,75 +563,75 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElementsWithFriendlyReminder(decorateToStringValue(prettifier, Vector(Vector("fee", "fie", "foe", "fum"))), decorateToStringValue(prettifier, Vector("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
     }
-    
+
   }
-  
+
   describe("col of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), List(3, 2, 1))
     val lists: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), List(4, 3, 2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi", "hello"), List("hi", "hello"), List("hi", "hello"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("used with contain only xx and contain only xx") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain only (3, 2, 1) and contain only (1, 3, 2))
         atLeast (2, lists) should (contain only (3, 1, 2) and contain only (2, 3, 1))
         atMost (2, lists) should (contain only (3, 1, 2) and contain only (2, 3, 1))
         no (lists) should (contain only (3, 6, 9) and contain only (3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain only (1, 2, 3) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " did not contain only " + "(1, 2, 3)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (contain only (1, 2, 3) and contain only (1, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " contained only " + "(1, 2, 3)" + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain only " + "(1, 3, 4)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (contain only ("hi", "hello") and contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain only () and contain only (1, 3, 2))
@@ -639,7 +639,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain only (1, 3, 2) and contain only ())
         }
@@ -647,7 +647,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e2.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain only (3, 2, 2, 1) and contain only (1, 3, 2))
@@ -655,7 +655,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (contain only (1, 3, 2) and contain only (3, 2, 2, 1))
         }
@@ -681,9 +681,9 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, Vector(Vector("hi", "hello"))) + " contained only (" + decorateToStringValue(prettifier, Vector("hi", "hello")) + "), did you forget to say : _*, but " + decorateToStringValue(prettifier, Vector(Vector("hi", "hello"))) + " did not contain only " + "(" + decorateToStringValue(prettifier, Vector("ho", "hey", "howdy")) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector("hi", "hello")))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (be (..) and contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
         atLeast (2, lists) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
@@ -691,67 +691,67 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         no (lists) should (be (List(3, 6, 9)) and contain only (3, 4, 5))
         no (nils) should (be (List(1, 6, 8)) and contain only (1, 3, 4))
         no (listsNil) should (be (List(2, 6, 8)) and contain only (3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was not equal to " + decorateToStringValue(prettifier, List(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " was equal to " + decorateToStringValue(prettifier, List(3, 2, 1)) + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (nils) should (be (List("hey")) and contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, Nil) + " was not equal to " + decorateToStringValue(prettifier, List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi", "hello")) and contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"ho\", \"hey\", \"howdy\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e5 = intercept[TestFailedException] {
           all (listsNil) should (be (List(3, 2, 1)) and contain only (1, 3, 2))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(prettifier, Nil) + " was not equal to " + decorateToStringValue(prettifier, List(3, 2, 1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
-        
+
         val e6 = intercept[TestFailedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain only (2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " was equal to " + decorateToStringValue(prettifier, List(3, 2, 1)) + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain only " + "(2, 3, 8)", thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain only ())
@@ -760,7 +760,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain only (3, 2, 2, 1))
@@ -787,65 +787,65 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, Vector(Vector(3, 2, 1))) + " was equal to " + decorateToStringValue(prettifier, Vector(Vector(3, 2, 1))) + ", but " + decorateToStringValue(prettifier, Vector(Vector(3, 2, 1))) + " did not contain only (" + decorateToStringValue(prettifier, Vector(2, 3, 8)) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector(3, 2, 1)))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not contain only xx and not contain only xx)") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain only (3, 2, 8) and not contain only (8, 3, 4))
         atLeast (2, lists) should (not contain only (3, 8, 5) and not contain only (8, 3, 4))
         atMost (2, lists) should (not contain only (2, 4, 3) and contain only (4, 3, 2))
         no (list1s) should (not contain only (1, 2, 3) and not contain only (1, 3, 2))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain only (2, 3, 4) and not contain only (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " contained only " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not contain only (3, 6, 8) and not contain only (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " did not contain only " + "(3, 6, 8)" + ", but " + decorateToStringValue(prettifier, List(4, 3, 2)) + " contained only " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not contain only ("hello", "hi") and not contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not contain only ("ho", "hey", "howdy") and not contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"ho\", \"hey\", \"howdy\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain only ("HI") and not contain only ("HO"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain only () and not contain only (8, 3, 4))
@@ -853,7 +853,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain only (8, 3, 4) and not contain only ())
         }
@@ -861,7 +861,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e2.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain only (3, 2, 2, 1) and not contain only (8, 3, 4))
@@ -869,7 +869,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeFileName.get should be (fileName)
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyDuplicate))
-        
+
         val e2 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not contain only (8, 3, 4) and not contain only (3, 2, 2, 1))
         }
@@ -900,65 +900,65 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, Vector(Vector("hi", "hello"))) + " did not contain only (" + decorateToStringValue(prettifier, Vector("ho", "hey", "howdy")) + "), did you forget to say : _*, but " + decorateToStringValue(prettifier, Vector(Vector("hi", "hello"))) + " contained only (" + decorateToStringValue(prettifier, Vector("hi", "hello")) + "), did you forget to say : _*", thisLineNumber - 2, Vector(Vector(Vector("hi", "hello")))), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not be (..) and not contain only (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) and not contain only (8, 3, 4))
         atLeast (2, lists) should (not be (List(3)) and not contain only (8, 3, 4))
         atMost (2, lists) should (not be (List(4, 3, 2)) and not contain only (3, 4, 2))
         no (list1s) should (not be (List(3, 2, 1)) and not contain only (1, 2, 3))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not be (List(4, 3, 2)) and not contain only (8, 3, 4))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was equal to " + decorateToStringValue(prettifier, List(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not be (List(3)) and not contain only (2, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was not equal to " + decorateToStringValue(prettifier, List(3)) + ", but " + decorateToStringValue(prettifier, List(4, 3, 2)) + " contained only " + "(2, 3, 4)", thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi", "hello")) and not contain only ("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain only ("hello", "hi"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) and not contain only ())
@@ -967,7 +967,7 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
         e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
         e1.message should be (Some(Resources.onlyEmpty))
       }
-      
+
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
           all (list1s) should (not be (List(2)) and not contain only (3, 2, 2, 1))

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -27,47 +27,47 @@ import exceptions.TestFailedException
 class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
 
   private val prettifier = Prettifier.default
-  
-  val invertedListOfStringEquality = 
+
+  //ADDITIONAL//
+
+  val invertedListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = a != b
     }
-  
+
   val upperCaseStringEquality =
     new Equality[String] {
       def areEqual(a: String, b: Any): Boolean = upperCase(a) == upperCase(b)
     }
-  
-  private def upperCase(value: Any): Any = 
+
+  private def upperCase(value: Any): Any =
     value match {
       case l: List[_] => l.map(upperCase(_))
       case s: String => s.toUpperCase
       case c: Char => c.toString.toUpperCase.charAt(0)
       case (s1: String, s2: String) => (s1.toUpperCase, s2.toUpperCase)
-      case e: java.util.Map.Entry[_, _] => 
+      case e: java.util.Map.Entry[_, _] =>
         (e.getKey, e.getValue) match {
           case (k: String, v: String) => Entry(k.toUpperCase, v.toUpperCase)
           case _ => value
         }
       case _ => value
     }
-  
-  val upperCaseListOfStringEquality = 
+
+  val upperCaseListOfStringEquality =
     new Equality[List[String]] {
       def areEqual(a: List[String], b: Any): Boolean = upperCase(a) == upperCase(b)
     }
-  
-  //ADDITIONAL//
-  
+
   val fileName: String = "ListShouldContainTheSameElementsAsLogicalAndSpec.scala"
-  
+
   describe("a List") {
-    
+
     val fumList: List[String] = List("fum", "foe", "fie", "fee")
     val toList: List[String] = List("you", "to", "birthday", "happy")
-    
+
     describe("when used with (contain theSameElementsAs (..) and contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain theSameElementsAs Set("fee", "fie", "foe", "fum") and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -92,7 +92,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -106,9 +106,9 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
-    
+
     describe("when used with (equal (..) and contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (equal (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -120,7 +120,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
@@ -133,7 +133,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -147,9 +147,9 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
-    
+
     describe("when used with (be (..) and contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (be (fumList) and contain theSameElementsAs Set("fie", "fee", "fum", "foe"))
         val e1 = intercept[TestFailedException] {
@@ -161,7 +161,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))
@@ -174,7 +174,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -190,7 +190,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
     }
 
     describe("when used with (contain theSameElementsAs (..) and be (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (contain theSameElementsAs Set("fie", "fee", "fum", "foe") and be (fumList))
         val e1 = intercept[TestFailedException] {
@@ -202,7 +202,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))
@@ -215,7 +215,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("HAPPY", "BIRTHDAY", "TO", "YOU"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -229,9 +229,9 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
       }
     }
-    
+
     describe("when used with (not contain theSameElementsAs xx and not contain theSameElementsAs xx)") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not contain theSameElementsAs (Set("fee", "fie", "foe", "fuu")) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
         val e1 = intercept[TestFailedException] {
@@ -243,7 +243,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))
@@ -256,7 +256,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -270,9 +270,9 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
-    
+
     describe("when used with (not equal (..) and not contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not equal (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
         val e1 = intercept[TestFailedException] {
@@ -284,7 +284,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
@@ -297,7 +297,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -311,9 +311,9 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
-    
+
     describe("when used with (not be (..) and not contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         fumList should (not be (toList) and not contain theSameElementsAs (Set("fie", "fee", "fuu", "foe")))
         val e1 = intercept[TestFailedException] {
@@ -325,7 +325,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("fee", "fie", "foe", "fum"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
         fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))
@@ -338,7 +338,7 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
@@ -352,24 +352,24 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
-    
+
   }
-  
+
   describe("col of Lists") {
-    
+
     val list1s: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), List(3, 2, 1))
     val lists: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), List(4, 3, 2))
     val nils: Vector[List[Int]] = Vector(Nil, Nil, Nil)
     val listsNil: Vector[List[Int]] = Vector(List(3, 2, 1), List(3, 2, 1), Nil)
     val hiLists: Vector[List[String]] = Vector(List("hi", "hello"), List("hi", "hello"), List("hi", "hello"))
-    
-    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String = 
+
+    def allErrMsg(index: Int, message: String, lineNumber: Int, left: Any): String =
       "'all' inspection failed, because: \n" +
       "  at index " + index + ", " + message + " (" + fileName + ":" + (lineNumber) + ") \n" +
       "in " + decorateToStringValue(prettifier, left)
-    
+
     describe("used with contain theSameElementsAs xx and contain theSameElementsAs xx") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (contain theSameElementsAs Set(3, 2, 1) and contain theSameElementsAs Set(1, 3, 2))
         atLeast (2, lists) should (contain theSameElementsAs Set(3, 1, 2) and contain theSameElementsAs Set(2, 3, 1))
@@ -377,60 +377,60 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         no (lists) should (contain theSameElementsAs Set(3, 6, 9) and contain theSameElementsAs Set(3, 4, 5))
         no (nils) should (contain theSameElementsAs Set(1, 2, 8) and contain theSameElementsAs Set(1, 3, 4))
         no (listsNil) should (contain theSameElementsAs Set(3, 8, 5) and contain theSameElementsAs Set(3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (contain theSameElementsAs Set(1, 2, 3) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set(1, 2, 3)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (contain theSameElementsAs Set(1, 2, 3) and contain theSameElementsAs Set(1, 3, 4))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " contained the same elements as " + decorateToStringValue(prettifier, Set(1, 2, 3)) + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set(1, 3, 4)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (nils) should (contain theSameElementsAs Set("hi", "hello") and contain theSameElementsAs Set("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, Nil) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("hi", "hello")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (contain theSameElementsAs Set("hi", "hello") and contain theSameElementsAs Set("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("ho", "hey", "howdy")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (be (..) and contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         atLeast (2, lists) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
@@ -438,179 +438,179 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends FunSpec {
         no (lists) should (be (List(3, 6, 9)) and contain theSameElementsAs Set(3, 4, 5))
         no (nils) should (be (List(1, 6, 8)) and contain theSameElementsAs Set(1, 3, 4))
         no (listsNil) should (be (List(2, 6, 8)) and contain theSameElementsAs Set(3, 4, 5))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was not equal to " + decorateToStringValue(prettifier, List(3, 2, 1)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " was equal to " + decorateToStringValue(prettifier, List(3, 2, 1)) + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (nils) should (be (List("hey")) and contain theSameElementsAs Set("hello", "hi"))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, Nil) + " was not equal to " + decorateToStringValue(prettifier, List("hey")), thisLineNumber - 2, nils), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("ho", "hey", "howdy"))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("ho", "hey", "howdy")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e5 = intercept[TestFailedException] {
           all (listsNil) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(1, 3, 2))
         }
         checkMessageStackDepth(e5, allErrMsg(2, decorateToStringValue(prettifier, Nil) + " was not equal to " + decorateToStringValue(prettifier, List(3, 2, 1)), thisLineNumber - 2, listsNil), fileName, thisLineNumber - 2)
-        
+
         val e6 = intercept[TestFailedException] {
           all (list1s) should (be (List(3, 2, 1)) and contain theSameElementsAs Set(2, 3, 8))
         }
         checkMessageStackDepth(e6, allErrMsg(0, decorateToStringValue(prettifier, List(3, 2, 1)) + " was equal to " + decorateToStringValue(prettifier, List(3, 2, 1)) + ", but " + decorateToStringValue(prettifier, List(3, 2, 1)) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set(2, 3, 8)), thisLineNumber - 2, list1s), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not contain theSameElementsAs xx and not contain theSameElementsAs xx)") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not contain theSameElementsAs (Set(3, 2, 8)) and not contain theSameElementsAs (Set(8, 3, 4)))
         atLeast (2, lists) should (not contain theSameElementsAs (Set(3, 8, 5)) and not contain theSameElementsAs (Set(8, 3, 4)))
         atMost (2, lists) should (not contain theSameElementsAs (Set(2, 4, 3)) and contain theSameElementsAs (Set(4, 3, 2)))
         no (list1s) should (not contain theSameElementsAs (Set(1, 2, 3)) and not contain theSameElementsAs (Set(1, 3, 2)))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not contain theSameElementsAs (Set(2, 3, 4)) and not contain theSameElementsAs (Set(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " contained the same elements as " + decorateToStringValue(prettifier, Set(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not contain theSameElementsAs (Set(3, 6, 8)) and not contain theSameElementsAs (Set(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set(3, 6, 8)) + ", but " + decorateToStringValue(prettifier, List(4, 3, 2)) + " contained the same elements as " + decorateToStringValue(prettifier, Set(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not contain theSameElementsAs (Set("hello", "hi")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not contain theSameElementsAs (Set("ho", "hey", "howdy")) and not contain theSameElementsAs (Set("hello", "hi")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("ho", "hey", "howdy")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
     }
-    
+
     describe("when used with (not be (..) and not contain theSameElementsAs (..))") {
-      
+
       it("should do nothing if valid, else throw a TFE with an appropriate error message") {
         all (list1s) should (not be (List(2)) and not contain theSameElementsAs (Set(8, 3, 4)))
         atLeast (2, lists) should (not be (List(3)) and not contain theSameElementsAs (Set(8, 3, 4)))
         atMost (2, lists) should (not be (List(4, 3, 2)) and not contain theSameElementsAs (Set(3, 4, 2)))
         no (list1s) should (not be (List(3, 2, 1)) and not contain theSameElementsAs (Set(1, 2, 3)))
-        
+
         val e1 = intercept[TestFailedException] {
           all (lists) should (not be (List(4, 3, 2)) and not contain theSameElementsAs (Set(8, 3, 4)))
         }
         checkMessageStackDepth(e1, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was equal to " + decorateToStringValue(prettifier, List(4, 3, 2)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (lists) should (not be (List(3)) and not contain theSameElementsAs (Set(2, 3, 4)))
         }
         checkMessageStackDepth(e2, allErrMsg(2, decorateToStringValue(prettifier, List(4, 3, 2)) + " was not equal to " + decorateToStringValue(prettifier, List(3)) + ", but " + decorateToStringValue(prettifier, List(4, 3, 2)) + " contained the same elements as " + decorateToStringValue(prettifier, Set(2, 3, 4)), thisLineNumber - 2, lists), fileName, thisLineNumber - 2)
-        
+
         val e3 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("ho", "hey", "howdy")))
         }
         checkMessageStackDepth(e3, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e4 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("hello", "hi")))
         }
         checkMessageStackDepth(e4, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use the implicit Equality in scope") {
         implicit val ise = upperCaseStringEquality
-        
+
         all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))
-        
+
         val e1 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
-      
+
       it("should use an explicitly provided Equality") {
         (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
-        
+
         val e2 = intercept[TestFailedException] {
           (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
         }


### PR DESCRIPTION
Add missing imports and at the proper places.
---

Basically, `sbt genContainTests1/test` was failing due to a missing import. This was submitted against 3.0.x branch because it is the version I'm using, but if this is not recommended, just let me know.
