### PR TITLE
fix for #978: SBT runner not reporting ...

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -466,7 +466,15 @@ class Framework extends SbtFramework {
               ),
               configSet
             )
-          suiteSortingReporter.registerReporter(suite.suiteId, sbtLogInfoReporter)
+
+          // we need to report for any nested suites as well
+          // fixes https://github.com/scalatest/scalatest/issues/978
+          def registerReporter(suite: Suite): Unit = {
+            suiteSortingReporter.registerReporter(suite.suiteId, sbtLogInfoReporter)
+            suite.nestedSuites.foreach(registerReporter)
+          }
+          registerReporter(suite)
+
         }
 
         runSuite(


### PR DESCRIPTION
Fix for https://github.com/scalatest/scalatest/issues/978 - SBT runner
not reporting full test output in 3.0.0.

The problem was that there was no SbtLogInfoReporter hooked up for any
nested suites. The
SuiteSortingReporter.dispatchToRegisteredSuiteReporter was hitting the
None branch for TestSucceeded events, because the suiteId for the nested
suite was not in the suiteReporterMap. To fix this, I call
registerReporter for all the nested suites, providing the same reporter.

I've considered the fact that it may be problematic to attach the same
SbtLogInfoReporter to multiple Suites. I don't know this code well, but
I can't imagine what could go wrong. The nested suites are run as part
of the same SBT Task.