### PR TITLE
TimeLimitedTests Timer Fix

### DIFF
--- a/scalatest.js/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/scalatest.js/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -97,4 +97,6 @@ private[scalatest] class Timer {
       )
   }
 
+  def cancel(): Unit = ()   // You can't cancel the one and only timer in javascript.
+
 }

--- a/scalatest/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/scalatest/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -68,9 +68,13 @@ private[scalatest] trait TimerTask extends Runnable {
 
   def run()
 
-  def cancel(): Unit = timerTaskRef.get match {
-    case Some(javaTimerTask) => javaTimerTask.cancel
-    case None =>
+  def cancel(): Unit = {
+    timerTaskRef.get match {
+      case Some(javaTimerTask) =>
+        javaTimerTask.cancel()
+
+      case None =>
+    }
   }
 
 }
@@ -99,6 +103,8 @@ private[scalatest] class Timer {
     timer.schedule(javaTimerTask, delay, period)
   }
 
-  def cancel(): Unit = timer.cancel
+  def cancel(): Unit = {
+    timer.cancel()
+  }
 
 }

--- a/scalatest/src/main/scala/org/scalatest/enablers/Timed.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Timed.scala
@@ -127,6 +127,7 @@ below:
           val result = f
           val endTime = scala.compat.Platform.currentTime
           task.cancel()
+          timer.cancel()
           result match {
             case Exceptional(ex) => throw ex  // If the result is Exceptional, the exception is already wrapped, just re-throw it to get the old behavior.
             case _ => 
@@ -142,6 +143,7 @@ below:
           case t: Throwable =>
             val endTime = scala.compat.Platform.currentTime
             task.cancel() // Duplicate code could be factored out I think. Maybe into a finally? Oh, not that doesn't work. So a method.
+            timer.cancel()
             if(task.timedOut || (endTime - startTime) > maxDuration) {
               if (task.needToResetInterruptedStatus)
                 Thread.interrupted() // Clear the interrupt status (There's a race condition here, but not sure we an do anything about that.)
@@ -206,6 +208,7 @@ below:
             t match {
               case Success(r) =>
                 task.cancel()
+                timer.cancel()
                 if (!promise.isCompleted) { // If it completed already, it will fail or have failed with a timeout exception
                 val endTime = scala.compat.Platform.currentTime
                   val duration = endTime - startTime
@@ -217,6 +220,7 @@ below:
 
               case Failure(e) =>
                 task.cancel()
+                timer.cancel()
                 if (!promise.isCompleted) { // If it completed already, it will fail or have failed with a timeout exception
                 val endTime = scala.compat.Platform.currentTime
                   val duration = endTime - startTime
@@ -303,6 +307,7 @@ below:
           t match {
             case Good(r) =>
               task.cancel()
+              timer.cancel()
               val endTime = scala.compat.Platform.currentTime
               val duration = endTime - startTime
               try {
@@ -317,6 +322,7 @@ below:
 
             case Bad(e) =>
               task.cancel()
+              timer.cancel()
               val endTime = scala.compat.Platform.currentTime
               val duration = endTime - startTime
               if (duration > maxDuration)


### PR DESCRIPTION
Fixed timer not canceled problem in TimeLimitedTests.

Note: This fix should be cherry-pick into 3.1.x if we merge this into 3.0.x.