### PR TITLE
Versions Upgrade + Fix for Scala 2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.11.8
   - 2.10.6
-  - 2.12.0-M4
+  - 2.12.0
 jdk:
   - oraclejdk7
   - openjdk6
@@ -46,9 +46,9 @@ env:
 
 matrix:
   exclude:
-    - scala: "2.12.0-M4"
+    - scala: "2.12.0"
       jdk: oraclejdk7
-    - scala: "2.12.0-M4"
+    - scala: "2.12.0"
       jdk: openjdk6
 
 branches:

--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, versi
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.0-M5 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.0 clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.11")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -23,7 +23,7 @@ object ScalatestBuild extends Build {
 
   val releaseVersion = "3.0.0"
 
-  val scalacheckVersion = "1.13.1"
+  val scalacheckVersion = "1.13.4"
 
   val githubTag = "release-3.0.0" // for scaladoc source urls
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -184,7 +184,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.11"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.13"
     )
 
   def scalatestTestOptions =
@@ -397,6 +397,7 @@ object ScalatestBuild extends Build {
       scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
       //jsEnv := NodeJSEnv(executable = "node").value,
       //jsEnv := PhantomJSEnv().value,
+      scalaJSUseRhino in Global := true, 
       scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,
       //postLinkJSEnv := NodeJSEnv(executable = "node").value,
@@ -614,6 +615,7 @@ object ScalatestBuild extends Build {
       scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
       //jsEnv := NodeJSEnv(executable = "node").value,
       //jsEnv := PhantomJSEnv().value,
+      scalaJSUseRhino in Global := true, 
       scalaJSStage in Global := FastOptStage,
       fork in test := false,
       testOptions in Test := scalatestTestJSOptions,

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -80,7 +80,7 @@ object ScalatestBuild extends Build {
   def sharedSettings: Seq[Setting[_]] = Seq(
     javaHome := getJavaHome,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.12.0-M4"),
+    crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.12.0"),
     version := releaseVersion,
     scalacOptions ++= Seq("-feature", "-target:jvm-1.6"),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",

--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -4607,7 +4607,7 @@ trait Firefox extends WebBrowser with Driver with ScreenshotCapturer {
    * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
    * </p>
    */
-  implicit val webDriver = new FirefoxDriver(firefoxProfile)
+  implicit val webDriver: WebDriver = new FirefoxDriver(firefoxProfile)
 
   /**
    * Captures a screenshot and saves it as a file in the specified directory.


### PR DESCRIPTION
-Bump up scalacheck version to 1.13.2.
-Bump up scala-js version to 0.6.13.
-Fixed compiler error when buidling with Scala 2.12.0.