### PR TITLE
ScalaCheckPropertyChecks & ScalaCheckDrivenPropertyChecks Expectation Support

### DIFF
--- a/project/GenScalaCheckGen.scala
+++ b/project/GenScalaCheckGen.scala
@@ -579,17 +579,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -624,18 +631,25 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
-          !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
+            !unmetCondition ==> (
+              if (exception.isEmpty) {
+                if (succeeded)
+                  Prop.passed
+                else
+                  Prop.falsified
+              }
+              else
+                Prop.exception(exception.get)
+            )
         }
         val prop = Prop.forAll(propF)
         val params = getScalaCheckParams(configParams, config)
@@ -670,18 +684,25 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
-          !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
+            !unmetCondition ==> (
+              if (exception.isEmpty) {
+                if (succeeded)
+                  Prop.passed
+                else
+                  Prop.falsified
+              }
+              else
+                Prop.exception(exception.get)
+            )
         }
         val prop = Prop.forAll(propF)
         val params = getScalaCheckParams(configParams, config)
@@ -717,17 +738,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -765,17 +793,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D, e: E) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d, e)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d, e))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -814,17 +849,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D, e: E, f: F) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d, e, f)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d, e, f))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -860,17 +902,24 @@ $arbShrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll(propF)
@@ -903,17 +952,24 @@ $arbShrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll(propF)
@@ -953,17 +1009,24 @@ $shrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll($genArgs$)(propF)
@@ -1006,17 +1069,24 @@ $shrinks$,
 $tupleBusters$
 
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll($genArgs$)(propF)
@@ -1059,7 +1129,7 @@ import org.scalacheck.Gen
     }
                                 """
 
-  val generatorSuiteTemplate = """
+  val generatorSuiteAssertTemplate = """
 
   it("generator-driven property that takes $n$ args, which succeeds") {
 
@@ -1898,6 +1968,915 @@ $okayAssertions$
   }
                                """
 
+  val generatorSuiteExpectTemplate = """
+
+  it("generator-driven property that takes $n$ args, which succeeds") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but with config params
+  it("generator-driven property that takes $n$ args, which succeeds, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set minSuccessful to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default minSuccessful to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default minSuccessful param set to 5") {
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set maxDiscarded to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default maxDiscarded to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // set minSize > maxSize with (param, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (param, default) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (default, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll (maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set maxSize with param (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as param") {
+    val result =
+    forAll (maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as param") {
+    val result =
+    forAll ($argNames$, maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set maxSize with default (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($argNames$) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenArgs$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+                                     """
+
   val checkersSuiteTemplate = """
 
   it("ScalaCheck property that takes $n$ args, which succeeds") {
@@ -2458,7 +3437,7 @@ $okayExpressions$
   }
 
   // Invitation style indicates how GeneratorDrivenPropertyChecks is imported
-  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, doItForCheckers: Boolean) {
+  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, doItForCheckers: Boolean, generatorSuiteTemplate: String, checkMethod: String) {
 
     targetDir.mkdirs()
 
@@ -2469,7 +3448,7 @@ $okayExpressions$
         if (withTables) "ScalaCheckPropertyChecks" else "ScalaCheckDrivenPropertyChecks"
       }
     val suiteClassName = traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite"
-    val fileName = suiteClassName + ".scala"
+    val fileName = checkMethod.capitalize + suiteClassName + ".scala"
 
     val bw = new BufferedWriter(new FileWriter(new File(targetDir, fileName)))
 
@@ -2483,9 +3462,11 @@ $okayExpressions$
       }
       if (!mixinInvitationStyle)
         bw.write("import " + traitOrObjectName + "._\n")
+      if (checkMethod == "expect")
+        bw.write("import org.scalatest.Expectations._\n")
       bw.write("\n")
       bw.write(
-        "class " + suiteClassName + " extends FunSpec " +
+        "class " + checkMethod.capitalize + suiteClassName + " extends FunSpec " +
           (if (mixinInvitationStyle) "with " + traitOrObjectName else "") + " {\n")
       bw.write(generatorSuitePostamble)
       val alpha = "abcdefghijklmnopqrstuv"
@@ -2516,8 +3497,8 @@ $okayExpressions$
         val nameGenTuples = alpha.take(i).map("(famousLastWords, \"" + _ + "\")").mkString(", ")
         val fiveFiveNameGenTuples = alpha.take(i).map("(fiveFive, \"" + _ + "\")").mkString(", ")
         val sevenElevenNameGenTuples = alpha.take(i).map("(sevenEleven, \"" + _ + "\")").mkString(", ")
-        val lengthAssertions = alpha.take(i).map("      assert(" + _ + ".length <= 5)").mkString("\n")
-        val okayAssertions = alpha.take(i).map("        assert(" + _ + " === (\"OKAY\"))").mkString("\n")
+        val lengthAssertions = alpha.take(i).map("      " + checkMethod + "(" + _ + ".length <= 5)").mkString("\n")
+        val okayAssertions = alpha.take(i).map("        " + checkMethod + "(" + _ + " === (\"OKAY\"))").mkString("\n")
         val lengthExpressions = alpha.take(i).map("      " + _ + ".length <= 5").mkString("\n")
         val okayExpressions = alpha.take(i).map("        " + _ + " == (\"OKAY\")").mkString("\n")
         st.setAttribute("n", i)
@@ -2568,13 +3549,19 @@ $okayExpressions$
   }
 
   def genTest(dir: File, version: String, scalaVersion: String) {
-    genGeneratorDrivenSuite(dir, true, false, false)
-    genGeneratorDrivenSuite(dir, false, false, false)
+    genGeneratorDrivenSuite(dir, true, false, false, generatorSuiteAssertTemplate, "assert")
+    genGeneratorDrivenSuite(dir, false, false, false, generatorSuiteAssertTemplate, "assert")
+    genGeneratorDrivenSuite(dir, true, true, false, generatorSuiteAssertTemplate, "assert")
+    genGeneratorDrivenSuite(dir, false, true, false, generatorSuiteAssertTemplate, "assert")
+    genGeneratorDrivenSuite(dir, true, true, true, generatorSuiteAssertTemplate, "assert")
+    genGeneratorDrivenSuite(dir, false, true, true, generatorSuiteAssertTemplate, "assert")
 
-    // TODO: Re-enable these
-    genGeneratorDrivenSuite(dir, true, true, false)
-    genGeneratorDrivenSuite(dir, false, true, false)
-    genGeneratorDrivenSuite(dir, true, true, true)
-    genGeneratorDrivenSuite(dir, false, true, true)
+    genGeneratorDrivenSuite(dir, true, false, false, generatorSuiteExpectTemplate, "expect")
+    genGeneratorDrivenSuite(dir, false, false, false, generatorSuiteExpectTemplate, "expect")
+    genGeneratorDrivenSuite(dir, true, true, false, generatorSuiteExpectTemplate, "expect")
+    genGeneratorDrivenSuite(dir, false, true, false, generatorSuiteExpectTemplate, "expect")
+    genGeneratorDrivenSuite(dir, true, true, true, generatorSuiteExpectTemplate, "expect")
+    genGeneratorDrivenSuite(dir, false, true, true, generatorSuiteExpectTemplate, "expect")
+
   }
 }

--- a/project/GenScalaCheckGen.scala
+++ b/project/GenScalaCheckGen.scala
@@ -2466,7 +2466,7 @@ $okayExpressions$
       if (doItForCheckers)
         "Checkers"
       else {
-        if (withTables) "PropertyChecks" else "ScalaCheckDrivenPropertyChecks"
+        if (withTables) "ScalaCheckPropertyChecks" else "ScalaCheckDrivenPropertyChecks"
       }
     val suiteClassName = traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite"
     val fileName = suiteClassName + ".scala"
@@ -2572,9 +2572,9 @@ $okayExpressions$
     genGeneratorDrivenSuite(dir, false, false, false)
 
     // TODO: Re-enable these
-    //genGeneratorDrivenSuite(dir, true, true, false)
-    //genGeneratorDrivenSuite(dir, false, true, false)
-    //genGeneratorDrivenSuite(dir, true, true, true)
-    //genGeneratorDrivenSuite(dir, false, true, true)
+    genGeneratorDrivenSuite(dir, true, true, false)
+    genGeneratorDrivenSuite(dir, false, true, false)
+    genGeneratorDrivenSuite(dir, true, true, true)
+    genGeneratorDrivenSuite(dir, false, true, true)
   }
 }

--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -47,6 +47,8 @@ trait CheckerAsserting[T] {
    */
   type Result
 
+  def succeed(result: T): (Boolean, Option[Throwable])
+
   /**
    * Perform the property check using the given <code>Prop</code> and <code>Test.Parameters</code>.
    *
@@ -176,6 +178,7 @@ abstract class UnitCheckerAsserting {
   implicit def assertingNatureOfT[T]: CheckerAsserting[T] { type Result = Unit } =
     new CheckerAssertingImpl[T] {
       type Result = Unit
+      def succeed(result: T) = (true, None)
       private[scalatest] def indicateSuccess(message: => String): Unit = ()
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Unit = {
         throw new GeneratorDrivenPropertyCheckFailedException(
@@ -201,6 +204,7 @@ abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
   implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): CheckerAsserting[Expectation] { type Result = Expectation } = {
     new CheckerAssertingImpl[Expectation] {
       type Result = Expectation
+      def succeed(result: Expectation) = (result.isYes, result.cause)
       private[scalatest] def indicateSuccess(message: => String): Expectation = Fact.Yes(message)(prettifier)
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Expectation = {
         val gdpcfe =
@@ -235,6 +239,7 @@ object CheckerAsserting extends ExpectationCheckerAsserting {
   implicit def assertingNatureOfAssertion: CheckerAsserting[Assertion] { type Result = Assertion } = {
     new CheckerAssertingImpl[Assertion] {
       type Result = Assertion
+      def succeed(result: Assertion) = (true, None)
       private[scalatest] def indicateSuccess(message: => String): Assertion = Succeeded
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
         throw new GeneratorDrivenPropertyCheckFailedException(

--- a/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Checkers.scala
@@ -223,6 +223,8 @@ repeatedly pass generated data to the function. In this case, the test data is c
  */
 trait Checkers extends Configuration {
 
+  protected val asserting: CheckerAsserting[org.scalatest.Assertion] = CheckerAsserting.assertingNatureOfAssertion
+
   /**
    * Convert the passed 1-arg function into a property, and check it.
    *
@@ -234,7 +236,6 @@ trait Checkers extends Configuration {
       config: PropertyCheckConfigurable,
       p: P => Prop,
       a1: Arbitrary[A1], s1: Shrink[A1], pp1: A1 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -254,7 +255,6 @@ trait Checkers extends Configuration {
       p: P => Prop,
       a1: Arbitrary[A1], s1: Shrink[A1], pp1: A1 => Pretty,
       a2: Arbitrary[A2], s2: Shrink[A2], pp2: A2 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -275,7 +275,6 @@ trait Checkers extends Configuration {
       a1: Arbitrary[A1], s1: Shrink[A1], pp1: A1 => Pretty,
       a2: Arbitrary[A2], s2: Shrink[A2], pp2: A2 => Pretty,
       a3: Arbitrary[A3], s3: Shrink[A3], pp3: A3 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -297,7 +296,6 @@ trait Checkers extends Configuration {
       a2: Arbitrary[A2], s2: Shrink[A2], pp2: A2 => Pretty,
       a3: Arbitrary[A3], s3: Shrink[A3], pp3: A3 => Pretty,
       a4: Arbitrary[A4], s4: Shrink[A4], pp4: A4 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -320,7 +318,6 @@ trait Checkers extends Configuration {
       a3: Arbitrary[A3], s3: Shrink[A3], pp3: A3 => Pretty,
       a4: Arbitrary[A4], s4: Shrink[A4], pp4: A4 => Pretty,
       a5: Arbitrary[A5], s5: Shrink[A5], pp5: A5 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -344,7 +341,6 @@ trait Checkers extends Configuration {
       a4: Arbitrary[A4], s4: Shrink[A4], pp4: A4 => Pretty,
       a5: Arbitrary[A5], s5: Shrink[A5], pp5: A5 => Pretty,
       a6: Arbitrary[A6], s6: Shrink[A6], pp6: A6 => Pretty,
-      asserting: CheckerAsserting[ASSERTION],
       prettifier: Prettifier,
       pos: source.Position
     ): asserting.Result = {
@@ -359,7 +355,7 @@ trait Checkers extends Configuration {
    * @param prms the test parameters
    * @throws TestFailedException if a test case is discovered for which the property doesn't hold.
    */
-  def check[ASSERTION](p: Prop, prms: Test.Parameters)(implicit asserting: CheckerAsserting[ASSERTION], prettifier: Prettifier, pos: source.Position): asserting.Result = {
+  def check[ASSERTION](p: Prop, prms: Test.Parameters)(implicit prettifier: Prettifier, pos: source.Position): asserting.Result = {
     asserting.check(p, prms, prettifier, pos)
   }
 
@@ -369,7 +365,7 @@ trait Checkers extends Configuration {
    * @param p the property to check
    * @throws TestFailedException if a test case is discovered for which the property doesn't hold.
    */
-  def check[ASSERTION](p: Prop, configParams: PropertyCheckConfigParam*)(implicit config: PropertyCheckConfigurable, asserting: CheckerAsserting[ASSERTION], prettifier: Prettifier, pos: source.Position): asserting.Result = {
+  def check[ASSERTION](p: Prop, configParams: PropertyCheckConfigParam*)(implicit config: PropertyCheckConfigurable, prettifier: Prettifier, pos: source.Position): asserting.Result = {
     val params = getScalaCheckParams(configParams, config)
     asserting.check(p, params, prettifier, pos)
   }

--- a/scalatest/src/main/scala/org/scalatest/prop/ScalaCheckPropertyChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/ScalaCheckPropertyChecks.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+package prop
+
+/**
+  * Trait that facilitates property checks on data supplied by tables and ScalaCheck generators.
+  *
+  * <p>
+  * This trait extends both <a href="TableDrivenPropertyChecks.html"><code>TableDrivenPropertyChecks</code></a> and
+  * <a href="ScalaCheckDrivenPropertyChecks.html"><code>ScalaCheckDrivenPropertyChecks</code></a>. Thus by mixing in
+  * this trait you can perform property checks on data supplied either by tables or generators. For the details of
+  * table- and generator-driven property checks, see the documentation for each by following the links above.
+  * </p>
+  *
+  * <p>
+  * For a quick example of using both table and generator-driven property checks in the same suite of tests, however,
+  * imagine you want to test this <code>Fraction</code> class:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * class Fraction(n: Int, d: Int) {
+  *
+  *   require(d != 0)
+  *   require(d != Integer.MIN_VALUE)
+  *   require(n != Integer.MIN_VALUE)
+  *
+  *   val numer = if (d &lt; 0) -1 * n else n
+  *   val denom = d.abs
+  *
+  *   override def toString = numer + " / " + denom
+  * }
+  * </pre>
+  *
+  * <p>
+  * If you mix in <code>PropertyChecks</code>, you could use a generator-driven property check to test that the passed values for numerator and
+  * denominator are properly normalized, like this:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * forAll { (n: Int, d: Int) =&gt;
+  *
+  *   whenever (d != 0 && d != Integer.MIN_VALUE
+  *       && n != Integer.MIN_VALUE) {
+  *
+  *     val f = new Fraction(n, d)
+  *
+  *     if (n &lt; 0 && d &lt; 0 || n &gt; 0 && d &gt; 0)
+  *       f.numer should be &gt; 0
+  *     else if (n != 0)
+  *       f.numer should be &lt; 0
+  *     else
+  *       f.numer shouldEqual 0
+  *
+  *     f.denom should be &gt; 0
+  *   }
+  * }
+  * </pre>
+  *
+  * <p>
+  * And you could use a table-driven property check to test that all combinations of invalid values passed to the <code>Fraction</code> constructor
+  * produce the expected <code>IllegalArgumentException</code>, like this:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * val invalidCombos =
+  *   Table(
+  *     ("n",               "d"),
+  *     (Integer.MIN_VALUE, Integer.MIN_VALUE),
+  *     (1,                 Integer.MIN_VALUE),
+  *     (Integer.MIN_VALUE, 1),
+  *     (Integer.MIN_VALUE, 0),
+  *     (1,                 0)
+  *   )
+  *
+  * forAll (invalidCombos) { (n: Int, d: Int) =&gt;
+  *   an [IllegalArgumentException] should be thrownBy {
+  *     new Fraction(n, d)
+  *   }
+  * }
+  * </pre>
+  *
+  * @author Bill Venners
+  */
+trait ScalaCheckPropertyChecks extends TableDrivenPropertyChecks with ScalaCheckDrivenPropertyChecks
+
+/**
+  * Companion object that facilitates the importing of <code>PropertyChecks</code> members as
+  * an alternative to mixing it in. One use case is to import <code>PropertyChecks</code> members so you can use
+  * them in the Scala interpreter.
+  *
+  * @author Bill Venners
+  */
+object ScalaCheckPropertyChecks extends ScalaCheckPropertyChecks


### PR DESCRIPTION
- Added ScalaCheckPropertyChecks
- Made changes to ScalaCheckDrivenPropertyChecks to correctly support Expectation.
- Removed CheckerAsserting implicit parameter from Checkers' methods.