### PR TITLE
GenGenTests Fix & VacuousYes as Discarded Evaluation

### DIFF
--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -2879,6 +2879,15 @@ $okayAssertions$
     }
     assert(result.isYes)
   }
+
+  it("generator-driven property that takes $n$ named args and generators, returns VacuousYes should be considered discarded evaluation") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        val x = -1
+        expect(x > 0) implies expect(x > -1)
+      }
+    assert(result.isNo)
+  }
 """
 
 // 1712  2205

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -1108,7 +1108,7 @@ import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 
 val generatorSuitePostamble = """
   val famousLastWords = for {
-    s <- Generator.oneOf("the", "program", "compiles", "therefore", "it", "should", "work")
+    s <- org.scalatest.prop.specificValues("the", "program", "compiles", "therefore", "it", "should", "work")
   } yield s
 
   val sevenEleven: Generator[String] =

--- a/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -28,6 +28,8 @@ trait PropCheckerAsserting[T] {
     */
   type Result
 
+  def discard(result: T): Boolean
+
   def succeed(result: T): (Boolean, Option[Throwable])
 
   private[scalatest] def indicateSuccess(message: => String): Result
@@ -129,6 +131,7 @@ abstract class ExpectationPropCheckerAsserting extends UnitPropCheckerAsserting 
   implicit def assertingNatureOfExpectation: PropCheckerAsserting[Expectation] { type Result = Expectation } = {
     new PropCheckerAssertingImpl[Expectation] {
       type Result = Expectation
+      def discard(result: Expectation): Boolean = result.isVacuousYes
       def succeed(result: Expectation): (Boolean, Option[Throwable]) = (result.isYes, result.cause)
       private[scalatest] def indicateSuccess(message: => String): Expectation = Fact.Yes(message)
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Expectation = {
@@ -155,6 +158,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
   implicit def assertingNatureOfAssertion: PropCheckerAsserting[Assertion] { type Result = Assertion } = {
     new PropCheckerAssertingImpl[Assertion] {
       type Result = Assertion
+      def discard(result: Assertion): Boolean = false
       def succeed(result: Assertion): (Boolean, Option[Throwable]) = (true, None)
       private[scalatest] def indicateSuccess(message: => String): Assertion = Succeeded
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyTest.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyTest.scala
@@ -29,6 +29,8 @@ trait PropertyTest {
 
   def check: PropertyTest.Result
 
+  def discard(v: RESULT): Boolean
+
   def succeed(v: RESULT): (Boolean, Option[Throwable])
 
   def checkForAll[A](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A])(fun: (A) => RESULT): PropertyTest.Result = {
@@ -50,16 +52,25 @@ trait PropertyTest {
       val argsPassed = List(if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a))
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextEdges, nextNextRnd, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
-          else
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          else {
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextEdges, nextNextRnd, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          }
 
         case Failure(ex: DiscardedEvaluationException) =>
           val nextDiscardedCount = discardedCount + 1
@@ -126,16 +137,25 @@ I'd then just feed the edges through along with the randomizer.
         )
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
-          else
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          else {
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          }
 
         case Failure(ex: DiscardedEvaluationException) =>
           val nextDiscardedCount = discardedCount + 1
@@ -201,16 +221,25 @@ I'd then just feed the edges through along with the randomizer.
         )
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
-          else
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          else {
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          }
 
         case Failure(ex: DiscardedEvaluationException) =>
           val nextDiscardedCount = discardedCount + 1
@@ -280,16 +309,25 @@ I'd then just feed the edges through along with the randomizer.
         )
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
-          else
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          else {
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          }
 
         case Failure(ex: DiscardedEvaluationException) =>
           val nextDiscardedCount = discardedCount + 1
@@ -363,16 +401,25 @@ I'd then just feed the edges through along with the randomizer.
         )
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
-          else
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          else {
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+          }
 
         case Failure(ex: DiscardedEvaluationException) =>
           val nextDiscardedCount = discardedCount + 1
@@ -450,16 +497,25 @@ I'd then just feed the edges through along with the randomizer.
         )
       result match {
         case Success(r) =>
-          val (success, cause) = succeed(r)
-          if (success) {
-            val nextSucceededCount = succeededCount + 1
-            if (nextSucceededCount < config.minSuccessful)
-              loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes)
+          if (discard(r)) {
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes)
             else
-              PropertyTest.CheckSuccess(argsPassed)
+              new PropertyTest.CheckExhausted(succeededCount, nextDiscardedCount, names, argsPassed)
           }
           else {
-            new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+            val (success, cause) = succeed(r)
+            if (success) {
+              val nextSucceededCount = succeededCount + 1
+              if (nextSucceededCount < config.minSuccessful)
+                loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes)
+              else
+                PropertyTest.CheckSuccess(argsPassed)
+            }
+            else {
+              new PropertyTest.CheckFailure(succeededCount, cause, names, argsPassed)
+            }
           }
 
         case Failure(ex: DiscardedEvaluationException) =>
@@ -518,6 +574,7 @@ object PropertyTest {
                                    ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA)(fun)
     }
@@ -530,6 +587,7 @@ object PropertyTest {
                                    ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA, genB)(fun)
     }
@@ -543,6 +601,7 @@ object PropertyTest {
                                    ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA, genB, genC)(fun)
     }
@@ -557,6 +616,7 @@ object PropertyTest {
                                       ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA, genB, genC, genD)(fun)
     }
@@ -572,6 +632,7 @@ object PropertyTest {
                                          ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA, genB, genC, genD, genE)(fun)
     }
@@ -588,6 +649,7 @@ object PropertyTest {
                                                   ): PropertyTest =
     new PropertyTest {
       type RESULT = ASSERTION
+      def discard(v: RESULT) = asserting.discard(v)
       def succeed(v: RESULT) = asserting.succeed(v)
       def check: Result = checkForAll(names, config, genA, genB, genC, genD, genE, genF)(fun)
     }


### PR DESCRIPTION
-Fixed broken GenGenTests
-Changes to take VacuousYes as discarded evaluation in property driven tests.