### PR TITLE
Switch from getSimpleName to getSimpleNameOfAnObjectsClass

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -23,6 +23,7 @@ import org.scalacheck.util.Pretty
 import org.scalatest.Assertion
 import org.scalatest.FailureMessages
 import org.scalatest.Resources
+import org.scalatest.Suite.getSimpleNameOfAnObjectsClass
 import org.scalatest.Succeeded
 import org.scalatest.UnquotedString
 import org.scalatest.exceptions.StackDepthException
@@ -114,7 +115,7 @@ abstract class UnitCheckerAsserting {
             val stackDepth = 1
             
             indicateFailure(
-              sde => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + "\n" +
+              sde => FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(sde))) + "\n" +
               ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
               "  " + FailureMessages.propertyFailed(prettifier, result.succeeded) + "\n" +
               (
@@ -138,7 +139,7 @@ abstract class UnitCheckerAsserting {
           case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
 
             indicateFailure(
-              sde => FailureMessages.propertyException(prettifier, UnquotedString(e.getClass.getSimpleName)) + "\n" +
+              sde => FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(e))) + "\n" +
               "  " + FailureMessages.thrownExceptionsMessage(prettifier, if (e.getMessage == null) "None" else UnquotedString(e.getMessage)) + "\n" +
               (
                 e match {
@@ -285,7 +286,7 @@ object CheckerAsserting extends UnitCheckerAsserting /*ExpectationCheckerAsserti
         result.discarded + " tests were discarded."
 
     case Test.PropException(args, e, labels) =>
-      FailureMessages.propertyException(prettifier, UnquotedString(e.getClass.getSimpleName)) + "\n" + prettyLabels(labels) + prettyArgs(args, prettifier)
+      FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(e))) + "\n" + prettyLabels(labels) + prettyArgs(args, prettifier)
   }
 
   private[enablers] def prettyLabels(labels: Set[String]) = {

--- a/scalatest/src/main/scala/org/scalatest/prop/GeneratorChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/GeneratorChecks.scala
@@ -17,6 +17,7 @@ package org.scalatest.prop
 
 import org.scalactic._
 import org.scalatest.FailureMessages
+import org.scalatest.Suite.getSimpleNameOfAnObjectsClass
 import org.scalatest.UnquotedString
 import org.scalatest.exceptions.StackDepthException
 import scala.annotation.tailrec
@@ -65,7 +66,7 @@ import GeneratorChecks.stackDepthMethodName
           else throw new TestFailedException((sde: StackDepthException) => Some("too many discarded evaluations"), None, pos, None)
         case Failure(ex) => 
           throw new GeneratorDrivenPropertyCheckFailedException(
-            (sde: StackDepthException) => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + "\n" +
+            (sde: StackDepthException) => FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(sde))) + "\n" +
               ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" + 
               "  " + FailureMessages.propertyFailed(prettifier, succeededCount) + "\n" +
               (


### PR DESCRIPTION
This PR fixes #992 by replacing the calls to `.getClass.getSimpleName` with `org.scalatest.Suite.getSimpleNameOfAnObjectsClass` which avoids `getSimpleName` and implements its own version on top of the more safe `.getName`. Note that there is  [SI-8110](https://issues.scala-lang.org/browse/SI-8110) open about the issues with `getSimpleName` on objects.

I couldn't submit any test because `sbt tests` runs forever even without my patch, not sure why, and because I'm not sure where to put them.