### PR TITLE
Fix for Finite Float/Double when Merging

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
@@ -55,6 +55,11 @@ trait FiniteFloatSpecSupport {
           case Success(bFloat: Float) if bFloat.isNaN => true
           case _ => false
         }
+      case Success(double: Double) if double.isNaN =>
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
+          case _ => false
+        }
       case _: Success[_] => a == b
       case Failure(ex) => b match {
         case _: Success[_] => false


### PR DESCRIPTION
Fixed failing FiniteFloatGeneratedSpec by adding correct NaN equality implementation.