### PR TITLE
Negation Fix for Neg and NegZ Ints and Longs.

### DIFF
--- a/project/GenAnyVals.scala
+++ b/project/GenAnyVals.scala
@@ -97,7 +97,7 @@ object GenAnyVals {
     st.setAttribute("typeMinValueNumber", typeMinValueNumber)
     st.setAttribute("typeMaxValue", typeMaxValue)
     st.setAttribute("typeMaxValueNumber", typeMaxValueNumber)
-    st.setAttribute("negationType", negationType(typeName))
+    st.setAttribute("negation", negation(typeName))
 
     val widensToOtherAnyVals =
       widensToTypes.map { targetType =>
@@ -144,7 +144,7 @@ object GenAnyVals {
     st.setAttribute("typeMinValueNumber", typeMinValueNumber)
     st.setAttribute("typeMaxValue", typeMaxValue)
     st.setAttribute("typeMaxValueNumber", typeMaxValueNumber)
-    st.setAttribute("negationType", negationType(typeName))
+    st.setAttribute("negation", negation(typeName))
 
     val widensToOtherAnyVals =
       widensToTypes.map { targetType =>
@@ -193,7 +193,7 @@ object GenAnyVals {
     st.setAttribute("typeMaxValueNumber", typeMaxValueNumber)
     st.setAttribute("classExtraMethods", classExtraMethods)
     st.setAttribute("objectExtraMethods", objectExtraMethods)
-    st.setAttribute("negationType", negationType(typeName))
+    st.setAttribute("negation", negation(typeName))
 
     val widensToOtherAnyVals =
       widensToTypes.map { targetType =>
@@ -242,7 +242,7 @@ object GenAnyVals {
     st.setAttribute("typeMaxValueNumber", typeMaxValueNumber)
     st.setAttribute("classExtraMethods", classExtraMethods)
     st.setAttribute("objectExtraMethods", objectExtraMethods)
-    st.setAttribute("negationType", negationType(typeName))
+    st.setAttribute("negation", negation(typeName))
 
     val widensToOtherAnyVals =
       widensToTypes.map { targetType =>
@@ -291,13 +291,25 @@ object GenAnyVals {
       "Finite"
     )
 
-  def negationType(typeName: String): String =
-    if (typeName.startsWith("Pos"))
-      "Neg" + typeName.drop(3)
-    else if (typeName.startsWith("Neg"))
-      "Pos" + typeName.drop(3)
+  def negation(typeName: String): String = {
+    val negationType =
+      if (typeName.startsWith("Pos"))
+        "Neg" + typeName.drop(3)
+      else if (typeName.startsWith("Neg")) {
+        typeName match {
+          case "NegInt" | "NegZInt" => "Int"
+          case "NegLong" | "NegZLong" => "Long"
+          case _ => "Pos" + typeName.drop(3)
+        }
+      }
+      else
+        typeName
+
+    if (primitiveTypes.contains(negationType))
+      s"def unary_- : $negationType = -value"
     else
-      typeName
+      s"def unary_- : $negationType = $negationType.ensuringValid(-value)"
+  }
 
   val allAnyValTypes =
     anyValTypes.flatMap(t => primitiveTypes.map(p => t + p)).filter( typeName =>

--- a/project/templates/DoubleAnyVal.template
+++ b/project/templates/DoubleAnyVal.template
@@ -186,7 +186,7 @@ final class $typeName$ private (val value: Double) extends AnyVal {
   /** Returns this value, unmodified. */
   def unary_+ : $typeName$ = this
   /** Returns the negation of this value. */
-  def unary_- : $negationType$ = $negationType$.ensuringValid(-value)
+  $negation$
 
   /**
    * Converts this <code>$typeName$</code>'s value to a string then concatenates the given string.

--- a/project/templates/FloatAnyVal.template
+++ b/project/templates/FloatAnyVal.template
@@ -189,7 +189,7 @@ final class $typeName$ private (val value: Float) extends AnyVal {
   /** Returns this value, unmodified. */
   def unary_+ : $typeName$ = this
   /** Returns the negation of this value. */
-  def unary_- : $negationType$ = $negationType$.ensuringValid(-value)
+  $negation$
 
   /**
    * Converts this <code>$typeName$</code>'s value to a string then concatenates the given string.

--- a/project/templates/IntAnyVal.template
+++ b/project/templates/IntAnyVal.template
@@ -180,7 +180,7 @@ final class $typeName$ private (val value: Int) extends AnyVal {
   /** Returns this value, unmodified. */
   def unary_+ : $typeName$ = this
   /** Returns the negation of this value. */
-  def unary_- : $negationType$ = $negationType$.ensuringValid(-value)
+  $negation$
   /**
    * Converts this <code>$typeName$</code>'s value to a string then concatenates the given string.
    */

--- a/project/templates/LongAnyVal.template
+++ b/project/templates/LongAnyVal.template
@@ -194,7 +194,7 @@ final class $typeName$ private (val value: Long) extends AnyVal {
   /** Returns this value, unmodified. */
   def unary_+ : $typeName$ = this
   /** Returns the negation of this value. */
-  def unary_- : $negationType$ = $negationType$.ensuringValid(-value)
+  $negation$
 
   /**
    * Converts this <code>$typeName$</code>'s value to a string then concatenates the given string.

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
@@ -222,7 +222,7 @@ class NegIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyCheck
 
     it("should offer a unary - method that returns PosInt") {
       forAll { (p: NegInt) =>
-        (-p) shouldEqual (PosInt.ensuringValid(-(p.toInt)))
+        (-p) shouldEqual (-(p.toInt))
       }
     }
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
@@ -232,7 +232,7 @@ class NegLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
 
       it("should offer a unary - method that returns PosLong") {
         forAll { (p: NegLong) =>
-          (-p) shouldEqual (PosLong.ensuringValid(-(p.toLong)))
+          (-p) shouldEqual (-(p.toLong))
         }
       }
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
@@ -222,7 +222,7 @@ class NegZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
 
     it("should offer a unary - method that returns PosZInt") {
       forAll { (p: NegZInt) =>
-        (-p) shouldEqual (PosZInt.ensuringValid(-(p.toInt)))
+        (-p) shouldEqual (-(p.toInt))
       }
     }
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
@@ -238,7 +238,7 @@ class NegZLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChe
 
     it("should offer a unary - method that returns PosZLong") {
       forAll { (p: NegZLong) =>
-        (-p) shouldEqual (PosZLong.ensuringValid(-(p.toLong)))
+        (-p) shouldEqual (-(p.toLong))
       }
     }
 


### PR DESCRIPTION
Changed NegInt, NegLong, NegZInt and NegZLong's unary_- to return primitive type because it won't work for Int.MinValue and Long.MaxValue.