### PR TITLE
make HtmlReporter handle parallel test executions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test-output/
 gentests/
 scalatest.js/target/
 *.swp
+.idea
+

--- a/scalatest/src/main/scala/org/scalatest/reporters/AbstractParallelReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/reporters/AbstractParallelReporter.scala
@@ -24,6 +24,8 @@ abstract class AbstractParallelReporter(filename: Option[String]) extends Resour
   val rawEventStreamFile: Option[OutputStream] = filename.map(f => Files.newOutputStream(Paths.get(f + ".txt")))
   val charset = Charset.forName("UTF8")
 
+  def this() = this(None)
+
   override def apply(event: Event): Unit = {
     events += event
     rawEventStreamFile.map(f => {

--- a/scalatest/src/main/scala/org/scalatest/reporters/AbstractParallelReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/reporters/AbstractParallelReporter.scala
@@ -1,0 +1,53 @@
+package org.scalatest.reporters
+
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.file.{Files, Paths}
+
+import org.scalatest.ResourcefulReporter
+import org.scalatest.events.{Event, RunCompleted}
+
+import scala.collection.mutable
+
+/**
+  * ScalaTest reporter which will take events generated from parallel test run and apply them through #applySequentially
+  * method to real implementation of this abstract class.
+  *
+  * * @param filename if optional filename is passed, two files will be created. One with nonsorted events as received
+  * and one with sorted events, as they are passed to lover instance. Given filename will have suffix appended. Once
+  * only ".txt" and once "Sorted.txt".
+  *
+  * Created by Ľubomír Varga on 27.1.2017.
+  */
+abstract class AbstractParallelReporter(filename: Option[String]) extends ResourcefulReporter {
+  val events: mutable.MutableList[Event] = mutable.MutableList()
+  val rawEventStreamFile: Option[OutputStream] = filename.map(f => Files.newOutputStream(Paths.get(f + ".txt")))
+  val charset = Charset.forName("UTF8")
+
+  override def apply(event: Event): Unit = {
+    events += event
+    rawEventStreamFile.map(f => {
+      f.write(event.toString.getBytes(charset))
+      f.write("\n".getBytes(charset))
+    })
+
+    event match {
+      case _: RunCompleted =>
+        val sortedFile = filename.map(f => Files.newOutputStream(Paths.get(f + "Sorted.txt")))
+        events.sortBy(_.ordinal).foreach(
+          e => {
+            sortedFile.map(_.write(e.toString.getBytes(charset)))
+            sortedFile.map(_.write("\n".getBytes(charset)))
+            applySequentially(e)
+          }
+        )
+        events.clear()
+        sortedFile.map(_.close())
+      case _ => {}
+    }
+  }
+
+  def applySequentially(event: Event): Unit
+
+  override def dispose(): Unit = rawEventStreamFile.map(_.close())
+}

--- a/scalatest/src/main/scala/org/scalatest/reporters/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/reporters/package.scala
@@ -1,0 +1,11 @@
+package org.scalatest
+
+/**
+  * This package should contain only reporters which are parallel friendly.
+  *
+  * Many reporters live outside of this package, because changing theirs fully qualified name (package) would make
+  * it incompatible. There are many tests running by specifying fully qualified name of reporter, thus changing package
+  * would break things.
+  */
+package object reporters {
+}

--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -32,8 +32,10 @@ import java.text.DecimalFormat
 import java.util.Iterator
 import java.util.Set
 import java.util.UUID
+
 import org.pegdown.PegDownProcessor
 import org.scalatest.exceptions.StackDepth
+
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
@@ -46,6 +48,7 @@ import StringReporter.makeDurationString
 import Suite.unparsedXml
 import Suite.xmlContent
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.reporters.AbstractParallelReporter
 
 /**
  * A <code>Reporter</code> that prints test status information in HTML format to a file.
@@ -55,7 +58,7 @@ private[scalatest] class HtmlReporter(
   presentAllDurations: Boolean,
   cssUrl: Option[URL],
   resultHolder: Option[SuiteResultHolder]
-) extends ResourcefulReporter {
+) extends AbstractParallelReporter {
 
   private val specIndent = 15
   private val targetDir = new File(directoryPath)
@@ -925,7 +928,7 @@ private[scalatest] class HtmlReporter(
   private var eventList = new ListBuffer[Event]()
   private var runEndEvent: Option[Event] = None
         
-  def apply(event: Event): Unit = {
+  def applySequentially(event: Event): Unit = {
         
     event match {
       case _: DiscoveryStarting  =>
@@ -1041,7 +1044,8 @@ private[scalatest] class HtmlReporter(
     }
   }
       
-  def dispose(): Unit = {
+  override def dispose(): Unit = {
+    super.dispose()
     runEndEvent match {
       case Some(event) => 
         event match {


### PR DESCRIPTION
I would like to improve reporter (now HtmlReporter) to be able to handle parallel test executions. These changes also does add git ignore for intelij idea directory.

PS: I know, that reporter will be now slower (it will wait till all test are finished and report generating will start after that time point), but it is able to handle parallel test executions. I hope I will make in near time replacement for html reporter, which will be fully parallel execution aware.