### PR TITLE
NumericString Scala-js Fix

### DIFF
--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericString.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericString.scala
@@ -39,7 +39,9 @@ private[scalactic] final class NumericString private (val value: String) extends
 
   def codePointAt(index: Int): Int = value.codePointAt(index)
 
+  // SKIP-SCALATESTJS-START
   def codePointBefore(index: Int): Int = value.codePointBefore(index)
+  // SKIP-SCALATESTJS-END
 
   def codePointCount(beginIndex: Int, endIndex: Int): Int =
     value.codePointCount(beginIndex, endIndex)
@@ -65,8 +67,10 @@ private[scalactic] final class NumericString private (val value: String) extends
   def contains(s: CharSequence): Boolean =
     value.contains(s)
 
+  // SKIP-SCALATESTJS-START
   def contentEquals(cs: CharSequence): Boolean =
     value.contentEquals(cs)
+  // SKIP-SCALATESTJS-END
 
   def endsWith(suffix: String): Boolean =
     value.endsWith(suffix)
@@ -116,8 +120,10 @@ private[scalactic] final class NumericString private (val value: String) extends
   def matches(regex: String): Boolean =
     value.matches(regex)
 
+  // SKIP-SCALATESTJS-START
   def offsetByCodePoints(index: Int, codePointOffset: Int): Int =
     value.offsetByCodePoints(index, codePointOffset)
+  // SKIP-SCALATESTJS-END
 
   def regionMatches(ignoreCase: Boolean, toffset: Int, other: String, ooffset: Int, len: Int): Boolean =
     value.regionMatches(ignoreCase, toffset, other, ooffset, len)
@@ -161,6 +167,7 @@ private[scalactic] final class NumericString private (val value: String) extends
   def toCharArray: Array[Char] =
     value.toCharArray
 
+  // SKIP-SCALATESTJS-START
   def toLowerCase: String =
     value.toLowerCase
 
@@ -172,6 +179,7 @@ private[scalactic] final class NumericString private (val value: String) extends
 
   def toUpperCase(locale: Locale): String =
     value.toUpperCase(locale: Locale)
+  // SKIP-SCALATESTJS-END
 
   def trim: String =
     value.trim
@@ -1145,12 +1153,14 @@ private[scalactic] final class NumericString private (val value: String) extends
   def padTo(len: Int, elem: Char): String =
     value.padTo(len, elem)
 
+  // SKIP-SCALATESTJS-START
   /** Returns a parallel implementation of this collection.
    *
    *  @return  a parallel implementation of this collection
    */
   def par: ParSeq[Char] =
     value.par
+  // SKIP-SCALATESTJS-END
 
   /** Partitions this `NumericString` in two strings according to a predicate.
    *

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
@@ -123,6 +123,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
         }
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer a codePointBefore method that is consistent with String") {
       forAll { (numStr: NumericString, pint: PosInt) =>
         whenever (numStr.length > 0) {
@@ -133,6 +134,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
         }
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer a codePointCount method that is consistent with String") {
       forAll { (numStr: NumericString, p1: PosInt, p2: PosInt) =>
         whenever (numStr.length > 0) {
@@ -194,6 +196,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
         }
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer a contentEquals method that is consistent with String") {
       forAll { (numStr: NumericString, str: String) =>
         val cs: CharSequence = str
@@ -206,6 +209,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.contentEquals(matchingCs)
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer an endsWith method that is consistent with String") {
       forAll { (numStr: NumericString, str: String, p1: PosInt) =>
         numStr.endsWith(str) shouldEqual
@@ -417,6 +421,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.matches(r2)
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer a offsetByCodePoints method that is consistent with String") {
       forAll { (numStr: NumericString, p1: PosInt, p2: PosInt) =>
         whenever (numStr.length > 0) {
@@ -428,6 +433,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
         }
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer regionMatches methods that are consistent with String") {
       forAll { (numStr: NumericString, i1: Int, str: String, i2: Int, len: Int ) =>
         numStr.regionMatches(true, i1, str, i2, len) shouldEqual
@@ -554,6 +560,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.toCharArray
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer toLowerCase methods that are consistent with String") {
       forAll { (numStr: NumericString) =>
         numStr.toLowerCase shouldEqual
@@ -572,6 +579,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.toUpperCase(Locale.getDefault)
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer a trim method that is consistent with String") {
       forAll { (numStr: NumericString) =>
         numStr.trim shouldEqual
@@ -801,6 +809,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
         }
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer a contentEquals method that accepts a StringBuffer") {
       forAll { (numStr: NumericString, str: String) =>
         var sb = new StringBuffer(str)
@@ -812,6 +821,7 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.contentEquals(sb)
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer a copyToArray method that takes start and len args") {
       forAll { (numStr: NumericString, start: PosInt, len: PosInt) =>
         val xs1 = Array.fill[Char](256)(0)
@@ -1351,12 +1361,14 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
           numStr.value.padTo(reasonableLen, elem)
       }
     }
+    // SKIP-SCALATESTJS-START
     it("should offer a par method consistent with StringOps") {
       forAll { (numStr: NumericString) =>
         numStr.par shouldEqual
           numStr.value.par
       }
     }
+    // SKIP-SCALATESTJS-END
     it("should offer a partition method consistent with StringOps") {
       def isEven(ch: Char): Boolean = (ch - '0') % 2 == 0
 


### PR DESCRIPTION
Skipped some code in NumericString for scala-js as they are not supported on scala-js.