### PR TITLE
GeneratorDrivenPropertyChecks Seed Enhancement

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
@@ -64,18 +64,16 @@ class ArgsParserSpec extends FunSpec {
       concurrentList,
       // SKIP-SCALATESTJS-END
       memberOfList,
-      // SKIP-SCALATESTJS-START
       beginsWithList,
-      // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY beginsWithList
       // SKIP-SCALATESTJS-START
       testNGList,
       suffixes,
       chosenStyleList,
       spanScaleFactorList,
       testSortingReporterTimeoutList,
-      slowpokeList
+      slowpokeList,
       // SKIP-SCALATESTJS-END
+      seedList
       ) = ArgsParser.parseArgs(args)
 
       // SKIP-SCALATESTJS-START
@@ -525,7 +523,8 @@ class ArgsParserSpec extends FunSpec {
                 expectedSuffixes: Option[Pattern],
                 expectedChosenStyleList: List[String],
                 expectedSpanScaleFactorList: List[String],
-                expectedTestSortingReporterTimeoutList: List[String]
+                expectedTestSortingReporterTimeoutList: List[String],
+                expectedSeedList: List[String]
                 ) = {
 
       val ParsedArgs(
@@ -545,18 +544,16 @@ class ArgsParserSpec extends FunSpec {
       concurrentList,
       // SKIP-SCALATESTJS-END
       memberOfList,
-      // SKIP-SCALATESTJS-START
       beginsWithList,
-      // SKIP-SCALATESTJS-END
-      //SCALATESTJS-ONLY beginsWithList
       // SKIP-SCALATESTJS-START
       testNGList,
       suffixes,
       chosenStyleList,
       spanScaleFactorList,
       testSortingReporterTimeoutList,
-      slowpokeList
+      slowpokeList,
       // SKIP-SCALATESTJS-END
+      seedList
       ) = ArgsParser.parseArgs(args)
 
       // SKIP-SCALATESTJS-START
@@ -588,6 +585,7 @@ class ArgsParserSpec extends FunSpec {
         assert(suffixes.get.toString === expectedSuffixes.get.toString)
       }
       // SKIP-SCALATESTJS-END
+      assert(seedList === expectedSeedList)
     }
 
     // SKIP-SCALATESTJS-START
@@ -607,6 +605,7 @@ class ArgsParserSpec extends FunSpec {
       Nil,
       Nil,
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -631,6 +630,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
 
@@ -649,6 +649,7 @@ class ArgsParserSpec extends FunSpec {
       Nil,
       Nil,
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -673,6 +674,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
 
@@ -695,6 +697,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
 
@@ -715,6 +718,7 @@ class ArgsParserSpec extends FunSpec {
       Nil,
       Nil,
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -740,6 +744,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
     // Try a TestNGSuite
@@ -761,6 +766,7 @@ class ArgsParserSpec extends FunSpec {
       List("-w", "com.example.root"),
       List("-b", "some/path/file.xml"),
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -786,6 +792,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
     // Test -u option
@@ -807,6 +814,7 @@ class ArgsParserSpec extends FunSpec {
       List("-w", "com.example.root"),
       List("-b", "some/path/file.xml"),
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -832,6 +840,7 @@ class ArgsParserSpec extends FunSpec {
       Some(Pattern.compile(".*(Spec|Suite)$")),
       Nil,
       Nil,
+      Nil,
       Nil
     )
     // Test -q option
@@ -853,6 +862,7 @@ class ArgsParserSpec extends FunSpec {
       List("-w", "com.example.root"),
       List("-b", "some/path/file.xml"),
       Some(Pattern.compile(".*(Spec|Suite)$")),
+      Nil,
       Nil,
       Nil,
       Nil
@@ -878,6 +888,7 @@ class ArgsParserSpec extends FunSpec {
       Some(Pattern.compile(".*(Spec|Suite|foo)$")),
       Nil,
       Nil,
+      Nil,
       Nil
     )
     // Test -F option
@@ -901,6 +912,7 @@ class ArgsParserSpec extends FunSpec {
       Some(Pattern.compile(".*(Spec|Suite|foo)$")),
       Nil,
       List("-F", "200"),
+      Nil,
       Nil
     )
     // Test -T option
@@ -924,7 +936,8 @@ class ArgsParserSpec extends FunSpec {
       Some(Pattern.compile(".*(Spec|Suite|foo)$")),
       Nil,
       Nil,
-      List("-T", "20")
+      List("-T", "20"),
+      Nil
     )
     // Test -h option
     verify(
@@ -945,6 +958,7 @@ class ArgsParserSpec extends FunSpec {
       List("-w", "com.example.root"),
       List("-b", "some/path/file.xml"),
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -970,6 +984,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
 
@@ -989,6 +1004,7 @@ class ArgsParserSpec extends FunSpec {
       Nil,
       Nil,
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -1017,6 +1033,7 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
 
@@ -1036,6 +1053,7 @@ class ArgsParserSpec extends FunSpec {
       Nil,
       Nil,
       None,
+      Nil,
       Nil,
       Nil,
       Nil
@@ -1064,9 +1082,32 @@ class ArgsParserSpec extends FunSpec {
       None,
       Nil,
       Nil,
+      Nil,
       Nil
     )
     // SKIP-SCALATESTJS-END
+
+    // Test to parse -S
+    verify(
+      Array("-S", "123456789"),
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      None,
+      Nil,
+      Nil,
+      Nil,
+      List("-S", "123456789")
+    )
   }
 
   describe("parseCompoundArgIntoSet should") {
@@ -1793,6 +1834,44 @@ class ArgsParserSpec extends FunSpec {
     assert(multipDashPSThreadNum.enableSuiteSortingReporter === true)
   }
   // SKIP-SCALATESTJS-END
+
+  it("parseLongArgument should work correctly") {
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-a", "123"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-S", "abc"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-S"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-S", "123", "-S"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-S", "123", "-S", "456"), "-S")
+    }
+    val spanScaleFactor = ArgsParser.parseLongArgument(List("-S", "888"), "-S")
+    assert(spanScaleFactor === Some(888))
+
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-a", "123"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-T", "abc"), "-S")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-T"), "-T")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-T", "123", "-T"), "-T")
+    }
+    intercept[IllegalArgumentException] {
+      ArgsParser.parseLongArgument(List("-T", "123", "-T", "456"), "-T")
+    }
+    val testSortingReporterTimeout = ArgsParser.parseLongArgument(List("-T", "888"), "-T")
+    assert(testSortingReporterTimeout === Some(888))
+  }
 
   it("""parseArgs should disallow -t"something""") {
     val e = intercept[IllegalArgumentException] {

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -487,6 +487,7 @@ occurredOnValues=Occurred when passed generated values (
 propCheckLabel=Label of failing property:
 propCheckLabels=Labels of failing property:
 suiteAndTestNamesFormattedForDisplay={0}, {1}
+initSeed=Init Seed: {0}
 notLoneElement=Expected {0} to contain exactly 1 element, but it has size {1}
 testNGConfigFailed=TestNG configuration failed
 jUnitTestFailed=A JUnit test failed

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
@@ -19,10 +19,10 @@ sealed trait PropertyCheckResult
 
 object PropertyCheckResult {
 
-  case class Success(args: List[PropertyArgument]) extends PropertyCheckResult
+  case class Success(args: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
 
-  case class Exhausted(succeeded: Long, discarded: Long, names: List[String], argsPassed: List[PropertyArgument]) extends PropertyCheckResult
+  case class Exhausted(succeeded: Long, discarded: Long, names: List[String], argsPassed: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
 
-  case class Failure(succeeded: Long, ex: Option[Throwable], names: List[String], argsPassed: List[PropertyArgument]) extends PropertyCheckResult
+  case class Failure(succeeded: Long, ex: Option[Throwable], names: List[String], argsPassed: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
 
 }

--- a/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -1215,9 +1215,16 @@ class Randomizer(private[scalatest] val seed: Long) { thisRandomizer =>
 
 object Randomizer {
 
+  import java.util.concurrent.atomic.AtomicReference
+
+  private[scalatest] val defaultSeed: AtomicReference[Option[Long]] = new AtomicReference(None)
+
   def default(): Randomizer =
-    new Randomizer(
-      (System.currentTimeMillis() ^ 0x5DEECE66DL) & ((1L << 48) - 1)
+    apply(
+      defaultSeed.get() match {
+        case Some(seed) => seed
+        case None => System.currentTimeMillis()
+      }
     )
 
   def apply(seed: Long): Randomizer = new Randomizer((seed ^ 0x5DEECE66DL) & ((1L << 48) - 1))

--- a/scalatest/src/main/scala/org/scalatest/tools/ArgsParser.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ArgsParser.scala
@@ -184,6 +184,7 @@ private[tools] object ArgsParser {
     val spanScaleFactor = new ListBuffer[String]()
     val testSortingReporterTimeout = new ListBuffer[String]()
     val slowpoke = new ListBuffer[String]()
+    val seeds = ListBuffer[String]()
     // SKIP-SCALATESTJS-END
 
     val it = args.iterator.buffered
@@ -395,6 +396,11 @@ private[tools] object ArgsParser {
         // SKIP-SCALATESTJS-END
         //SCALATESTJS-ONLY throw new IllegalArgumentException("Argument not supported by ScalaTest-js: " + s)
       }
+      else if (s == "-S") {
+        seeds += s
+        if (it.hasNext)
+          seeds += it.next()
+      }
       else if (s == "-T") {
         // SKIP-SCALATESTJS-START
         testSortingReporterTimeout += s
@@ -443,16 +449,16 @@ private[tools] object ArgsParser {
       concurrent.toList,
       // SKIP-SCALATESTJS-END
       membersOnly.toList,
-      //SCALATESTJS-ONLY wildcard.toList
-      // SKIP-SCALATESTJS-START
       wildcard.toList,
+      // SKIP-SCALATESTJS-START
       testNGXMLFiles.toList,
       genSuffixesPattern(suffixes.toList),
       chosenStyles.toList,
       spanScaleFactor.toList,
       testSortingReporterTimeout.toList,
-      slowpoke.toList
+      slowpoke.toList,
       // SKIP-SCALATESTJS-END
+      seeds.toList
     )
   }
 
@@ -1231,6 +1237,34 @@ private[tools] object ArgsParser {
       defaultValue
     else if (lb.size == 1)
       lb(0)
+    else
+      throw new IllegalArgumentException("Only one " + dashArg + " can be specified.")
+  }
+
+  def parseLongArgument(args: List[String], dashArg: String): Option[Long] = {
+    val it = args.iterator
+    val lb = new ListBuffer[Long]()
+    while (it.hasNext) {
+      val dash = it.next
+      if (dash != dashArg)
+        throw new IllegalArgumentException("Every other element, starting with the first, must be " + dashArg)
+      if (it.hasNext) {
+        val spanString = it.next
+        try {
+          lb += spanString.toLong
+        }
+        catch {
+          case e: NumberFormatException =>
+            throw new IllegalArgumentException(dashArg + " must be followed by a number, but '" + spanString + "' is not a number.")
+        }
+      }
+      else
+        throw new IllegalArgumentException("Last element must be a number, not a " + dashArg + ".")
+    }
+    if (lb.size == 0)
+      None
+    else if (lb.size == 1)
+      Some(lb(0))
     else
       throw new IllegalArgumentException("Only one " + dashArg + " can be specified.")
   }

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -19,12 +19,15 @@ import org.scalatest._
 import org.scalatest.events._
 import ArgsParser._
 import SuiteDiscoveryHelper._
+
 import scala.collection.JavaConverters._
-import java.io.{StringWriter, PrintWriter}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean, AtomicReference}
-import java.util.concurrent.{ThreadFactory, Executors, ExecutorService, LinkedBlockingQueue}
-import org.scalatest.time.{Span, Millis}
-import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Status => SbtStatus, Runner => SbtRunner, _}
+import java.io.{PrintWriter, StringWriter}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
+
+import org.scalatest.time.{Millis, Span}
+import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Runner => SbtRunner, Status => SbtStatus, _}
+
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 import StringReporter.fragmentsForEvent
@@ -33,6 +36,7 @@ import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
 import Suite.mergeMap
+import org.scalatest.prop.Randomizer
 
 
 /**
@@ -925,7 +929,8 @@ import java.net.{ServerSocket, InetAddress}
       chosenStyles, 
       spanScaleFactors, 
       testSortingReporterTimeouts,
-      slowpokeArgs
+      slowpokeArgs,
+      seedArgs
     ) = parseArgs(FriendlyParamsTranslator.translateArguments(args))
     
     if (!runpathArgs.isEmpty)
@@ -971,6 +976,11 @@ import java.net.{ServerSocket, InetAddress}
       }
     
     Runner.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
+
+    parseLongArgument(seedArgs, "-S") match {
+      case Some(seed) => Randomizer.defaultSeed.getAndSet(Some(seed))
+      case None => // do nothing
+    }
 
     val autoSelectors = parseSuiteArgs(suiteArgs)
 

--- a/scalatest/src/main/scala/org/scalatest/tools/ParsedArgs.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ParsedArgs.scala
@@ -34,16 +34,14 @@ private[scalatest] case class ParsedArgs(
   concurrent: List[String],
   // SKIP-SCALATESTJS-END
   membersOnly: List[String],
-  // SKIP-SCALATESTJS-START
   wildcard: List[String],
-  // SKIP-SCALATESTJS-END
-  //SCALATESTJS-ONLY wildcard: List[String]
   // SKIP-SCALATESTJS-START
   testNGXMLFiles: List[String],
   genSuffixesPattern: Option[Pattern],
   chosenStyles: List[String], 
   spanScaleFactor: List[String], 
   testSortingReporterTimeout: List[String],
-  slowpokeParams: List[String]
+  slowpokeParams: List[String],
   // SKIP-SCALATESTJS-END
+  seeds: List[String]
 )

--- a/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
@@ -39,6 +39,7 @@ import org.scalatest.testng.TestNGWrapperSuite
 import Suite.{mergeMap, CHOSEN_STYLES, SELECTED_TAG, testSortingReporterTimeout}
 import ArgsParser._
 import org.scalactic.Requirements._
+import org.scalatest.prop.Randomizer
 
 /*
 Command line args:
@@ -80,7 +81,7 @@ Q - equalivalent to -q Suite -q Spec
 r - custom reporter (currently deprecated, will be runpath)
 R - space-separated runpath (temporarily)
 s - suite class name (to become a glob)
-S -
+S - initial seed for Randomizer.default
 t - test name
 T - sorting timeout                        --sorting-timeout
 u - JUnit XML reporter
@@ -879,7 +880,8 @@ object Runner {
       chosenStyles, 
       spanScaleFactors, 
       testSortingReporterTimeouts,
-      slowpokeArgs
+      slowpokeArgs,
+      seedArgs
     ) = parseArgs(args)
 
     val fullReporterConfigurations: ReporterConfigurations =
@@ -904,8 +906,15 @@ object Runner {
     val testNGList: List[String] = parseSuiteArgsIntoNameStrings(testNGArgs, "-b")
     val chosenStyleSet: Set[String] = parseChosenStylesIntoChosenStyleSet(chosenStyles, "-y")
     val slowpokeConfig: Option[SlowpokeConfig] = parseSlowpokeConfig(slowpokeArgs)
+    val seedList: Option[Long] = parseLongArgument(seedArgs, "-S")
+
     spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
     testSortingReporterTimeout = Span(parseDoubleArgument(testSortingReporterTimeouts, "-T", 2.0), Seconds)
+
+    seedList match {
+      case Some(seed) => Randomizer.defaultSeed.getAndSet(Some(seed))
+      case None => // do nothing
+    }
 
     // If there's a graphic reporter, we need to leave it out of
     // reporterSpecs, because we want to pass all reporterSpecs except

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -31,6 +31,7 @@ import org.scalatest.events.SuiteCompleted
 import org.scalatest.events.SuiteStarting
 import org.scalatest.events.TopOfClass
 import org.scalatools.testing.{Framework => SbtFramework, _}
+import org.scalatest.prop.Randomizer
 
 /**
  * Class that makes ScalaTest tests visible to SBT (prior to version 0.13).
@@ -151,7 +152,8 @@ class ScalaTestFramework extends SbtFramework {
             chosenStyles, 
             spanScaleFactors, 
             testSortingReporterTimeouts,
-            slowpokeArgs
+            slowpokeArgs,
+            seedArgs
           ) = parseArgs(FriendlyParamsTranslator.translateArguments(args))
           
           if (!runpathArgs.isEmpty)
@@ -202,6 +204,11 @@ class ScalaTestFramework extends SbtFramework {
           }
           
           Runner.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
+
+          parseLongArgument(seedArgs, "-S") match {
+            case Some(seed) => Randomizer.defaultSeed.getAndSet(Some(seed))
+            case None => // do nothing
+          }
           
           val fullReporterConfigurations = parseReporterArgsIntoConfigurations(reporterArgs)
           val sbtNoFormat = java.lang.Boolean.getBoolean("sbt.log.noformat")


### PR DESCRIPTION
Changed GeneratorDrivenPropertyChecks to display init seed when test fails, and added -S argument so that user can specify init seed to use to facilitate reproducing problem.