### PR TITLE
Public ScreenshotCapturer

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/ScreenshotCapturer.scala
+++ b/scalatest/src/main/scala/org/scalatest/ScreenshotCapturer.scala
@@ -19,7 +19,7 @@ package org.scalatest
 /**
  * Trait containing one abstract method that can capture a screenshot and save it as a file to a given directory.
  */
-private[scalatest] trait ScreenshotCapturer { 
+trait ScreenshotCapturer {
 
   /**
    * Captures a screenshot and saves it as a file in the specified directory.


### PR DESCRIPTION
Made ScreenshotCapturer public.  This interface is actually exposed by WebBrowser sub-classes such as this one: 

http://doc.scalatest.org/3.0.0/index.html#org.scalatest.selenium.HtmlUnit

I couldn't recall the reason to keep it private[scalatest], and it is now preventing selenium to move to org.scalatestplus.play package.