### PR TITLE
path matchers

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableSpec.scala
@@ -131,6 +131,73 @@ class ShouldBeReadableSpec extends FunSpec with Matchers {
 
     }
 
+    describe("when work with 'path should be (readable)'") {
+
+      it("should do nothing when path is readable") {
+        readableFile.toPath should be (readable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not readable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath should be (readable)
+        }
+        assert(caught1.message === Some(wasNotReadable(secretFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'path should not be readable'") {
+
+      it("should do nothing when path is not readable") {
+        secretFile.toPath should not be readable
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is readable") {
+        val caught1 = intercept[TestFailedException] {
+          readableFile.toPath should not be readable
+        }
+        assert(caught1.message === Some(wasReadable(readableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'path shouldBe readable'") {
+
+      it("should do nothing when path is readable") {
+        readableFile.toPath shouldBe readable
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not readable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath shouldBe readable
+        }
+        assert(caught1.message === Some(wasNotReadable(secretFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'path shouldNot be (readable)'") {
+
+      it("should do nothing when path is not readable") {
+        secretFile.toPath shouldNot be (readable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is readable") {
+        val caught1 = intercept[TestFailedException] {
+          readableFile.toPath shouldNot be (readable)
+        }
+        assert(caught1.message === Some(wasReadable(readableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
     describe("when work with 'all(xs) should be (readable)'") {
 
       it("should do nothing when all(xs) is readable") {
@@ -184,7 +251,7 @@ class ShouldBeReadableSpec extends FunSpec with Matchers {
       }
     }
 
-    describe("when work with 'all(xs) shouldNot be (readable)'") {
+    describe("when work with 'all(paths) shouldNot be (readable)'") {
 
       it("should do nothing when all(xs) is not readable") {
         all(List(secretFile)) shouldNot be (readable)
@@ -200,6 +267,77 @@ class ShouldBeReadableSpec extends FunSpec with Matchers {
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
       }
       
+    }
+
+    describe("when work with 'all(paths) should be (readable)'") {
+
+      it("should do nothing when all(paths) is readable") {
+        all(List(readableFile.toPath)) should be (readable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is not readable") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should be (readable)
+        }
+        assert(caught1.message === Some(allError(left1, wasNotReadable(secretFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'all(paths) should not be readable'") {
+
+      it("should do nothing when all(paths) is not readable") {
+        all(List(secretFile.toPath)) should not be readable
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is readable") {
+        val left1 = List(readableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should not be readable
+        }
+        assert(caught1.message === Some(allError(left1, wasReadable(readableFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'all(paths) shouldBe readable'") {
+
+      it("should do nothing when all(paths) is readable") {
+        all(List(readableFile.toPath)) shouldBe readable
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is not readable") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) shouldBe readable
+        }
+        assert(caught1.message === Some(allError(left1, wasNotReadable(secretFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) shouldNot be (readable)'") {
+
+      it("should do nothing when all(paths) is not readable") {
+        all(List(secretFile.toPath)) shouldNot be (readable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is readable") {
+        val left1 = List(readableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) shouldNot be (readable)
+        }
+        assert(caught1.message === Some(allError(left1, wasReadable(readableFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
     }
   }
   

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
@@ -145,6 +145,88 @@ class ShouldBeWritableLogicalAndSpec extends FunSpec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
       }
     }
+
+    describe("when work with 'path should be (writable)'") {
+
+      it("should do nothing when path is writable") {
+        writableFile.toPath should (equal (writableFile.toPath) and be (writable))
+        writableFile.toPath should (be (writable) and equal (writableFile.toPath))
+
+        writableFile.toPath should (be (writableFile.toPath) and be (writable))
+        writableFile.toPath should (be (writable) and be (writableFile.toPath))
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not writable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath should (equal (secretFile.toPath) and be (writable))
+        }
+        assert(caught1.message === Some(equaled(secretFile.toPath, secretFile.toPath) + ", but " + wasNotWritable(secretFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught2 = intercept[TestFailedException] {
+          secretFile.toPath should (be (writable) and equal (secretFile.toPath))
+        }
+        assert(caught2.message === Some(wasNotWritable(secretFile.toPath)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught3 = intercept[TestFailedException] {
+          secretFile.toPath should (be (secretFile.toPath) and be (writable))
+        }
+        assert(caught3.message === Some(wasEqualTo(secretFile.toPath, secretFile.toPath) + ", but " + wasNotWritable(secretFile.toPath)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught4 = intercept[TestFailedException] {
+          secretFile.toPath should (be (writable) and be (secretFile.toPath))
+        }
+        assert(caught4.message === Some(wasNotWritable(secretFile.toPath)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'path should not be sorted'") {
+
+      it("should do nothing when path is not writable") {
+        secretFile.toPath should (not equal writableFile.toPath and not be writable)
+        secretFile.toPath should (not be writable and not equal writableFile.toPath)
+
+        secretFile.toPath should (not be writableFile.toPath and not be writable)
+        secretFile.toPath should (not be writable and not be writableFile.toPath)
+      }
+
+      it("should throw TestFailedException with correct stack depth when paths is not sorted") {
+        val caught1 = intercept[TestFailedException] {
+          writableFile.toPath should (not equal secretFile.toPath and not be writable)
+        }
+        assert(caught1.message === Some(didNotEqual(writableFile.toPath, secretFile.toPath) + ", but " + wasWritable(writableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught2 = intercept[TestFailedException] {
+          writableFile.toPath should (not be writable and not equal secretFile.toPath)
+        }
+        assert(caught2.message === Some(wasWritable(writableFile.toPath)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught3 = intercept[TestFailedException] {
+          writableFile.toPath should (not be secretFile.toPath and not be writable)
+        }
+        assert(caught3.message === Some(wasNotEqualTo(writableFile.toPath, secretFile.toPath) + ", but " + wasWritable(writableFile.toPath)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught4 = intercept[TestFailedException] {
+          writableFile.toPath should (not be writable and not be secretFile.toPath)
+        }
+        assert(caught4.message === Some(wasWritable(writableFile.toPath)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
     
     describe("when work with 'all(xs) should be (writable)'") {
       
@@ -230,6 +312,96 @@ class ShouldBeWritableLogicalAndSpec extends FunSpec {
           all(left4) should (not be writable and not equal secretFile)
         }
         assert(caught4.message === Some(allError(wasWritable(writableFile), thisLineNumber - 2, left4)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) should be (writable)'") {
+
+      it("should do nothing when all(paths) is writable") {
+        all(List(writableFile.toPath)) should (be (writableFile.toPath) and be (writable))
+        all(List(writableFile.toPath)) should (be (writable) and be (writableFile.toPath))
+
+        all(List(writableFile.toPath)) should (equal (writableFile.toPath) and be (writable))
+        all(List(writableFile.toPath)) should (be (writable) and equal (writableFile.toPath))
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(pats) is not writable") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should (be (secretFile.toPath) and be (writable))
+        }
+        assert(caught1.message === Some(allError(wasEqualTo(secretFile.toPath, secretFile.toPath) + ", but " + wasNotWritable(secretFile.toPath), thisLineNumber - 2, left1)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left2 = List(secretFile.toPath)
+        val caught2 = intercept[TestFailedException] {
+          all(left2) should (be (writable) and be (secretFile.toPath))
+        }
+        assert(caught2.message === Some(allError(wasNotWritable(secretFile.toPath), thisLineNumber - 2, left2)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left3 = List(secretFile.toPath)
+        val caught3 = intercept[TestFailedException] {
+          all(left3) should (equal (secretFile.toPath) and be (writable))
+        }
+        assert(caught3.message === Some(allError(equaled(secretFile.toPath, secretFile.toPath) + ", but " + wasNotWritable(secretFile.toPath), thisLineNumber - 2, left3)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left4 = List(secretFile.toPath)
+        val caught4 = intercept[TestFailedException] {
+          all(left4) should (be (writable) and equal (secretFile.toPath))
+        }
+        assert(caught4.message === Some(allError(wasNotWritable(secretFile.toPath), thisLineNumber - 2, left4)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) should not be writable'") {
+      
+      it("should do nothing when all(paths) is not writable") {
+        all(List(secretFile.toPath)) should (not be writable and not be writableFile.toPath)
+        all(List(secretFile.toPath)) should (not be writableFile.toPath and not be writable)
+
+        all(List(secretFile.toPath)) should (not be writable and not equal writableFile.toPath)
+        all(List(secretFile.toPath)) should (not equal writableFile.toPath and not be writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is writable") {
+        val left1 = List(writableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should (not be secretFile.toPath and not be writable)
+        }
+        assert(caught1.message === Some(allError(wasNotEqualTo(writableFile.toPath, secretFile.toPath) + ", but " + wasWritable(writableFile.toPath), thisLineNumber - 2, left1)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left2 = List(writableFile.toPath)
+        val caught2 = intercept[TestFailedException] {
+          all(left2) should (not be writable and not be secretFile.toPath)
+        }
+        assert(caught2.message === Some(allError(wasWritable(writableFile.toPath), thisLineNumber - 2, left2)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left3 = List(writableFile.toPath)
+        val caught3 = intercept[TestFailedException] {
+          all(left3) should (not equal secretFile.toPath and not be writable)
+        }
+        assert(caught3.message === Some(allError(didNotEqual(writableFile.toPath, secretFile.toPath) + ", but " + wasWritable(writableFile.toPath), thisLineNumber - 2, left3)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left4 = List(writableFile.toPath)
+        val caught4 = intercept[TestFailedException] {
+          all(left4) should (not be writable and not equal secretFile.toPath)
+        }
+        assert(caught4.message === Some(allError(wasWritable(writableFile.toPath), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
       }

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
@@ -166,6 +166,109 @@ class ShouldBeWritableLogicalOrSpec extends FunSpec {
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
       }
     }
+
+    describe("when work with 'path should be (writable)'") {
+
+      it("should do nothing when path is writable") {
+
+        writableFile.toPath should (be (writable) or be (writableFile.toPath))
+        secretFile.toPath should (be (writable) or be (secretFile.toPath))
+        writableFile.toPath should (be (writable) or be (secretFile.toPath))
+
+        writableFile.toPath should (be (writableFile.toPath) or be (writable))
+        writableFile.toPath should (be (secretFile.toPath) or be (writable))
+        secretFile.toPath should (be (secretFile.toPath) or be (writable))
+
+        writableFile.toPath should (be (writable) or equal (writableFile.toPath))
+        secretFile.toPath should (be (writable) or equal (secretFile.toPath))
+        writableFile.toPath should (be (writable) or equal (secretFile.toPath))
+
+        writableFile.toPath should (equal (writableFile.toPath) or be (writable))
+        writableFile.toPath should (equal (secretFile.toPath) or be (writable))
+        secretFile.toPath should (equal (secretFile.toPath) or be (writable))
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not writable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath should (be (writable) or be (writableFile.toPath))
+        }
+        assert(caught1.message === Some(wasNotWritable(secretFile.toPath) + ", and " + wasNotEqualTo(secretFile.toPath, writableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught2 = intercept[TestFailedException] {
+          secretFile.toPath should (be (writableFile.toPath) or be (writable))
+        }
+        assert(caught2.message === Some(wasNotEqualTo(secretFile.toPath, writableFile.toPath) + ", and " + wasNotWritable(secretFile.toPath)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught3 = intercept[TestFailedException] {
+          secretFile.toPath should (be (writable) or equal (writableFile.toPath))
+        }
+        assert(caught3.message === Some(wasNotWritable(secretFile.toPath) + ", and " + didNotEqual(secretFile.toPath, writableFile.toPath)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught4 = intercept[TestFailedException] {
+          secretFile.toPath should (equal (writableFile.toPath) or be (writable))
+        }
+        assert(caught4.message === Some(didNotEqual(secretFile.toPath, writableFile.toPath) + ", and " + wasNotWritable(secretFile.toPath)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'path should not be writable'") {
+
+      it("should do nothing when path is not writable") {
+        secretFile.toPath should (not be writable or not be writableFile.toPath)
+        writableFile.toPath should (not be writable or not be secretFile.toPath)
+        secretFile.toPath should (not be writable or not be secretFile.toPath)
+
+        secretFile.toPath should (not be writableFile.toPath or not be writable)
+        secretFile.toPath should (not be secretFile.toPath or not be writable)
+        writableFile.toPath should (not be secretFile.toPath or not be writable)
+
+        secretFile.toPath should (not be writable or not equal writableFile.toPath)
+        writableFile.toPath should (not be writable or not equal secretFile.toPath)
+        secretFile.toPath should (not be writable or not equal secretFile.toPath)
+
+        secretFile.toPath should (not equal writableFile.toPath or not be writable)
+        secretFile.toPath should (not equal secretFile.toPath or not be writable)
+        writableFile.toPath should (not equal secretFile.toPath or not be writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is writable") {
+        val caught1 = intercept[TestFailedException] {
+          writableFile.toPath should (not be writable or not be writableFile.toPath)
+        }
+        assert(caught1.message === Some(wasWritable(writableFile.toPath) + ", and " + wasEqualTo(writableFile.toPath, writableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught2 = intercept[TestFailedException] {
+          writableFile.toPath should (not be writableFile.toPath or not be writable)
+        }
+        assert(caught2.message === Some(wasEqualTo(writableFile.toPath, writableFile.toPath) + ", and " + wasWritable(writableFile.toPath)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught3 = intercept[TestFailedException] {
+          writableFile.toPath should (not be writable or not equal writableFile.toPath)
+        }
+        assert(caught3.message === Some(wasWritable(writableFile.toPath) + ", and " + equaled(writableFile.toPath, writableFile.toPath)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val caught4 = intercept[TestFailedException] {
+          writableFile.toPath should (not equal writableFile.toPath or not be writable)
+        }
+        assert(caught4.message === Some(equaled(writableFile.toPath, writableFile.toPath) + ", and " + wasWritable(writableFile.toPath)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
     
     describe("when work with 'all(xs) should be (writable)'") {
       
@@ -271,6 +374,115 @@ class ShouldBeWritableLogicalOrSpec extends FunSpec {
           all(left4) should (not be writable or not equal writableFile)
         }
         assert(caught4.message === Some(allError(wasWritable(writableFile) + ", and " + equaled(writableFile, writableFile), thisLineNumber - 2, left4)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) should be (writable)'") {
+
+      it("should do nothing when all(paths) is writable") {
+        all(List(writableFile.toPath)) should (be (writable) or be (writableFile.toPath))
+        all(List(secretFile.toPath)) should (be (writable) or be (secretFile.toPath))
+        all(List(writableFile.toPath)) should (be (writable) or be (secretFile.toPath))
+
+        all(List(writableFile.toPath)) should (be (writableFile.toPath) or be (writable))
+        all(List(writableFile.toPath)) should (be (secretFile.toPath) or be (writable))
+        all(List(secretFile.toPath)) should (be (secretFile.toPath) or be (writable))
+
+        all(List(writableFile.toPath)) should (be (writable) or equal (writableFile.toPath))
+        all(List(secretFile.toPath)) should (be (writable) or equal (secretFile.toPath))
+        all(List(writableFile.toPath)) should (be (writable) or equal (secretFile.toPath))
+
+        all(List(writableFile.toPath)) should (equal (writableFile.toPath) or be (writable))
+        all(List(writableFile.toPath)) should (equal (secretFile.toPath) or be (writable))
+        all(List(secretFile.toPath)) should (equal (secretFile.toPath) or be (writable))
+      }
+
+      it("should throw TestFailedException with correct stack depth when paths is not sorted") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should (be (writableFile.toPath) or be (writable))
+        }
+        assert(caught1.message === Some(allError(wasNotEqualTo(secretFile.toPath, writableFile.toPath) + ", and " + wasNotWritable(secretFile.toPath), thisLineNumber - 2, left1)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left2 = List(secretFile.toPath)
+        val caught2 = intercept[TestFailedException] {
+          all(left2) should (be (writable) or be (writableFile.toPath))
+        }
+        assert(caught2.message === Some(allError(wasNotWritable(secretFile.toPath) + ", and " + wasNotEqualTo(secretFile.toPath, writableFile.toPath), thisLineNumber - 2, left2)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left3 = List(secretFile.toPath)
+        val caught3 = intercept[TestFailedException] {
+          all(left3) should (equal (writableFile.toPath) or be (writable))
+        }
+        assert(caught3.message === Some(allError(didNotEqual(secretFile.toPath, writableFile.toPath) + ", and " + wasNotWritable(secretFile.toPath), thisLineNumber - 2, left3)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left4 = List(secretFile.toPath)
+        val caught4 = intercept[TestFailedException] {
+          all(left4) should (be (writable) or equal (writableFile.toPath))
+        }
+        assert(caught4.message === Some(allError(wasNotWritable(secretFile.toPath) + ", and " + didNotEqual(secretFile.toPath, writableFile.toPath), thisLineNumber - 2, left4)))
+        assert(caught4.failedCodeFileName === Some(fileName))
+        assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) should not be sorted'") {
+      it("should do nothing when paths is not sorted") {
+        all(List(secretFile.toPath)) should (not be writable or not be writableFile.toPath)
+        all(List(writableFile.toPath)) should (not be writable or not be secretFile.toPath)
+        all(List(secretFile.toPath)) should (not be writable or not be secretFile.toPath)
+
+        all(List(secretFile.toPath)) should (not be writableFile.toPath or not be writable)
+        all(List(secretFile.toPath)) should (not be secretFile.toPath or not be writable)
+        all(List(writableFile.toPath)) should (not be secretFile.toPath or not be writable)
+
+        all(List(secretFile.toPath)) should (not be writable or not equal writableFile.toPath)
+        all(List(writableFile.toPath)) should (not be writable or not equal secretFile.toPath)
+        all(List(secretFile.toPath)) should (not be writable or not equal secretFile.toPath)
+
+        all(List(secretFile.toPath)) should (not equal writableFile.toPath or not be writable)
+        all(List(secretFile.toPath)) should (not equal secretFile.toPath or not be writable)
+        all(List(writableFile.toPath)) should (not equal secretFile.toPath or not be writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when paths is not sorted") {
+        val left1 = List(writableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should (not be writableFile.toPath or not be writable)
+        }
+        assert(caught1.message === Some(allError(wasEqualTo(writableFile.toPath, writableFile.toPath) + ", and " + wasWritable(writableFile.toPath), thisLineNumber - 2, left1)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left2 = List(writableFile.toPath)
+        val caught2 = intercept[TestFailedException] {
+          all(left2) should (not be writable or not be writableFile.toPath)
+        }
+        assert(caught2.message === Some(allError(wasWritable(writableFile.toPath) + ", and " + wasEqualTo(writableFile.toPath, writableFile.toPath), thisLineNumber - 2, left2)))
+        assert(caught2.failedCodeFileName === Some(fileName))
+        assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left3 = List(writableFile.toPath)
+        val caught3 = intercept[TestFailedException] {
+          all(left3) should (not equal writableFile.toPath or not be writable)
+        }
+        assert(caught3.message === Some(allError(equaled(writableFile.toPath, writableFile.toPath) + ", and " + wasWritable(writableFile.toPath), thisLineNumber - 2, left3)))
+        assert(caught3.failedCodeFileName === Some(fileName))
+        assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+        val left4 = List(writableFile.toPath)
+        val caught4 = intercept[TestFailedException] {
+          all(left4) should (not be writable or not equal writableFile.toPath)
+        }
+        assert(caught4.message === Some(allError(wasWritable(writableFile.toPath) + ", and " + equaled(writableFile.toPath, writableFile.toPath), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
         assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
       }

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableSpec.scala
@@ -123,6 +123,73 @@ class ShouldBeWritableSpec extends FunSpec {
       }
       
     }
+
+    describe("when work with 'path should be (writable)'") {
+
+      it("should do nothing when path is writable") {
+        writableFile.toPath should be (writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not writable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath should be (writable)
+        }
+        assert(caught1.message === Some(wasNotWritable(secretFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'path should not be writable'") {
+
+      it("should do nothing when path is not writable") {
+        secretFile.toPath should not be writable
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is writable") {
+        val caught1 = intercept[TestFailedException] {
+          writableFile.toPath should not be writable
+        }
+        assert(caught1.message === Some(wasWritable(writableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'path shouldBe writable'") {
+
+      it("should do nothing when path is writable") {
+        writableFile.toPath shouldBe writable
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is not writable") {
+        val caught1 = intercept[TestFailedException] {
+          secretFile.toPath shouldBe writable
+        }
+        assert(caught1.message === Some(wasNotWritable(secretFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'path shouldNot be (writable)'") {
+
+      it("should do nothing when path is not writable") {
+        secretFile.toPath shouldNot be (writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when path is writable") {
+        val caught1 = intercept[TestFailedException] {
+          writableFile.toPath shouldNot be (writable)
+        }
+        assert(caught1.message === Some(wasWritable(writableFile.toPath)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
     
     describe("when work with 'all(xs) should be (writable)'") {
       
@@ -193,6 +260,77 @@ class ShouldBeWritableSpec extends FunSpec {
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
       }
       
+    }
+
+    describe("when work with 'all(paths) should be (writable)'") {
+
+      it("should do nothing when all(paths) is writable") {
+        all(List(writableFile.toPath)) should be (writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is not writable") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should be (writable)
+        }
+        assert(caught1.message === Some(allError(left1, wasNotWritable(secretFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'all(paths) should not be writable'") {
+
+      it("should do nothing when all(paths) is not writable") {
+        all(List(secretFile.toPath)) should not be writable
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is writable") {
+        val left1 = List(writableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) should not be writable
+        }
+        assert(caught1.message === Some(allError(left1, wasWritable(writableFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
+    }
+
+    describe("when work with 'all(paths) shouldBe writable'") {
+
+      it("should do nothing when all(paths) is writable") {
+        all(List(writableFile.toPath)) shouldBe writable
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is not writable") {
+        val left1 = List(secretFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) shouldBe writable
+        }
+        assert(caught1.message === Some(allError(left1, wasNotWritable(secretFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+    }
+
+    describe("when work with 'all(paths) shouldNot be (writable)'") {
+
+      it("should do nothing when all(paths) is not writable") {
+        all(List(secretFile.toPath)) shouldNot be (writable)
+      }
+
+      it("should throw TestFailedException with correct stack depth when all(paths) is writable") {
+        val left1 = List(writableFile.toPath)
+        val caught1 = intercept[TestFailedException] {
+          all(left1) shouldNot be (writable)
+        }
+        assert(caught1.message === Some(allError(left1, wasWritable(writableFile.toPath), thisLineNumber - 2)))
+        assert(caught1.failedCodeFileName === Some(fileName))
+        assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
+      }
+
     }
   }
   

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
@@ -135,6 +135,83 @@ class ShouldExistLogicalAndSpec extends FunSpec {
       assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
   }
+
+  describe("The exist syntax when used with Path") {
+
+    it("should do nothing when the path exists") {
+      existFile.toPath should (equal (existFile.toPath) and exist)
+      existFile.toPath should (exist and equal (existFile.toPath))
+      existFile.toPath should (be (existFile.toPath) and exist)
+      existFile.toPath should (exist and be (existFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val e1 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (equal (imaginaryFile.toPath) and exist)
+      }
+      assert(e1.message === Some(equaled(imaginaryFile.toPath, imaginaryFile.toPath) + ", but " + doesNotExist(imaginaryFile.toPath)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e2 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (exist and equal (imaginaryFile.toPath))
+      }
+      assert(e2.message === Some(exists(existFile.toPath) + ", but " + didNotEqual(existFile.toPath, imaginaryFile.toPath)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e3 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (be (imaginaryFile.toPath) and exist)
+      }
+      assert(e3.message === Some(wasEqualTo(imaginaryFile.toPath, imaginaryFile.toPath) + ", but " + doesNotExist(imaginaryFile.toPath)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e4 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (exist and be (imaginaryFile.toPath))
+      }
+      assert(e4.message === Some(exists(existFile.toPath) + ", but " + wasNotEqualTo(existFile.toPath, imaginaryFile.toPath)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      imaginaryFile.toPath should (equal (imaginaryFile.toPath) and not (exist))
+      imaginaryFile.toPath should (not (exist) and equal (imaginaryFile.toPath))
+      imaginaryFile.toPath should (be (imaginaryFile.toPath) and not (exist))
+      imaginaryFile.toPath should (not (exist) and be (imaginaryFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val e1 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (equal (existFile.toPath) and not (exist))
+      }
+      assert(e1.message === Some(equaled(existFile.toPath, existFile.toPath) + ", but " + exists(existFile.toPath)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e2 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (not (exist) and equal (existFile.toPath))
+      }
+      assert(e2.message === Some(doesNotExist(imaginaryFile.toPath) + ", but " + didNotEqual(imaginaryFile.toPath, existFile.toPath)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e3 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (be (existFile.toPath) and not (exist))
+      }
+      assert(e3.message === Some(wasEqualTo(existFile.toPath, existFile.toPath) + ", but " + exists(existFile.toPath)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e4 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (not (exist) and be (existFile.toPath))
+      }
+      assert(e4.message === Some(doesNotExist(imaginaryFile.toPath) + ", but " + wasNotEqualTo(imaginaryFile.toPath, existFile.toPath)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+  }
   
   describe("The exist syntax when used with all(xs)") {
     
@@ -220,5 +297,90 @@ class ShouldExistLogicalAndSpec extends FunSpec {
       assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
     
+  }
+
+  describe("The exist syntax when used with all(paths)") {
+
+    it("should do nothing when the path exists") {
+      all(List(existFile.toPath)) should (equal (existFile.toPath) and exist)
+      all(List(existFile.toPath)) should (exist and equal (existFile.toPath))
+      all(List(existFile.toPath)) should (be (existFile.toPath) and exist)
+      all(List(existFile.toPath)) should (exist and be (existFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val left1 = List(imaginaryFile.toPath)
+      val e1 = intercept[exceptions.TestFailedException] {
+        all(left1) should (equal (imaginaryFile.toPath) and exist)
+      }
+      assert(e1.message === Some(allError(left1, equaled(imaginaryFile.toPath, imaginaryFile.toPath) + ", but " + doesNotExist(imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left2 = List(existFile.toPath)
+      val e2 = intercept[exceptions.TestFailedException] {
+        all(left2) should (exist and equal (imaginaryFile.toPath))
+      }
+      assert(e2.message === Some(allError(left2, exists(existFile.toPath) + ", but " + didNotEqual(existFile.toPath, imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left3 = List(imaginaryFile.toPath)
+      val e3 = intercept[exceptions.TestFailedException] {
+        all(left3) should (be (imaginaryFile.toPath) and exist)
+      }
+      assert(e3.message === Some(allError(left3, wasEqualTo(imaginaryFile.toPath, imaginaryFile.toPath) + ", but " + doesNotExist(imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left4 = List(existFile.toPath)
+      val e4 = intercept[exceptions.TestFailedException] {
+        all(left4) should (exist and be (imaginaryFile.toPath))
+      }
+      assert(e4.message === Some(allError(left4, exists(existFile.toPath) + ", but " + wasNotEqualTo(existFile.toPath, imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      all(List(imaginaryFile.toPath)) should (equal (imaginaryFile.toPath) and not (exist))
+      all(List(imaginaryFile.toPath)) should (not (exist) and equal (imaginaryFile.toPath))
+      all(List(imaginaryFile.toPath)) should (be (imaginaryFile.toPath) and not (exist))
+      all(List(imaginaryFile.toPath)) should (not (exist) and be (imaginaryFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val left1 = List(existFile.toPath)
+      val e1 = intercept[exceptions.TestFailedException] {
+        all(left1) should (equal (existFile.toPath) and not (exist))
+      }
+      assert(e1.message === Some(allError(left1, equaled(existFile.toPath, existFile.toPath) + ", but " + exists(existFile.toPath), thisLineNumber - 2)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left2 = List(imaginaryFile.toPath)
+      val e2 = intercept[exceptions.TestFailedException] {
+        all(left2) should (not (exist) and equal (existFile.toPath))
+      }
+      assert(e2.message === Some(allError(left2, doesNotExist(imaginaryFile.toPath) + ", but " + didNotEqual(imaginaryFile.toPath, existFile.toPath), thisLineNumber - 2)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left3 = List(existFile.toPath)
+      val e3 = intercept[exceptions.TestFailedException] {
+        all(left3) should (be (existFile.toPath) and not (exist))
+      }
+      assert(e3.message === Some(allError(left3, wasEqualTo(existFile.toPath, existFile.toPath) + ", but " + exists(existFile.toPath), thisLineNumber - 2)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left4 = List(imaginaryFile.toPath)
+      val e4 = intercept[exceptions.TestFailedException] {
+        all(left4) should (not (exist) and be (existFile.toPath))
+      }
+      assert(e4.message === Some(allError(left4, doesNotExist(imaginaryFile.toPath) + ", but " + wasNotEqualTo(imaginaryFile.toPath, existFile.toPath), thisLineNumber - 2)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
@@ -157,6 +157,105 @@ class ShouldExistLogicalOrSpec extends FunSpec {
       assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
   }
+
+  describe("The exist syntax when used with Path") {
+
+    it("should do nothing when the path exists") {
+      existFile.toPath should (equal (existFile.toPath) or exist)
+      existFile.toPath should (equal (imaginaryFile.toPath) or exist)
+      imaginaryFile.toPath should (equal (imaginaryFile.toPath) or exist)
+
+      existFile.toPath should (exist or equal (existFile.toPath))
+      imaginaryFile.toPath should (exist or equal (imaginaryFile.toPath))
+      existFile.toPath should (exist or equal (imaginaryFile.toPath))
+
+      existFile.toPath should (be (existFile.toPath) or exist)
+      existFile.toPath should (be (imaginaryFile.toPath) or exist)
+      imaginaryFile.toPath should (be (imaginaryFile.toPath) or exist)
+
+      existFile.toPath should (exist or be (existFile.toPath))
+      imaginaryFile.toPath should (exist or be (imaginaryFile.toPath))
+      existFile.toPath should (exist or be (imaginaryFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val e1 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (equal (existFile.toPath) or exist)
+      }
+      assert(e1.message === Some(didNotEqual(imaginaryFile.toPath, existFile.toPath) + ", and " + doesNotExist(imaginaryFile.toPath)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e2 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (exist or equal (existFile.toPath))
+      }
+      assert(e2.message === Some(doesNotExist(imaginaryFile.toPath) + ", and " + didNotEqual(imaginaryFile.toPath, existFile.toPath)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e3 = intercept[exceptions.TestFailedException] {
+        imaginaryFile should (be (existFile) or exist)
+      }
+      assert(e3.message === Some(wasNotEqualTo(imaginaryFile.toPath, existFile.toPath) + ", and " + doesNotExist(imaginaryFile.toPath)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e4 = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should (exist or be (existFile.toPath))
+      }
+      assert(e4.message === Some(doesNotExist(imaginaryFile.toPath) + ", and " + wasNotEqualTo(imaginaryFile.toPath, existFile.toPath)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      imaginaryFile.toPath should (equal (imaginaryFile.toPath) or not (exist))
+      imaginaryFile.toPath should (equal (existFile.toPath) or not (exist))
+      existFile.toPath should (equal (existFile.toPath) or not (exist))
+
+      imaginaryFile.toPath should (not (exist) or equal (imaginaryFile.toPath))
+      existFile.toPath should (not (exist) or equal (existFile.toPath))
+      imaginaryFile.toPath should (not (exist) or equal (existFile.toPath))
+
+      imaginaryFile.toPath should (be (imaginaryFile.toPath) or not (exist))
+      imaginaryFile.toPath should (be (existFile.toPath) or not (exist))
+      existFile.toPath should (be (existFile.toPath) or not (exist))
+
+      imaginaryFile.toPath should (not (exist) or be (imaginaryFile.toPath))
+      existFile.toPath should (not (exist) or be (existFile.toPath))
+      imaginaryFile.toPath should (not (exist) or be (existFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val e1 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (equal (imaginaryFile.toPath) or not (exist))
+      }
+      assert(e1.message === Some(didNotEqual(existFile.toPath, imaginaryFile.toPath) + ", and " + exists(existFile.toPath)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e2 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (not (exist) or equal (imaginaryFile.toPath))
+      }
+      assert(e2.message === Some(exists(existFile.toPath) + ", and " + didNotEqual(existFile.toPath, imaginaryFile.toPath)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e3 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (be (imaginaryFile.toPath) or not (exist))
+      }
+      assert(e3.message === Some(wasNotEqualTo(existFile.toPath, imaginaryFile.toPath) + ", and " + exists(existFile.toPath)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val e4 = intercept[exceptions.TestFailedException] {
+        existFile.toPath should (not (exist) or be (imaginaryFile.toPath))
+      }
+      assert(e4.message === Some(exists(existFile.toPath) + ", and " + wasNotEqualTo(existFile.toPath, imaginaryFile.toPath)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+  }
   
   describe("The exist syntax when used with all(xs)") {
     
@@ -264,5 +363,112 @@ class ShouldExistLogicalOrSpec extends FunSpec {
       assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
     
+  }
+
+  describe("The exist syntax when used with all(paths)") {
+
+    it("should do nothing when the path exists") {
+      all(List(existFile.toPath)) should (equal (existFile.toPath) or exist)
+      all(List(existFile.toPath)) should (equal (imaginaryFile.toPath) or exist)
+      all(List(imaginaryFile.toPath)) should (equal (imaginaryFile.toPath) or exist)
+
+      all(List(existFile.toPath)) should (exist or equal (existFile.toPath))
+      all(List(imaginaryFile.toPath)) should (exist or equal (imaginaryFile.toPath))
+      all(List(existFile.toPath)) should (exist or equal (imaginaryFile.toPath))
+
+      all(List(existFile.toPath)) should (be (existFile.toPath) or exist)
+      all(List(existFile.toPath)) should (be (imaginaryFile.toPath) or exist)
+      all(List(imaginaryFile.toPath)) should (be (imaginaryFile.toPath) or exist)
+
+      all(List(existFile.toPath)) should (exist or be (existFile.toPath))
+      all(List(imaginaryFile.toPath)) should (exist or be (imaginaryFile.toPath))
+      all(List(existFile.toPath)) should (exist or be (imaginaryFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val left1 = List(imaginaryFile.toPath)
+      val e1 = intercept[exceptions.TestFailedException] {
+        all(left1) should (equal (existFile.toPath) or exist)
+      }
+      assert(e1.message === Some(allError(left1, didNotEqual(imaginaryFile.toPath, existFile.toPath) + ", and " + doesNotExist(imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left2 = List(imaginaryFile.toPath)
+      val e2 = intercept[exceptions.TestFailedException] {
+        all(left2) should (exist or equal (existFile.toPath))
+      }
+      assert(e2.message === Some(allError(left2, doesNotExist(imaginaryFile.toPath) + ", and " + didNotEqual(imaginaryFile.toPath, existFile.toPath), thisLineNumber - 2)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left3 = List(imaginaryFile.toPath)
+      val e3 = intercept[exceptions.TestFailedException] {
+        all(left3) should (be (existFile.toPath) or exist)
+      }
+      assert(e3.message === Some(allError(left3, wasNotEqualTo(imaginaryFile.toPath, existFile.toPath) + ", and " + doesNotExist(imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left4 = List(imaginaryFile.toPath)
+      val e4 = intercept[exceptions.TestFailedException] {
+        all(left4) should (exist or be (existFile.toPath))
+      }
+      assert(e4.message === Some(allError(left4, doesNotExist(imaginaryFile.toPath) + ", and " + wasNotEqualTo(imaginaryFile.toPath, existFile.toPath), thisLineNumber - 2)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      all(List(imaginaryFile.toPath)) should (equal (imaginaryFile.toPath) or not (exist))
+      all(List(imaginaryFile.toPath)) should (equal (existFile.toPath) or not (exist))
+      all(List(existFile.toPath)) should (equal (existFile.toPath) or not (exist))
+
+      all(List(imaginaryFile.toPath)) should (not (exist) or equal (imaginaryFile.toPath))
+      all(List(existFile.toPath)) should (not (exist) or equal (existFile.toPath))
+      all(List(imaginaryFile.toPath)) should (not (exist) or equal (existFile.toPath))
+
+      all(List(imaginaryFile.toPath)) should (be (imaginaryFile.toPath) or not (exist))
+      all(List(imaginaryFile.toPath)) should (be (existFile.toPath) or not (exist))
+      all(List(existFile.toPath)) should (be (existFile.toPath) or not (exist))
+
+      all(List(imaginaryFile.toPath)) should (not (exist) or be (imaginaryFile.toPath))
+      all(List(existFile.toPath)) should (not (exist) or be (existFile.toPath))
+      all(List(imaginaryFile.toPath)) should (not (exist) or be (existFile.toPath))
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val left1 = List(existFile.toPath)
+      val e1 = intercept[exceptions.TestFailedException] {
+        all(left1) should (equal (imaginaryFile.toPath) or not (exist))
+      }
+      assert(e1.message === Some(allError(left1, didNotEqual(existFile.toPath, imaginaryFile.toPath) + ", and " + exists(existFile.toPath), thisLineNumber - 2)))
+      assert(e1.failedCodeFileName === Some(fileName))
+      assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left2 = List(existFile.toPath)
+      val e2 = intercept[exceptions.TestFailedException] {
+        all(left2) should (not (exist) or equal (imaginaryFile.toPath))
+      }
+      assert(e2.message === Some(allError(left2, exists(existFile.toPath) + ", and " + didNotEqual(existFile.toPath, imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e2.failedCodeFileName === Some(fileName))
+      assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left3 = List(existFile.toPath)
+      val e3 = intercept[exceptions.TestFailedException] {
+        all(left3) should (be (imaginaryFile.toPath) or not (exist))
+      }
+      assert(e3.message === Some(allError(left3, wasNotEqualTo(existFile.toPath, imaginaryFile.toPath) + ", and " + exists(existFile.toPath), thisLineNumber - 2)))
+      assert(e3.failedCodeFileName === Some(fileName))
+      assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val left4 = List(existFile.toPath)
+      val e4 = intercept[exceptions.TestFailedException] {
+        all(left4) should (not (exist) or be (imaginaryFile.toPath))
+      }
+      assert(e4.message === Some(allError(left4, exists(existFile.toPath) + ", and " + wasNotEqualTo(existFile.toPath, imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e4.failedCodeFileName === Some(fileName))
+      assert(e4.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
   }
 }

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldExistSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldExistSpec.scala
@@ -88,6 +88,48 @@ class ShouldExistSpec extends FunSpec {
       assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
   }
+
+  describe("The exist syntax when used with Path") {
+
+    it("should do nothing when the path exists") {
+      existFile.toPath should exist
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val e = intercept[exceptions.TestFailedException] {
+        imaginaryFile.toPath should exist
+      }
+      assert(e.message === Some(doesNotExist(imaginaryFile.toPath)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      imaginaryFile.toPath should not (exist)
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val e = intercept[exceptions.TestFailedException] {
+        existFile.toPath should not (exist)
+      }
+      assert(e.message === Some(exists(existFile.toPath)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with shouldNot and the path does not exists") {
+      imaginaryFile.toPath shouldNot exist
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with shouldNot and the path exists") {
+      val e = intercept[exceptions.TestFailedException] {
+        existFile.toPath shouldNot exist
+      }
+      assert(e.message === Some(exists(existFile.toPath)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+  }
   
   describe("The exist syntax when used with all(xs)") {
     
@@ -129,6 +171,51 @@ class ShouldExistSpec extends FunSpec {
         all(left) shouldNot exist
       }
       assert(e.message === Some(allError(left, exists(existFile), thisLineNumber - 2)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+  }
+
+  describe("The exist syntax when used with all(paths)") {
+
+    it("should do nothing when the path exists") {
+      all(List(existFile.toPath)) should exist
+    }
+
+    it("should throw TFE with correct stack depth and message when the path does not exist") {
+      val left = List(imaginaryFile.toPath)
+      val e = intercept[exceptions.TestFailedException] {
+        all(left) should exist
+      }
+      assert(e.message === Some(allError(left, doesNotExist(imaginaryFile.toPath), thisLineNumber - 2)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with not and the path does not exists") {
+      all(List(imaginaryFile.toPath)) should not (exist)
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with not and the path exists") {
+      val left = List(existFile.toPath)
+      val e = intercept[exceptions.TestFailedException] {
+        all(left) should not (exist)
+      }
+      assert(e.message === Some(allError(left, exists(existFile.toPath), thisLineNumber - 2)))
+      assert(e.failedCodeFileName === Some(fileName))
+      assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
+    }
+
+    it("should do nothing when it is used with shouldNot and the path does not exists") {
+      all(List(imaginaryFile.toPath)) shouldNot exist
+    }
+
+    it("should throw TFE with correct stack depth and message when it is used with shouldNot and the path exists") {
+      val left = List(existFile.toPath)
+      val e = intercept[exceptions.TestFailedException] {
+        all(left) shouldNot exist
+      }
+      assert(e.message === Some(allError(left, exists(existFile.toPath), thisLineNumber - 2)))
       assert(e.failedCodeFileName === Some(fileName))
       assert(e.failedCodeLineNumber === Some(thisLineNumber - 4))
     }

--- a/scalatest/src/main/scala/org/scalatest/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/Matchers.scala
@@ -7315,6 +7315,9 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      * <pre class="stHighlight">
      * file should exist
      *      ^
+     *
+     * path should exist
+     *      ^
      * </pre>
      */
     def should(existWord: ExistWord)(implicit existence: Existence[T]): Assertion = {
@@ -7329,6 +7332,9 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      * <pre class="stHighlight">
      * file should not (exist)
      *      ^
+     *
+     * path should not (exist)
+     *      ^
      * </pre>
      */
     def should(notExist: ResultOfNotExist)(implicit existence: Existence[T]): Assertion = {
@@ -7342,6 +7348,9 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *
      * <pre class="stHighlight">
      * file shouldNot exist
+     *      ^
+     *
+     * path shouldNot exist
      *      ^
      * </pre>
      */

--- a/scalatest/src/main/scala/org/scalatest/enablers/Existence.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Existence.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest.enablers
 
+import java.nio.file.Files
+
 /**
  * Supertrait for typeclasses that enable the <code>exist</code> matcher syntax.
  *
@@ -56,5 +58,15 @@ object Existence {
     new Existence[FILE] {
       def exists(file: FILE): Boolean = file.exists
     }
-  
+
+  /**
+   * Enable <code>Existence</code> implementation for <code>java.nio.file.Path</code>
+   *
+   * @tparam PATH any subtype of <code>java.nio.file.Path</code>
+   * @return <code>Existence[PATH]</code> that supports <code>java.nio.file.Path</code> in <code>exist</code> syntax
+   */
+  implicit def existenceOfPath[PATH <: java.nio.file.Path]: Existence[PATH] =
+    new Existence[PATH] {
+      def exists(path: PATH): Boolean = Files.exists(path)
+    }
 }

--- a/scalatest/src/main/scala/org/scalatest/enablers/Readability.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Readability.scala
@@ -15,9 +15,12 @@
  */
 package org.scalatest.enablers
 
+import java.nio.file.Files
+
 import Aggregating.tryEquality
 import org.scalactic.Equality
 import org.scalatest.FailureMessages
+
 import scala.annotation.tailrec
 import scala.collection.GenTraversable
 
@@ -68,6 +71,17 @@ object Readability {
   implicit def readabilityOfFile[FILE <: java.io.File]: Readability[FILE] =
     new Readability[FILE] {
       def isReadable(file: FILE): Boolean = file.canRead
+    }
+
+  /**
+   * Enable <code>Readability</code> implementation for <code>java.nio.file.Path</code>.
+   *
+   * @tparam PATH any subtype of <code>java.nio.file.Path</code>
+   * @return <code>Readability[PATH]</code> that supports <code>java.nio.file.Path</code> in <code>be readable</code> syntax
+   */
+  implicit def readabilityOfPath[PATH <: java.nio.file.Path]: Readability[PATH] =
+    new Readability[PATH] {
+      def isReadable(path: PATH): Boolean = Files.isReadable(path)
     }
 
   import scala.language.reflectiveCalls

--- a/scalatest/src/main/scala/org/scalatest/enablers/Writability.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Writability.scala
@@ -15,9 +15,12 @@
  */
 package org.scalatest.enablers
 
+import java.nio.file.Files
+
 import Aggregating.tryEquality
 import org.scalactic.Equality
 import org.scalatest.FailureMessages
+
 import scala.annotation.tailrec
 import scala.collection.GenTraversable
 
@@ -67,6 +70,17 @@ object Writability {
   implicit def writabilityOfFile[FILE <: java.io.File]: Writability[FILE] =
     new Writability[FILE] {
       def isWritable(file: FILE): Boolean = file.canWrite
+    }
+
+  /**
+   * Enable <code>Writability</code> implementation for <code>java.nio.file.Path</code>.
+   *
+   * @tparam PATH any subtype of <code>java.nio.file.Path</code>
+   * @return <code>Writability[PATH]</code> that supports <code>java.nio.file.Path</code> in <code>be</code> <code>writable</code> syntax
+   */
+  implicit def writabilityOfPath[PATH <: java.nio.file.Path]: Writability[PATH] =
+    new Writability[PATH] {
+      def isWritable(path: PATH): Boolean = Files.isWritable(path)
     }
 
   import scala.language.reflectiveCalls


### PR DESCRIPTION
ScalaTest has had file matchers (`file should exist`, `file shouldBe readable` and `file shouldBe writable`) for a long time. These are all based on the `java.io.File` class, which has been 'replaced' with the new `java.nio.files.Path` class as of Java 7. As I'm using this new-ish class, I found ScalaTest doesn't support this class yet. It's quite a simple addition, so I thought I'll submit this PR. If there is any functionality that I missed for `File` that also needs to be added for `Path`, let me know!

Added syntax should enable things like:

```scala
val path = Paths.get("path/to/some/file")

path should exist
path shouldNot exist
path should not (exist)

path shouldBe writable
path should be (writable)
path should not be writable
path shouldNot be (writable)

path shouldBe readable
path should be (readable)
path should not be readable
path shouldNot be (readable)

// as well as all equivalents with all(List(...))
```