### PR TITLE
Build Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
-  - 2.11.8
+  - 2.11.11
   - 2.10.6
-  - 2.12.0
+  - 2.12.2
 jdk:
   - oraclejdk7
   - openjdk6
@@ -46,10 +46,18 @@ env:
 
 matrix:
   exclude:
-    - scala: "2.12.0"
+    - scala: "2.12.2"
       jdk: oraclejdk7
-    - scala: "2.12.0"
+    - scala: "2.12.2"
       jdk: openjdk6
+    - scala: "2.11.11"
+      jdk: oraclejdk7
+    - scala: "2.11.11"
+      jdk: oraclejdk8
+    - scala: "2.10.6"
+      jdk: oraclejdk7
+    - scala: "2.10.6"
+      jdk: oraclejdk8
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ With Sonatype credentials and GPG file in place, you can now publish to Sonatype
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.11 and 2.10, and make sure you're on Java 6) to Sonatype, use the following command:
 
-  `$ sbt clean publishSigned "project scalatestAppJS" clean publishSigned ++2.10.6 "project scalatestApp" clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.11.11 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.10.6 "project scalatestApp" clean publishSigned "project scalatestAppJS" clean publishSigned`
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.0 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Building ScalaTest
 The followings are needed for building ScalaTest:
 
 *   JDK 6, 7 or 8
-*   [SBT 0.13.2](http://www.scala-sbt.org/0.13.2/docs/Getting-Started/Setup.html)
+*   [SBT 0.13](http://www.scala-sbt.org/0.13/docs/Setup.html)
 
 for JDK 6 or 7, use the following options in your SBT launch file:
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.15

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -162,7 +162,6 @@ object ScalatestBuild extends Build {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
           "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
-          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
           scalacheckDependency("optional")
         )
       case _ =>

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -19,7 +19,7 @@ object ScalatestBuild extends Build {
 
   // To temporarily switch sbt to a different Scala version:
   // > ++ 2.10.5
-  val buildScalaVersion = "2.11.8"
+  val buildScalaVersion = "2.11.11"
 
   val releaseVersion = "3.0.3"
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -61,24 +61,35 @@ object ScalatestBuild extends Build {
       case _ => Credentials(Path.userHome / ".ivy2" / ".credentials")
     }
 
-  def getJavaHome: Option[File] =
-    envVar("JAVA_HOME") match {
-      case Some(javaHome) => Some(file(javaHome))
-      case None =>
-        val javaHome = new File(System.getProperty("java.home"))
-        val javaHomeBin = new File(javaHome, "bin")
-        val javac = new File(javaHomeBin, "javac")
-        val javacExe = new File(javaHomeBin, "javac.exe")
-        if (javac.exists || javacExe.exists)
-          Some(file(javaHome.getAbsolutePath))
-        else {
-          println("WARNING: No JAVA_HOME detected, javac on PATH will be used.  Set JAVA_HOME enviroment variable to a JDK to remove this warning.")
-          None
-        }
+  def getJavaHome(scalaMajorVersion: String): Option[File] = {
+    scalaMajorVersion match {
+      case "2.10" | "2.11" =>  // force to use Java 6
+        if (!System.getProperty("java.version").startsWith("1.6"))
+          throw new IllegalStateException("Please use JDK 6 to build for Scala 2.10 and 2.11.")
+
+      case _ =>
     }
 
+    val javaHome = new File(System.getProperty("java.home"))
+    val javaHomeBin = new File(javaHome, "bin")
+    val javac = new File(javaHomeBin, "javac")
+    val javacExe = new File(javaHomeBin, "javac.exe")
+    if (javac.exists || javacExe.exists)
+      Some(file(javaHome.getAbsolutePath))
+    else {
+      val javaHomeParentBin = new File(javaHome.getParent, "bin")
+      val parentJavac = new File(javaHomeParentBin, "javac")
+      val parentJavacExe = new File(javaHomeParentBin, "javac.exe")
+      if (parentJavac.exists || parentJavacExe.exists)
+        Some(file(javaHome.getParentFile.getAbsolutePath))
+      else
+        println("WARNING: javac from java.home not found, javac on PATH will be used.  Try to use JDK instead of JRE to launch SBT to remove this warning.")
+      None
+    }
+  }
+
   def sharedSettings: Seq[Setting[_]] = Seq(
-    javaHome := getJavaHome,
+    javaHome := getJavaHome(scalaBinaryVersion.value),
     scalaVersion := buildScalaVersion,
     crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.11.11"),
     version := releaseVersion,
@@ -778,7 +789,7 @@ object ScalatestBuild extends Build {
     )
 
   def gentestsSharedSettings: Seq[Setting[_]] = Seq(
-    javaHome := getJavaHome,
+    javaHome := getJavaHome(scalaBinaryVersion.value),
     scalaVersion := buildScalaVersion,
     scalacOptions ++= Seq("-feature"),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -19,7 +19,7 @@ object ScalatestBuild extends Build {
 
   // To temporarily switch sbt to a different Scala version:
   // > ++ 2.10.5
-  val buildScalaVersion = "2.11.11"
+  val buildScalaVersion = "2.12.2"
 
   val releaseVersion = "3.0.3"
 
@@ -80,7 +80,7 @@ object ScalatestBuild extends Build {
   def sharedSettings: Seq[Setting[_]] = Seq(
     javaHome := getJavaHome,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.12.0"),
+    crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.11.11"),
     version := releaseVersion,
     scalacOptions ++= Seq("-feature", "-target:jvm-1.6"),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",

--- a/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
@@ -39,30 +39,16 @@ class FutureSugarSpec extends UnitSpec with Accumulation with FutureSugar with S
     Future.successful(10).validating(isRound).futureValue shouldBe 10
     // Scala 2.10 has problem compiling the following:
     // Future.failed(SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-    if (ScalacticVersions.BuiltForScalaVersion == "2.12") {
-      // In 2.12, failed always return a Failure now, not Success, and that causing the futureValue to rethrow the exception
-      val e = intercept[TestFailedException] {
-        Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue
-      }
-      e.cause shouldBe Some(SomeException("oops"))
-    }
-    else
-      Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
+    Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
   }
 
   it should "allow multiple validation functions to be passed to validating" in {
     Future.successful(12).validating(isRound, isDivBy3).failed.futureValue shouldBe ValidationFailedException("12 was not a round number")
     Future.successful(10).validating(isRound, isDivBy3).failed.futureValue shouldBe ValidationFailedException("10 was not divisible by 3")
     Future.successful(30).validating(isRound, isDivBy3).futureValue shouldBe 30
+    // Scala 2.10 has problem compiling the following:
     // Future.failed(SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-    if (ScalacticVersions.BuiltForScalaVersion == "2.12") {
-      val e = intercept[TestFailedException] {
-        Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-      }
-      e.cause shouldBe Some(SomeException("oops"))
-    }
-    else
-      Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
+    Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
   }
 
   it should "require at least one parameter to be passed to validating" in {

--- a/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalatest.tools
+/*package org.scalatest.tools
 
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
@@ -45,5 +45,5 @@ class SbtCommandParserSpec extends FunSpec with Matchers {
       canParsePhrase("""st --""")
     }
   }
-}
+}*/
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
@@ -136,7 +136,7 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
                 case dtne: DuplicateTestNameException => throw dtne
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
                   if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 9))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other
@@ -172,8 +172,12 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
 
               if (isIgnore)
                 registerIgnoredTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 3, 0, Some(testLocation), None, methodTags.map(new Tag(_)): _*)
-              else
-                registerTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 2, 1, None, Some(testLocation), None, None, methodTags.map(new Tag(_)): _*)
+              else {
+                if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+                  registerTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 3, 1, None, Some(testLocation), None, None, methodTags.map(new Tag(_)): _*)
+                else
+                  registerTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 2, 1, None, Some(testLocation), None, None, methodTags.map(new Tag(_)): _*)
+              }
             }
           }
         }

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -125,7 +125,7 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
                   if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 9))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other

--- a/scalatest/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.tools
+/*package org.scalatest.tools
 
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 import scala.util.parsing.combinator.lexical.StdLexical
@@ -122,5 +122,5 @@ private[scalatest] object SbtCommandParser {
     (new SbtCommandParser).parseCommand("""st wildcard("a", "b", "c") stdout(config = "dropteststarting droptestpending")""")
 */
   }
-}
+}*/
 


### PR DESCRIPTION
-Bumped up to use Scala 2.12.2 and 2.11.11.
-Force to use Java 6 when builds for Scala 2.11 and 2.10.
-Fixed failing tests when build with Scala 2.12.2.
-Bumped up SBT version to 0.13.15.