### PR TITLE
Scala-js 0.6.16

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -188,7 +188,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.13"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.16"
     )
 
   def scalatestTestOptions =


### PR DESCRIPTION
Bump up scala-js version to 0.6.16.