### PR TITLE
EitherValues: Print value of Either when `right.value` or `left.value` fails

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -38,7 +38,7 @@ class EitherValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
-      caught.message.value should be (Resources.eitherLeftValueNotDefined)
+      caught.message.value should be (Resources.eitherLeftValueNotDefined(e))
     }
     
     it("should return the right value inside an either if right.value is defined") {
@@ -55,7 +55,7 @@ class EitherValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
-      caught.message.value should be (Resources.eitherRightValueNotDefined)
+      caught.message.value should be (Resources.eitherRightValueNotDefined(e))
     }
 
     it("should allow an immediate application of parens to invoke apply on the type contained in the Left") {

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -572,8 +572,8 @@ concurrentDocSpecMod=Two threads attempted to modify Doc's internal data, which 
 tryNotAFailure=The Try on which failure was invoked was not a Failure.
 tryNotASuccess=The Try on which success was invoked was not a Success.
 optionValueNotDefined=The Option on which value was invoked was not defined.
-eitherLeftValueNotDefined=The Either on which left.value was invoked was not defined as a Left.
-eitherRightValueNotDefined=The Either on which right.value was invoked was not defined as a Right.
+eitherLeftValueNotDefined=The Either on which left.value was invoked was not defined as a Left, but as: {0}.
+eitherRightValueNotDefined=The Either on which right.value was invoked was not defined as a Right, but as: {0}.
 partialFunctionValueNotDefined=The PartialFunction on which valueAt( {0} ) was invoked was not defined.
 
 insidePartialFunctionNotDefined=The partial function passed as the second parameter to inside was not defined at the value passed as the first parameter to inside, which was: {0}

--- a/scalatest/src/main/scala/org/scalatest/EitherValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/EitherValues.scala
@@ -121,7 +121,7 @@ trait EitherValues {
       }
       catch {
         case cause: NoSuchElementException => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(cause), pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined(leftProj.e)), Some(cause), pos)
       }
     }
   }
@@ -149,7 +149,7 @@ trait EitherValues {
       }
       catch {
         case cause: NoSuchElementException => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(cause), pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined(rightProj.e)), Some(cause), pos)
       }
     }
   }


### PR DESCRIPTION
This provides a more detailed error message when calling `.value` on an Either fails.

Currently, calling `.value` on a LeftProjection or RightProjection just fails with no details when the either is a right or a left respectively. This makes `EitherValues` clunky to use as it doesn't give enough details when a failure occurs. This PR changes the failure message so that it prints the actual value of the `Either`.