### PR TITLE
scala.js 1.0.0-M1 support

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M1")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.18")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -23,7 +23,7 @@ object ScalatestBuild extends Build {
 
   val releaseVersion = "3.0.3"
 
-  val scalacheckVersion = "1.13.4"
+  val scalacheckVersion = "1.13.5"
 
   val githubTag = "release-3.0.3" // for scaladoc source urls
 
@@ -150,8 +150,8 @@ object ScalatestBuild extends Build {
       // if scala 2.11+ is used, add dependency on scala-xml module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
-          "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
-          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+          "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",
           scalacheckDependency("optional")
         )
       case _ =>
@@ -188,7 +188,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.16"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.18"
     )
 
   def scalatestTestOptions =

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -348,7 +348,7 @@ object ScalatestBuild extends Build {
     .settings(
       projectTitle := "Scalactic.js",
       organization := "org.scalactic",
-      moduleName := "scalactic",
+      // moduleName := "scalactic",
       sourceGenerators in Compile += {
         Def.task {
           GenScalacticJS.genScala((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++
@@ -424,7 +424,7 @@ object ScalatestBuild extends Build {
    .settings(
      projectTitle := "ScalaTest",
      organization := "org.scalatest",
-     moduleName := "scalatest",
+    //  moduleName := "scalatest",
      initialCommands in console := """|import org.scalatest._
                                       |import org.scalactic._
                                       |import Matchers._""".stripMargin,
@@ -527,7 +527,7 @@ object ScalatestBuild extends Build {
     .settings(
       projectTitle := "ScalaTest",
       organization := "org.scalatest",
-      moduleName := "scalatest",
+      // moduleName := "scalatest",
       initialCommands in console := """|import org.scalatest._
                                       |import org.scalactic._
                                       |import Matchers._""".stripMargin,
@@ -713,7 +713,7 @@ object ScalatestBuild extends Build {
       projectTitle := "ScalaTest App",
       name := "scalatest-app",
       organization := "org.scalatest",
-      moduleName := "scalatest-app",
+      // moduleName := "scalatest-app",
       libraryDependencies ++= crossBuildLibraryDependencies(scalaVersion.value),
       libraryDependencies ++= scalatestJSLibraryDependencies,
       // include the scalactic classes and resources in the jar

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -188,7 +188,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.18"
+      "org.scala-js" %% "scalajs-test-interface" % "1.0.0-M1"
     )
 
   def scalatestTestOptions =
@@ -397,11 +397,11 @@ object ScalatestBuild extends Build {
       projectTitle := "Scalactic Test.js",
       organization := "org.scalactic",
       //jsDependencies += RuntimeDOM % "test",
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
-      scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
+      //scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
       //jsEnv := NodeJSEnv(executable = "node").value,
       //jsEnv := PhantomJSEnv().value,
-      scalaJSUseRhino in Global := true, 
+      //scalaJSUseRhino in Global := true, 
       scalaJSStage in Global := FastOptStage,
       //postLinkJSEnv := PhantomJSEnv().value,
       //postLinkJSEnv := NodeJSEnv(executable = "node").value,
@@ -530,7 +530,7 @@ object ScalatestBuild extends Build {
                                       |import Matchers._""".stripMargin,
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + scalatestApp.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       libraryDependencies ++= scalatestJSLibraryDependencies,
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "optional",
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % "optional",
       //jsDependencies += RuntimeDOM % "test",
       sourceGenerators in Compile += {
         Def.task {
@@ -609,12 +609,12 @@ object ScalatestBuild extends Build {
       projectTitle := "ScalaTest Test",
       organization := "org.scalatest",
       libraryDependencies ++= crossBuildLibraryDependencies(scalaVersion.value),
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
       //jsDependencies += RuntimeDOM % "test",
-      scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
+      //scalaJSOptimizerOptions ~= { _.withDisableOptimizer(true) },
       //jsEnv := NodeJSEnv(executable = "node").value,
       //jsEnv := PhantomJSEnv().value,
-      scalaJSUseRhino in Global := true, 
+      //scalaJSUseRhino in Global := true, 
       scalaJSStage in Global := FastOptStage,
       fork in test := false,
       testOptions in Test := scalatestTestJSOptions,

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -186,9 +186,12 @@ object ScalatestBuild extends Build {
       "org.eclipse.jetty" % "jetty-webapp" % "8.1.18.v20150929" % "test"
     )
 
+  val scalaJSVersion =
+    Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.18")
+
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "1.0.0-M1"
+      "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
   def scalatestTestOptions =

--- a/scalatest.js/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/scalatest.js/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -60,7 +60,7 @@ final class TaskRunner(task: TaskDef,
   def taskDef(): TaskDef = task
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: (Array[Task]) => Unit): Unit = {
-    implicit val execCtx = JSExecutionContext.runNow
+    implicit val execCtx = JSExecutionContext.queue
     val future = executionFuture(eventHandler, loggers)
     future.recover { case t =>
 println("GOT TO THIS RECOVER CALL")
@@ -77,7 +77,7 @@ println("GOT TO THIS RECOVER CALL")
 
   def executionFuture(eventHandler: EventHandler, loggers: Array[Logger]): Future[Unit] = {
     val suiteStartTime = Platform.currentTime
-    val suite = TestUtils.newInstance(task.fullyQualifiedName, cl)(Seq.empty).asInstanceOf[Suite]
+    val suite = TestUtils.newInstance(task.fullyQualifiedName, cl, Seq.empty)(Seq.empty).asInstanceOf[Suite]
     val sbtLogInfoReporter = new SbtLogInfoReporter(
       loggers,
       presentAllDurations,

--- a/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
@@ -44,7 +44,7 @@ import org.scalatest.exceptions.NotAllowedException
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
@@ -45,7 +45,7 @@ import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
@@ -46,7 +46,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
@@ -42,7 +42,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSuiteLike.scala
@@ -39,7 +39,7 @@ import Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
@@ -42,7 +42,7 @@ MustVerb, StringVerbBlockRegistration, SubjectWithAfterWordRegistration}
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
@@ -44,7 +44,7 @@ import org.scalatest.exceptions.NotAllowedException
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FeatureSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFeatureSpecMod, "FeatureSpec")

--- a/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala
@@ -45,7 +45,7 @@ import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FlatSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentSpecMod, "Spec")

--- a/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
@@ -45,7 +45,7 @@ import words.BehaveWord
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FreeSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFreeSpecMod, "FreeSpec")

--- a/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
@@ -42,7 +42,7 @@ import words.BehaveWord
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FunSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentSpecMod, "FunSpec")

--- a/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala
@@ -39,7 +39,7 @@ import Suite.autoTagClassAnnotations
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FunSuiteLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFunSuiteMod, "FunSuite")

--- a/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/PropSpecLike.scala
@@ -39,7 +39,7 @@ import Suite.autoTagClassAnnotations
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait PropSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentPropSpecMod, "PropSpec")

--- a/scalatest/src/main/scala/org/scalatest/Suites.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suites.scala
@@ -52,7 +52,7 @@ import org.scalactic.exceptions.NullArgumentException
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 class Suites(suitesToNest: Suite*) extends Suite { thisSuite =>
 
   requireNonNull(suitesToNest)

--- a/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
@@ -41,7 +41,7 @@ import words.{CanVerb, ResultOfAfterWordApplication, ShouldVerb, BehaveWord,
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait WordSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentWordSpecMod, "WordSpecLike")

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
@@ -46,7 +46,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
@@ -46,7 +46,7 @@ import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
@@ -47,7 +47,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpecLike.scala
@@ -47,7 +47,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
@@ -41,7 +41,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
@@ -48,7 +48,7 @@ StringVerbBlockRegistration, SubjectWithAfterWordRegistration}
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
@@ -44,7 +44,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait FeatureSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
@@ -45,7 +45,7 @@ import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait FlatSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
@@ -46,7 +46,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait FreeSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
@@ -46,7 +46,7 @@ import words.BehaveWord
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait FunSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
@@ -40,7 +40,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait FunSuiteLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
@@ -40,7 +40,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
 trait PropSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
@@ -47,7 +47,7 @@ StringVerbBlockRegistration, SubjectWithAfterWordRegistration}
  *
  * @author Bill Venners
  */
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait WordSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/scalatest/src/main/scala/org/scalatest/path/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FreeSpecLike.scala
@@ -45,7 +45,7 @@ import Suite.autoTagClassAnnotations
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FreeSpecLike extends org.scalatest.Suite with OneInstancePerTest with Informing with Notifying with Alerting with Documenting { thisSuite =>
   
   private final val engine = PathEngine.getEngine()

--- a/scalatest/src/main/scala/org/scalatest/path/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FunSpecLike.scala
@@ -45,7 +45,7 @@ import org.scalatest.PathEngine.isInTargetPath
  * @author Bill Venners
  */
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
-//SCALATESTJS-ONLY @scala.scalajs.js.annotation.JSExportDescendentClasses(ignoreInvalidDescendants = true)
+//SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 trait FunSpecLike extends org.scalatest.Suite with OneInstancePerTest with Informing with Notifying with Alerting with Documenting { thisSuite =>
   
   private final val engine = PathEngine.getEngine()


### PR DESCRIPTION
This PR lets build scalatest with either scala.js 0.6.18 or with scala.js 1.0.0-M1. I'd need this to build my own projects that I wont to run with 1.0.0-M1. I published this locally and was able to build and run my own projects this way

There are a few things pending which I'm not sure how to do as the build is fairly complex:

* Cross build on 0.6.18 and 1.0.0-M1 on travis
* Cross publish for both versions

This fixes #1178 