### PR TITLE
CompileMacro Implicit View Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -1797,6 +1797,7 @@ class AssertionsSpec extends FunSpec {
           |assert(org.exists(_ == 'b'))
         """.stripMargin)
     }
+
     it("should result in type Assertion and, on success, return the Succeeded value") {
       val x = 1
       assert(assert(x + 1 == 2) eq Succeeded)
@@ -6152,6 +6153,26 @@ class AssertionsSpec extends FunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
+
+      it("should do nothing when used with 'val i: Int = null'") {
+        assertTypeError("val i: Int = null")
+      }
+
+      it("should throw TestFailedException with correct message and stack depth when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          assertTypeError("arrayList.asScala")
+        }
+        assert(e.message == Some(Resources.expectedTypeErrorButGotNone("arrayList.asScala")))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+      }
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -6191,7 +6212,36 @@ class AssertionsSpec extends FunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
+
+      it("should do nothing when used with 'val i: Int = null'") {
+        assertTypeError(
+          """
+            |val i: Int = null
+            |""".stripMargin
+        )
+      }
+
+      it("should throw TestFailedException with correct message and stack depth when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          assertTypeError(
+            """
+              |arrayList.asScala
+              |""".stripMargin
+          )
+        }
+        assert(e.message == Some(Resources.expectedTypeErrorButGotNone(Prettifier.lineSeparator + "arrayList.asScala" + Prettifier.lineSeparator)))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 8)))
+      }
     }
+
     it("should result in type Assertion and, on success, return the Succeeded value") {
       assert(assertTypeError("val x: String = 1") eq Succeeded)
     }
@@ -6224,6 +6274,22 @@ class AssertionsSpec extends FunSpec {
 
       it("should do nothing when used with 'val i: Int = null'") {
         assertDoesNotCompile("val i: Int = null")
+      }
+
+      it("should throw TestFailedException with correct message and stack depth when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          assertDoesNotCompile("arrayList.asScala".stripMargin)
+        }
+        assert(e.message == Some(Resources.expectedCompileErrorButGotNone("arrayList.asScala")))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
 
     }
@@ -6273,6 +6339,25 @@ class AssertionsSpec extends FunSpec {
             |""".stripMargin
         )
       }
+
+      it("should throw TestFailedException with correct message and stack depth when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          assertDoesNotCompile(
+            """
+              |arrayList.asScala
+              |""".stripMargin)
+        }
+        assert(e.message == Some(Resources.expectedCompileErrorButGotNone(Prettifier.lineSeparator + "arrayList.asScala" + Prettifier.lineSeparator)))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 7)))
+      }
     }
   }
 
@@ -6304,6 +6389,17 @@ class AssertionsSpec extends FunSpec {
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+      }
+
+      it("should do nothing when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        assertCompiles("arrayList.asScala")
       }
     }
 
@@ -6345,6 +6441,20 @@ class AssertionsSpec extends FunSpec {
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
+      }
+
+      it("should do nothing when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        assertCompiles(
+          """
+            |arrayList.asScala
+            |""".stripMargin)
       }
     }
     it("should result in type Assertion and, on success, return the Succeeded value") {

--- a/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ExpectationsSpec.scala
@@ -423,6 +423,22 @@ class ExpectationsSpec extends FunSpec with Expectations {
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isYes)
       }
+
+      it("should return No with correct fact message when the code compiles with implicit view in scope ") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact = expectDoesNotCompile("arrayList.asScala".stripMargin)
+
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isNo)
+        assert(fact.factMessage == Resources.expectedCompileErrorButGotNone("arrayList.asScala"))
+        assert(!fact.isVacuousYes)
+      }
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -474,6 +490,26 @@ class ExpectationsSpec extends FunSpec with Expectations {
         ))
         assert(!fact.isVacuousYes)
       }
+
+      it("should throw TestFailedException with correct message and stack depth when the code compiles with implicit view in scope ") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact =
+          expectDoesNotCompile(
+            """
+              |arrayList.asScala
+              |""".stripMargin)
+
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isNo)
+        assert(fact.factMessage == Resources.expectedCompileErrorButGotNone(NEWLINE + "arrayList.asScala" + NEWLINE))
+        assert(!fact.isVacuousYes)
+      }
     }
   }
 
@@ -507,6 +543,21 @@ class ExpectationsSpec extends FunSpec with Expectations {
         else
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("unclosed string literal", "println(\"test)"))
 
+        assert(!fact.isVacuousYes)
+      }
+
+      it("should return Yes with correct fact message when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact = expectCompiles("arrayList.asScala")
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isYes)
+        assert(fact.factMessage == Resources.compiledSuccessfully("arrayList.asScala"))
         assert(!fact.isVacuousYes)
       }
     }
@@ -569,6 +620,26 @@ class ExpectationsSpec extends FunSpec with Expectations {
           ))
         assert(!fact.isVacuousYes)
       }
+
+      it("should return Yes with correct fact message when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact =
+          expectCompiles(
+            """
+              |arrayList.asScala
+              |""".stripMargin)
+
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isYes)
+        assert(fact.factMessage == Resources.compiledSuccessfully(NEWLINE + "arrayList.asScala" + NEWLINE))
+        assert(!fact.isVacuousYes)
+      }
     }
   }
 
@@ -592,7 +663,7 @@ class ExpectationsSpec extends FunSpec with Expectations {
         assert(!fact.isVacuousYes)
       }
 
-      it("should return No with correct fact message when parse failed") {
+      it("should return No with correct fact message when parse failed ") {
         val fact = expectTypeError("println(\"test)")
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
@@ -600,6 +671,30 @@ class ExpectationsSpec extends FunSpec with Expectations {
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but eof found.", "println(\"test)"))
         else
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("unclosed string literal", "println(\"test)"))
+        assert(!fact.isVacuousYes)
+      }
+
+      it("should return Yes with correct fact message when used with 'val i: Int = null'") {
+        val fact = expectTypeError("val i: Int = null")
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isYes)
+        assert(fact.factMessage == Resources.gotTypeErrorAsExpected("val i: Int = null"))
+        assert(!fact.isVacuousYes)
+      }
+
+      it("should return No with correct fact message when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact = expectTypeError("arrayList.asScala")
+
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isNo)
+        assert(fact.factMessage == Resources.expectedTypeErrorButGotNone("arrayList.asScala"))
         assert(!fact.isVacuousYes)
       }
     }
@@ -659,6 +754,38 @@ class ExpectationsSpec extends FunSpec with Expectations {
               |println("test)
               |""".stripMargin
           ))
+        assert(!fact.isVacuousYes)
+      }
+
+      it("should return Yes with correct fact message when used with 'val i: Int = null'") {
+        val fact =
+          expectTypeError(
+            """
+              |val i: Int = null
+              |""".stripMargin)
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isYes)
+        assert(fact.factMessage == Resources.gotTypeErrorAsExpected(NEWLINE + "val i: Int = null" + NEWLINE))
+        assert(!fact.isVacuousYes)
+      }
+
+      it("should return No with correct fact message when the code compiles with implicit view in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val fact =
+          expectTypeError(
+            """
+              |arrayList.asScala
+              |""".stripMargin)
+
+        assert(fact.isInstanceOf[Fact.Leaf])
+        assert(fact.isNo)
+        assert(fact.factMessage == Resources.expectedTypeErrorButGotNone(NEWLINE + "arrayList.asScala" + NEWLINE))
         assert(!fact.isVacuousYes)
       }
     }

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
@@ -52,6 +52,7 @@ class ShouldCompileSpec extends FunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
+
     }
 
     describe("when work with triple quotes string literal with stripMargin") {

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
@@ -48,6 +48,22 @@ class ShouldNotCompileSpec extends FunSpec {
       it("should do nothing when used with 'val i: Int = null") {
         "val i: Int = null" shouldNot compile
       }
+
+      it("should work correctly with the implicit view is in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          "arrayList.asScala" shouldNot compile
+        }
+        assert(e.message == Some(Resources.expectedCompileErrorButGotNone("arrayList.asScala")))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+      }
     }
 
     describe("when work with triple quotes string literal with stripMargin") {
@@ -80,8 +96,25 @@ class ShouldNotCompileSpec extends FunSpec {
           |val i: Int = null
           |""".stripMargin shouldNot compile
       }
-    }
 
+      it("should work correctly with the implicit view is in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          """
+            |arrayList.asScala
+            |""".stripMargin shouldNot compile
+        }
+        assert(e.message == Some(Resources.expectedCompileErrorButGotNone(lineSeparator + "arrayList.asScala" + lineSeparator)))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+      }
+    }
 
   }
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
@@ -55,6 +55,22 @@ class ShouldNotTypeCheckSpec extends FunSpec {
       it("should do nothing when used with 'val i: Int = null") {
         "val i: Int = null" shouldNot typeCheck
       }
+
+      it("should work correctly with the implicit view is in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          "arrayList.asScala" shouldNot typeCheck
+        }
+        assert(e.message == Some(Resources.expectedTypeErrorButGotNone("arrayList.asScala")))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+      }
     }
 
     describe("when work with triple quotes string literal with stripMargin") {
@@ -93,6 +109,24 @@ class ShouldNotTypeCheckSpec extends FunSpec {
         """
           |val i: Int = null
           |""".stripMargin shouldNot typeCheck
+      }
+
+      it("should work correctly with the implicit view is in scope") {
+        import scala.collection.JavaConverters._
+
+        val arrayList: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+
+        arrayList.add("Foo")
+        arrayList.add("Bar")
+
+        val e = intercept[TestFailedException] {
+          """
+            |arrayList.asScala
+            |""".stripMargin shouldNot typeCheck
+        }
+        assert(e.message == Some(Resources.expectedTypeErrorButGotNone(lineSeparator + "arrayList.asScala" + lineSeparator)))
+        assert(e.failedCodeFileName === (Some(fileName)))
+        assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
     }
   }

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -676,6 +676,7 @@ compiledSuccessfully={0} compiled successfully
 expectedTypeErrorButGotParseError=Expected a type error, but got the following parse error: "{0}", for code: {1}
 expectedNoErrorButGotTypeError=Expected no compiler error, but got the following type error: "{0}", for code: {1}
 expectedNoErrorButGotParseError=Expected no compiler error, but got the following parse error: "{0}", for code: {1}
+anExpressionOfTypeNullIsIneligibleForImplicitConversion=an expression of type Null is ineligible for implicit conversion
 
 beTripleEqualsNotAllowed=The deprecation cycle for 'be ===' has finished and the syntax is no longer supported. Please use equal, be, or === syntax instead.
 

--- a/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
@@ -45,6 +45,27 @@ private[scalatest] object CompileMacro {
     }
   }
 
+  def containsAnyValNullStatement(c: Context)(trees: List[c.Tree]): Boolean = {
+
+    import c.universe._
+
+    trees match {
+      case head :: tail =>
+        head match {
+          case Block(stats, expr) =>
+            containsAnyValNullStatement(c)(tail ++ stats ++ List(expr))
+
+          case ValDef(mods, name, tpt, Literal(Constant(null))) if tpt.tpe == null /*&& rhs.symbol == definitions.NullClass*/ =>
+            true
+
+          case _ => containsAnyValNullStatement(c)(tail)
+        }
+
+      case _ => false
+    }
+
+  }
+
   // parse and type check a code snippet, generate code to throw TestFailedException when type check passes or parse error
   def assertTypeErrorImpl(c: Context)(code: c.Expr[String])(pos: c.Expr[source.Position]): c.Expr[Assertion] = {
     import c.universe._
@@ -53,11 +74,20 @@ private[scalatest] object CompileMacro {
     val codeStr = getCodeStringFromCodeExpression(c)("assertNoTypeError", code)
 
     try {
-      c.typeCheck(c.parse("{ "+codeStr+" }"))  // parse and type check code snippet
-      // If reach here, type check passes, let's generate code to throw TestFailedException
-      val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(codeStr))
-      reify {
-        throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+      val tree = c.parse("{ "+codeStr+" }")
+      if (!containsAnyValNullStatement(c)(List(tree))) {
+        c.typeCheck(tree) // parse and type check code snippet
+        // If reach here, type check passes, let's generate code to throw TestFailedException
+        val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(codeStr))
+        reify {
+          throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+        }
+      }
+      else {
+        reify {
+          // statement such as val i: Int = null, compile fails as expected, generate code to return Succeeded
+          Succeeded
+        }
       }
     } catch {
       case e: TypecheckException =>
@@ -81,21 +111,41 @@ private[scalatest] object CompileMacro {
     val codeStr = getCodeStringFromCodeExpression(c)("expectNoTypeError", code)
 
     try {
-      c.typeCheck(c.parse("{ "+codeStr+" }"))  // parse and type check code snippet
-      // If reach here, type check passes, let's generate code to throw TestFailedException
-      val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(codeStr))
-      reify {
-        Fact.No(
-          messageExpr.splice,
-          messageExpr.splice,
-          messageExpr.splice,
-          messageExpr.splice,
-          Vector.empty,
-          Vector.empty,
-          Vector.empty,
-          Vector.empty
-        )(prettifier.splice)
+      val tree = c.parse("{ "+codeStr+" }")
+      if (!containsAnyValNullStatement(c)(List(tree))) {
+        c.typeCheck(tree)  // parse and type check code snippet
+        // If reach here, type check passes, let's generate code to throw TestFailedException
+        val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(codeStr))
+        reify {
+          Fact.No(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )(prettifier.splice)
+        }
       }
+      else {
+        val messageExpr = c.literal(Resources.gotTypeErrorAsExpected(codeStr))
+        reify {
+          // statement such as val i: Int = null, type check fails as expected, return Yes
+          Fact.Yes(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )(prettifier.splice)
+        }
+      }
+
     } catch {
       case e: TypecheckException =>
         val messageExpr = c.literal(Resources.gotTypeErrorAsExpected(codeStr))
@@ -138,12 +188,20 @@ private[scalatest] object CompileMacro {
     val codeStr = getCodeStringFromCodeExpression(c)("assertDoesNotCompile", code)
 
     try {
-      c.typeCheck(c.parse("{ "+codeStr+" }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-      // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
-      val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
-      reify {
-        throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+      val tree = c.parse("{ "+codeStr+" }")
+      if (!containsAnyValNullStatement(c)(List(tree))) {
+        c.typeCheck(tree, c.universe.WildcardType)  // parse and type check code snippet
+        // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
+        val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
+        reify {
+          throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+        }
       }
+      else
+        reify {
+          // statement such as val i: Int = null, compile fails as expected, generate code to return Succeeded
+          Succeeded
+        }
     } catch {
       case e: TypecheckException =>
         reify {
@@ -169,21 +227,40 @@ private[scalatest] object CompileMacro {
     val codeStr = getCodeStringFromCodeExpression(c)("expectDoesNotCompile", code)
 
     try {
-      c.typeCheck(c.parse("{ "+codeStr+" }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-      // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
-      val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
-      reify {
-        Fact.No(
-          messageExpr.splice,
-          messageExpr.splice,
-          messageExpr.splice,
-          messageExpr.splice,
-          Vector.empty,
-          Vector.empty,
-          Vector.empty,
-          Vector.empty
-        )(prettifier.splice)
-        //throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
+      val tree = c.parse("{ "+codeStr+" }")
+      if (!containsAnyValNullStatement(c)(List(tree))) {
+        c.typeCheck(tree, c.universe.WildcardType) // parse and type check code snippet
+        // Both parse and type check succeeded, the code snippet compiles unexpectedly, let's generate code to throw TestFailedException
+        val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(codeStr))
+        reify {
+          Fact.No(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )(prettifier.splice)
+          //throw new exceptions.TestFailedException(messageExpr.splice, stackDepth)
+        }
+      }
+      else {
+        val messageExpr = c.literal(Resources.didNotCompile(codeStr))
+        reify {
+          // statement such as val i: Int = null, compile fails as expected, generate code to return Fact.Yes
+          Fact.Yes(
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            messageExpr.splice,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty,
+            Vector.empty
+          )(prettifier.splice)
+        }
       }
     } catch {
       case e: TypecheckException =>
@@ -228,7 +305,8 @@ private[scalatest] object CompileMacro {
     val codeStr = getCodeStringFromCodeExpression(c)("assertCompiles", code)
 
     try {
-      c.typeCheck(c.parse("{ " + codeStr + " }")) // parse and type check code snippet
+      val tree = c.parse("{ " + codeStr + " }")
+      c.typeCheck(tree) // parse and type check code snippet
       // Both parse and type check succeeded, the code snippet compiles as expected, generate code to return Succeeded
       reify {
         Succeeded
@@ -314,12 +392,20 @@ private[scalatest] object CompileMacro {
     // parse and type check a code snippet, generate code to throw TestFailedException if both parse and type check succeeded
     def checkNotCompile(code: String): c.Expr[Assertion] = {
       try {
-        c.typeCheck(c.parse("{ " + code + " }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-        // both parse and type check succeeded, compiles succeeded unexpectedly, generate code to throw TestFailedException
-        val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(code))
-        reify {
-          throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+        val tree = c.parse("{ " + code + " }")
+        if (!containsAnyValNullStatement(c)(List(tree))) {
+          c.typecheck(tree)
+          // both parse and type check succeeded, compiles succeeded unexpectedly, generate code to throw TestFailedException
+          val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(code))
+          reify {
+            throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+          }
         }
+        else
+          reify {
+            // statement such as val i: Int = null, compile fails as expected, generate code to return Succeeded
+            Succeeded
+          }
       } catch {
         case e: TypecheckException =>
           reify {
@@ -413,23 +499,33 @@ private[scalatest] object CompileMacro {
     // parse and type check a code snippet, generate code to throw TestFailedException if both parse and type check succeeded
     def checkNotCompile(code: String): c.Expr[Fact] = {
       try {
-        c.typeCheck(c.parse("{ " + code + " }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-        // both parse and type check succeeded, compiles succeeded unexpectedly, generate code to throw TestFailedException
-        val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(code))
-        reify {
-          Fact.No(messageExpr.splice)(prettifier.splice)
+        val tree = c.parse("{ " + code + " }")
+        if (!containsAnyValNullStatement(c)(List(tree))) {
+          c.typeCheck(tree)  // parse and type check code snippet
+          // both parse and type check succeeded, compiles succeeded unexpectedly, generate code to throw TestFailedException
+          val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(code))
+          reify {
+            Fact.No(messageExpr.splice)(prettifier.splice)
+          }
+        }
+        else {
+          val messageExpr = c.literal(Resources.compiledSuccessfully(code))
+          reify {
+            // statement such as val i: Int = null, type check error as expected, return Yes
+            Fact.Yes(messageExpr.splice)(prettifier.splice)
+          }
         }
       } catch {
         case e: TypecheckException =>
           val messageExpr = c.literal(Resources.compiledSuccessfully(code))
           reify {
-            // type check error, compile fails as expected, generate code to return Succeeded
+            // type check error, compile fails as expected, generate code to return Yes
             Fact.Yes(messageExpr.splice)(prettifier.splice)
           }
         case e: ParseException =>
           val messageExpr = c.literal(Resources.compiledSuccessfully(code))
           reify {
-            // parse error, compile fails as expected, generate code to return Succeeded
+            // parse error, compile fails as expected, generate code to return Yes
             Fact.Yes(messageExpr.splice)(prettifier.splice)
           }
       }
@@ -499,11 +595,20 @@ private[scalatest] object CompileMacro {
     // parse and type check a code snippet, generate code to throw TestFailedException if parse error or both parse and type check succeeded
     def checkNotTypeCheck(code: String): c.Expr[Assertion] = {
       try {
-        c.typeCheck(c.parse("{ " + code + " }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-        // both parse and type check succeeded unexpectedly, generate code to throw TestFailedException
-        val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(code))
-        reify {
-          throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+        val tree = c.parse("{ " + code + " }")
+        if (!containsAnyValNullStatement(c)(List(tree))) {
+          c.typeCheck(tree) // parse and type check code snippet
+          // both parse and type check succeeded unexpectedly, generate code to throw TestFailedException
+          val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(code))
+          reify {
+            throw new exceptions.TestFailedException((_: StackDepthException) => Some(messageExpr.splice), None, pos.splice)
+          }
+        }
+        else {
+          reify {
+            // statement such as val i: Int = null, type check fails as expected, generate code to return Succeeded
+            Succeeded
+          }
         }
       } catch {
         case e: TypecheckException =>
@@ -599,21 +704,31 @@ private[scalatest] object CompileMacro {
     // parse and type check a code snippet, generate code to throw TestFailedException if parse error or both parse and type check succeeded
     def checkNotTypeCheck(code: String): c.Expr[Fact] = {
       try {
-        c.typeCheck(c.parse("{ " + code + " }"), c.universe.WildcardType, false, true, false)  // parse and type check code snippet
-        // both parse and type check succeeded unexpectedly, generate code to throw TestFailedException
-        val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(code))
-        reify {
-          Fact.No(messageExpr.splice)(prettifier.splice)
+        val tree = c.parse("{ " + code + " }")
+        if (!containsAnyValNullStatement(c)(List(tree))) {
+          c.typeCheck(tree)  // parse and type check code snippet
+          // both parse and type check succeeded unexpectedly, generate code to throw TestFailedException
+          val messageExpr = c.literal(Resources.expectedTypeErrorButGotNone(code))
+          reify {
+            Fact.No(messageExpr.splice)(prettifier.splice)
+          }
+        }
+        else {
+          val messageExpr = c.literal(Resources.gotTypeErrorAsExpected(code))
+          reify {
+            // statement such as val i: Int = null, type check fails as expected, generate code to return Yes
+            Fact.Yes(messageExpr.splice)(prettifier.splice)
+          }
         }
       } catch {
         case e: TypecheckException =>
           val messageExpr = c.literal(Resources.gotTypeErrorAsExpected(code))
           reify {
-            // type check error as expected, generate code to return Succeeded
+            // type check error as expected, generate code to return Yes
             Fact.Yes(messageExpr.splice)(prettifier.splice)
           }
         case e: ParseException =>
-          // expect type check error but got parse error, generate code to throw TestFailedException
+          // expect type check error but got parse error, generate code to throw No
           val messageExpr = c.literal(Resources.expectedTypeErrorButGotParseError(e.getMessage, code))
           reify {
             Fact.No(messageExpr.splice)(prettifier.splice)

--- a/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
@@ -394,7 +394,7 @@ private[scalatest] object CompileMacro {
       try {
         val tree = c.parse("{ " + code + " }")
         if (!containsAnyValNullStatement(c)(List(tree))) {
-          c.typecheck(tree)
+          c.typeCheck(tree)
           // both parse and type check succeeded, compiles succeeded unexpectedly, generate code to throw TestFailedException
           val messageExpr = c.literal(Resources.expectedCompileErrorButGotNone(code))
           reify {


### PR DESCRIPTION
Fixed implicit view not available problem when used with compile macro.

Note: This fix should be cherry picked into 3.1 and 3.2 branch.