### PR TITLE
Build for Scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, versi
 
   `$ sbt clean publishSigned "project scalatestAppJS" clean publishSigned ++2.10.6 "project scalatestApp" clean publishSigned "project scalatestAppJS" clean publishSigned`
 
-To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12, and make sure you're on Java 8) to Sonatype, use the following command:
+To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12 and 2.13, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.0 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.0 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/common-test/src/main/scala/org/scalatest/CompatParColls.scala
+++ b/common-test/src/main/scala/org/scalatest/CompatParColls.scala
@@ -1,0 +1,20 @@
+package org.scalatest
+
+/**
+  * This compatibility workaround is taken from https://github.com/scala/scala-parallel-collections/issues/22
+  */
+private[org] object CompatParColls {
+  val Converters = {
+    import Compat._
+
+    {
+      import scala.collection.parallel._
+
+      CollectionConverters
+    }
+  }
+
+  object Compat {
+    object CollectionConverters
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -19,7 +19,7 @@ object ScalatestBuild extends Build {
 
   // To temporarily switch sbt to a different Scala version:
   // > ++ 2.10.5
-  val buildScalaVersion = "2.11.8"
+  val buildScalaVersion = "2.11.11"
 
   val releaseVersion = "3.0.4"
 

--- a/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
@@ -18,6 +18,9 @@ package org.scalactic
 import scala.collection.GenTraversable
 import scala.collection.mutable.Buffer
 import scala.collection.mutable.ListBuffer
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ChainSpec extends UnitSpec {
   "A Chain" can "be constructed with one element" in {

--- a/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.Buffer
 import scala.collection.mutable.ListBuffer
 // SKIP-SCALATESTJS-START
 import SharedHelpers.serializeRoundtrip
+import org.scalatest.CompatParColls.Converters._
 // SKIP-SCALATESTJS-END
 
 class EverySpec extends UnitSpec {

--- a/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
@@ -39,15 +39,7 @@ class FutureSugarSpec extends UnitSpec with Accumulation with FutureSugar with S
     Future.successful(10).validating(isRound).futureValue shouldBe 10
     // Scala 2.10 has problem compiling the following:
     // Future.failed(SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-    if (ScalacticVersions.BuiltForScalaVersion == "2.12") {
-      // In 2.12, failed always return a Failure now, not Success, and that causing the futureValue to rethrow the exception
-      val e = intercept[TestFailedException] {
-        Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue
-      }
-      e.cause shouldBe Some(SomeException("oops"))
-    }
-    else
-      Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
+    Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
   }
 
   it should "allow multiple validation functions to be passed to validating" in {
@@ -55,14 +47,7 @@ class FutureSugarSpec extends UnitSpec with Accumulation with FutureSugar with S
     Future.successful(10).validating(isRound, isDivBy3).failed.futureValue shouldBe ValidationFailedException("10 was not divisible by 3")
     Future.successful(30).validating(isRound, isDivBy3).futureValue shouldBe 30
     // Future.failed(SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-    if (ScalacticVersions.BuiltForScalaVersion == "2.12") {
-      val e = intercept[TestFailedException] {
-        Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
-      }
-      e.cause shouldBe Some(SomeException("oops"))
-    }
-    else
-      Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
+    Future.failed[Int](SomeException("oops")).validating(isRound).failed.futureValue shouldBe SomeException("oops")
   }
 
   it should "require at least one parameter to be passed to validating" in {

--- a/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -525,7 +525,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalArgumentException] {
         require(a == 3 && { println("hi"); b == 3})
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")))
       else
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")))
@@ -539,7 +539,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalArgumentException] {
         require({ println("hi"); b == 5} && a == 5)
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)))
       else
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)))
@@ -1671,7 +1671,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalArgumentException] {
         require(a == 3 && { println("hi"); b == 3}, ", dude")
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")) + ", dude")
       else
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")) + ", dude")
@@ -1685,7 +1685,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalArgumentException] {
         require({ println("hi"); b == 5} && a == 5, ", dude")
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)) + ", dude")
       else
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)) + ", dude")
@@ -2777,7 +2777,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalStateException] {
         requireState(a == 3 && { println("hi"); b == 3})
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")))
       else
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")))
@@ -2791,7 +2791,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalStateException] {
         requireState({ println("hi"); b == 5} && a == 5)
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)))
       else
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)))
@@ -3923,7 +3923,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalStateException] {
         requireState(a == 3 && { println("hi"); b == 3}, ", dude")
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")) + ", dude")
       else
         assert(e.getMessage == commaBut(equaled(3, 3), wasFalse("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(3)" + lineSeparator + "}")) + ", dude")
@@ -3937,7 +3937,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
       val e = intercept[IllegalStateException] {
         requireState({ println("hi"); b == 5} && a == 5, ", dude")
       }
-      if (ScalacticVersions.BuiltForScalaVersion == "2.12")
+      if (ScalacticVersions.BuiltForScalaVersion == "2.12" || ScalacticVersions.BuiltForScalaVersion == "2.13")
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)) + ", dude")
       else
         assert(e.getMessage == commaBut(wasTrue("{" + lineSeparator + "  scala.this.Predef.println(\"hi\");" + lineSeparator + "  b.==(5)" + lineSeparator + "}"), didNotEqual(3, 5)) + ", dude")

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
@@ -537,7 +537,11 @@ class PosIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyCheck
     }
 
     it("should offer 'to' and 'until' methods that are consistent with Int") {
-      forAll { (pint: PosInt, end: Int, step: Int) =>
+      forAll { (pint: PosInt, end: Int, generatedStep: PosInt) =>
+        // We need to make sure the range produced's size is less than or equal to Int.MaxValue,
+        // so the following code avoid produce range the goes overflow of int values.
+        val step: Int = if (end < 0) -generatedStep.value else generatedStep.value
+
         Try(pint.to(end)) shouldEqual Try(pint.toInt.to(end))
         Try(pint.to(end, step)) shouldEqual Try(pint.toInt.to(end, step))
         Try(pint.until(end)) shouldEqual Try(pint.toInt.until(end))

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
@@ -34,6 +34,11 @@ class PosZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
 
   implicit val arbPosZInt: Arbitrary[PosZInt] = Arbitrary(posZIntGen)
 
+  val posIntGen: Gen[PosInt] =
+    for {i <- choose(0, Int.MaxValue)} yield PosInt.from(i).get
+
+  implicit val arbPosInt: Arbitrary[PosInt] = Arbitrary(posIntGen)
+
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       case Success(double: Double) if double.isNaN =>  // This is because in scala.js x/0 results to NaN not ArithmetricException like in jvm, and we need to make sure Success(NaN) == Success(NaN) is true to pass the test.
@@ -539,7 +544,11 @@ class PosZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
     }
 
     it("should offer 'to' and 'until' methods that are consistent with Int") {
-      forAll { (pzint: PosZInt, end: Int, step: Int) =>
+      forAll { (pzint: PosZInt, end: Int, generatedStep: PosInt) =>
+        // We need to make sure the range produced's size is less than or equal to Int.MaxValue,
+        // so the following code avoid produce range the goes overflow of int values.
+        val step: Int = if (end < 0) -generatedStep.value else generatedStep.value
+
         Try(pzint.to(end)) shouldEqual Try(pzint.toInt.to(end))
         Try(pzint.to(end, step)) shouldEqual Try(pzint.toInt.to(end, step))
         Try(pzint.until(end)) shouldEqual Try(pzint.toInt.until(end))

--- a/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -888,7 +888,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 3 && { println("hi"); b == 3})
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}"))))
       else
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}"))))
@@ -904,7 +904,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestFailedException] {
         assert({ println("hi"); b == 5} && a == 5)
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5))))
       else
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5))))
@@ -2331,7 +2331,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 3 && { println("hi"); b == 3}, ", dude")
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}")) + ", dude"))
       else
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}")) + ", dude"))
@@ -2347,7 +2347,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestFailedException] {
         assert({ println("hi"); b == 5} && a == 5, ", dude")
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5)) + ", dude"))
       else
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5)) + ", dude"))
@@ -3767,7 +3767,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 3 && { println("hi"); b == 3})
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}"))))
       else
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}"))))
@@ -3783,7 +3783,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestCanceledException] {
         assume({ println("hi"); b == 5} && a == 5)
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5))))
       else
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5))))
@@ -5210,7 +5210,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 3 && { println("hi"); b == 3}, ", dude")
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}")) + ", dude"))
       else
         assert(e.message == Some(commaBut(equaled(3, 3), wasFalse("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(3)" + Prettifier.lineSeparator + "}")) + ", dude"))
@@ -5226,7 +5226,7 @@ class AssertionsSpec extends FunSpec {
       val e = intercept[TestCanceledException] {
         assume({ println("hi"); b == 5} && a == 5, ", dude")
       }
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5)) + ", dude"))
       else
         assert(e.message == Some(commaBut(wasTrue("{" + Prettifier.lineSeparator + "  scala.this.Predef.println(\"hi\");" + Prettifier.lineSeparator + "  b.==(5)" + Prettifier.lineSeparator + "}"), didNotEqual(3, 5)) + ", dude"))

--- a/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
@@ -30,6 +30,9 @@ import matchers.BePropertyMatchResult
 import matchers.BePropertyMatcher
 import matchers.HavePropertyMatchResult
 import matchers.HavePropertyMatcher
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class InspectorShorthandsSpec extends FunSpec with TableDrivenPropertyChecks {
 

--- a/scalatest-test/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
@@ -23,6 +23,9 @@ import SharedHelpers._
 import FailureMessages._
 import Matchers._
 import org.scalactic.Prettifier
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class InspectorsForMapSpec extends FunSpec with Inspectors with TableDrivenPropertyChecks {
 

--- a/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -27,6 +27,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import scala.annotation.tailrec
 import scala.collection.GenTraversable
 import FailureMessages.decorateToStringValue
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class InspectorsSpec extends FunSpec with Inspectors with TableDrivenPropertyChecks {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
@@ -23,6 +23,9 @@ import Prop._
 import org.scalactic.Prettifier
 import org.scalatest.prop.Checkers
 import org.scalatest.exceptions.TestFailedException
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldContainElementSpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldContainKeySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldContainKeySpec.scala
@@ -20,6 +20,9 @@ import Matchers._
 import org.scalactic.Prettifier
 import org.scalatest.prop.Checkers
 import org.scalatest.exceptions.TestFailedException
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldContainKeySpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldContainValueSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldContainValueSpec.scala
@@ -20,6 +20,9 @@ import Matchers._
 import org.scalactic.Prettifier
 import org.scalatest.prop.Checkers
 import org.scalatest.exceptions.TestFailedException
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldContainValueSpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSizeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSizeSpec.scala
@@ -22,6 +22,9 @@ import org.scalatest.enablers.Length
 import org.scalatest.enablers.Size
 import Matchers._
 import org.scalactic.Prettifier
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldLengthSizeSpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
@@ -25,6 +25,9 @@ import Integer.MIN_VALUE
 import org.scalatest.enablers.Length
 import org.scalatest.enablers.Size
 import org.scalatest.exceptions.TestFailedException
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldLengthSpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
@@ -25,6 +25,9 @@ import org.scalatest.prop.Checkers
 import Integer.MIN_VALUE
 import org.scalatest.enablers.Size
 import org.scalatest.exceptions.TestFailedException
+// SKIP-SCALATESTJS-START
+import org.scalatest.CompatParColls.Converters._
+// SKIP-SCALATESTJS-END
 
 class ShouldSizeSpec extends FunSpec with Checkers with ReturnsNormallyThrowsAssertion {
 

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/FuturesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/FuturesSpec.scala
@@ -24,6 +24,7 @@ import exceptions.{TestCanceledException, TestFailedException, TestPendingExcept
 import java.util.concurrent.TimeUnit
 import org.scalactic.source
 import org.scalatest.SharedHelpers.thisLineNumber
+import scala.compat.Platform.EOL
 
 class FuturesSpec extends FunSpec with Matchers with OptionValues with Futures with SeveredStackTraces {
 
@@ -71,7 +72,7 @@ class FuturesSpec extends FunSpec with Matchers with OptionValues with Futures w
           canceledFuture.isReadyWithin(Span(1, Second))
         }
         caught.message.value should be (Resources.futureWasCanceled)
-        withClue(caught.getStackTraceString) {
+        withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
           caught.failedCodeLineNumber.value should equal (thisLineNumber - 4)
         }
         caught.failedCodeFileName.value should be ("FuturesSpec.scala")
@@ -186,7 +187,7 @@ class FuturesSpec extends FunSpec with Matchers with OptionValues with Futures w
           canceledFuture.futureValue
         }
         caught.message.value should be (Resources.futureWasCanceled)
-        withClue(caught.getStackTraceString) {
+        withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
           caught.failedCodeLineNumber.value should equal (thisLineNumber - 4)
         }
         caught.failedCodeFileName.value should be ("FuturesSpec.scala")
@@ -447,7 +448,7 @@ class FuturesSpec extends FunSpec with Matchers with OptionValues with Futures w
           }
         }
         caught.message.value should be (Resources.futureWasCanceled)
-        withClue(caught.getStackTraceString) {
+        withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
           caught.failedCodeLineNumber.value should equal (thisLineNumber - 6)
         }
         caught.failedCodeFileName.value should be ("FuturesSpec.scala")

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/JavaFuturesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/JavaFuturesSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.exceptions.TestPendingException
 import org.scalatest.exceptions.TestCanceledException
 import org.scalatest.exceptions.StackDepthException
 import org.scalactic.source
+import scala.compat.Platform.EOL
 
 class JavaFuturesSpec extends FunSpec with Matchers with OptionValues with JavaFutures with SeveredStackTraces {
 
@@ -74,7 +75,7 @@ class JavaFuturesSpec extends FunSpec with Matchers with OptionValues with JavaF
             canceledFuture.isReadyWithin(Span(1, Millisecond))
           }
           caught.message.value should be(Resources.futureWasCanceled)
-          withClue(caught.getStackTraceString) {
+          withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
             caught.failedCodeLineNumber.value should equal(thisLineNumber - 4)
           }
           caught.failedCodeFileName.value should be("JavaFuturesSpec.scala")
@@ -153,7 +154,7 @@ class JavaFuturesSpec extends FunSpec with Matchers with OptionValues with JavaF
             canceledFuture.futureValue
           }
           caught.message.value should be(Resources.futureWasCanceled)
-          withClue(caught.getStackTraceString) {
+          withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
             caught.failedCodeLineNumber.value should equal(thisLineNumber - 4)
           }
           caught.failedCodeFileName.value should be("JavaFuturesSpec.scala")
@@ -287,7 +288,7 @@ class JavaFuturesSpec extends FunSpec with Matchers with OptionValues with JavaF
             }
           }
           caught.message.value should be(Resources.futureWasCanceled)
-          withClue(caught.getStackTraceString) {
+          withClue(caught.getStackTrace().mkString("", EOL, EOL)) {
             caught.failedCodeLineNumber.value should equal(thisLineNumber - 6)
           }
           caught.failedCodeFileName.value should be("JavaFuturesSpec.scala")

--- a/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
@@ -135,8 +135,8 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, (_: StackDepthException) => 8))
                 case dtne: DuplicateTestNameException => throw dtne
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
-                  if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                  if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 9))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other
@@ -170,10 +170,16 @@ trait SpecLike extends TestSuite with Informing with Notifying with Alerting wit
                 case None => methodTags.contains(IgnoreTagName)
               }
 
+              val registerTestStackDepth =
+                if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
+                  3
+                else
+                  2
+
               if (isIgnore)
                 registerIgnoredTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 3, 0, Some(testLocation), None, methodTags.map(new Tag(_)): _*)
               else
-                registerTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", 2, 1, None, Some(testLocation), None, None, methodTags.map(new Tag(_)): _*)
+                registerTest(testName, Transformer(testFun), Resources.registrationAlreadyClosed, sourceFileName, "ensureScopesAndTestsRegistered", registerTestStackDepth, 1, None, Some(testLocation), None, None, methodTags.map(new Tag(_)): _*)
             }
           }
         }

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -124,8 +124,8 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
                 case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideDefNotObject, Some(e), posOrElseStackDepthFun(e.position, _ => 8))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) =>
-                  if (ScalaTestVersions.BuiltForScalaVersion == "2.12")
-                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 6))
+                  if (ScalaTestVersions.BuiltForScalaVersion == "2.12" || ScalaTestVersions.BuiltForScalaVersion == "2.13")
+                    throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 9))
                   else
                     throw new NotAllowedException(FailureMessages.exceptionWasThrownInObject(Prettifier.default, UnquotedString(other.getClass.getName), UnquotedString(scopeDesc)), Some(other), Right((_: StackDepthException) => 8))
                 case other: Throwable => throw other


### PR DESCRIPTION
Made compatible to build with Scala 2.13.

Note: Changes should be cherry-picked into 3.1/3.2 branches.