### PR TITLE
Fix for Neg + NonZero Failing Test (Scala 2.10)

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
@@ -48,6 +48,7 @@ trait NegIntSpecSupport {
           case Success(bFloat: Float) if bFloat.isNaN => true
           case _ => false
         }
+
       case _: Success[_] => a == b
       case Failure(ex) => b match {
         case _: Success[_] => false
@@ -334,10 +335,20 @@ class NegIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyCheck
 
     it("should offer 'to' and 'until' methods that are consistent with Int") {
       forAll { (pint: NegInt, end: Int, step: Int) =>
-        Try(pint.to(end)) shouldEqual Try(pint.toInt.to(end))
-        Try(pint.to(end, step)) shouldEqual Try(pint.toInt.to(end, step))
-        Try(pint.until(end)) shouldEqual Try(pint.toInt.until(end))
-        Try(pint.until(end, step)) shouldEqual Try(pint.toInt.until(end, step))
+        // The reason we need this is that in Scala 2.10, the equals check (used by shouldEqual below) will call range.length
+        // and it'll cause IllegalArgumentException to be thrown when we do the Try(x) shouldEqual Try(y) assertion below,
+        // while starting from scala 2.11 the equals call implementation does not call .length.
+        // To make the behavior consistent for all scala versions, we explicitly call .length for all returned Range, and
+        // shall it throws IllegalArgumentException, it will be wrapped as Failure for the Try.
+        def ensuringValid(range: Range): Range = {
+          range.length  // IllegalArgumentException will be thrown if it is an invalid range, this will turn the Success to Failure for Try
+          range
+        }
+
+        Try(ensuringValid(pint.to(end))) shouldEqual Try(ensuringValid(pint.toInt.to(end)))
+        Try(ensuringValid(pint.to(end, step))) shouldEqual Try(ensuringValid(pint.toInt.to(end, step)))
+        Try(ensuringValid(pint.until(end))) shouldEqual Try(ensuringValid(pint.toInt.until(end)))
+        Try(ensuringValid(pint.until(end, step))) shouldEqual Try(ensuringValid(pint.toInt.until(end, step)))
       }
     }
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
@@ -333,11 +333,21 @@ class NegZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
     }
 
     it("should offer 'to' and 'until' methods that are consistent with Int") {
+      // The reason we need this is that in Scala 2.10, the equals check (used by shouldEqual below) will call range.length
+      // and it'll cause IllegalArgumentException to be thrown when we do the Try(x) shouldEqual Try(y) assertion below,
+      // while starting from scala 2.11 the equals call implementation does not call .length.
+      // To make the behavior consistent for all scala versions, we explicitly call .length for all returned Range, and
+      // shall it throws IllegalArgumentException, it will be wrapped as Failure for the Try.
+      def ensuringValid(range: Range): Range = {
+        range.length  // IllegalArgumentException will be thrown if it is an invalid range, this will turn the Success to Failure for Try
+        range
+      }
+
       forAll { (pzint: NegZInt, end: Int, step: Int) =>
-        Try(pzint.to(end)) shouldEqual Try(pzint.toInt.to(end))
-        Try(pzint.to(end, step)) shouldEqual Try(pzint.toInt.to(end, step))
-        Try(pzint.until(end)) shouldEqual Try(pzint.toInt.until(end))
-        Try(pzint.until(end, step)) shouldEqual Try(pzint.toInt.until(end, step))
+        Try(ensuringValid(pzint.to(end)))shouldEqual Try(ensuringValid(pzint.toInt.to(end)))
+        Try(ensuringValid(pzint.to(end, step))) shouldEqual Try(ensuringValid(pzint.toInt.to(end, step)))
+        Try(ensuringValid(pzint.until(end))) shouldEqual Try(ensuringValid(pzint.toInt.until(end)))
+        Try(ensuringValid(pzint.until(end, step))) shouldEqual Try(ensuringValid(pzint.toInt.until(end, step)))
       }
     }
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
@@ -361,10 +361,20 @@ class NonZeroIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyC
 
     it("should offer 'to' and 'until' methods that are consistent with Int") {
       forAll { (nzint: NonZeroInt, end: Int, step: Int) =>
-        Try(nzint.to(end)) shouldEqual Try(nzint.toInt.to(end))
-        Try(nzint.to(end, step)) shouldEqual Try(nzint.toInt.to(end, step))
-        Try(nzint.until(end)) shouldEqual Try(nzint.toInt.until(end))
-        Try(nzint.until(end, step)) shouldEqual Try(nzint.toInt.until(end, step))
+        // The reason we need this is that in Scala 2.10, the equals check (used by shouldEqual below) will call range.length
+        // and it'll cause IllegalArgumentException to be thrown when we do the Try(x) shouldEqual Try(y) assertion below,
+        // while starting from scala 2.11 the equals call implementation does not call .length.
+        // To make the behavior consistent for all scala versions, we explicitly call .length for all returned Range, and
+        // shall it throws IllegalArgumentException, it will be wrapped as Failure for the Try.
+        def ensuringValid(range: Range): Range = {
+          range.length  // IllegalArgumentException will be thrown if it is an invalid range, this will turn the Success to Failure for Try
+          range
+        }
+
+        Try(ensuringValid(nzint.to(end))) shouldEqual Try(ensuringValid(nzint.toInt.to(end)))
+        Try(ensuringValid(nzint.to(end, step))) shouldEqual Try(ensuringValid(nzint.toInt.to(end, step)))
+        Try(ensuringValid(nzint.until(end))) shouldEqual Try(ensuringValid(nzint.toInt.until(end)))
+        Try(ensuringValid(nzint.until(end, step))) shouldEqual Try(ensuringValid(nzint.toInt.until(end, step)))
       }
     }
 


### PR DESCRIPTION
Fixed failing tests in NegIntSpec, NegZIntSpec and NonZeroIntSpec when built under Scala 2.10.