### PR TITLE
SbtCommandParser & Combinator Parser Dependency Removal

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -157,7 +157,7 @@ object ScalatestBuild extends Build {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
           "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",
+          //"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",   This is needed only by SbtCommandParser, but we are not support it currently.
           scalacheckDependency("optional")
         )
       case _ =>

--- a/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalatest.tools
+/*package org.scalatest.tools
 
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
@@ -45,5 +45,5 @@ class SbtCommandParserSpec extends FunSpec with Matchers {
       canParsePhrase("""st --""")
     }
   }
-}
+}*/
 

--- a/scalatest/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest.tools
 
-import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+/*import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 import scala.util.parsing.combinator.lexical.StdLexical
 
 private[scalatest] class SbtCommandParser extends StandardTokenParsers {
@@ -122,5 +122,5 @@ private[scalatest] object SbtCommandParser {
     (new SbtCommandParser).parseCommand("""st wildcard("a", "b", "c") stdout(config = "dropteststarting droptestpending")""")
 */
   }
-}
+}*/
 


### PR DESCRIPTION
Commentted out SbtCommandParser that we currently does not support, and combinator parser dependency that it brought in.