### PR TITLE
Travis Exclude Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
   exclude:
     - scala: "2.13.0-M2"
       jdk: openjdk6
-    - scala: "2.12.3"
+    - scala: "2.12.4"
       jdk: openjdk6
     - scala: "2.11.11"
       jdk: oraclejdk8


### PR DESCRIPTION
Should exclude scala 2.12.4 not 2.12.3 in travis, this is causing failure in the following travis build: 

https://travis-ci.org/scalatest/scalatest/builds/291832764?utm_source=email&utm_medium=notification

