### PR TITLE
Anyvals Invalid Test Adjustments

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
@@ -171,9 +171,6 @@ class NegDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeC
       NegDouble.ensuringValid(Double.NegativeInfinity).isNegInfinity shouldBe true
       NegDouble(-1.0).isNegInfinity shouldBe false
     }
-    it("should not offer a isPosInfinity method") {
-      "NegDouble(-1.0f).isPosInfinity" shouldNot compile
-    }
     it("should be sortable") {
       val xs = List(NegDouble(-2.2), NegDouble(-4.4), NegDouble(-1.1),
         NegDouble(-3.3))

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
@@ -170,9 +170,6 @@ class NegFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with
     it("should offer a isNegInfinity method that returns true if the instance is NegativeInfinity") {
       "NegFiniteDouble(-1.0).isNegInfinity" shouldNot compile
     }
-    it("should not offer a isPosInfinity method") {
-      "NegFiniteDouble(-1.0f).isPosInfinity" shouldNot compile
-    }
     it("should be sortable") {
       val xs = List(NegFiniteDouble(-2.2), NegFiniteDouble(-4.4), NegFiniteDouble(-1.1),
         NegFiniteDouble(-3.3))

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
@@ -182,9 +182,6 @@ class NegZFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with
     it("should not offer a PositiveInfinity factory method") {
       "NegZFiniteFloat.PositiveInfinity" shouldNot compile
     }
-    it("should not offer a isNegInfinity method") {
-      "NegZFiniteFloat(-1.0f).isNegInfinity" shouldNot compile
-    }
     it("should not offer a isPosInfinity method") {
       "NegZFiniteFloat(-1.0f).isPosInfinity" shouldNot compile
     }

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
@@ -183,12 +183,6 @@ class NonZeroFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks w
     it("should not offer a NegativeInfinity factory method") {
       "NonZeroFiniteFloat.NegativeInfinity" shouldNot compile
     }
-    it("should not offer a isNegInfinity method") {
-      "NonZeroFiniteFloat(-1.0f).isNegInfinity" shouldNot compile
-    }
-    it("should not offer a isPosInfinity method") {
-      "NonZeroFiniteFloat(-1.0f).isPosInfinity" shouldNot compile
-    }
     it("should offer a MinPositiveValue factory method") {
       NonZeroFiniteFloat.MinPositiveValue shouldEqual NonZeroFiniteFloat.ensuringValid(Float.MinPositiveValue)
     }

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
@@ -225,9 +225,11 @@ class NonZeroLongSpec extends FunSpec with Matchers with GeneratorDrivenProperty
         "takesNonZeroLong(0L)" shouldNot compile
       }
 
-      it("should not compile when -8 is passed in") {
-        "takesNonZeroLong(-8)" shouldNot compile
-        "takesNonZeroLong(-8L)" shouldNot compile
+      it("should compile when -8 is passed in") {
+        "takesNonZeroLong(-8)" should compile
+        takesNonZeroLong(-8) shouldEqual -8L
+        "takesNonZeroLong(-8L)" should compile
+        takesNonZeroLong(-8L) shouldEqual -8L
       }
 
       it("should not compile when x is passed in") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
@@ -173,9 +173,6 @@ class PosDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeC
       PosDouble.ensuringValid(Double.PositiveInfinity).isPosInfinity shouldBe true
       PosDouble(1.0).isPosInfinity shouldBe false
     }
-    it("should not offer a isNegInfinity method") {
-      "PosDouble(1.0).isNegInfinity" shouldNot compile
-    }
 
     it("should be sortable") {
       val xs = List(PosDouble(2.2), PosDouble(4.4), PosDouble(1.1),

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
@@ -172,9 +172,6 @@ class PosFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with
     it("should not ffer a isPosInfinity method") {
       "PosFiniteDouble(1.0).isPosInfinity" shouldNot compile
     }
-    it("should not offer a isNegInfinity method") {
-      "PosFiniteDouble(1.0).isNegInfinity" shouldNot compile
-    }
 
     it("should be sortable") {
       val xs = List(PosFiniteDouble(2.2), PosFiniteDouble(4.4), PosFiniteDouble(1.1),

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
@@ -182,9 +182,6 @@ class PosZFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with
     it("should not offer a NegativeInfinity factory method") {
       "PosZFiniteFloat.NegativeInfinity" shouldNot compile
     }
-    it("should not offer a isPosInfinity method") {
-      "PosZFiniteFloat(1.0f).isPosInfinity" shouldNot compile
-    }
     it("should not offer a isNegInfinity method") {
       "PosZFiniteFloat(1.0f).isNegInfinity" shouldNot compile
     }


### PR DESCRIPTION
Removed anyvals tests that are no longer valid, and adjusted one incorrect test.

The incorrect test was passing in 3.1.x because shouldNot compile called typeChecked with implicit view disabled, what's more interesting, is that the rectified test that calls should compile will pass too in current (old) 3.1.x, the reason is because should compile has been calling typeCheck with implicit view enabled, which is inconsistent behavior by itself.

Anyway, all the problem mentioned above is fixed now with latest CompileMacro code, both should compile and shouldNot compile will call typeCheck with implicit view enabled.