### PR TITLE
[3.0.x] Framework and ScalaTestFramework set spanScaleFactor by Class Loader

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -969,8 +969,17 @@ import java.net.{ServerSocket, InetAddress}
         case Some(SlowpokeConfig(delayInMillis, periodInMillis)) => (true, delayInMillis, periodInMillis)
         case _ => (false, 60000L, 60000L)
       }
-    
-    Runner.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
+
+    // We need to use the following code to set Runner object instance for different Runner using different class loader.
+    import scala.reflect.runtime._
+
+    val runtimeMirror = universe.runtimeMirror(testClassLoader)
+
+    val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
+    val obj = runtimeMirror.reflectModule(module)
+    val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+
+    runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 
     val autoSelectors = parseSuiteArgs(suiteArgs)
 

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -201,7 +201,16 @@ class ScalaTestFramework extends SbtFramework {
               slowpokeDetectionPeriod.getAndSet(60000L)
           }
           
-          Runner.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
+          // We need to use the following code to set Runner object instance for different Runner using different class loader.
+          import scala.reflect.runtime._
+
+          val runtimeMirror = universe.runtimeMirror(testLoader)
+
+          val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
+          val obj = runtimeMirror.reflectModule(module)
+          val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+
+          runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
           
           val fullReporterConfigurations = parseReporterArgsIntoConfigurations(reporterArgs)
           val sbtNoFormat = java.lang.Boolean.getBoolean("sbt.log.noformat")


### PR DESCRIPTION
Changed Framework and ScalaTestFramework to set spanScaleFactor for Runner object instance for different Runner using different class loader.

This enables setting different spanScaleFactor for different projects that runs in parallel.

Changes in this PR should be cherry-pick into 3.1.x, for 3.2.x a separate PR will be submitted.