### PR TITLE
WebBrowser Enhancement

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/selenium/WebBrowserSpec.scala
@@ -39,7 +39,7 @@ import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar
 import scala.reflect.ClassTag
-
+import org.scalatest.SharedHelpers.thisLineNumber
 
 trait InputFieldBehaviour extends JettySpec with Matchers with SpanSugar with WebBrowser with HtmlUnit {
   def inputField[T <: ValueElement](file: String, fn: (String) => T, typeDescription: String, description: String, value1: String, value2: String, lineNumber: Int): Unit = {
@@ -157,19 +157,6 @@ trait InputFieldBehaviour extends JettySpec with Matchers with SpanSugar with We
       fn("secret1").value should be ("first secret! second secret! third secret!")                   
     }
 
-  }
-
-  private[this] def myLineNumber = {
-    val st = Thread.currentThread.getStackTrace
-
-    st.foreach(s => println("--" + s.toString()))
-
-    if (!st(2).getMethodName.contains("myLineNumber"))
-      st(3).getLineNumber
-    else if (!st(3).getMethodName.contains("myLineNumber"))
-      st(4).getLineNumber
-    else
-      st(5).getLineNumber
   }
 
 }
@@ -1317,7 +1304,7 @@ class WebBrowserSpec extends JettySpec with Matchers with SpanSugar with WebBrow
     }
   
     it("should support capturing screenshot", Slow) {
-      go to "http://www.artima.com"
+      go to "http://www.scalatest.org"
       try {
         capture
         capture to ("MyScreenShot.png")
@@ -1330,7 +1317,7 @@ class WebBrowserSpec extends JettySpec with Matchers with SpanSugar with WebBrow
     }
     
     it("should support setting capture target directory", Slow) {
-      go to "http://www.artima.com"
+      go to "http://www.scalatest.org"
       val tempDir = new File(System.getProperty("java.io.tmpdir"))
       val targetDir1 = new File(tempDir, "scalatest-test-target1")
       val targetDir2 = new File(tempDir, "scalatest-test-target2")
@@ -2029,17 +2016,6 @@ class WebBrowserSpec extends JettySpec with Matchers with SpanSugar with WebBrow
       }
       """ should compile
     }
-  }
-  
-  def thisLineNumber = {
-    val st = Thread.currentThread.getStackTrace
-
-    if (!st(2).getMethodName.contains("thisLineNumber"))
-      st(2).getLineNumber
-    else if (!st(3).getMethodName.contains("thisLineNumber"))
-      st(3).getLineNumber
-    else
-      st(4).getLineNumber
   }
 }
 // class ParallelWebBrowserSpec extends WebBrowserSpec with ParallelTestExecution

--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -3800,7 +3800,7 @@ trait WebBrowser {
      * @param queryString the string with which to search, first by ID then by name
      * @param driver the <code>WebDriver</code> with which to drive the browser
      */
-    def on(queryString: String)(implicit driver: WebDriver): Unit = {
+    def on(queryString: String)(implicit driver: WebDriver, pos: source.Position = implicitly[source.Position]): Unit = {
       // stack depth is not correct if just call the button("...") directly.
       val target = tryQueries(queryString)(q => q.webElement)
       on(target)
@@ -3841,7 +3841,7 @@ trait WebBrowser {
    * @param queryString the string with which to search, first by ID then by name
    * @param driver the <code>WebDriver</code> with which to drive the browser
    */
-  def clickOn(queryString: String)(implicit driver: WebDriver): Unit = {
+  def clickOn(queryString: String)(implicit driver: WebDriver, pos: source.Position = implicitly[source.Position]): Unit = {
     click on queryString
   }
   
@@ -4064,7 +4064,7 @@ trait WebBrowser {
    * @param query <code>Query</code> used to select <code>WebElement</code> which is contained in the frame to switch to 
    * @return a FrameWebElementTarget instance
    */
-  def frame(query: Query)(implicit driver: WebDriver) = new FrameWebElementTarget(query.webElement)
+  def frame(query: Query)(implicit driver: WebDriver, pos: source.Position = implicitly[source.Position]) = new FrameWebElementTarget(query.webElement)
   
   /**
    * This class supports switching to a window by name or handle in ScalaTest's Selenium DSL.


### PR DESCRIPTION
-Improved WebBrowser's createTypedElement performance, as complained here: #372
-Removed unnecessary 'with' in WebBrowser's value element classes.

These changes should be cherry-picked into 3.1.x and subsequently pulled into 3.2.x.