### PR TITLE
Fix  indicateFailure in the UnitPropCheckerAsserting

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -609,7 +609,7 @@ abstract class UnitPropCheckerAsserting {
             FailureMessages.propertyFailed(prettifier, succeeded),
             argsPassed,
             labels,
-            None,
+            Some(ex),
             pos
           )
 


### PR DESCRIPTION
I can't see reason why property-based test failed, because argument `optionalCause` always is None.