### PR TITLE
Scala 2.10 Reflection Fix

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -987,22 +987,22 @@ import java.net.{ServerSocket, InetAddress}
       }
 
     val runnerInstance =
-    if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
-      val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
-      val module = runnerCompanionClass.getField("MODULE$")
-      val obj = module.get(runnerCompanionClass)
-      obj.asInstanceOf[Runner.type]
-    }
-    else {
-      // We need to use the following code to set Runner object instance for different Runner using different class loader.
-      import scala.reflect.runtime._
+      if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+        val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
+        val module = runnerCompanionClass.getField("MODULE$")
+        val obj = module.get(runnerCompanionClass)
+        obj.asInstanceOf[Runner.type]
+      }
+      else {
+        // We need to use the following code to set Runner object instance for different Runner using different class loader.
+        import scala.reflect.runtime._
 
-      val runtimeMirror = universe.runtimeMirror(testClassLoader)
+        val runtimeMirror = universe.runtimeMirror(testClassLoader)
 
-      val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-      val obj = runtimeMirror.reflectModule(module)
-      obj.instance.asInstanceOf[Runner.type]
-    }
+        val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
+        val obj = runtimeMirror.reflectModule(module)
+        obj.instance.asInstanceOf[Runner.type]
+      }
 
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -986,14 +986,23 @@ import java.net.{ServerSocket, InetAddress}
         case _ => (false, 60000L, 60000L)
       }
 
-    // We need to use the following code to set Runner object instance for different Runner using different class loader.
-    import scala.reflect.runtime._
+    val runnerInstance =
+    if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+      val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
+      val module = runnerCompanionClass.getField("MODULE$")
+      val obj = module.get(runnerCompanionClass)
+      obj.asInstanceOf[Runner.type]
+    }
+    else {
+      // We need to use the following code to set Runner object instance for different Runner using different class loader.
+      import scala.reflect.runtime._
 
-    val runtimeMirror = universe.runtimeMirror(testClassLoader)
+      val runtimeMirror = universe.runtimeMirror(testClassLoader)
 
-    val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-    val obj = runtimeMirror.reflectModule(module)
-    val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+      val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
+      val obj = runtimeMirror.reflectModule(module)
+      obj.instance.asInstanceOf[Runner.type]
+    }
 
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -200,15 +200,24 @@ class ScalaTestFramework extends SbtFramework {
               slowpokeDetectionDelay.getAndSet(60000L)
               slowpokeDetectionPeriod.getAndSet(60000L)
           }
-          
-          // We need to use the following code to set Runner object instance for different Runner using different class loader.
-          import scala.reflect.runtime._
 
-          val runtimeMirror = universe.runtimeMirror(testLoader)
+          val runnerInstance =
+            if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+              val runnerCompanionClass = testLoader.loadClass("org.scalatest.tools.Runner$")
+              val module = runnerCompanionClass.getField("MODULE$")
+              val obj = module.get(runnerCompanionClass)
+              obj.asInstanceOf[Runner.type]
+            }
+            else {
+              // We need to use the following code to set Runner object instance for different Runner using different class loader.
+              import scala.reflect.runtime._
 
-          val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-          val obj = runtimeMirror.reflectModule(module)
-          val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+              val runtimeMirror = universe.runtimeMirror(testLoader)
+
+              val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
+              val obj = runtimeMirror.reflectModule(module)
+              obj.instance.asInstanceOf[Runner.type]
+            }
 
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
           


### PR DESCRIPTION
Changed the use of scala reflection in ObjectMeta and Framework to use java reflection in scala 2.10, because scala reflection in scala 2.10 is not thread-safe.