### PR TITLE
Fix build compilation when using coursier

### DIFF
--- a/project/GenExamplesJS.scala
+++ b/project/GenExamplesJS.scala
@@ -16,7 +16,7 @@
 
 import sbt.IO
 
-import io.Source
+import scala.io.Source
 import java.io.{File, FileWriter, BufferedWriter}
 
 object GenExamplesJS {

--- a/project/GenExamplesNative.scala
+++ b/project/GenExamplesNative.scala
@@ -16,7 +16,7 @@
 
 import sbt.IO
 
-import io.Source
+import scala.io.Source
 import java.io.{File, FileWriter, BufferedWriter}
 
 object GenExamplesNative {

--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -16,7 +16,7 @@
 
 import sbt.IO
 
-import io.Source
+import scala.io.Source
 import java.io.{File, FileWriter, BufferedWriter}
 
 object GenScalaTestJS {

--- a/project/GenScalaTestNative.scala
+++ b/project/GenScalaTestNative.scala
@@ -16,7 +16,7 @@
 
 import sbt.IO
 
-import io.Source
+import scala.io.Source
 import java.io.{File, FileWriter, BufferedWriter}
 
 object GenScalaTestNative {


### PR DESCRIPTION
I am using coursier in my global sbt configuration. The current scalatest master build does not compile without these changes. I am not completely sure what is causing the issue, but it seems that `io` package gets shadowed by `"io.get-coursier" % "sbt-coursier" % "1.0.0"` sbt plugin.