### PR TITLE
EndWith Regex Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/words/EndWithWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/EndWithWordSpec.scala
@@ -19,23 +19,23 @@ import org.scalatest._
 import Matchers._
 
 class EndWithWordSpec extends FreeSpec with FileMocks {
-  
+
   "EndWithWord " - {
-    
+
     "should have pretty toString" in {
       endWith.toString should be ("endWith")
     }
-    
+
     "apply(String) method returns Matcher" - {
-      
+
       val mt = endWith ("er")
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith (\"er\")")
       }
-      
+
       val mr = mt("Programmer")
-      
+
       "should have correct MatcherResult" in {
         mr.matches shouldBe true
         mr.failureMessage shouldBe "\"Programmer\" did not end with substring \"er\""
@@ -50,11 +50,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         mr.negatedFailureMessageArgs shouldBe Vector("Programmer", "er")
         mr.midSentenceFailureMessageArgs shouldBe Vector("Programmer", "er")
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector("Programmer", "er")
-
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr.matches shouldBe false
         nmr.failureMessage shouldBe "\"Programmer\" ended with substring \"er\""
@@ -69,21 +68,20 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         nmr.negatedFailureMessageArgs shouldBe Vector("Programmer", "er")
         nmr.midSentenceFailureMessageArgs shouldBe Vector("Programmer", "er")
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("Programmer", "er")
-
       }
     }
-    
+
     "regex(String) method returns Matcher" - {
-      
+
       val decimal = """(-)?(\d+)(\.\d*)?"""
       val mt = endWith regex decimal
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"" + decimal + "\"")
       }
-      
+
       val mr = mt("b2.7")
-      
+
       "should have correct MatcherResult" in {
         mr.matches shouldBe true
         mr.failureMessage shouldBe "\"b2.7\" did not end with a substring that matched the regular expression " + decimal
@@ -98,11 +96,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         mr.negatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
         mr.midSentenceFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr.matches shouldBe false
         nmr.failureMessage shouldBe "\"b2.7\" ended with a substring that matched the regular expression " + decimal
@@ -117,72 +114,69 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         nmr.negatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
         nmr.midSentenceFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-
       }
     }
-    
+
     "regex(Regex) method returns Matcher" - {
-      
+
       val decimal = """(-)?(\d+)(\.\d*)?"""
       val mt = endWith regex decimal.r
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"" + decimal + "\"")
       }
-      
-      val mr = mt("b2.7")
-      
+
+      val mr = mt("a1.6b2.7")
+
       "should have correct MatcherResult" in {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe "\"b2.7\" did not end with a substring that matched the regular expression " + decimal
-        mr.negatedFailureMessage shouldBe "\"b2.7\" ended with a substring that matched the regular expression " + decimal
-        mr.midSentenceFailureMessage shouldBe "\"b2.7\" did not end with a substring that matched the regular expression " + decimal
-        mr.midSentenceNegatedFailureMessage shouldBe "\"b2.7\" ended with a substring that matched the regular expression " + decimal
+        mr.failureMessage shouldBe "\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal
+        mr.negatedFailureMessage shouldBe "\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal
+        mr.midSentenceFailureMessage shouldBe "\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal
+        mr.midSentenceNegatedFailureMessage shouldBe "\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal
         mr.rawFailureMessage shouldBe "{0} did not end with a substring that matched the regular expression {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} ended with a substring that matched the regular expression {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not end with a substring that matched the regular expression {1}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} ended with a substring that matched the regular expression {1}"
-        mr.failureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        mr.negatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        mr.midSentenceFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-
+        mr.failureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        mr.negatedFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        mr.midSentenceFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe "\"b2.7\" ended with a substring that matched the regular expression " + decimal
-        nmr.negatedFailureMessage shouldBe "\"b2.7\" did not end with a substring that matched the regular expression " + decimal
-        nmr.midSentenceFailureMessage shouldBe "\"b2.7\" ended with a substring that matched the regular expression " + decimal
-        nmr.midSentenceNegatedFailureMessage shouldBe "\"b2.7\" did not end with a substring that matched the regular expression " + decimal
+        nmr.failureMessage shouldBe "\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal
+        nmr.negatedFailureMessage shouldBe "\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal
+        nmr.midSentenceFailureMessage shouldBe "\"a1.6b2.7\" ended with a substring that matched the regular expression " + decimal
+        nmr.midSentenceNegatedFailureMessage shouldBe "\"a1.6b2.7\" did not end with a substring that matched the regular expression " + decimal
         nmr.rawFailureMessage shouldBe "{0} ended with a substring that matched the regular expression {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not end with a substring that matched the regular expression {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} ended with a substring that matched the regular expression {1}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not end with a substring that matched the regular expression {1}"
-        nmr.failureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        nmr.negatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        nmr.midSentenceFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("b2.7", UnquotedString(decimal))
-
+        nmr.failureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        nmr.negatedFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        nmr.midSentenceFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
+        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("a1.6b2.7", UnquotedString(decimal))
       }
     }
-    
+
     "regex(a(b*)c withGroup bb) method returns Matcher" - {
-      
+
       val bb = "bb"
-      
+
       val mt = endWith regex ("""a(b*)c""" withGroup bb)
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"a(b*)c\" withGroup (\"" + bb + "\")")
       }
-      
+
       val mr1 = mt("abbc")
-      
+
       "when apply with \"abbc\"" - {
-      
+
         "should have correct MatcherResult" in {
           mr1.matches shouldBe true
           mr1.failureMessage shouldBe "\"abbc\" ended with a substring that matched the regular expression a(b*)c, but \"bb\" did not match group bb"
@@ -197,11 +191,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           mr1.negatedFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))
           mr1.midSentenceFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))
           mr1.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))
-
         }
-      
+
         val nmr = mr1.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr.matches shouldBe false
           nmr.failureMessage shouldBe "\"abbc\" ended with a substring that matched the regular expression a(b*)c and group bb"
@@ -216,17 +209,15 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           nmr.negatedFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))
           nmr.midSentenceFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), UnquotedString("bb"))
           nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbc", UnquotedString("a(b*)c"), "bb", UnquotedString("bb"))
-
         }
-        
+
       }
-      
+
       val mr2 = mt("abbbc")
-        
+
       "when apply with \"abbbc\"" - {
-          
+
         "should have correct MatcherResult" in {
-            
           mr2.matches shouldBe false
             
           mr2.failureMessage shouldBe "\"abbbc\" ended with a substring that matched the regular expression a(b*)c, but \"bbb\" did not match group bb"
@@ -252,12 +243,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           mr2.midSentenceFailureMessageArgs shouldBe Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))
             
           mr2.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb"))
-
-            
         }
-          
+
         val nmr = mr2.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr.matches shouldBe true
           nmr.failureMessage shouldBe "\"abbbc\" ended with a substring that matched the regular expression a(b*)c and group bb"
@@ -272,15 +261,14 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           nmr.negatedFailureMessageArgs shouldBe Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))
           nmr.midSentenceFailureMessageArgs shouldBe Vector("abbbc", UnquotedString("a(b*)c"), UnquotedString("bb"))
           nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbbc", UnquotedString("a(b*)c"), "bbb", UnquotedString("bb"))
-
         }
-          
+
       }
-      
+
       val mr3 = mt("ABBC")
-      
+
       "when apply with \"ABBC\"" - {
-        
+
         "should have correct MatcherResult" in {
           mr3.matches shouldBe false
           mr3.failureMessage shouldBe "\"ABBC\" did not end with a substring that matched the regular expression a(b*)c"
@@ -295,11 +283,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           mr3.negatedFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
           mr3.midSentenceFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
           mr3.midSentenceNegatedFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
-
         }
-        
+
         val nmr = mr3.negated
-      
+
         "should have correct negated MatcherResult" in {
           nmr.matches shouldBe true
           nmr.failureMessage shouldBe "\"ABBC\" ended with a substring that matched the regular expression a(b*)c"
@@ -314,23 +301,22 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
           nmr.negatedFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
           nmr.midSentenceFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
           nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("ABBC", UnquotedString("a(b*)c"))
-
         }
       }
     }
-    
+
     "regex(a(b*)(c*) withGroup bb) method returns Matcher" - {
       val bb = "bb"
       val cc = "cc"
-      
+
       val mt = endWith regex ("""a(b*)(c*)""" withGroups (bb, cc))
-      
+
       "should have pretty toString" in {
         mt.toString should be ("endWith regex \"a(b*)(c*)\" withGroups (\"" + bb + "\", \"" + cc + "\")")
       }
-      
+
       val mr = mt("abbccc")
-      
+
       "should have correct MatcherResult" in {
         mr.matches shouldBe false
         mr.failureMessage shouldBe "\"abbccc\" ended with a substring that matched the regular expression a(b*)(c*), but \"ccc\" did not match group cc at index 1"
@@ -345,11 +331,10 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         mr.negatedFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))
         mr.midSentenceFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))
-
       }
-      
+
       val nmr = mr.negated
-      
+
       "should have correct negated MatcherResult" in {
         nmr.matches shouldBe true
         nmr.failureMessage shouldBe "\"abbccc\" ended with a substring that matched the regular expression a(b*)(c*) and group bb, cc"
@@ -364,7 +349,6 @@ class EndWithWordSpec extends FreeSpec with FileMocks {
         nmr.negatedFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)
         nmr.midSentenceFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), UnquotedString("bb, cc"))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector("abbccc", UnquotedString("a(b*)(c*)"), "ccc", UnquotedString("cc"), 1)
-
       }
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
@@ -48,7 +48,7 @@ private[scalatest] object MatchersHelper {
   // 1           0            1                      Some(G)
   // 1           1            0                      Some(M)
   // 1           1            1                      Some(M) prefer a Scala style one of a Java style, such as when using BeanProperty annotation
-  // 
+  //
   def accessProperty(objectWithProperty: AnyRef, propertySymbol: Symbol, isBooleanProperty: Boolean): Option[Any] = {
 
     // If 'title passed, propertyName would be "title"
@@ -226,12 +226,12 @@ private[scalatest] object MatchersHelper {
   }
   // SKIP-SCALATESTJS-END
 
-  def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String], 
+  def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String],
                                  didNotMatchMessage: => String, matchMessage: => String, notGroupAtIndexMessage:  => String, notGroupMessage: => String,
                                  andGroupMessage: => String): MatchResult = {
     if (groups.size == 0 || !matches)
       MatchResult(
-        matches, 
+        matches,
         didNotMatchMessage,
         matchMessage,
         Vector(left, UnquotedString(regex.toString))
@@ -239,54 +239,60 @@ private[scalatest] object MatchersHelper {
     else {
       val count = pMatcher.groupCount
       val failed = // Find the first group that fails
-        groups.zipWithIndex.find { case (group, idx) => 
+        groups.zipWithIndex.find { case (group, idx) =>
           val groupIdx = idx + 1
           !(groupIdx <= count && pMatcher.group(groupIdx) == group)
         }
       failed match {
         case Some((group, idx)) =>
           MatchResult(
-            false, 
+            false,
             if (groups.size > 1) notGroupAtIndexMessage else notGroupMessage,
             andGroupMessage,
-            if (groups.size > 1) Vector(left, UnquotedString(regex.toString), pMatcher.group(idx + 1), UnquotedString(group), idx) else Vector(left, UnquotedString(regex.toString), pMatcher.group(1), UnquotedString(group)), 
+            if (groups.size > 1) Vector(left, UnquotedString(regex.toString), pMatcher.group(idx + 1), UnquotedString(group), idx) else Vector(left, UnquotedString(regex.toString), pMatcher.group(1), UnquotedString(group)),
             Vector(left, UnquotedString(regex.toString), UnquotedString(groups.mkString(", ")))
           )
-        case None => 
+        case None =>
           // None of group failed
           MatchResult(
-            true, 
+            true,
             notGroupMessage,
             andGroupMessage,
-            Vector(left, UnquotedString(regex.toString), pMatcher.group(1),  UnquotedString(groups.mkString(", "))), 
+            Vector(left, UnquotedString(regex.toString), pMatcher.group(1),  UnquotedString(groups.mkString(", "))),
             Vector(left, UnquotedString(regex.toString), UnquotedString(groups.mkString(", ")))
           )
       }
     }
   }
-  
+
   def fullyMatchRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.matches
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotFullyMatchRegex, Resources.rawFullyMatchedRegex, Resources.rawFullyMatchedRegexButNotGroupAtIndex,
                                Resources.rawFullyMatchedRegexButNotGroup, Resources.rawFullyMatchedRegexAndGroup)
   }
-  
+
   def startWithRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.lookingAt
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotStartWithRegex, Resources.rawStartedWithRegex, Resources.rawStartedWithRegexButNotGroupAtIndex,
       Resources.rawStartedWithRegexButNotGroup, Resources.rawStartedWithRegexAndGroup)
   }
-  
+
   def endWithRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
-    val found = pMatcher.find
-    val matches = found && pMatcher.end == left.length
+    var end = -1
+    while (!pMatcher.hitEnd && end != left.length) {
+      if (pMatcher.find)
+        end = pMatcher.end
+    }
+
+    val matches = end == left.length
+
     checkPatternMatchAndGroups(matches, left, pMatcher, regex, groups, Resources.rawDidNotEndWithRegex, Resources.rawEndedWithRegex, Resources.rawEndedWithRegexButNotGroupAtIndex,
                                Resources.rawEndedWithRegexButNotGroup, Resources.rawEndedWithRegexAndGroup)
   }
-  
+
   def includeRegexWithGroups(left: String, regex: Regex, groups: IndexedSeq[String]): MatchResult = {
     val pMatcher = regex.pattern.matcher(left)
     val matches = pMatcher.find

--- a/scalatest/src/main/scala/org/scalatest/words/EndWithWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/EndWithWord.scala
@@ -61,18 +61,18 @@ final class EndWithWord {
    * </pre>
    */
   def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  
+
   /**
    * This method enables the following syntax:
    *
    * <pre class="stHighlight">
-   * string should not { endWith regex ("a(b*)c" withGroup "bb") } 
+   * string should not { endWith regex ("a(b*)c" withGroup "bb") }
    *                             ^
    * </pre>
-   */	
-  def regex(regexWithGroups: RegexWithGroups) = 
+   */
+  def regex(regexWithGroups: RegexWithGroups) =
     new Matcher[String] {
-      def apply(left: String): MatchResult = 
+      def apply(left: String): MatchResult =
         endWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       override def toString: String = "endWith regex " + Prettifier.default(regexWithGroups)
     }
@@ -89,9 +89,17 @@ final class EndWithWord {
   def regex(rightRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult = {
-        val allMatches = rightRegex.findAllIn(left)
+        val pMatcher = rightRegex.pattern.matcher(left)
+        var end = -1
+        while (!pMatcher.hitEnd && end != left.length) {
+          if (pMatcher.find)
+            end = pMatcher.end
+        }
+
+        val matches = end == left.length
+
         MatchResult(
-          allMatches.hasNext && (allMatches.end == left.length),
+          matches,
           Resources.rawDidNotEndWithRegex,
           Resources.rawEndedWithRegex,
           Vector(left, UnquotedString(rightRegex.toString))
@@ -99,7 +107,7 @@ final class EndWithWord {
       }
       override def toString: String = "endWith regex \"" + Prettifier.default(rightRegex) + "\""
     }
-  
+
   /**
    * Overrides toString to return "endWith"
    */


### PR DESCRIPTION
Fix EndWith regex problem.

This is resubmission of the following PR: 

https://github.com/scalatest/scalatest/pull/871

with some code tweak to pass all tests in current 3.0.x.

This fix should be cherry-picked into 3.1.x and subsequently pulled into 3.2.x.

PS: We should get CLA from kevinshieh first before merging in this fix.
  