### PR TITLE
Resubmit: Wrap <script> sections of HtmlReporter in <![CDATA[]]>

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -240,7 +240,7 @@ private[scalatest] class HtmlReporter(
             case None => NodeSeq.Empty
           }
         }
-        <script type="text/javascript">
+        <script type="text/javascript"><![CDATA[
           { unparsedXml(
             "function toggleDetails(contentId, linkId) {" + "\n" + 
             "  var ele = document.getElementById(contentId);" + "\n" + 
@@ -258,7 +258,7 @@ private[scalatest] class HtmlReporter(
             "  if (top === self) { document.getElementById('printlink').style.display = 'none'; }" + "\n" + 
             "}" + "\n")
           }
-        </script>
+        ]]></script>
       </head>
       <body class="specification">
         <div id="suite_header_name">{ suiteResult.suiteName }</div>
@@ -520,7 +520,7 @@ private[scalatest] class HtmlReporter(
         }
         <script type="text/javascript" src="js/d3.v2.min.js"></script>
         <script type="text/javascript" src="js/sorttable.js"></script>
-        <script type="text/javascript">
+        <script type="text/javascript"><![CDATA[
           { unparsedXml(
             "var tagMap = {};" + "\n" +     
             "var SUCCEEDED_BIT = 1;" + "\n" + 
@@ -563,7 +563,7 @@ private[scalatest] class HtmlReporter(
             "  detailsView.style.width = (window.innerWidth - left - 30) + \"px\";" + "\n" + 
             "  detailsView.style.height = (window.innerHeight - headerView.offsetHeight - 20) + \"px\";" + "\n" + 
             "}\n") }
-        </script>
+        ]]></script>
       </head>
       <body onresize="resizeDetailsView()">
         <div class="scalatest-report"> 


### PR DESCRIPTION
This is re-submission of: 

https://github.com/scalatest/scalatest/pull/1127

against branch 3.0.x.

One of the sections had an unescaped &, which trips up browsers when the
generated files are presented as XML/XHTML.

Preventively, this wraps the two longer <script> elements in a CDATA
block, even if only one currently needs a fix.
  
This fix should be cherry-pick into 3.1.x and subsequently pulled in 3.2.x.