### PR TITLE
recovertT* Typo Fix

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpec.scala
@@ -481,7 +481,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpec.scala
@@ -439,7 +439,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpec.scala
@@ -448,7 +448,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSpec.scala
@@ -445,7 +445,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSuite.scala
@@ -423,7 +423,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
@@ -476,7 +476,7 @@ package org.scalatest
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <code>recoverToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>

--- a/scalatest/src/main/scala/org/scalatest/RecoverMethods.scala
+++ b/scalatest/src/main/scala/org/scalatest/RecoverMethods.scala
@@ -115,7 +115,7 @@ import org.scalactic.source
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
  * <a href="Assertions.html#expectedExceptions"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <code>assertThrows</code>. The first one allows you to perform further
+ * <code>recoverToSucceededIf</code> is to <code>assertThrows</code>. The first one allows you to perform further
  * assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>


### PR DESCRIPTION
Fixed typos in 'recovertT*' methods.

This is re submission of the following PR: 

https://github.com/scalatest/scalatest/pull/1023

against 3.0.x.