### PR TITLE
Duplicated 'the' Fix

### DIFF
--- a/scalactic/src/main/scala/org/scalactic/Snapshots.scala
+++ b/scalactic/src/main/scala/org/scalactic/Snapshots.scala
@@ -148,7 +148,7 @@ final class SnapshotSeq(underlying: collection.immutable.IndexedSeq[Snapshot]) e
    * <p>
    * If the string element does not already exist in this sequence, this method returns itself. If the element
    * is contained in this sequence, this method returns a new <code>MultiSelOptionSeq</code> with the passed value
-   * removed from the the original <code>MultiSelOptionSeq</code>, leaving any other elements in the same order.
+   * removed from the original <code>MultiSelOptionSeq</code>, leaving any other elements in the same order.
    * </p>
    *
    * @param the string element to append to this sequence

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
@@ -152,7 +152,7 @@ class ShouldBePropertyMatcherSpec extends FunSpec with Checkers with ReturnsNorm
       assert(caught9.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead")
     }
 
-    it("should do nothing if the the property returns true, when used in a logical-and expression") {
+    it("should do nothing if the property returns true, when used in a logical-and expression") {
 
       myFile should ((be (file)) and (be (file)))
       myFile should (be (file) and (be (file)))

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpec.scala
@@ -834,7 +834,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/FlatSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/FlatSpec.scala
@@ -854,7 +854,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/FreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpec.scala
@@ -884,7 +884,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/FunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSpec.scala
@@ -773,7 +773,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/FunSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSuite.scala
@@ -701,7 +701,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/WordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/WordSpec.scala
@@ -1037,7 +1037,7 @@ package org.scalatest
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Futures.scala
@@ -35,7 +35,7 @@ import exceptions.StackDepthException
  * </p>
  *
  * <p>
- * 1. Invoking <code>isReadyWithin</code>, to assert that a future is ready within a a specified time period.
+ * 1. Invoking <code>isReadyWithin</code>, to assert that a future is ready within a specified time period.
  * Here's an example:
  * </p>
  * 

--- a/scalatest/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
@@ -32,7 +32,7 @@ import scala.util.Success
  * </p>
  *
  * <p>
- * 1. Invoking <code>isReadyWithin</code>, to assert that a future is ready within a a specified time period.
+ * 1. Invoking <code>isReadyWithin</code>, to assert that a future is ready within a specified time period.
  * Here's an example:
  * </p>
  * 

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Waiters.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Waiters.scala
@@ -92,7 +92,7 @@ import org.scalactic.source
  * <p>
  * Note that if a <code>Waiter</code> receives <em>more </em> than the expected number of dismissals, it will not report
  * this as an error: <em>i.e.</em>, receiving greater than the number of expected dismissals without any failed assertion will simply
- * cause the the test to complete, not to fail. The only way a <code>Waiter</code> will cause a test to fail is if one of the
+ * cause the test to complete, not to fail. The only way a <code>Waiter</code> will cause a test to fail is if one of the
  * asynchronous assertions to which it is applied fails.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncConfigMapFixture.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncConfigMapFixture.scala
@@ -83,7 +83,7 @@ trait AsyncConfigMapFixture { this: fixture.AsyncTestSuite =>
   type FixtureParam = ConfigMap
 
   /**
-    * Invoke the test function, passing to the the test function the <code>configMap</code>
+    * Invoke the test function, passing to the test function the <code>configMap</code>
     * obtained by invoking <code>configMap</code> on the passed <code>OneArgTest</code>.
     *
     * <p>

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpec.scala
@@ -145,7 +145,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpec.scala
@@ -144,7 +144,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpec.scala
@@ -145,7 +145,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpec.scala
@@ -145,7 +145,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuite.scala
@@ -144,7 +144,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestDataFixture.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestDataFixture.scala
@@ -52,7 +52,7 @@ trait AsyncTestDataFixture { this: fixture.AsyncTestSuite =>
   type FixtureParam = TestData
 
   /**
-    * Invoke the test function, passing to the the test function
+    * Invoke the test function, passing to the test function
     * the <code>TestData</code> for the test.
     *
     * <p>

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpec.scala
@@ -145,7 +145,7 @@ package org.scalatest.fixture
  * an [[org.scalatest.Failed org.scalatest.Failed]] wrapping the exception describing
  * the failure. To ensure clean up happens even if a test fails, you should invoke the test function and do the cleanup using
  * <code>complete</code>-<code>lastly</code>, as shown in the previous example. The <code>complete</code>-<code>lastly</code> syntax, defined in <code>CompleteLastly</code>, which is extended by <code>AsyncTestSuite</code>, ensures
- * the second, cleanup block of code is executed, whether the the first block throws an exception or returns a future. If it returns a
+ * the second, cleanup block of code is executed, whether the first block throws an exception or returns a future. If it returns a
  * future, the cleanup will be executed when the future completes.
  * </p>
  *

--- a/scalatest/src/main/scala/org/scalatest/fixture/ConfigMapFixture.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/ConfigMapFixture.scala
@@ -82,7 +82,7 @@ trait ConfigMapFixture { this: fixture.TestSuite =>
   type FixtureParam = ConfigMap
 
   /**
-   * Invoke the test function, passing to the the test function the <code>configMap</code>
+   * Invoke the test function, passing to the test function the <code>configMap</code>
    * obtained by invoking <code>configMap</code> on the passed <code>OneArgTest</code>.
    *
    * <p>

--- a/scalatest/src/main/scala/org/scalatest/fixture/NoArg.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/NoArg.scala
@@ -233,7 +233,7 @@ trait NoArg extends DelayedInit with (() => Unit) {
    * <p>
    * This trait is intended to be mixed
    * into classes that are constructed within the body (or as the body) of tests, not mixed into <code>Suite</code>s themselves. For an example,
-   * the the main Scaladoc comment for this trait.
+   * the main Scaladoc comment for this trait.
    * </p>
    */
   final val styleName: Int = 0 // So can't mix into Suite

--- a/scalatest/src/main/scala/org/scalatest/fixture/TestDataFixture.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/TestDataFixture.scala
@@ -52,7 +52,7 @@ trait TestDataFixture { this: fixture.TestSuite =>
   type FixtureParam = TestData
 
   /**
-   * Invoke the test function, passing to the the test function 
+   * Invoke the test function, passing to the test function 
    * the <code>TestData</code> for the test.
    *
    * <p>

--- a/scalatest/src/main/scala/org/scalatest/fixture/UnitFixture.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/UnitFixture.scala
@@ -37,7 +37,7 @@ trait UnitFixture { this: fixture.TestSuite =>
   type FixtureParam = Unit
 
   /**
-   * Invoke the test function, passing <code>()</code>, the unit value, to the the test function.
+   * Invoke the test function, passing <code>()</code>, the unit value, to the test function.
    *
    * <p>
    * To enable stacking of traits that define <code>withFixture(NoArgTest)</code>, this method does not

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpec.scala
@@ -804,7 +804,7 @@ import RefSpec.isTestMethod
  *
  * <p>
  * The &ldquo;<code>f.</code>&rdquo; in front of each use of a fixture object provides a visual indication of which objects 
- * are part of the fixture, but if you prefer, you can import the the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
+ * are part of the fixture, but if you prefer, you can import the members with &ldquo;<code>import f._</code>&rdquo; and use the names directly.
  * </p>
  *
  * <p>

--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -2434,7 +2434,7 @@ trait WebBrowser {
      * <p>
      * If the string element does not already exist in this sequence, this method returns itself. If the element
      * is contained in this sequence, this method returns a new <code>MultiSelOptionSeq</code> with the passed value
-     * removed from the the original <code>MultiSelOptionSeq</code>, leaving any other elements in the same order.
+     * removed from the original <code>MultiSelOptionSeq</code>, leaving any other elements in the same order.
      * </p>
      *
      * @param the string element to append to this sequence


### PR DESCRIPTION
Fixed duplicated 'the' typo.

This is re-submission of the following PR: 

https://github.com/scalatest/scalatest/pull/1020

against branch 3.0.x. 