### PR TITLE
isEmpty Refactor

### DIFF
--- a/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -480,7 +480,7 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
                 leftTree match {
                   case leftApply: Apply =>
                     leftApply.fun match {
-                      case leftApplySelect: Select if isSupportedLengthSizeOperator(leftApplySelect.name.decoded) && leftApply.args.size == 0 =>
+                      case leftApplySelect: Select if isSupportedLengthSizeOperator(leftApplySelect.name.decoded) && leftApply.args.isEmpty =>
                         /**
                          * support for a.length() == xxx, a.size() == xxxx
                          *
@@ -700,7 +700,7 @@ private[org] class BooleanMacro[C <: Context](val context: C, helperName: String
 
           case _ => simpleMacroBool(tree.duplicate, getText(tree), prettifierTree) // something else, just call simpleMacroBool
         }
-      case apply: Apply if apply.args.size == 0 =>
+      case apply: Apply if apply.args.isEmpty =>
         /**
          * For unary operation that takes 0 arguments, for example a.isEmpty
          *

--- a/scalatest/src/main/scala/org/scalatest/Filter.scala
+++ b/scalatest/src/main/scala/org/scalatest/Filter.scala
@@ -153,7 +153,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
         testName <- includedTestNames(testNamesAsList, tags)
         if !tags.contains(testName) ||
                 (tags(testName).contains(IgnoreTag) && (tags(testName) intersect (tagsToExclude + "org.scalatest.Ignore")).size == 1) ||
-                (tags(testName) intersect tagsToExclude).size == 0
+                (tags(testName) intersect tagsToExclude).isEmpty
       } yield (testName, tags.contains(testName) && tags(testName).contains(IgnoreTag))
 
     filtered
@@ -169,7 +169,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
         testName <- includedTestNames(testNamesAsList, testTags)
         if !testTags.contains(testName) ||
                 (testTags(testName).contains(IgnoreTag) && (testTags(testName) intersect (tagsToExclude + "org.scalatest.Ignore")).size == 1) ||
-                (testTags(testName) intersect tagsToExclude).size == 0
+                (testTags(testName) intersect tagsToExclude).isEmpty
       } yield (testName, testTags.contains(testName) && testTags(testName).contains(IgnoreTag))
 
     filtered
@@ -241,7 +241,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
     val runnableTests = 
       for {
         testName <- includedTestNames(testNamesAsList, tags)
-        if !tags.contains(testName) || (!tags(testName).contains(IgnoreTag) && (tags(testName) intersect tagsToExclude).size == 0)
+        if !tags.contains(testName) || (!tags(testName).contains(IgnoreTag) && (tags(testName) intersect tagsToExclude).isEmpty)
       } yield testName
 
     runnableTests.size

--- a/scalatest/src/main/scala/org/scalatest/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/Matchers.scala
@@ -3412,7 +3412,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
 
         val firstFailureOption = results.find(pv => !pv.matches)
 
-        val justOneProperty = propertyMatchers.length == 0
+        val justOneProperty = propertyMatchers.isEmpty
 
         // if shouldBeTrue is false, then it is like "not have ()", and should throw TFE if firstFailureOption.isDefined is false
         // if shouldBeTrue is true, then it is like "not (not have ()), which should behave like have ()", and should throw TFE if firstFailureOption.isDefined is true

--- a/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
@@ -229,7 +229,7 @@ private[scalatest] object MatchersHelper {
   def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String],
                                  didNotMatchMessage: => String, matchMessage: => String, notGroupAtIndexMessage:  => String, notGroupMessage: => String,
                                  andGroupMessage: => String): MatchResult = {
-    if (groups.size == 0 || !matches)
+    if (groups.isEmpty || !matches)
       MatchResult(
         matches,
         didNotMatchMessage,

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -1462,7 +1462,7 @@ private[scalatest] object Suite {
   // (e.g. DiscoverySuite).
   //
   def formatterForSuiteStarting(suite: Suite): Option[Formatter] =
-    if ((suite.testNames.size == 0) && (suite.nestedSuites.size > 0))
+    if ((suite.testNames.isEmpty) && (suite.nestedSuites.size > 0))
       Some(MotionToSuppress)
     else
       Some(IndentedText(suite.suiteName + ":", suite.suiteName, 0))

--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -2133,7 +2133,7 @@ trait WebBrowser {
 
     private def groupElements = driver.findElements(By.name(groupName)).asScala.toList.filter(e => isRadioButton(TagMeta(e)))
 
-    if (groupElements.length == 0)
+    if (groupElements.isEmpty)
       throw new TestFailedException(
                      (_: StackDepthException) => Some("No radio buttons with group name '" + groupName + "' was found."),
                      None,

--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -946,7 +946,7 @@ private[scalatest] class HtmlReporter(
         val (suiteEvents, otherEvents) = extractSuiteEvents(suiteId)
         eventList = otherEvents
         val sortedSuiteEvents = suiteEvents.sorted
-        if (sortedSuiteEvents.length == 0)
+        if (sortedSuiteEvents.isEmpty)
           throw new IllegalStateException("Expected SuiteStarting for completion event: " + event + " in the head of suite events, but we got no suite event at all")
         sortedSuiteEvents.head match {
           case suiteStarting: SuiteStarting => 
@@ -976,7 +976,7 @@ private[scalatest] class HtmlReporter(
         val (suiteEvents, otherEvents) = extractSuiteEvents(suiteId)
         eventList = otherEvents
         val sortedSuiteEvents = suiteEvents.sorted
-        if (sortedSuiteEvents.length == 0)
+        if (sortedSuiteEvents.isEmpty)
           throw new IllegalStateException("Expected SuiteStarting for completion event: " + event + " in the head of suite events, but we got no suite event at all")
         sortedSuiteEvents.head match {
           case suiteStarting: SuiteStarting => 

--- a/scalatest/src/main/scala/org/scalatest/words/HaveWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/HaveWord.scala
@@ -157,7 +157,7 @@ final class HaveWord {
 
         val firstFailureOption = results.find(pv => !pv.matches)
 
-        val justOneProperty = propertyMatchers.length == 0
+        val justOneProperty = propertyMatchers.isEmpty
 
         firstFailureOption match {
 

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfNotWordForAny.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfNotWordForAny.scala
@@ -360,7 +360,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
 
     val firstFailureOption = results.find(pv => !pv.matches)
 
-    val justOneProperty = propertyMatchers.length == 0
+    val justOneProperty = propertyMatchers.isEmpty
 
     // if shouldBeTrue is false, then it is like "not have ()", and should throw TFE if firstFailureOption.isDefined is false
     // if shouldBeTrue is true, then it is like "not (not have ()), which should behave like have ()", and should throw TFE if firstFailureOption.isDefined is true


### PR DESCRIPTION
Changed .size == 0 and .length == 0 to use .isEmpty for performance improvement.

These changes should be cherry-picked into 3.1.x and subsequently pulled into 3.2.x.