### PR TITLE
3.0.5 Publish Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,15 @@ With Sonatype credentials and GPG file in place, you can now publish to Sonatype
 
 Before publishing any patch release, binary compatibility with previous version should be checked, using Java 6 (for Scala 2.10 and 2.11):
 
-    $ sbt ++2.11.11 scalactic/package scalactic/mimaReportBinaryIssues
-    $ sbt ++2.11.11 scalatest/package scalatest/mimaReportBinaryIssues
-    $ sbt ++2.11.11 scalacticJS/package scalacticJS/mimaReportBinaryIssues
-    $ sbt ++2.11.11 scalatestJS/package scalatestJS/mimaReportBinaryIssues
+    $ sbt ++2.11.12 scalactic/package scalactic/mimaReportBinaryIssues
+    $ sbt ++2.11.12 scalatest/package scalatest/mimaReportBinaryIssues
+    $ sbt ++2.11.12 scalacticJS/package scalacticJS/mimaReportBinaryIssues
+    $ sbt ++2.11.12 scalatestJS/package scalatestJS/mimaReportBinaryIssues
 
-    $ sbt ++2.10.6 scalactic/package scalactic/mimaReportBinaryIssues
-    $ sbt ++2.10.6 scalatest/package scalatest/mimaReportBinaryIssues
-    $ sbt ++2.10.6 scalacticJS/package scalacticJS/mimaReportBinaryIssues
-    $ sbt ++2.10.6 scalatestJS/package scalatestJS/mimaReportBinaryIssues
+    $ sbt ++2.10.7 scalactic/package scalactic/mimaReportBinaryIssues
+    $ sbt ++2.10.7 scalatest/package scalatest/mimaReportBinaryIssues
+    $ sbt ++2.10.7 scalacticJS/package scalacticJS/mimaReportBinaryIssues
+    $ sbt ++2.10.7 scalatestJS/package scalatestJS/mimaReportBinaryIssues
 
 and using Java 8 (for Scala 2.12 and 2.13): 
 
@@ -143,8 +143,8 @@ and using Java 8 (for Scala 2.12 and 2.13):
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.11 and 2.10, and make sure you're on Java 6) to Sonatype, use the following command:
 
-  `$ sbt clean publishSigned ++2.11.12 "project scalatestAppJS" clean publishSigned ++2.10.7 "project scalatestApp" clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.11.12 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.10.7 "project scalatestApp" clean publishSigned "project scalatestAppJS" clean publishSigned`
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12 and 2.13, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.4 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/project/GenScalacticJS.scala
+++ b/project/GenScalacticJS.scala
@@ -16,6 +16,7 @@
 
 import io.Source
 import java.io.{BufferedWriter, File, FileWriter}
+import sbt.IO
 
 import GenCompatibleClasses.generatorSource
 
@@ -79,11 +80,27 @@ object GenScalacticJS {
     }
   }
 
+  def copyResourceDir(sourceDirName: String, packageDirName: String, targetDir: File, skipList: List[String]): Seq[File] = {
+    val packageDir = new File(targetDir, packageDirName)
+    packageDir.mkdirs()
+    val sourceDir = new File(sourceDirName)
+    sourceDir.listFiles.toList.filter(f => f.isFile && !skipList.contains(f.getName)).map { sourceFile =>
+      val destFile = new File(packageDir, sourceFile.getName)
+      if (!destFile.exists || sourceFile.lastModified > destFile.lastModified)
+        IO.copyFile(sourceFile, destFile)
+      destFile
+    }
+  }
+
   def genScala(targetDir: File, version: String, scalaVersion: String): Seq[File] =
     copyDir("scalactic/src/main/scala/org/scalactic", "org/scalactic", targetDir, List.empty) ++
     copyDir("scalactic/src/main/scala/org/scalactic/exceptions", "org/scalactic/exceptions", targetDir, List.empty) ++
     copyDir("scalactic/src/main/scala/org/scalactic/source", "org/scalactic/source", targetDir, List.empty) ++
     GenVersions.genScalacticVersions(new File(targetDir, "org/scalactic"), version, scalaVersion)
+
+  def genHtml(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
+    copyResourceDir("scalatest/src/main/html", "html", targetDir, List.empty)
+  }
 
   def genMacroScala(targetDir: File, version: String, scalaVersion: String): Seq[File] =
     copyDir("scalactic-macro/src/main/scala/org/scalactic", "org/scalactic", targetDir, List.empty) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -221,7 +221,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.21"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.22"
     )
 
   def scalatestTestOptions =


### PR DESCRIPTION
- Fixed publishing problem to publish 3.0.5.
- Bumped up to use scala-js 0.6.22.

Note: We should create a release tag after this is merged into 3.0.x.