### PR TITLE
Cherry Pick from 3.0.x 20180129

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
 addSbtPlugin("org.scala-native" % "sbt-crossproject"         % "0.2.0")
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -255,7 +255,7 @@ object ScalatestBuild extends Build {
 
   def scalatestJSLibraryDependencies =
     Seq(
-      "org.scala-js" %% "scalajs-test-interface" % "0.6.21"
+      "org.scala-js" %% "scalajs-test-interface" % "0.6.22"
     )
 
   def scalatestTestOptions =

--- a/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -480,7 +480,7 @@ private[org] class BooleanMacro[C <: Context](val context: C) {
                 leftTree match {
                   case leftApply: Apply =>
                     leftApply.fun match {
-                      case leftApplySelect: Select if isSupportedLengthSizeOperator(leftApplySelect.name.decoded) && leftApply.args.size == 0 =>
+                      case leftApplySelect: Select if isSupportedLengthSizeOperator(leftApplySelect.name.decoded) && leftApply.args.isEmpty =>
                         /**
                          * support for a.length() == xxx, a.size() == xxxx
                          *
@@ -700,7 +700,7 @@ private[org] class BooleanMacro[C <: Context](val context: C) {
 
           case _ => simpleMacroBool(tree.duplicate, getText(tree), prettifierTree) // something else, just call simpleMacroBool
         }
-      case apply: Apply if apply.args.size == 0 =>
+      case apply: Apply if apply.args.isEmpty =>
         /**
          * For unary operation that takes 0 arguments, for example a.isEmpty
          *

--- a/scalatest/src/main/scala/org/scalatest/Filter.scala
+++ b/scalatest/src/main/scala/org/scalatest/Filter.scala
@@ -153,7 +153,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
         testName <- includedTestNames(testNamesAsList, tags)
         if !tags.contains(testName) ||
                 (tags(testName).contains(IgnoreTag) && (tags(testName) intersect (tagsToExclude + "org.scalatest.Ignore")).size == 1) ||
-                (tags(testName) intersect tagsToExclude).size == 0
+                (tags(testName) intersect tagsToExclude).isEmpty
       } yield (testName, tags.contains(testName) && tags(testName).contains(IgnoreTag))
 
     filtered
@@ -169,7 +169,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
         testName <- includedTestNames(testNamesAsList, testTags)
         if !testTags.contains(testName) ||
                 (testTags(testName).contains(IgnoreTag) && (testTags(testName) intersect (tagsToExclude + "org.scalatest.Ignore")).size == 1) ||
-                (testTags(testName) intersect tagsToExclude).size == 0
+                (testTags(testName) intersect tagsToExclude).isEmpty
       } yield (testName, testTags.contains(testName) && testTags(testName).contains(IgnoreTag))
 
     filtered
@@ -241,7 +241,7 @@ final class Filter private (val tagsToInclude: Option[Set[String]], val tagsToEx
     val runnableTests = 
       for {
         testName <- includedTestNames(testNamesAsList, tags)
-        if !tags.contains(testName) || (!tags(testName).contains(IgnoreTag) && (tags(testName) intersect tagsToExclude).size == 0)
+        if !tags.contains(testName) || (!tags(testName).contains(IgnoreTag) && (tags(testName) intersect tagsToExclude).isEmpty)
       } yield testName
 
     runnableTests.size

--- a/scalatest/src/main/scala/org/scalatest/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/Matchers.scala
@@ -3412,7 +3412,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
 
         val firstFailureOption = results.find(pv => !pv.matches)
 
-        val justOneProperty = propertyMatchers.length == 0
+        val justOneProperty = propertyMatchers.isEmpty
 
         // if shouldBeTrue is false, then it is like "not have ()", and should throw TFE if firstFailureOption.isDefined is false
         // if shouldBeTrue is true, then it is like "not (not have ()), which should behave like have ()", and should throw TFE if firstFailureOption.isDefined is true

--- a/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
@@ -229,7 +229,7 @@ private[scalatest] object MatchersHelper {
   def checkPatternMatchAndGroups(matches: Boolean, left: String, pMatcher: java.util.regex.Matcher, regex: Regex, groups: IndexedSeq[String], 
                                  didNotMatchMessage: => String, matchMessage: => String, notGroupAtIndexMessage:  => String, notGroupMessage: => String,
                                  andGroupMessage: => String): MatchResult = {
-    if (groups.size == 0 || !matches)
+    if (groups.isEmpty || !matches)
       MatchResult(
         matches, 
         didNotMatchMessage,

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -1462,7 +1462,7 @@ private[scalatest] object Suite {
   // (e.g. DiscoverySuite).
   //
   def formatterForSuiteStarting(suite: Suite): Option[Formatter] =
-    if ((suite.testNames.size == 0) && (suite.nestedSuites.size > 0))
+    if ((suite.testNames.isEmpty) && (suite.nestedSuites.size > 0))
       Some(MotionToSuppress)
     else
       Some(IndentedText(suite.suiteName + ":", suite.suiteName, 0))

--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -2239,7 +2239,7 @@ trait WebBrowser {
 
     private def groupElements = driver.findElements(By.name(groupName)).asScala.toList.filter(e => isRadioButton(TagMeta(e)))
 
-    if (groupElements.length == 0)
+    if (groupElements.isEmpty)
       throw new TestFailedException(
                      (_: StackDepthException) => Some("No radio buttons with group name '" + groupName + "' was found."),
                      None,

--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -946,7 +946,7 @@ private[scalatest] class HtmlReporter(
         val (suiteEvents, otherEvents) = extractSuiteEvents(suiteId)
         eventList = otherEvents
         val sortedSuiteEvents = suiteEvents.sorted
-        if (sortedSuiteEvents.length == 0)
+        if (sortedSuiteEvents.isEmpty)
           throw new IllegalStateException("Expected SuiteStarting for completion event: " + event + " in the head of suite events, but we got no suite event at all")
         sortedSuiteEvents.head match {
           case suiteStarting: SuiteStarting => 
@@ -976,7 +976,7 @@ private[scalatest] class HtmlReporter(
         val (suiteEvents, otherEvents) = extractSuiteEvents(suiteId)
         eventList = otherEvents
         val sortedSuiteEvents = suiteEvents.sorted
-        if (sortedSuiteEvents.length == 0)
+        if (sortedSuiteEvents.isEmpty)
           throw new IllegalStateException("Expected SuiteStarting for completion event: " + event + " in the head of suite events, but we got no suite event at all")
         sortedSuiteEvents.head match {
           case suiteStarting: SuiteStarting => 

--- a/scalatest/src/main/scala/org/scalatest/words/HaveWord.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/HaveWord.scala
@@ -157,7 +157,7 @@ final class HaveWord {
 
         val firstFailureOption = results.find(pv => !pv.matches)
 
-        val justOneProperty = propertyMatchers.length == 0
+        val justOneProperty = propertyMatchers.isEmpty
 
         firstFailureOption match {
 

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfNotWordForAny.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfNotWordForAny.scala
@@ -360,7 +360,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
 
     val firstFailureOption = results.find(pv => !pv.matches)
 
-    val justOneProperty = propertyMatchers.length == 0
+    val justOneProperty = propertyMatchers.isEmpty
 
     // if shouldBeTrue is false, then it is like "not have ()", and should throw TFE if firstFailureOption.isDefined is false
     // if shouldBeTrue is true, then it is like "not (not have ()), which should behave like have ()", and should throw TFE if firstFailureOption.isDefined is true


### PR DESCRIPTION
Cherry-picks changes from 3.0.x: 
- Replaced .size == 0 and .length == 0 with .isEmpty
- Bumped up to use scala-js 0.6.22.

These changes should be pulled into 3.2.x.