### PR TITLE
Revert PR 1300

### DIFF
--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -284,8 +284,7 @@ object GenScalaTestJS {
         "SuiteSuite.scala",          // skipped because it depends on java reflection
         "MatchersSerializableSpec.scala",   // skipped because testing java serialization
         "SeveredStackTracesSpec.scala", // skipped because stack trace isn't really helpful after linked in different js env like node.
-        "SeveredStackTracesFailureSpec.scala", // skipped because stack trace isn't really helpful after linked in different js env like node.
-        "NonImplicitAssertionsSuite.scala"  // skipped because a scala-js problem under scala 2.11/2.10, see here: https://github.com/scala-js/scala-js/issues/3228
+        "SeveredStackTracesFailureSpec.scala" // skipped because stack trace isn't really helpful after linked in different js env like node.
       )) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/concurrent", "org/scalatest/concurrent", targetDir,
       List(


### PR DESCRIPTION
Reverted temporary workaround since scala-js 0.6.22 is released now.