### PR TITLE
don't use octal escapes

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
@@ -34,8 +34,8 @@ class StringReporterSuite extends FunSuite with Matchers {
     assert(Fragment("   ", AnsiCyan).toPossiblyColoredText(true) === "   ")
   }
 
-  val cyanRegex = "\033\\[36m"
-  val resetRegex = "\033\\[0m"
+  val cyanRegex = "\u001b\\[36m"
+  val resetRegex = "\u001b\\[0m"
 
   // Have to pad the strings to get the count of appearances to be one less than 
   // the array resulting from splitting on it, because split doesn't give me one

--- a/scalatest/src/main/scala/org/scalatest/tools/AnsiColor.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/AnsiColor.scala
@@ -19,15 +19,15 @@ private[scalatest] sealed trait AnsiColor extends Product with Serializable {
   val code: String
 }
 private[scalatest] case object AnsiGreen extends AnsiColor {
-  val code: String =  "\033[32m"
+  val code: String =  "\u001b[32m"
 }
 private[scalatest] case object AnsiCyan extends AnsiColor {
-  val code: String =  "\033[36m"
+  val code: String =  "\u001b[36m"
 }
 private[scalatest] case object AnsiYellow extends AnsiColor {
-  val code: String =  "\033[33m"
+  val code: String =  "\u001b[33m"
 }
 private[scalatest] case object AnsiRed extends AnsiColor {
-  val code: String =  "\033[31m"
+  val code: String =  "\u001b[31m"
 }
 

--- a/scalatest/src/main/scala/org/scalatest/tools/AnsiReset.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/AnsiReset.scala
@@ -16,6 +16,6 @@
 package org.scalatest.tools
 
 private[scalatest] object AnsiReset {
-  val code: String =  "\033[0m"
+  val code: String =  "\u001b[0m"
 }
 

--- a/scalatest/src/main/scala/org/scalatest/tools/StringReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/StringReporter.scala
@@ -1037,11 +1037,11 @@ private[scalatest] object StringReporter {
     Vector.empty ++ resultAsList
   }
 
-  final val ansiReset = "\033[0m"
-  final val ansiGreen = "\033[32m"
-  final val ansiCyan = "\033[36m"
-  final val ansiYellow = "\033[33m"
-  final val ansiRed = "\033[31m"
+  final val ansiReset = "\u001b[0m"
+  final val ansiGreen = "\u001b[32m"
+  final val ansiCyan = "\u001b[36m"
+  final val ansiYellow = "\u001b[33m"
+  final val ansiRed = "\u001b[31m"
 
   def makeDurationString(duration: Long) = {
 


### PR DESCRIPTION
they are deprecated and will be removed in Scala 2.13

this came up at https://github.com/scala/scala/pull/6324