### PR TITLE
Save failure cause in case of TryValues.success invocation on failed Try

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
@@ -60,6 +60,7 @@ class TryValuesSpec extends FunSpec {
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("TryValuesSpec.scala")
       caught.message.value should be (Resources.tryNotASuccess)
+      caught.cause.value shouldBe an[Exception]
     }
   } 
 }

--- a/scalatest/src/main/scala/org/scalatest/TryValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/TryValues.scala
@@ -130,8 +130,8 @@ trait TryValues {
     def success: Success[T] = {
       theTry match {
         case success: Success[T] => success
-        case _ => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotASuccess), None, pos)
+        case Failure(cause) =>
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotASuccess), Some(cause), pos)
       }
     }
   }


### PR DESCRIPTION
Let's say, we invoke `someFun()` in test, which returns `Try[T]`,
and we expect, that `someFun()` will return `Success(_)`.

We write such code:

```
import org.scalatest.TryValues._
val x = someFun().success.value
```

But `someFun()` unexpectedly returns `Failure(e)`,
and test fails with something like that:

```
org.scalatest.exceptions.TestFailedException: The Try on which success was invoked was not a Success.
[stack trace...]
```

And there is no information about `e` from returned `Failure(e)`!

We need to manually write `throw someFun().failure.exception` and
rerun test to get reason of failure... That's so annoying.

This commit adds cause of failure to `TestFailedException` to avoid
this clumsy debugging.