### PR TITLE
TypeMatcher AnyVal Support

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeATypeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeATypeSpec.scala
@@ -26,8 +26,11 @@ class ShouldBeATypeSpec extends FunSpec with Matchers {
   
   case class Book(title: String)
   
-  def wasNotAnInstanceOf(left: Any, right: Class[_]) = 
-    FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(right.getName), UnquotedString(left.getClass.getName))
+  def wasNotAnInstanceOf(left: Any, right: Class[_]): String =
+    wasNotAnInstanceOf(left, right.getName)
+
+  def wasNotAnInstanceOf(left: Any, className: String): String =
+    FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(className), UnquotedString(left.getClass.getName))
     
   def wasAnInstanceOf(left: Any, right: Class[_]) = 
     FailureMessages.wasAnInstanceOf(prettifier, left, UnquotedString(right.getName))
@@ -53,6 +56,11 @@ class ShouldBeATypeSpec extends FunSpec with Matchers {
     it("should do nothing if the LHS is an instance of specified RHS") {
       aTaleOfTwoCities should be (a [Book])
       aTaleOfTwoCities shouldBe a [Book]
+
+      1 should be (a [AnyVal])
+      1 shouldBe a [AnyVal]
+
+      aTaleOfTwoCities should not be a [AnyVal]
     }
 
     it("should throw TestFailedException if LHS is not an instance of specified RHS") { 
@@ -69,6 +77,20 @@ class ShouldBeATypeSpec extends FunSpec with Matchers {
       assert(caught2.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, classOf[String])))
       assert(caught2.failedCodeFileName === Some(fileName))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val caught3 = intercept[exceptions.TestFailedException] {
+        aTaleOfTwoCities shouldBe a [AnyVal]
+      }
+      assert(caught3.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, "AnyVal")))
+      assert(caught3.failedCodeFileName === Some(fileName))
+      assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val caught4 = intercept[exceptions.TestFailedException] {
+        aTaleOfTwoCities should be (a [AnyVal])
+      }
+      assert(caught4.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, "AnyVal")))
+      assert(caught4.failedCodeFileName === Some(fileName))
+      assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
 
     it("should do nothing if LHS is not an instance of specified RHS, when used with not") { 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnTypeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnTypeSpec.scala
@@ -25,9 +25,12 @@ class ShouldBeAnTypeSpec extends FunSpec with Matchers {
   val fileName: String = "ShouldBeAnTypeSpec.scala"
   
   case class Book(title: String)
-  
-  def wasNotAnInstanceOf(left: Any, right: Class[_]) = 
-    FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(right.getName), UnquotedString(left.getClass.getName))
+
+  def wasNotAnInstanceOf(left: Any, right: Class[_]): String =
+    wasNotAnInstanceOf(left, right.getName)
+
+  def wasNotAnInstanceOf(left: Any, className: String): String =
+    FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(className), UnquotedString(left.getClass.getName))
     
   def wasAnInstanceOf(left: Any, right: Class[_]) = 
     FailureMessages.wasAnInstanceOf(prettifier, left, UnquotedString(right.getName))
@@ -53,6 +56,11 @@ class ShouldBeAnTypeSpec extends FunSpec with Matchers {
     it("should do nothing if the LHS is an instance of specified RHS") { 
       aTaleOfTwoCities should be (an [Book])
       aTaleOfTwoCities shouldBe an [Book]
+
+      1 should be (an [AnyVal])
+      1 shouldBe an [AnyVal]
+
+      aTaleOfTwoCities should not be an [AnyVal]
     }
 
     it("should throw TestFailedException if LHS is not an instance of specified RHS") { 
@@ -69,6 +77,20 @@ class ShouldBeAnTypeSpec extends FunSpec with Matchers {
       assert(caught2.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, classOf[String])))
       assert(caught2.failedCodeFileName === Some(fileName))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val caught3 = intercept[exceptions.TestFailedException] {
+        aTaleOfTwoCities shouldBe an [AnyVal]
+      }
+      assert(caught3.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, "AnyVal")))
+      assert(caught3.failedCodeFileName === Some(fileName))
+      assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
+
+      val caught4 = intercept[exceptions.TestFailedException] {
+        aTaleOfTwoCities should be (an [AnyVal])
+      }
+      assert(caught4.message === Some(wasNotAnInstanceOf(aTaleOfTwoCities, "AnyVal")))
+      assert(caught4.failedCodeFileName === Some(fileName))
+      assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
 
     it("should do nothing if LHS is not an instance of specified RHS, when used with not") { 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
@@ -252,6 +252,22 @@ class ShouldBeShorthandSpec extends FunSpec with EmptyMocks with BookPropertyMat
       assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
     }
 
+    it("should work with AnMatcher") {
+      val x: Any = 40
+      x shouldBe an [Int]
+
+      val y: Int = 40
+      y shouldBe an [Int]
+    }
+
+    it("should work with AMatcher") {
+      val x: Any = 40L
+      x shouldBe a [Long]
+
+      val y: Long = 40
+      y shouldBe a [Long]
+    }
+
     it("should with +-") {
 
       val sevenDotOh = 7.0

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
@@ -268,6 +268,14 @@ class ShouldBeShorthandSpec extends FunSpec with EmptyMocks with BookPropertyMat
       y shouldBe a [Long]
     }
 
+    /*it("should work correctly with AnyVal") {
+      case class TestModel(value: String)
+
+      val m = TestModel("test")
+
+      m shouldBe an [AnyVal]  // This should fail
+    }*/
+
     it("should with +-") {
 
       val sevenDotOh = 7.0

--- a/scalatest-test/src/test/scala/org/scalatest/words/BeWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/BeWordSpec.scala
@@ -18,14 +18,11 @@ package org.scalatest.words
 import org.scalatest._
 import org.scalatest.exceptions.NotAllowedException
 import Matchers._
-import matchers.{BePropertyMatcher, 
-                 BePropertyMatchResult, 
-                 AMatcher, 
-                 AnMatcher, 
-                 BeMatcher, 
-                 MatchResult}
+import matchers.{AMatcher, AnMatcher, BeMatcher, BePropertyMatchResult, BePropertyMatcher, MatchResult}
 import org.scalactic._
 import org.scalatest.UnquotedString
+
+import scala.reflect.ClassTag
 
 class BeWordSpec extends FunSpec with FileMocks {
   
@@ -1142,7 +1139,7 @@ class BeWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAType = new ResultOfATypeInvocation(clazz)
+      val resultOfAType = new ResultOfATypeInvocation(ClassTag(clazz))
       
       val mt = be (resultOfAType)
       
@@ -1200,7 +1197,7 @@ class BeWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAnType = new ResultOfAnTypeInvocation(clazz)
+      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag(clazz))
       
       val mt = be (resultOfAnType)
       

--- a/scalatest-test/src/test/scala/org/scalatest/words/BeWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/BeWordSpec.scala
@@ -1139,7 +1139,7 @@ class BeWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAType = new ResultOfATypeInvocation(ClassTag(clazz))
+      val resultOfAType = new ResultOfATypeInvocation(ClassTag[MyFile](clazz))
       
       val mt = be (resultOfAType)
       
@@ -1197,7 +1197,7 @@ class BeWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag(clazz))
+      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag[MyFile](clazz))
       
       val mt = be (resultOfAnType)
       

--- a/scalatest-test/src/test/scala/org/scalatest/words/NotWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/NotWordSpec.scala
@@ -1703,7 +1703,7 @@ class NotWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAType = new ResultOfATypeInvocation(ClassTag(clazz))
+      val resultOfAType = new ResultOfATypeInvocation(ClassTag[MyFile](clazz))
       
       val mt = not be (resultOfAType)
       
@@ -1761,7 +1761,7 @@ class NotWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag(clazz))
+      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag[MyFile](clazz))
       
       val mt = not be (resultOfAnType)
       

--- a/scalatest-test/src/test/scala/org/scalatest/words/NotWordSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/NotWordSpec.scala
@@ -18,15 +18,10 @@ package org.scalatest.words
 import org.scalatest._
 import Matchers._
 import SharedHelpers.createTempDirectory
-import matchers.{BePropertyMatcher, 
-                 BePropertyMatchResult, 
-                 AMatcher, 
-                 AnMatcher, 
-                 BeMatcher, 
-                 MatchResult}
-import matchers.{NegatedFailureMessage, 
-                 MidSentenceFailureMessage, 
-                 MidSentenceNegatedFailureMessage}
+import matchers.{AMatcher, AnMatcher, BeMatcher, BePropertyMatchResult, BePropertyMatcher, MatchResult}
+import matchers.{MidSentenceFailureMessage, MidSentenceNegatedFailureMessage, NegatedFailureMessage}
+
+import scala.reflect.ClassTag
 
 // SKIP-SCALATESTJS-START
 import java.io.File
@@ -1708,7 +1703,7 @@ class NotWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAType = new ResultOfATypeInvocation(clazz)
+      val resultOfAType = new ResultOfATypeInvocation(ClassTag(clazz))
       
       val mt = not be (resultOfAType)
       
@@ -1766,7 +1761,7 @@ class NotWordSpec extends FunSpec with FileMocks {
       )
       
       val clazz = classOf[MyFile]
-      val resultOfAnType = new ResultOfAnTypeInvocation(clazz)
+      val resultOfAnType = new ResultOfAnTypeInvocation(ClassTag(clazz))
       
       val mt = not be (resultOfAnType)
       

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfATypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfATypeInvocationSpec.scala
@@ -25,7 +25,7 @@ class ResultOfATypeInvocationSpec extends FunSpec {
   describe("ResultOfATypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfATypeInvocation(ClassTag(classOf[FunSpec]))
+      val result = new ResultOfATypeInvocation(ClassTag[FunSpec](classOf[FunSpec]))
       result.toString should be ("a [org.scalatest.FunSpec]")
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfATypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfATypeInvocationSpec.scala
@@ -18,12 +18,14 @@ package org.scalatest.words
 import org.scalatest._
 import Matchers._
 
+import scala.reflect.ClassTag
+
 class ResultOfATypeInvocationSpec extends FunSpec {
   
   describe("ResultOfATypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfATypeInvocation(classOf[FunSpec])
+      val result = new ResultOfATypeInvocation(ClassTag(classOf[FunSpec]))
       result.toString should be ("a [org.scalatest.FunSpec]")
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfAnTypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfAnTypeInvocationSpec.scala
@@ -18,12 +18,14 @@ package org.scalatest.words
 import org.scalatest._
 import Matchers._
 
+import scala.reflect.ClassTag
+
 class ResultOfAnTypeInvocationSpec extends FunSpec {
   
   describe("ResultOfAnTypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfAnTypeInvocation(classOf[Inspectors])
+      val result = new ResultOfAnTypeInvocation(ClassTag(classOf[Inspectors]))
       result.toString should be ("an [org.scalatest.Inspectors]")
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfAnTypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfAnTypeInvocationSpec.scala
@@ -25,7 +25,7 @@ class ResultOfAnTypeInvocationSpec extends FunSpec {
   describe("ResultOfAnTypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfAnTypeInvocation(ClassTag(classOf[Inspectors]))
+      val result = new ResultOfAnTypeInvocation(ClassTag[Inspectors](classOf[Inspectors]))
       result.toString should be ("an [org.scalatest.Inspectors]")
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfTheTypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfTheTypeInvocationSpec.scala
@@ -19,12 +19,14 @@ import org.scalatest._
 import Matchers._
 import org.scalactic._
 
+import scala.reflect.ClassTag
+
 class ResultOfTheTypeInvocationSpec extends FunSpec {
   
   describe("ResultOfTheTypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfTheTypeInvocation(classOf[FunSpec], source.Position.here)
+      val result = new ResultOfTheTypeInvocation(ClassTag(classOf[FunSpec]), source.Position.here)
       result.toString should be ("the [org.scalatest.FunSpec]")
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/words/ResultOfTheTypeInvocationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/words/ResultOfTheTypeInvocationSpec.scala
@@ -26,7 +26,7 @@ class ResultOfTheTypeInvocationSpec extends FunSpec {
   describe("ResultOfTheTypeInvocation ") {
     
     it("should have pretty toString") {
-      val result = new ResultOfTheTypeInvocation(ClassTag(classOf[FunSpec]), source.Position.here)
+      val result = new ResultOfTheTypeInvocation(ClassTag[FunSpec](classOf[FunSpec]), source.Position.here)
       result.toString should be ("the [org.scalatest.FunSpec]")
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/Matchers.scala
@@ -6634,7 +6634,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * </pre>
    */
   def a[T: ClassTag]: ResultOfATypeInvocation[T] =
-    new ResultOfATypeInvocation(classTag.runtimeClass.asInstanceOf[Class[T]])
+    new ResultOfATypeInvocation(classTag)
 
   /**
    * This method enables the following syntax: 
@@ -6645,7 +6645,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * </pre>
    */
   def an[T : ClassTag]: ResultOfAnTypeInvocation[T] =
-    new ResultOfAnTypeInvocation(classTag.runtimeClass.asInstanceOf[Class[T]])
+    new ResultOfAnTypeInvocation(classTag)
 
   /**
    * This method enables the following syntax: 
@@ -6656,7 +6656,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * </pre>
    */
   def the[T : ClassTag](implicit pos: source.Position): ResultOfTheTypeInvocation[T] =
-    new ResultOfTheTypeInvocation(classTag.runtimeClass.asInstanceOf[Class[T]], pos)
+    new ResultOfTheTypeInvocation(classTag, pos)
 
   // This is where ShouldMatchers.scala started 
 

--- a/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
@@ -45,7 +45,7 @@ object TypeMatcherHelper {
       def apply(left: Any): MatchResult = {
         val clazz = aType.clazz
         MatchResult(
-          clazz.isAssignableFrom(left.getClass),
+          conform(clazz, left),
           Resources.rawWasNotAnInstanceOf,
           Resources.rawWasAnInstanceOf,
           Vector(left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)),

--- a/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
@@ -16,10 +16,12 @@
 package org.scalatest.matchers
 
 import org.scalactic.source
-import org.scalatest.{UnquotedString, Suite, FailureMessages, Resources}
+import org.scalatest.{FailureMessages, Resources, Suite, UnquotedString}
 import org.scalactic.Prettifier
 import org.scalatest.MatchersHelper._
-import org.scalatest.words.{ResultOfAnTypeInvocation, ResultOfATypeInvocation}
+import org.scalatest.words.{ResultOfATypeInvocation, ResultOfAnTypeInvocation}
+
+import scala.reflect.ClassTag
 //import org.scalatest.words.{FactResultOfAnTypeInvocation, FactResultOfATypeInvocation}
 
 /**
@@ -64,7 +66,7 @@ object TypeMatcherHelper {
       def apply(left: Any): MatchResult = {
         val clazz = anType.clazz
         MatchResult(
-          clazz.isAssignableFrom(left.getClass),
+          conform(clazz, left),
           Resources.rawWasNotAnInstanceOf,
           Resources.rawWasAnInstanceOf,
           Vector(left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)),
@@ -85,7 +87,7 @@ object TypeMatcherHelper {
       def apply(left: Any): MatchResult = {
         val clazz = aType.clazz
         MatchResult(
-          !clazz.isAssignableFrom(left.getClass),
+          !conform(clazz, left),
           Resources.rawWasAnInstanceOf,
           Resources.rawWasNotAnInstanceOf,
           Vector(left, UnquotedString(clazz.getName)),
@@ -106,7 +108,7 @@ object TypeMatcherHelper {
       def apply(left: Any): MatchResult = {
         val clazz = anType.clazz
         MatchResult(
-          !clazz.isAssignableFrom(left.getClass),
+          !conform(clazz, left),
           Resources.rawWasAnInstanceOf,
           Resources.rawWasNotAnInstanceOf,
           Vector(left, UnquotedString(clazz.getName)),
@@ -115,6 +117,24 @@ object TypeMatcherHelper {
       }
       override def toString: String = "not be " + Prettifier.default(anType)
     }
+
+  // This method is inspired from ClassTag's unapply method starting Scala 2.11,
+  // we can't use ClassTag's unapply directly because in Scala 2.10 it wasn't
+  // written this way and it can't meet our purpose.
+  private def conform[T](runtimeClass: Class[T], x: Any): Boolean =
+    if (null != x && (
+      (runtimeClass.isInstance(x))
+        || (x.isInstanceOf[Byte]    && runtimeClass.isAssignableFrom(classOf[Byte]))
+        || (x.isInstanceOf[Short]   && runtimeClass.isAssignableFrom(classOf[Short]))
+        || (x.isInstanceOf[Char]    && runtimeClass.isAssignableFrom(classOf[Char]))
+        || (x.isInstanceOf[Int]     && runtimeClass.isAssignableFrom(classOf[Int]))
+        || (x.isInstanceOf[Long]    && runtimeClass.isAssignableFrom(classOf[Long]))
+        || (x.isInstanceOf[Float]   && runtimeClass.isAssignableFrom(classOf[Float]))
+        || (x.isInstanceOf[Double]  && runtimeClass.isAssignableFrom(classOf[Double]))
+        || (x.isInstanceOf[Boolean] && runtimeClass.isAssignableFrom(classOf[Boolean]))
+        || (x.isInstanceOf[Unit]    && runtimeClass.isAssignableFrom(classOf[Unit])))
+    ) true
+    else false
 
   /**
    * Check if the given <code>left</code> is an instance of the type as described in the given <code>ResultOfATypeInvocation</code>.
@@ -125,7 +145,7 @@ object TypeMatcherHelper {
    */
   def assertAType(left: Any, aType: ResultOfATypeInvocation[_], prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = {
     val clazz = aType.clazz
-    if (!clazz.isAssignableFrom(left.getClass)) {
+    if (!conform(clazz, left)) {
       val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, clazz.getName)
       throw newTestFailedException(FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)), None, pos)
     }
@@ -141,7 +161,7 @@ object TypeMatcherHelper {
    */
   /*private[scalatest] def expectAType(left: Any, aType: ResultOfATypeInvocation[_], prettifier: Prettifier): org.scalatest.Fact = {
     val clazz = aType.clazz
-    if (!clazz.isAssignableFrom(left.getClass)) {
+    if (!conform(clazz, left.getClass)) {
       val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, clazz.getName)
       org.scalatest.Fact.No(FailureMessages.wasNotAnInstanceOf(aType.prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)))(aType.prettifier)
     }
@@ -157,7 +177,7 @@ object TypeMatcherHelper {
    */
   def assertAnType(left: Any, anType: ResultOfAnTypeInvocation[_], prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = {
     val clazz = anType.clazz
-    if (!clazz.isAssignableFrom(left.getClass)) {
+    if (!conform(clazz, left)) {
       val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, clazz.getName)
       throw newTestFailedException(FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)), None, pos)
     }
@@ -173,7 +193,7 @@ object TypeMatcherHelper {
    */
   /*private[scalatest] def expectAnType(left: Any, anType: ResultOfAnTypeInvocation[_]): org.scalatest.Fact = {
     val clazz = anType.clazz
-    if (!clazz.isAssignableFrom(left.getClass)) {
+    if (!conform(clazz, left)) {
       val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, clazz.getName)
       org.scalatest.Fact.No(FailureMessages.wasNotAnInstanceOf(anType.prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName)))(anType.prettifier)
     } else org.scalatest.Fact.Yes(FailureMessages.wasAnInstanceOf(anType.prettifier, left, UnquotedString(clazz.getName)))(anType.prettifier)
@@ -189,7 +209,7 @@ object TypeMatcherHelper {
    */
   def assertATypeShouldBeTrue(left: Any, aType: ResultOfATypeInvocation[_], shouldBeTrue: Boolean, prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = {
     val clazz = aType.clazz
-    if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
+    if (conform(clazz, left) != shouldBeTrue) {
       throw newTestFailedException(
         if (shouldBeTrue)
           FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))
@@ -211,7 +231,7 @@ object TypeMatcherHelper {
    */
   /*def expectATypeWillBeTrue(left: Any, aType: FactResultOfATypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
     val clazz = aType.clazz
-    if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
+    if (conform(clazz, left) != shouldBeTrue) {
       org.scalatest.Fact.No(
         if (shouldBeTrue)
           FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))
@@ -238,7 +258,7 @@ object TypeMatcherHelper {
    */
   def assertAnTypeShouldBeTrue(left: Any, anType: ResultOfAnTypeInvocation[_], shouldBeTrue: Boolean, prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = {
     val clazz = anType.clazz
-    if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
+    if (conform(clazz, left) != shouldBeTrue) {
       throw newTestFailedException(
         if (shouldBeTrue)
           FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))
@@ -260,7 +280,7 @@ object TypeMatcherHelper {
    */
   /*def expectAnTypeWillBeTrue(left: Any, anType: FactResultOfAnTypeInvocation[_], shouldBeTrue: Boolean): org.scalatest.Fact = {
     val clazz = anType.clazz
-    if (clazz.isAssignableFrom(left.getClass) != shouldBeTrue) {
+    if (conform(clazz, left) != shouldBeTrue) {
       org.scalatest.Fact.No(
         if (shouldBeTrue)
           FailureMessages.wasNotAnInstanceOf(prettifier, left, UnquotedString(clazz.getName), UnquotedString(left.getClass.getName))

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfATypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfATypeInvocation.scala
@@ -21,13 +21,17 @@ import org.scalatest.MatchersHelper.indicateSuccess
 import org.scalatest.MatchersHelper.indicateFailure
 import org.scalactic._
 
+import scala.reflect.ClassTag
+
 /**
  * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of
  * the matchers DSL.
  *
  * @author Bill Venners
  */
-final class ResultOfATypeInvocation[T](val clazz: Class[T]) {
+final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
+
+  val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
 
   /**
    * This method enables the following syntax: 

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfATypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfATypeInvocation.scala
@@ -33,6 +33,8 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
 
   val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
 
+  def this(c: Class[_]) = this(ClassTag(c).asInstanceOf[ClassTag[T]])
+
   /**
    * This method enables the following syntax: 
    *

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfAnTypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfAnTypeInvocation.scala
@@ -32,6 +32,8 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
 
   val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
 
+  def this(c: Class[_]) = this(ClassTag(c).asInstanceOf[ClassTag[T]])
+
   /**
    * This method enables the following syntax: 
    *

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfAnTypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfAnTypeInvocation.scala
@@ -20,13 +20,17 @@ import org.scalatest.MatchersHelper.indicateSuccess
 import org.scalatest.MatchersHelper.indicateFailure
 import org.scalactic._
 
+import scala.reflect.ClassTag
+
 /**
  * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of
  * the matchers DSL.
  *
  * @author Bill Venners
  */
-final class ResultOfAnTypeInvocation[T](val clazz: Class[T]) {
+final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
+
+  val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
 
   /**
    * This method enables the following syntax: 

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfTheTypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfTheTypeInvocation.scala
@@ -19,14 +19,18 @@ import org.scalactic._
 import org.scalatest.Resources
 import org.scalatest.MatchersHelper.checkExpectedException
 
+import scala.reflect.ClassTag
+
 /**
  * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of
  * the matchers DSL.
  *
  * @author Bill Venners
  */
-final class ResultOfTheTypeInvocation[T](clazz: Class[T], pos: source.Position) {
-  
+final class ResultOfTheTypeInvocation[T](clazzTag: ClassTag[T], pos: source.Position) {
+
+  val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
+
   /**
    * This method enables the following syntax: 
    *

--- a/scalatest/src/main/scala/org/scalatest/words/ResultOfTheTypeInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/ResultOfTheTypeInvocation.scala
@@ -31,6 +31,8 @@ final class ResultOfTheTypeInvocation[T](clazzTag: ClassTag[T], pos: source.Posi
 
   val clazz: Class[T] = clazzTag.runtimeClass.asInstanceOf[Class[T]]
 
+  def this(c: Class[_], pos: source.Position) = this(ClassTag(c).asInstanceOf[ClassTag[T]], pos)
+
   /**
    * This method enables the following syntax: 
    *


### PR DESCRIPTION
Make Type Matcher to handle AnyVal correctly.

This PR is branched off from the following PR: 

https://github.com/scalatest/scalatest/pull/1364

and is in attempt to fix the issue reported here: 

https://github.com/scalatest/scalatest/issues/1358

The MIMA test passed, thus it should be binary compatible with 3.0.5.  This fix should be cherry-pick into 3.1.x and subsequently be pulled into 3.2.x.