### PR TITLE
Bump scalacheck version to 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.4
-  - 2.13.0-M2
+  - 2.13.0-M4
 addons:
   apt:
     packages:
@@ -55,9 +55,9 @@ env:
 
 matrix:
   exclude:
-    - scala: "2.13.0-M2"
+    - scala: "2.13.0-M4"
       jdk: openjdk6
-    - scala: "2.13.0-M2"
+    - scala: "2.13.0-M4"
       jdk: oraclejdk9
     - scala: "2.12.4"
       jdk: openjdk6

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ and using Java 8 (for Scala 2.12 and 2.13):
     $ sbt ++2.12.4 scalacticJS/package scalacticJS/mimaReportBinaryIssues
     $ sbt ++2.12.4 scalatestJS/package scalatestJS/mimaReportBinaryIssues
 
-    $ sbt ++2.13.0-M2 scalactic/package scalactic/mimaReportBinaryIssues
-    $ sbt ++2.13.0-M2 scalatest/package scalatest/mimaReportBinaryIssues
-    $ sbt ++2.13.0-M2 scalacticJS/package scalacticJS/mimaReportBinaryIssues
-    $ sbt ++2.13.0-M2 scalatestJS/package scalatestJS/mimaReportBinaryIssues
+    $ sbt ++2.13.0-M4 scalactic/package scalactic/mimaReportBinaryIssues
+    $ sbt ++2.13.0-M4 scalatest/package scalatest/mimaReportBinaryIssues
+    $ sbt ++2.13.0-M4 scalacticJS/package scalacticJS/mimaReportBinaryIssues
+    $ sbt ++2.13.0-M4 scalatestJS/package scalatestJS/mimaReportBinaryIssues
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.11 and 2.10, and make sure you're on Java 6) to Sonatype, use the following command:
 
@@ -167,7 +167,7 @@ To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, versi
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12 and 2.13, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.4 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.4 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M4 clean publishSigned "project scalatestAppJS" clean publishSigned`
 
 To publish scalactic, scalatest and scalatest-app (for Scala-native version 2.11, and make sure you're on Java 8) to Sonatype, use the following command: 
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -39,8 +39,7 @@ object ScalatestBuild extends Build {
   val releaseVersion = "3.1.0-SNAP7"
   val previousReleaseVersion = "3.0.5"
 
-  val scalacheckVersion = "1.13.5"
-  val nativeScalacheckVersion = "1.14.0-18db189-SNAPSHOT"
+  val scalacheckVersion = "1.14.0"
 
   val easyMockVersion = "3.2"
   val jmockVersion = "2.8.3"
@@ -207,10 +206,10 @@ object ScalatestBuild extends Build {
         Seq(
           "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
           //"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",   This is needed only by SbtCommandParser, but we are not support it currently.
-          "org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "optional"
+          "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "optional"
         )
       case _ =>
-        Seq("org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "optional")
+        Seq("org.scalacheck" %%% "scalacheck" % scalacheckVersion % "optional")
     }
   }
 
@@ -372,7 +371,7 @@ object ScalatestBuild extends Build {
       .settings(sharedSettings: _*)
       .settings(
         projectTitle := "Common test classes used by scalactic.native and scalatest.native",
-        libraryDependencies += "org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "optional",
+        libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "optional",
         sourceGenerators in Compile += {
           Def.task{
             GenCommonTestNative.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value)
@@ -630,7 +629,7 @@ object ScalatestBuild extends Build {
     .settings(
       projectTitle := "Scalactic Test.native",
       organization := "org.scalactic",
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "test",
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
       testOptions in Test ++=
         Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oDIF")),
       nativeOptimizerDriver in NativeTest := {
@@ -890,7 +889,7 @@ object ScalatestBuild extends Build {
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
       libraryDependencies += "org.scala-native" %%% "test-interface" % "0.3.6",
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "optional",
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "optional",
       //jsDependencies += RuntimeDOM % "test",
       sourceGenerators in Compile += {
         Def.task {
@@ -972,7 +971,7 @@ object ScalatestBuild extends Build {
       projectTitle := "ScalaTest Test",
       organization := "org.scalatest",
       libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-      libraryDependencies += "org.scalacheck" %%% "scalacheck" % nativeScalacheckVersion % "test",
+      libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
       // libraryDependencies += "io.circe" %%% "circe-parser" % "0.7.1" % "test",
       fork in test := false,
       nativeOptimizerDriver in NativeTest := {

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -3,6 +3,17 @@
 export SBT_OPTS="-server -Xms2G -Xmx2G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 export MODE=$1
 
+# Travis switches JDK BEFORE it installs APK packages, so the switch can fail.
+
+function include {
+    [[ -f "$1" ]] && source "$1"
+}
+
+# Locations from https://github.com/travis-ci/travis-ci/issues/8681
+include ~/.jdk_switcher_rc
+include /opt/jdk_switcher/jdk_switcher.sh
+jdk_switcher use $TRAVIS_JDK_VERSION
+
 if [[ $MODE = 'RegularTests1' ]] ; then
   echo "Doing 'sbt genRegularTests1/test'"
 


### PR DESCRIPTION
Not using new features, just version bump due to the binary incompatibility.