### PR TITLE
3.1 Scala-js/Scala-native Test Count Fix

### DIFF
--- a/scalatest.js/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/scalatest.js/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -159,12 +159,17 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
 
     def createTask(t: TaskDef): Task =
       new TaskRunner(t, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
-        presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, None)
+        presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
 
     for {
       taskDef <- if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
       val task = createTask(taskDef)
     } yield task
+  }
+
+  private def send(msg: String): Unit = {
+    receiveMessage(msg)
+    ()
   }
 
   def receiveMessage(msg: String): Option[String] = {
@@ -196,7 +201,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
     val taskDef = deserializer(task)
     new TaskRunner(taskDef, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
-      presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, None)
+      presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
   }
 
 }

--- a/scalatest.native/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/scalatest.native/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -159,12 +159,17 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
 
     def createTask(t: TaskDef): Task =
       new TaskRunner(t, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
-        presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, None)
+        presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
 
     for {
       taskDef <- if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
       val task = createTask(taskDef)
     } yield task
+  }
+
+  private def send(msg: String): Unit = {
+    receiveMessage(msg)
+    ()
   }
 
   def receiveMessage(msg: String): Option[String] = {
@@ -196,7 +201,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
     val taskDef = deserializer(task)
     new TaskRunner(taskDef, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
-      presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, None)
+      presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
   }
 
 }


### PR DESCRIPTION
Cherry-picked scala-js test count fix from: 

https://github.com/scalatest/scalatest/pull/1371

and apply the same fix for scala-native.

This fix should be pull into 3.2.x also.