### PR TITLE
Bumped up to use Scala 2.12.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.4
+  - 2.12.6
   - 2.13.0-M2
 addons:
   apt:
@@ -54,7 +54,7 @@ matrix:
   exclude:
     - scala: "2.13.0-M2"
       jdk: openjdk6
-    - scala: "2.12.4"
+    - scala: "2.12.6"
       jdk: openjdk6
     - scala: "2.11.12"
       jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ Before publishing any patch release, binary compatibility with previous version 
 
 and using Java 8 (for Scala 2.12 and 2.13): 
 
-    $ sbt ++2.12.4 scalactic/package scalactic/mimaReportBinaryIssues
-    $ sbt ++2.12.4 scalatest/package scalatest/mimaReportBinaryIssues
-    $ sbt ++2.12.4 scalacticJS/package scalacticJS/mimaReportBinaryIssues
-    $ sbt ++2.12.4 scalatestJS/package scalatestJS/mimaReportBinaryIssues
+    $ sbt ++2.12.6 scalactic/package scalactic/mimaReportBinaryIssues
+    $ sbt ++2.12.6 scalatest/package scalatest/mimaReportBinaryIssues
+    $ sbt ++2.12.6 scalacticJS/package scalacticJS/mimaReportBinaryIssues
+    $ sbt ++2.12.6 scalatestJS/package scalatestJS/mimaReportBinaryIssues
 
     $ sbt ++2.13.0-M2 scalactic/package scalactic/mimaReportBinaryIssues
     $ sbt ++2.13.0-M2 scalatest/package scalatest/mimaReportBinaryIssues
@@ -147,4 +147,4 @@ To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, versi
 
 To publish scalactic, scalatest and scalatest-app (for Scala and Scala-js, version 2.12 and 2.13, and make sure you're on Java 8) to Sonatype, use the following command:
 
-  `$ sbt ++2.12.4 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`
+  `$ sbt ++2.12.6 clean publishSigned "project scalatestAppJS" clean publishSigned ++2.13.0-M2 clean publishSigned "project scalatestAppJS" clean publishSigned`

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -22,7 +22,7 @@ object ScalatestBuild extends Build {
 
   // To temporarily switch sbt to a different Scala version:
   // > ++ 2.10.5
-  val buildScalaVersion = "2.12.4"
+  val buildScalaVersion = "2.12.6"
 
   val releaseVersion = "3.0.5"
 


### PR DESCRIPTION
Bumped up to use Scala 2.12.6.

Note: 
This change should be cherry-picked into 3.1.x branch and subsequently pulled into 3.2.x.