### PR TITLE
Fix Retries.withRetry delay

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/Retries.scala
+++ b/scalatest/src/main/scala/org/scalatest/Retries.scala
@@ -345,11 +345,15 @@ trait Retries {
     val firstOutcome = blk
     firstOutcome match {
       case Failed(ex) =>
+        if (delay != Span.Zero)
+          SleepHelper.sleep(delay.millisPart)
         blk match {
           case Succeeded => Canceled(Resources.testFlickered, ex)
           case other => firstOutcome
         }
       case Canceled(ex) =>
+        if (delay != Span.Zero)
+          SleepHelper.sleep(delay.millisPart)
         blk match {
           case Succeeded => Succeeded
           case failed: Failed => failed // Never hide a failure.

--- a/scalatest/src/main/scala/org/scalatest/Retries.scala
+++ b/scalatest/src/main/scala/org/scalatest/Retries.scala
@@ -787,7 +787,6 @@ trait Retries {
       case Canceled(ex) =>
         if (delay != Span.Zero)
           SleepHelper.sleep(delay.millisPart)
-        SleepHelper.sleep(delay.millisPart)
         blk match {
           case Succeeded => Succeeded
           case failed: Failed => failed // Never hide a failure.

--- a/scalatest/src/main/scala/org/scalatest/Retries.scala
+++ b/scalatest/src/main/scala/org/scalatest/Retries.scala
@@ -16,8 +16,6 @@
 package org.scalatest
 
 import org.scalatest.concurrent.SleepHelper
-import org.scalatest.concurrent.SleepHelper
-import org.scalatest.concurrent.SleepHelper
 import time.Span
 
 /**


### PR DESCRIPTION
Noticed that `Retries.withRetry` where not using its delay parameter. And that `Retries.withRetryOnCancel` where calling sleep twice.