### PR TITLE
Fix Travis build with openjdk6

### DIFF
--- a/.sbtrepos
+++ b/.sbtrepos
@@ -1,0 +1,8 @@
+[repositories]
+  local
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  maven-central:  http://repo1.maven.org/maven2/
+  sonatype-public: http://oss.sonatype.org/content/repositories/public
+  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-releases: http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ jdk:
 dist: trusty
 sudo: true
 
-sbt_args: -J-Xss10m
-
 env:
   #see https://github.com/scalatest/scalatest/pull/245
   #global values should be replaced using http://docs.travis-ci.com/user/encryption-keys/ with valid values
@@ -76,7 +74,11 @@ branches:
     - 3.1.x
     - 3.2.x
 
-script: ./travis_build.sh $MODE
+script:
+  # work around https://github.com/travis-ci/travis-ci/issues/9713
+  - if [[ $JAVA_HOME = *java-6* ]]; then jdk_switcher use openjdk6; fi
+  - java -version
+  - ./travis_build.sh $MODE
 
 notifications:
   email:

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-export SBT_OPTS="-server -Xms2G -Xmx2G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
+# Maven Central and Bintray are unreachable over HTTPS
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" ]]; then
+  SBT_OPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=./.sbtrepos"
+fi
+
+export SBT_OPTS="$SBT_OPTS -server -Xms2G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 export MODE=$1
 
 if [[ $MODE = 'RegularTests1' ]] ; then
@@ -126,7 +131,6 @@ fi
 
 if [[ $MODE = 'genGenTests' ]] ; then
   echo "Doing 'sbt genGenTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx2G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   while :; do echo -n ...; sleep 300; done &
   sbt ++$TRAVIS_SCALA_VERSION genGenTests/test
@@ -134,14 +138,12 @@ fi
 
 if [[ $MODE = 'genTablesTests' ]] ; then
   echo "Doing 'sbt genTablesTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx2G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genTablesTests/test
 fi
 
 if [[ $MODE = 'genInspectorsTests' ]] ; then
   echo "Doing 'sbt genInspectorsTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx2G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genInspectorsTests/test
 fi
@@ -158,42 +160,36 @@ fi
 
 if [[ $MODE = 'genTheyTests' ]] ; then
   echo "Doing 'sbt genTheyTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genTheyTests/test
 fi
 
 if [[ $MODE = 'genContainTests1' ]] ; then
   echo "Doing 'sbt genContainTests1/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genContainTests1/test
 fi
 
 if [[ $MODE = 'genContainTests2' ]] ; then
   echo "Doing 'sbt genContainTests2/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genContainTests2/test
 fi
 
 if [[ $MODE = 'genSortedTests' ]] ; then
   echo "Doing 'sbt genSortedTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genSortedTests/test
 fi
 
 if [[ $MODE = 'genLoneElementTests' ]] ; then
   echo "Doing 'sbt genLoneElementTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genLoneElementTests/test
 fi
 
 if [[ $MODE = 'genEmptyTests' ]] ; then
   echo "Doing 'sbt genEmptyTests/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION genEmptyTests/test
 fi
@@ -206,7 +202,6 @@ fi
 
 if [[ $MODE = 'examples' ]] ; then
   echo "Doing 'sbt examples/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   project examples
   sbt ++$TRAVIS_SCALA_VERSION examples/test:compile
@@ -214,7 +209,6 @@ fi
 
 if [[ $MODE = 'examplesJS' ]] ; then
   echo "Doing 'sbt examplesJS/test'"
-  export SBT_OPTS="-server -Xms1G -Xmx3G -Xss10M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8 -XX:MaxPermSize=512M -XX:-UseGCOverheadLimit"
 
   sbt ++$TRAVIS_SCALA_VERSION examplesJS/test:compile
 fi


### PR DESCRIPTION
There are two issues with the Travis build:

- There's a hack required to get openjdk6 to work on Travis, see for example https://github.com/scala/scala-xml/pull/246
- There's a new  hack required to let sbt retrieve artifacts while using openjdk6 on Travis, which see https://github.com/scala/scala-xml/pull/247

However, if you are publishing from Travis or even openjdk6, you may have issues.  See discussion at https://github.com/scala/sbt-scala-module/issues/41

It seems like there are 3 places where `SBT_OPTS` are set and overwritten in the Scalatest build config.

- In `sbt_args` in `.travis.yml`
- In `SBT_OPTS` at the top of `travis_build.sh`
- And in each of the `MODE` builds of `travis_build.sh`

I'd like to just override them once when the JDK6 build is happening...

Fixes #1380.