### PR TITLE
[3.0.x] Scala 2.13.0-M5 Scala-js Test Build Fix

### DIFF
--- a/project/GenColCompatHelper.scala
+++ b/project/GenColCompatHelper.scala
@@ -45,7 +45,7 @@ object GenColCompatHelper {
           |
           |  def aggregate[A, B](col: Iterable[A], z: =>B)(seqop: (B, A) => B, combop: (B, B) => B): B = col.foldLeft(z)(seqop)
           |
-          |  def className(col: scala.collection.Iterable[_]): String = scala.runtime.ScalaRunTime.stringOf(col)
+          |  def className(col: scala.collection.Iterable[_]): String = org.scalactic.NameUtil.getSimpleNameOfAnObjectsClass(col)
           |}
         """.stripMargin
       else

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -25,7 +25,7 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.5
   val buildScalaVersion = "2.12.7"
 
-  val releaseVersion = "3.0.6-SNAP3"
+  val releaseVersion = "3.0.6-SNAP4"
 
   val previousReleaseVersion = "3.0.5"
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -318,7 +318,7 @@ object ScalatestBuild extends Build {
       sourceGenerators in Compile += {
         Def.task{
           ScalacticGenResourcesJVM.genResources((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value) ++
-          GenColCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
+          GenColCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value) ++
           GenNumberCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value)
         }.taskValue
       },
@@ -340,7 +340,7 @@ object ScalatestBuild extends Build {
         Def.task{
           GenScalacticJS.genMacroScala((sourceManaged in Compile).value, version.value, scalaVersion.value) ++
           ScalacticGenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value) ++
-          GenColCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
+          GenColCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value) ++
           GenNumberCompatHelper.genMain((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value)
         }.taskValue
       },

--- a/scalactic-macro/src/main/scala/org/scalactic/NameUtil.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/NameUtil.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2001-2018 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalactic
+
+private[org] object NameUtil {
+
+  // This attempts to strip dollar signs that happen when using the interpreter. It is quite fragile
+  // and already broke once. In the early days, all funky dollar sign encrusted names coming out of
+  // the interpreter started with "line". Now they don't, but in both cases they seemed to have at
+  // least one "$iw$" in them. So now I leave the string alone unless I see a "$iw$" in it. Worst case
+  // is sometimes people will get ugly strings coming out of the interpreter. -bv April 3, 2012
+  def stripDollars(s: String): String = {
+    val lastDollarIndex = s.lastIndexOf('$')
+    if (lastDollarIndex < s.length - 1)
+      if (lastDollarIndex == -1 || !s.contains("$iw$")) s else s.substring(lastDollarIndex + 1)
+    else {
+      // The last char is a dollar sign
+      val lastNonDollarChar = s.reverse.find(_ != '$')
+      lastNonDollarChar match {
+        case None => s
+        case Some(c) => {
+          val lastNonDollarIndex = s.lastIndexOf(c)
+          if (lastNonDollarIndex == -1) s
+          else stripDollars(s.substring(0, lastNonDollarIndex + 1))
+        }
+      }
+    }
+  }
+
+  def getSimpleNameOfAnObjectsClass(o: AnyRef) = stripDollars(parseSimpleName(o.getClass.getName))
+
+  // [bv: this is a good example of the expression type refactor. I moved this from SuiteClassNameListCellRenderer]
+  // this will be needed by the GUI classes, etc.
+  def parseSimpleName(fullyQualifiedName: String) = {
+
+    val dotPos = fullyQualifiedName.lastIndexOf('.')
+
+    // [bv: need to check the dotPos != fullyQualifiedName.length]
+    if (dotPos != -1 && dotPos != fullyQualifiedName.length)
+      fullyQualifiedName.substring(dotPos + 1)
+    else
+      fullyQualifiedName
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
@@ -45,7 +45,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a - from within an in clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "in the wrong place, at the wrong time" - {
             }
@@ -57,7 +57,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       }
       it("should, if they call a - with a nested in from within an in clause, result in a TestFailedException when running the test") {
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "in the wrong place, at the wrong time" - {
               "should never run" in {
@@ -74,7 +74,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a nested it from within an it clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "should never run" in {
               assert(1 === 1)
@@ -88,7 +88,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a nested it with tags from within an it clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "should never run" taggedAs(mytags.SlowAsMolasses) in {
               assert(1 === 1)
@@ -102,7 +102,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a describe with a nested ignore from within an it clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "in the wrong place, at the wrong time" - {
               "should never run" ignore {
@@ -118,7 +118,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a nested ignore from within an it clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "should never run" ignore {
               assert(1 === 1)
@@ -132,7 +132,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       it("should, if they call a nested ignore with tags from within an it clause, result in a TestFailedException when running the test") {
 
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           "should blow up" in {
             "should never run" taggedAs(mytags.SlowAsMolasses) ignore {
               assert(1 === 1)
@@ -159,7 +159,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       }
 
       class BFreeSpec extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new BFreeSpec
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new BFreeSpec
       }
       val b = new BFreeSpec
 
@@ -250,7 +250,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
 
     describe("(with info calls)") {
       class InfoInsideTestSpec extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new InfoInsideTestSpec
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new InfoInsideTestSpec
         val msg = "hi there, dude"
         val testName = "test name"
         testName in {
@@ -267,7 +267,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
         assert(testStartingIndex < testSucceededIndex)
       }
       class InfoBeforeTestSpec extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new InfoBeforeTestSpec
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new InfoBeforeTestSpec
         val msg = "hi there, dude"
         val testName = "test name"
         info(msg)
@@ -284,7 +284,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
         val msg = "hi there, dude"
         val testName = "test name"
         class MySpec extends PathFreeSpec {
-          //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new MySpec
+          //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new MySpec
           testName in {}
           info(msg)
         }
@@ -323,7 +323,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     it("should throw NullArgumentException if a null test tag is provided") {
       // it
       class ExampleSpec1 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec1
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec1
         "hi" taggedAs(null) in {}
       }
       intercept[NullArgumentException] {
@@ -331,7 +331,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       }
 
       class ExampleSpec2 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec2
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec2
         "hi" taggedAs(mytags.SlowAsMolasses, null) in {}
       }
       val caught = intercept[NullArgumentException] {
@@ -340,7 +340,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       assert(caught.getMessage === "a test tag was null")
 
       class ExampleSpec3 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec3
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec3
         "hi" taggedAs(mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) in {}
       }
       intercept[NullArgumentException] {
@@ -349,7 +349,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
 
       // ignore
       class ExampleSpec4 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec4
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec4
         "hi" taggedAs(null) ignore {}
       }
       intercept[NullArgumentException] {
@@ -357,7 +357,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       }
 
       class ExampleSpec5 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec5
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec5
         "hi" taggedAs(mytags.SlowAsMolasses, null) ignore {}
       }
       val caught2 = intercept[NullArgumentException] {
@@ -366,7 +366,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
       assert(caught2.getMessage === "a test tag was null")
 
       class ExampleSpec6 extends PathFreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new ExampleSpec6
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new ExampleSpec6
         "hi" taggedAs(mytags.SlowAsMolasses, null, mytags.WeakAsAKitten) ignore {}
       }
       intercept[NullArgumentException] {
@@ -1037,8 +1037,8 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should generate NotAllowedException wrapping a TestFailedException when assert fails in scope") {
-      class TestSpec extends FreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new TestSpec
+      class TestSpec extends PathFreeSpec {
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new TestSpec
         "a feature" - {
           val a = 1
           assert(a == 2)
@@ -1061,8 +1061,8 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should generate NotAllowedException wrapping a TestCanceledException when assume fails in scope") {
-      class TestSpec extends FreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new TestSpec
+      class TestSpec extends PathFreeSpec {
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new TestSpec
         "a feature" - {
           val a = 1
           assume(a == 2)
@@ -1085,8 +1085,8 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should generate NotAllowedException wrapping a non-fatal RuntimeException is thrown inside scope") {
-      class TestSpec extends FreeSpec {
-        //SCALATESTJS-ONLY override def newInstance: FreeSpecLike = new TestSpec
+      class TestSpec extends PathFreeSpec {
+        //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike = new TestSpec
         "a feature" - {
           throw new RuntimeException("on purpose")
         }
@@ -1129,7 +1129,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
 
     // SKIP-SCALATESTJS-START
     it("should propagate AnnotationFormatError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new AnnotationFormatError("on purpose")
         }
@@ -1141,7 +1141,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate AWTError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new AWTError("on purpose")
         }
@@ -1153,7 +1153,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate CoderMalfunctionError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new CoderMalfunctionError(new RuntimeException("on purpose"))
         }
@@ -1165,7 +1165,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate FactoryConfigurationError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new FactoryConfigurationError("on purpose")
         }
@@ -1177,7 +1177,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate LinkageError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new LinkageError("on purpose")
         }
@@ -1189,7 +1189,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate ThreadDeath when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new ThreadDeath
         }
@@ -1201,7 +1201,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate TransformerFactoryConfigurationError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new TransformerFactoryConfigurationError("on purpose")
         }
@@ -1213,7 +1213,7 @@ class FreeSpecSpec extends org.scalatest.FunSpec with GivenWhenThen {
     }
 
     it("should propagate VirtualMachineError when it is thrown inside scope") {
-      class TestSpec extends FreeSpec {
+      class TestSpec extends PathFreeSpec {
         "a feature" - {
           throw new VirtualMachineError("on purpose") {}
         }

--- a/scalatest/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
@@ -15,11 +15,13 @@
  */
 package org.scalatest
 
+import org.scalactic.NameUtil
+
 private[scalatest] case class DeferredAbortedSuite(suiteClassName: String, t: Throwable) extends Suite {
 
   override def run(testName: Option[String], args: Args): Status = {
     throw t
   }
 
-  override def suiteName: String = Suite.stripDollars(Suite.parseSimpleName(suiteClassName))
+  override def suiteName: String = NameUtil.stripDollars(NameUtil.parseSimpleName(suiteClassName))
 }

--- a/scalatest/src/main/scala/org/scalatest/JSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/JSuite.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import Suite.getSimpleNameOfAnObjectsClass
+import org.scalactic.NameUtil.getSimpleNameOfAnObjectsClass
 
 // Scala version o fwhat I'm thinking JSuite might have in Java
 private[scalatest] trait JSuite { thisSuite =>

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -34,7 +34,7 @@ import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
 import Suite.getEscapedIndentedTextForTest
-import Suite.getSimpleNameOfAnObjectsClass
+import NameUtil.getSimpleNameOfAnObjectsClass
 import Suite.getTopOfMethod
 import Suite.isTestMethodGoodies
 import Suite.reportTestIgnored
@@ -1398,21 +1398,6 @@ private[scalatest] object Suite {
 
   private[scalatest] val defaultTestSortingReporterTimeoutInSeconds = 2.0
 
-  def getSimpleNameOfAnObjectsClass(o: AnyRef) = stripDollars(parseSimpleName(o.getClass.getName))
-
-  // [bv: this is a good example of the expression type refactor. I moved this from SuiteClassNameListCellRenderer]
-  // this will be needed by the GUI classes, etc.
-  def parseSimpleName(fullyQualifiedName: String) = {
-
-    val dotPos = fullyQualifiedName.lastIndexOf('.')
-
-    // [bv: need to check the dotPos != fullyQualifiedName.length]
-    if (dotPos != -1 && dotPos != fullyQualifiedName.length)
-      fullyQualifiedName.substring(dotPos + 1)
-    else
-      fullyQualifiedName
-  }
-
   // SKIP-SCALATESTJS-START
   def checkForPublicNoArgConstructor(clazz: java.lang.Class[_]) = {
     
@@ -1426,29 +1411,6 @@ private[scalatest] object Suite {
     }
   }
   // SKIP-SCALATESTJS-END
-
-  // This attempts to strip dollar signs that happen when using the interpreter. It is quite fragile
-  // and already broke once. In the early days, all funky dollar sign encrusted names coming out of
-  // the interpreter started with "line". Now they don't, but in both cases they seemed to have at
-  // least one "$iw$" in them. So now I leave the string alone unless I see a "$iw$" in it. Worst case
-  // is sometimes people will get ugly strings coming out of the interpreter. -bv April 3, 2012
-  def stripDollars(s: String): String = {
-    val lastDollarIndex = s.lastIndexOf('$')
-    if (lastDollarIndex < s.length - 1)
-      if (lastDollarIndex == -1 || !s.contains("$iw$")) s else s.substring(lastDollarIndex + 1)
-    else {
-      // The last char is a dollar sign
-      val lastNonDollarChar = s.reverse.find(_ != '$')
-      lastNonDollarChar match {
-        case None => s
-        case Some(c) => {
-          val lastNonDollarIndex = s.lastIndexOf(c)
-          if (lastNonDollarIndex == -1) s
-          else stripDollars(s.substring(0, lastNonDollarIndex + 1))
-        }
-      }
-    }
-  }
 
   def diffStrings(s: String, t: String): Tuple2[String, String] = Prettifier.diffStrings(s, t)
   

--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -16,6 +16,7 @@
 package org.scalatest.enablers
 
 import org.scalactic._
+import NameUtil.getSimpleNameOfAnObjectsClass
 import org.scalacheck.Prop
 import org.scalacheck.Prop.Arg
 import org.scalacheck.Test
@@ -23,7 +24,6 @@ import org.scalacheck.util.Pretty
 import org.scalatest.Assertion
 import org.scalatest.FailureMessages
 import org.scalatest.Resources
-import org.scalatest.Suite.getSimpleNameOfAnObjectsClass
 import org.scalatest.Succeeded
 import org.scalatest.UnquotedString
 import org.scalatest.exceptions.StackDepthException

--- a/scalatest/src/main/scala/org/scalatest/junit/JUnit3Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/junit/JUnit3Suite.scala
@@ -19,6 +19,7 @@ import org.scalatest._
 import org.scalatest.events._
 import exceptions._
 import org.scalactic.Requirements._
+import org.scalactic.NameUtil
 import Suite.getIndentedTextForTest
 import Suite.wrapReporterIfNecessary
 import _root_.junit.framework.AssertionFailedError
@@ -290,7 +291,7 @@ private[scalatest] class MyTestListener(report: Reporter, tracker: Tracker, stat
   private def getSuiteNameForTestCase(testCase: Test) =
     testCase match {
       case junit3Suite: JUnit3Suite => junit3Suite.suiteName
-      case _ => Suite.getSimpleNameOfAnObjectsClass(testCase) // Should never happen, but just in case
+      case _ => NameUtil.getSimpleNameOfAnObjectsClass(testCase) // Should never happen, but just in case
     }
 
   def getMessageGivenThrowable(throwable: Throwable, isAssertionFailedError: Boolean) =

--- a/scalatest/src/main/scala/org/scalatest/path/FreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FreeSpec.scala
@@ -694,7 +694,7 @@ import org.scalatest._
 // SKIP-SCALATESTJS-START
 class FreeSpec extends org.scalatest.path.FreeSpecLike {
 // SKIP-SCALATESTJS-END
-//SCALATESTJS-ONLY abstract class FreeSpec extends FreeSpecLike {
+//SCALATESTJS-ONLY abstract class FreeSpec extends org.scalatest.path.FreeSpecLike {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/path/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FreeSpecLike.scala
@@ -52,9 +52,9 @@ trait FreeSpecLike extends org.scalatest.Suite with OneInstancePerTest with Info
   import engine._
 
   // SKIP-SCALATESTJS-START
-  override def newInstance: FreeSpecLike = this.getClass.newInstance.asInstanceOf[FreeSpecLike]
+  override def newInstance: org.scalatest.path.FreeSpecLike = this.getClass.newInstance.asInstanceOf[org.scalatest.path.FreeSpecLike]
   // SKIP-SCALATESTJS-END
-  //SCALATESTJS-ONLY override def newInstance: FreeSpecLike
+  //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FreeSpecLike
 
   /**
    * Returns an <code>Informer</code> that during test execution will forward strings (and other objects) passed to its

--- a/scalatest/src/main/scala/org/scalatest/path/FunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FunSpec.scala
@@ -696,7 +696,7 @@ import org.scalatest._
 // SKIP-SCALATESTJS-START
 class FunSpec extends org.scalatest.path.FunSpecLike {
 // SKIP-SCALATESTJS-END
-//SCALATESTJS-ONLY abstract class FunSpec extends FunSpecLike {
+//SCALATESTJS-ONLY abstract class FunSpec extends org.scalatest.path.FunSpecLike {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/path/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/FunSpecLike.scala
@@ -52,9 +52,9 @@ trait FunSpecLike extends org.scalatest.Suite with OneInstancePerTest with Infor
   import engine._
 
   // SKIP-SCALATESTJS-START
-  override def newInstance: FunSpecLike = this.getClass.newInstance.asInstanceOf[FunSpecLike]
+  override def newInstance: org.scalatest.path.FunSpecLike = this.getClass.newInstance.asInstanceOf[org.scalatest.path.FunSpecLike]
   // SKIP-SCALATESTJS-END
-  //SCALATESTJS-ONLY override def newInstance: FunSpecLike
+  //SCALATESTJS-ONLY override def newInstance: org.scalatest.path.FunSpecLike
 
   /**
    * Returns an <code>Informer</code> that during test execution will forward strings (and other objects) passed to its

--- a/scalatest/src/main/scala/org/scalatest/prop/GeneratorChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/GeneratorChecks.scala
@@ -16,8 +16,8 @@
 package org.scalatest.prop
 
 import org.scalactic._
+import NameUtil.getSimpleNameOfAnObjectsClass
 import org.scalatest.FailureMessages
-import org.scalatest.Suite.getSimpleNameOfAnObjectsClass
 import org.scalatest.UnquotedString
 import org.scalatest.exceptions.StackDepthException
 import scala.annotation.tailrec


### PR DESCRIPTION
Fixed broken test build for scala-js using scala version 2.13.0-M5 