### PR TITLE
[3.0.x] Minor Fixes

### DIFF
--- a/project/GenInspectorsShorthands.scala
+++ b/project/GenInspectorsShorthands.scala
@@ -40,7 +40,7 @@ trait GenInspectorsShorthandsBase {
 
   class DynamicFirstArrayElementTemplate(colType: String, errorFun: String, errorValue: String) extends Template {
     override def toString =
-      "\" + decorateToStringValue(prettifier, " + getErrorMessageValuesFunName(colType, errorFun) + "(xs, " + errorValue + ").deep) + \""
+      "\" + decorateToStringValue(prettifier, deep(" + getErrorMessageValuesFunName(colType, errorFun) + "(xs, " + errorValue + "))) + \""
   }
 
   class DynamicFirstElementLengthTemplate(colType: String, errorFun: String, errorValue: String) extends Template {
@@ -71,7 +71,7 @@ trait GenInspectorsShorthandsBase {
 
   class DynamicNextArrayElementTemplate(colType: String, errorFun: String, errorValue: String) extends Template {
     override def toString =
-      "\" + " + errorFun + "[" + colType + "](itr, " + errorValue + ").deep + \""
+      "\" + deep(" + errorFun + "[" + colType + "](itr, " + errorValue + ")) + \""
   }
 
   class DynamicNextElementLengthTemplate(colType: String, errorFun: String, errorValue: String) extends Template {
@@ -1063,7 +1063,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForAllSucceededSpec"
@@ -1101,7 +1102,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -1143,7 +1145,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForAtLeastSucceededSpec"
@@ -1362,7 +1365,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -1403,7 +1407,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForEverySucceededSpec"
@@ -1623,7 +1628,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -1664,7 +1670,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForExactlySucceededSpec"
@@ -1885,7 +1892,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -1926,7 +1934,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForNoSucceededSpec"
@@ -2145,7 +2154,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -2186,7 +2196,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForBetweenSucceededSpec"
@@ -2407,7 +2418,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className
@@ -2448,7 +2460,8 @@ trait GenInspectorsShorthandsBase {
               "collection.GenTraversable",
               "collection.GenMap",
               "org.scalatest.refspec.RefSpec",
-              "org.scalatest.CompatParColls.Converters._"
+              "org.scalatest.CompatParColls.Converters._",
+              "org.scalactic.ArrayHelper.deep"
             ),
             classTemplate = new ClassTemplate {
               val name = "InspectorShorthandsForAtMostSucceededSpec"
@@ -2679,7 +2692,8 @@ trait GenInspectorsShorthandsBase {
                 "collection.GenTraversable",
                 "collection.GenMap",
                 "org.scalatest.refspec.RefSpec",
-                "org.scalatest.CompatParColls.Converters._"
+                "org.scalatest.CompatParColls.Converters._",
+                "org.scalactic.ArrayHelper.deep"
               ),
               classTemplate = new ClassTemplate {
                 val name = className

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -105,7 +105,7 @@ object ScalatestBuild extends Build {
     scalaVersion := buildScalaVersion,
     crossScalaVersions := Seq(buildScalaVersion, "2.10.6", "2.12.0"),
     version := releaseVersion,
-    scalacOptions ++= Seq("-feature", "-target:jvm-1.6") ++ (if (scalaVersion.value == "2.13.0-M4") Seq("-Xsource:2.12") else Seq.empty),
+    scalacOptions ++= Seq("-feature", "-target:jvm-1.6"),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",
     libraryDependencies ++= scalaLibraries(scalaVersion.value),
     publishTo <<= version { v: String =>

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -25,7 +25,7 @@ object ScalatestBuild extends Build {
   // > ++ 2.10.5
   val buildScalaVersion = "2.12.7"
 
-  val releaseVersion = "3.0.6-SNAP4"
+  val releaseVersion = "3.0.6-SNAP5"
 
   val previousReleaseVersion = "3.0.5"
 


### PR DESCRIPTION
- Removed -Xsource:2.12 from scalatest.scala, which is no longer required by Scala 2.13.0-M5.
- Fixed compile error in generated inspector shorthand tests, under Scala 2.13.0-M5.