### PR TITLE
Always use java reflection in Framework.runner

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -992,21 +992,11 @@ import java.net.{ServerSocket, InetAddress}
       }
 
     val runnerInstance =
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+      {
         val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
         val module = runnerCompanionClass.getField("MODULE$")
         val obj = module.get(runnerCompanionClass)
         obj.asInstanceOf[Runner.type]
-      }
-      else {
-        // We need to use the following code to set Runner object instance for different Runner using different class loader.
-        import scala.reflect.runtime._
-
-        val runtimeMirror = universe.runtimeMirror(testClassLoader)
-
-        val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-        val obj = runtimeMirror.reflectModule(module)
-        obj.instance.asInstanceOf[Runner.type]
       }
 
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -206,21 +206,11 @@ class ScalaTestFramework extends SbtFramework {
           }
 
           val runnerInstance =
-            if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+            {
               val runnerCompanionClass = testLoader.loadClass("org.scalatest.tools.Runner$")
               val module = runnerCompanionClass.getField("MODULE$")
               val obj = module.get(runnerCompanionClass)
               obj.asInstanceOf[Runner.type]
-            }
-            else {
-              // We need to use the following code to set Runner object instance for different Runner using different class loader.
-              import scala.reflect.runtime._
-
-              val runtimeMirror = universe.runtimeMirror(testLoader)
-
-              val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-              val obj = runtimeMirror.reflectModule(module)
-              obj.instance.asInstanceOf[Runner.type]
             }
 
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)


### PR DESCRIPTION
I was doing some performance testing of sbt and noticed that the
Framework.runner method took O(175ms) to run on my machine. By
comparison, the utest Framework.runner method takes only O(5ms) to run
on my machine. One piece of low hanging fruit is to replace the use of
scala reflection with java reflection. After this change, the
Framework.runner time dropped to O(50-75ms) on my machine.