### PR TITLE
add _root_ to the macros defined in TypeMatcherMacro

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/matchers/TypeMatcherMacroSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/matchers/TypeMatcherMacroSpec.scala
@@ -1,0 +1,54 @@
+package org.scalatest.matchers
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TypeMatcherMacroSpec extends FlatSpec with Matchers {
+
+  case class Organization(name: String)
+  val org = Organization("acme")
+
+  "assertTypeImpl" should "work when a val called 'org' is in scope" in {
+    org.name shouldBe a[String]
+    org.name shouldBe an[String]
+  }
+
+  "aTypeMatcherImpl" should "work when a val called 'org' is in scope" in {
+    org.name should be(a[String])
+  }
+
+  "anTypeMatcherImpl" should "work when a val called 'org' is in scope" in {
+    org.name should be(an[String])
+  }
+
+  "notATypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (not be a [Int] and not be a [Double])
+  }
+
+  "notAnTypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (not be an[Int] and not be an[Double])
+  }
+
+  "andNotATypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (be(a[String]) and not be a[Int])
+  }
+
+  "andNotAnTypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (be(an[String]) and not be an[Int])
+  }
+
+  "orNotATypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (be(a[Double]) or not be a[Int])
+  }
+
+  "orNotAnTypeMatcher" should "work when a val called 'org' is in scope" in {
+    org.name should (be(an[Double]) or not be an[Int])
+  }
+
+  "assertATypeShouldBeTrueImpl" should "work when a val called 'org' is in scope" in {
+    org.name should not be a[Int]
+  }
+
+  "assertAnTypeShouldBeTrueImpl" should "work when a val called 'org' is in scope" in {
+    org.name should not be an[Int]
+  }
+}

--- a/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
@@ -76,7 +76,10 @@ private[scalatest] object TypeMatcherMacro {
           Select(
             Select(
               Select(
-                Ident(newTermName("org")),
+                Select(
+                  Ident(newTermName("_root_")),
+                  newTermName("org")
+                ),
                 newTermName("scalatest")
               ),
               newTermName("matchers")
@@ -112,7 +115,10 @@ private[scalatest] object TypeMatcherMacro {
           Select(
             Select(
               Select(
-                Ident(newTermName("org")),
+                Select(
+                  Ident(newTermName("_root_")),
+                  newTermName("org")
+                ),
                 newTermName("scalatest")
               ),
               newTermName("matchers")
@@ -147,7 +153,10 @@ private[scalatest] object TypeMatcherMacro {
           Select(
             Select(
               Select(
-                Ident(newTermName("org")),
+                Select(
+                  Ident(newTermName("_root_")),
+                  newTermName("org")
+                ),
                 newTermName("scalatest")
               ),
               newTermName("matchers")
@@ -181,7 +190,10 @@ private[scalatest] object TypeMatcherMacro {
           Select(
             Select(
               Select(
-                Ident(newTermName("org")),
+                Select(
+                  Ident(newTermName("_root_")),
+                  newTermName("org")
+                ),
                 newTermName("scalatest")
               ),
               newTermName("matchers")
@@ -353,7 +365,10 @@ private[scalatest] object TypeMatcherMacro {
                 Select(
                   Select(
                     Select(
-                      Ident(newTermName("org")),
+                      Select(
+                        Ident(newTermName("_root_")),
+                        newTermName("org")
+                      ),
                       newTermName("scalatest")
                     ),
                     newTermName("matchers")
@@ -407,7 +422,10 @@ private[scalatest] object TypeMatcherMacro {
               Select(
                 Select(
                   Select(
-                    Ident(newTermName("org")),
+                    Select(
+                      Ident(newTermName("_root_")),
+                      newTermName("org")
+                    ),
                     newTermName("scalatest")
                   ),
                   newTermName("matchers")
@@ -460,7 +478,10 @@ private[scalatest] object TypeMatcherMacro {
                 Select(
                   Select(
                     Select(
-                      Ident(newTermName("org")),
+                      Select(
+                        Ident(newTermName("_root_")),
+                        newTermName("org")
+                      ),
                       newTermName("scalatest")
                     ),
                     newTermName("matchers")
@@ -506,7 +527,10 @@ private[scalatest] object TypeMatcherMacro {
               Select(
                 Select(
                   Select(
-                    Ident(newTermName("org")),
+                    Select(
+                      Ident(newTermName("_root_")),
+                      newTermName("org")
+                    ),
                     newTermName("scalatest")
                   ),
                   newTermName("matchers")


### PR DESCRIPTION
Sanitises the `TypeMatcherMacro` to avoid the following error when a val in scope is called `org` 

> Error:(180, 16) value scalatest is not a member of Organization 
         org.name shouldBe a[String]

which would be throw while compiling something like 

```scala
    "work when a val called 'org' is in scope" in {
      case class Organization(name: String)

      val org = Organization("acme")

      org.name shouldBe a[String]
    }
```

