### PR TITLE
[3.0.x] Deprecate 'to' and 'until' function in Pos Float and Double AnyVals

### DIFF
--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosDouble.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosDouble.scala
@@ -375,6 +375,7 @@ final class PosDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Double) = NumberCompatHelper.doubleUntil(value, end)
 
   /**
@@ -387,6 +388,7 @@ final class PosDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Exclusive[Double]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until's function instead")
   def until(end: Double, step: Double) = NumberCompatHelper.doubleUntil(value, end, step)
 
   /**
@@ -397,6 +399,7 @@ final class PosDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Double) = NumberCompatHelper.doubleTo(value, end)
 
   /**
@@ -408,6 +411,7 @@ final class PosDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Inclusive[Double]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Double, step: Double) = NumberCompatHelper.doubleTo(value, end, step)
 }
 

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosFloat.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosFloat.scala
@@ -387,6 +387,7 @@ import scala.util.Try
   * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Float) = NumberCompatHelper.floatUntil(value, end)
 
   /**
@@ -399,6 +400,7 @@ import scala.util.Try
   * @return A [[scala.collection.immutable.NumericRange.Exclusive[Float]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Float, step: Float) = NumberCompatHelper.floatUntil(value, end, step)
 
   /**
@@ -409,6 +411,7 @@ import scala.util.Try
   * @return A [[scala.collection.immutable.Range.Partial[Float], NumericRange[Float]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Float) = NumberCompatHelper.floatTo(value, end)
 
   /**
@@ -420,6 +423,7 @@ import scala.util.Try
   * @return A [[scala.collection.immutable.NumericRange.Inclusive[Float]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Float, step: Float) = NumberCompatHelper.floatTo(value, end, step)
 }
 

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZDouble.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZDouble.scala
@@ -368,6 +368,7 @@ final class PosZDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Double) = NumberCompatHelper.doubleUntil(value, end)
 
   /**
@@ -380,6 +381,7 @@ final class PosZDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Exclusive[Double]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Double, step: Double) = NumberCompatHelper.doubleUntil(value, end, step)
 
   /**
@@ -390,6 +392,7 @@ final class PosZDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Double) = NumberCompatHelper.doubleTo(value, end)
 
   /**
@@ -401,6 +404,7 @@ final class PosZDouble private (val value: Double) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Inclusive[Double]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Double, step: Double) = NumberCompatHelper.doubleTo(value, end, step)
 }
 

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZFloat.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZFloat.scala
@@ -367,6 +367,7 @@ final class PosZFloat private (val value: Float) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Float) = NumberCompatHelper.floatUntil(value, end)
 
   /**
@@ -379,6 +380,7 @@ final class PosZFloat private (val value: Float) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Exclusive[Float]]] from `this` up to but
   * not including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's until function instead")
   def until(end: Float, step: Float) = NumberCompatHelper.floatUntil(value, end, step)
 
   /**
@@ -389,6 +391,7 @@ final class PosZFloat private (val value: Float) extends AnyVal {
   * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Float) = NumberCompatHelper.floatTo(value, end)
 
   /**
@@ -400,6 +403,7 @@ final class PosZFloat private (val value: Float) extends AnyVal {
   * @return A [[scala.collection.immutable.NumericRange.Inclusive[Float]]] from `'''this'''` up to
   * and including `end`.
   */
+  @deprecated("This function will be removed in future version of Scalactic, use BigDecimal's to function instead")
   def to(end: Float, step: Float)= NumberCompatHelper.floatTo(value, end, step)
 }
 


### PR DESCRIPTION
Deprecated until and to function in PosDouble, PosFloat, PosZDouble and PosZFloat.