### PR TITLE
scalatest-app 0.3.6 Native Test Interface

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -1206,7 +1206,7 @@ object ScalatestBuild extends Build {
         organization := "org.scalatest",
         moduleName := "scalatest-app",
         libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-        libraryDependencies += "org.scala-native" %%% "test-interface" % "0.3.3",
+        libraryDependencies += "org.scala-native" %%% "test-interface" % "0.3.6",
         // include the scalactic classes and resources in the jar
         mappings in (Compile, packageBin) ++= mappings.in(scalacticNative, Compile, packageBin).value,
         // include the scalactic sources in the source jar


### PR DESCRIPTION
Changed org.scala-native's test-interface's version to 0.3.6 for scalatest-app native.