### PR TITLE
[3.1.x] In-House Generator from 3.2.x

### DIFF
--- a/project/GenAnyVals.scala
+++ b/project/GenAnyVals.scala
@@ -686,7 +686,7 @@ object GenAnyVals {
       "Float.MaxValue", "3.4028235E38",
       round("PosZ", "Float") +
       ceil("Pos", "Float") +
-      floor("Pos", "Float") +
+      floor("PosZ", "Float") +
       plus("Pos", "Float", "positive", "PosZ", "non-negative") +
       isPosInfinity("Float"),
       positiveInfinity("Pos", "Float") +
@@ -697,7 +697,7 @@ object GenAnyVals {
       "Double.MaxValue", "1.7976931348623157E308",
       round("PosZ", "Double") +
       ceil("Pos", "Double") +
-      floor("Pos", "Double") +
+      floor("PosZ", "Double") +
       plus("Pos", "Double", "positive", "PosZ", "non-negative") +
       isPosInfinity("Double"),
       positiveInfinity("Pos", "Double") +
@@ -752,16 +752,16 @@ object GenAnyVals {
       negZWidens("Double")) :::
     genFloatAnyVal(dir, "PosFiniteFloat", "finite positive", "Note: a <code>PosFiniteFloat</code> may not equal 0.0. If you want positive number or 0, use [[PosZFiniteFloat]].", "i > 0.0f && i != Float.PositiveInfinity", "PosFiniteFloat(42.1f)", "PosFiniteFloat(0.0f)", "42.1f", "0.0f", "Float.MinPositiveValue", "1.4E-45",
       "Float.MaxValue", "3.4028235E38",
-      round("PosFinite", "Float") +
+      round("PosZFinite", "Float") +
       ceil("PosFinite", "Float") +
-      floor("PosFinite", "Float"),
+      floor("PosZFinite", "Float"),
       minPositiveValue("Pos", "Float"),
       posFiniteWidens("Float")) :::
     genDoubleAnyVal(dir, "PosFiniteDouble", "finite positive", "", "i > 0.0  && i != Double.PositiveInfinity", "PosFiniteDouble(1.1)", "PosFiniteDouble(-1.1)", "1.1", "-1.1", "Double.MinPositiveValue", "4.9E-324",
       "Double.MaxValue", "1.7976931348623157E308",
-      round("PosFinite", "Double") +
+      round("PosZFinite", "Double") +
       ceil("PosFinite", "Double") +
-      floor("PosFinite", "Double"),
+      floor("PosZFinite", "Double"),
       minPositiveValue("PosFinite", "Double"),
       posFiniteWidens("Double")) :::
     genFloatAnyVal(dir, "PosZFiniteFloat", "finite non-negative", "", "i >= 0.0f && i != Float.PositiveInfinity", "PosZFiniteFloat(1.1f)", "PosZFiniteFloat(-1.0f)", "1.1f", "-1.1f", "0.0f", "0.0f",
@@ -780,14 +780,14 @@ object GenAnyVals {
       posZFiniteWidens("Double")) :::
     genFloatAnyVal(dir, "NegFiniteFloat", "finite negative", "Note: a <code>NegFiniteFloat</code> may not equal 0.0. If you want negative number or 0, use [[NegZFiniteFloat]].", "i < 0.0f && i != Float.NegativeInfinity", "NegFiniteFloat(-42.1f)", "NegFiniteFloat(0.0f)", "-42.1f", "0.0f",
       "Float.MinValue", "-3.4028235E38", "-Float.MinPositiveValue", "-1.4E-45",
-      round("NegFinite", "Float") +
-      ceil("NegFinite", "Float") +
+      round("NegZFinite", "Float") +
+      ceil("NegZFinite", "Float") +
       floor("NegFinite", "Float"),
       "",
       negFiniteWidens("Float")) :::
     genDoubleAnyVal(dir, "NegFiniteDouble", "finite negative", "", "i < 0.0  && i != Double.NegativeInfinity", "NegFiniteDouble(-1.1)", "NegFiniteDouble(1.1)", "-1.1", "1.1", "Double.MinValue", "-1.7976931348623157E308", "-Double.MinPositiveValue", "-4.9E-324",
-      round("NegFinite", "Double") +
-      ceil("NegFinite", "Double") +
+      round("NegZFinite", "Double") +
+      ceil("NegZFinite", "Double") +
       floor("NegFinite", "Double"),
       "",
       negFiniteWidens("Double")) :::

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -23,138 +23,7 @@ object GenGen {
 
   val generatorSource = new File("GenGen.scala")
 
-val scaladocForTableFor1VerbatimString = """
-/**
- * A table with 1 column.
- *
- * <p>
- * For an overview of using tables, see the documentation for trait
- * <a href="TableDrivenPropertyChecks.html">TableDrivenPropertyChecks</a>.
- * </p>
- *
- * <p>
- * This table is a sequence of objects, where each object represents one row of the (one-column) table.
- * This table also carries with it a <em>heading</em> tuple that gives a string name to the
- * lone column of the table.
- * </p>
- *
- * <p>
- * A handy way to create a <code>TableFor1</code> is via an <code>apply</code> factory method in the <code>Table</code>
- * singleton object provided by the <code>Tables</code> trait. Here's an example:
- * </p>
- *
- * <pre class="stHighlight">
- * val examples =
- *   Table(
- *     "a",
- *       0,
- *       1,
- *       2,
- *       3,
- *       4,
- *       5,
- *       6,
- *       7,
- *       8,
- *       9
- *   )
- * </pre>
- *
- * <p>
- * Because you supplied a list of non-tuple objects, the type you'll get back will be a <code>TableFor1</code>.
- * </p>
- *
- * <p>
- * The table provides an <code>apply</code> method that takes a function with a parameter list that matches
- * the type of the objects contained in this table. The <code>apply</code> method will invoke the
- * function with the object in each row passed as the lone argument, in ascending order by index. (<em>I.e.</em>,
- * the zeroth object is checked first, then the object with index 1, then index 2, and so on until all the rows
- * have been checked (or until a failure occurs). The function represents a property of the code under test
- * that should succeed for every row of the table. If the function returns normally, that indicates the property
- * check succeeded for that row. If the function completes abruptly with an exception, that indicates the
- * property check failed and the <code>apply</code> method will complete abruptly with a
- * <code>TableDrivenPropertyCheckFailedException</code> that wraps the exception thrown by the supplied property function.
- * </p>
- * 
- * <p>
- * The usual way you'd invoke the <code>apply</code> method that checks a property is via a <code>forAll</code> method
- * provided by trait <code>TableDrivenPropertyChecks</code>. The <code>forAll</code> method takes a <code>TableFor1</code> as its
- * first argument, then in a curried argument list takes the property check function. It invokes <code>apply</code> on
- * the <code>TableFor1</code>, passing in the property check function. Here's an example:
- * </p>
- *
- * <pre class="stHighlight">
- * forAll (examples) { (a) =>
- *   a should equal (a * 1)
- * }
- * </pre>
- *
- * <p>
- * Because <code>TableFor1</code> is a <code>Seq[(A)]</code>, you can use it as a <code>Seq</code>. For example, here's how
- * you could get a sequence of <a href="../Outcome.html"><code>Outcome</code></a>s for each row of the table, indicating whether a property check succeeded or failed
- * on each row of the table:
- * </p>
- *
- * <pre class="stHighlight">
- * for (row <- examples) yield {
- *   outcomeOf { row._1 should not equal (7) }
- * }
- * </pre>
- *
- * <p>
- * Note: the <code>outcomeOf</code> method, contained in the <code>OutcomeOf</code> trait, will execute the supplied code (a by-name parameter) and
- * transform it to an <code>Outcome</code>. If no exception is thrown by the code, <code>outcomeOf</code> will result in a
- * <a href="../Succeeded\$.html"><code>Succeeded</code></a>, indicating the "property check"
- * succeeded. If the supplied code completes abruptly in an exception that would normally cause a test to fail, <code>outcomeOf</code> will result in
- * in a <a href="../Failed.html"><code>Failed</code></a> instance containing that exception. For example, the previous for expression would give you:
- * </p>
- *
- * <pre class="stHighlight">
- * Vector(Succeeded, Succeeded, Succeeded, Succeeded, Succeeded, Succeeded, Succeeded,
- *     Failed(org.scalatest.TestFailedException: 7 equaled 7), Succeeded, Succeeded)
- * </pre>
- *
- * <p>
- * This shows that all the property checks succeeded, except for the one at index 7.
- * </p>
- *
- * <p>
- * One other way to use a <code>TableFor1</code> is to test subsequent return values
- * of a stateful function. Imagine, for example, you had an object named <code>FiboGen</code>
- * whose <code>next</code> method returned the <em>next</em> fibonacci number, where next
- * means the next number in the series following the number previously returned by <code>next</code>.
- * So the first time <code>next</code> was called, it would return 0. The next time it was called
- * it would return 1. Then 1. Then 2. Then 3, and so on. <code>FiboGen</code> would need to
- * be stateful, because it has to remember where it is in the series. In such a situation,
- * you could create a <code>TableFor1</code> (a table with one column, which you could alternatively
- * think of as one row), in which each row represents
- * the next value you expect.
- * </p>
- *
- * <pre class="stHighlight">
- * val first14FiboNums =
- *   Table("n", 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233)
- * </pre>
- *
- * <p>
- * Then in your <code>forAll</code> simply call the function and compare it with the
- * expected return value, like this:
- * </p>
- *
- * <pre class="stHighlight">
- *  forAll (first14FiboNums) { n =>
- *    FiboGen.next should equal (n)
- *  }
- * </pre>
- *
- * @param heading a string name for the lone column of this table
- * @param rows a variable length parameter list of objects containing the data of this table
- *
- * @author Bill Venners 
- */
-"""
-
-val copyrightTemplate = """/*
+  val copyrightTemplate = """/*
  * Copyright 2001-$year$ Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -171,32 +40,37 @@ val copyrightTemplate = """/*
  */
 package org.scalatest
 package prop
+
+import org.scalactic.anyvals.PosZInt
+
 """
 
-val propertyCheckPreamble = """
-import org.scalacheck.Arbitrary
-import org.scalacheck.Shrink
-import org.scalacheck.Prop
-import org.scalacheck.Gen
-import org.scalacheck.Prop._
-import org.scalatest.exceptions.DiscardedEvaluationException
-import org.scalatest.enablers.CheckerAsserting
+  val propertyCheckPreamble = """
 import org.scalactic._
+import org.scalatest.FailureMessages
+import org.scalatest.UnquotedString
+import org.scalatest.exceptions.StackDepthException
+import scala.annotation.tailrec
+import scala.util.{Try, Failure, Success}
+import org.scalatest.exceptions.DiscardedEvaluationException
+import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
+import org.scalatest.exceptions.StackDepth
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.enablers.PropCheckerAsserting
 
 /**
- * Trait containing methods that faciliate property checks against generated data using ScalaCheck.
+ * Trait containing methods that faciliate property checks against generated data using [[Generator]].
  *
  * <p>
  * This trait contains <code>forAll</code> methods that provide various ways to check properties using
- * generated data. Use of this trait requires that ScalaCheck be on the class path when you compile and run your tests.
- * It also contains a <code>wherever</code> method that can be used to indicate a property need only hold whenever
- * some condition is true.
+ * generated data.  It also contains a <code>wherever</code> method that can be used to indicate a property
+ * need only hold whenever some condition is true.
  * </p>
  *
  * <p>
  * For an example of trait <code>GeneratorDrivenPropertyChecks</code> in action, imagine you want to test this <code>Fraction</code> class:
  * </p>
- *  
+ *
  * <pre class="stHighlight">
  * class Fraction(n: Int, d: Int) {
  *
@@ -238,26 +112,24 @@ import org.scalactic._
  *
  * <p>
  * Trait <code>GeneratorDrivenPropertyChecks</code> provides overloaded <code>forAll</code> methods
- * that allow you to check properties using the data provided by a ScalaCheck generator. The simplest form
+ * that allow you to check properties using the data provided by [[Generator]]. The simplest form
  * of <code>forAll</code> method takes two parameter lists, the second of which is implicit. The first parameter list
- * is a "property" function with one to six parameters. An implicit <code>Arbitrary</code> generator and <code>Shrink</code> object needs to be supplied for
- * The <code>forAll</code> method will pass each row of data to
- * each parameter type. ScalaCheck provides many implicit <code>Arbitrary</code> generators for common types such as
- * <code>Int</code>, <code>String</code>, <code>List[Float]</code>, <em>etc.</em>, in its <code>org.scalacheck.Arbitrary</code> companion
- * object. So long as you use types for which ScalaCheck already provides implicit <code>Arbitrary</code> generators, you needn't
- * worry about them. Same for <code>Shrink</code> objects, which are provided by ScalaCheck's <code>org.scalacheck.Shrink</code> companion
- * object. Most often you can simply pass a property function to <code>forAll</code>, and the compiler will grab the implicit
- * values provided by ScalaCheck.
+ * is a "property" function with one to six parameters. An implicit [[Generator]] generator object needs to be supplied for.
+ * The <code>forAll</code> method will pass each row of data to each parameter type. ScalaTest provides many implicit [[Generator]]s for
+ * common types such as <code>Int</code>, <code>String</code>, <code>List[Float]</code>, <em>etc.</em>, in its [[Generator]] companion
+ * object. So long as you use types for which ScalaTest already provides implicit [[Generator]]s, you needn't
+ * worry about them. Most often you can simply pass a property function to <code>forAll</code>, and the compiler will grab the implicit
+ * values provided by ScalaTest.
  * </p>
  *
  * <p>
- * The <code>forAll</code> methods use the supplied <code>Arbitrary</code> generators to generate example
+ * The <code>forAll</code> methods use the supplied [[Generator]]s to generate example
  * arguments and pass them to the property function, and
  * generate a <code>GeneratorDrivenPropertyCheckFailedException</code> if the function
  * completes abruptly for any exception that would <a href="../Suite.html#errorHandling">normally cause</a> a test to
  * fail in ScalaTest other than <code>DiscardedEvaluationException</code>. An
  * <code>DiscardedEvaluationException</code>,
- * which is thrown by the <code>whenever</code> method (defined in trait <code>Whenever</code>, which this trait extends) to indicate
+ * which is thrown by the <code>whenever</code> method (defined in trait [[Whenever]], which this trait extends) to indicate
  * a condition required by the property function is not met by a row
  * of passed data, will simply cause <code>forAll</code> to discard that row of data.
  * </p>
@@ -313,7 +185,7 @@ import org.scalactic._
  * <a name="supplyingGenerators"></a><h2>Supplying generators</h2>
  *
  * <p>
- * ScalaCheck provides a nice library of compositors that makes it easy to create your own custom generators. If you
+ * ScalaTest provides a nice library of compositors that makes it easy to create your own custom generators. If you
  * want to supply custom generators to a property check, place them in parentheses after <code>forAll</code>, before
  * the property check function (a curried form of <code>forAll</code>).
  * </p>
@@ -323,9 +195,9 @@ import org.scalactic._
  * </p>
  *
  * <pre class="stHighlight">
- * import org.scalacheck.Gen
+ * import org.scalatest.prop.Generator
  *
- * val evenInts = for (n <- Gen.choose(-1000, 1000)) yield 2 * n
+ * val evenInts = for (n <- Generator.chooseInt(-1000, 1000)) yield 2 * n
  * </pre>
  *
  * <p>
@@ -337,7 +209,7 @@ import org.scalactic._
  * </pre>
  *
  * <p>
- * Custom generators are necessary when you want to pass data types not supported by ScalaCheck's arbitrary generators,
+ * Custom generators are necessary when you want to pass data types not supported by ScalaTest's [[Generator]]s,
  * but are also useful when some of the values in the full range for the passed types are not valid. For such values you
  * would use a <code>whenever</code> clause. In the <code>Fraction</code> class shown above, neither the passed numerator or
  * denominator can be <code>Integer.MIN_VALUE</code>, and the passed denominator cannot be zero. This shows up in the
@@ -355,7 +227,7 @@ import org.scalactic._
  *
  * <pre class="stHighlight">
  * val validNumers =
- *   for (n <- Gen.choose(Integer.MIN_VALUE + 1, Integer.MAX_VALUE)) yield n
+ *   for (n <- Generator.chooseInt(Integer.MIN_VALUE + 1, Integer.MAX_VALUE)) yield n
  * val validDenoms =
  *   for (d <- validNumers if d != 0) yield d
  * </pre>
@@ -383,15 +255,6 @@ import org.scalactic._
  *   }
  * }
  * </pre>
- *
- * <p>
- * Note that even if you use generators that don't produce the invalid values, you still need the
- * <code>whenever</code> clause. The reason is that once a property fails, ScalaCheck will try and shrink
- * the values to the smallest values that still cause the property to fail. During this shrinking process ScalaCheck
- * may pass invalid values. The <code>whenever</code> clause is still needed to guard against those values. (The
- * <code>whenever</code> clause also clarifies to readers of the code exactly what the property is in a succinct
- * way, without requiring that they find and understand the generator definitions.)
- * </p>
  *
  * <a name="supplyingGeneratorsAndArgNames"></a><h2>Supplying both generators and argument names</h2>
  *
@@ -435,7 +298,7 @@ import org.scalactic._
  *
  * <p>
  * The property checks performed by the <code>forAll</code> methods of this trait can be flexibly configured via the services
- * provided by supertrait <code>Configuration</code>.  The five configuration parameters for property checks along with their 
+ * provided by supertrait <code>Configuration</code>.  The five configuration parameters for property checks along with their
  * default values and meanings are described in the following table:
  * </p>
  *
@@ -511,7 +374,7 @@ import org.scalactic._
  * <p>
  * The <code>forAll</code> methods of trait <code>GeneratorDrivenPropertyChecks</code> each take a <code>PropertyCheckConfiguration</code>
  * object as an implicit parameter. This object provides values for each of the five configuration parameters. Trait <code>Configuration</code>
- * provides an implicit <code>val</code> named <code>generatorDrivenConfig</code> with each configuration parameter set to its default value. 
+ * provides an implicit <code>val</code> named <code>generatorDrivenConfig</code> with each configuration parameter set to its default value.
  * If you want to set one or more configuration parameters to a different value for all property checks in a suite you can override this
  * val (or hide it, for example, if you are importing the members of the <code>GeneratorDrivenPropertyChecks</code> companion object rather
  * than mixing in the trait.) For example, if
@@ -545,11 +408,11 @@ import org.scalactic._
  * </pre>
  *
  * <p>
- * This invocation of <code>forAll</code> will use 500 for <code>minSuccessful</code> and whatever values are specified by the 
+ * This invocation of <code>forAll</code> will use 500 for <code>minSuccessful</code> and whatever values are specified by the
  * implicitly passed <code>PropertyCheckConfiguration</code> object for the other configuration parameters.
  * If you want to set multiple configuration parameters in this way, just list them separated by commas:
  * </p>
- * 
+ *
  * <pre class="stHighlight">
  * forAll (minSuccessful(500), maxDiscardedFactor(0.6)) { (n: Int, d: Int) => ...
  * </pre>
@@ -558,7 +421,7 @@ import org.scalactic._
  * If you are using an overloaded form of <code>forAll</code> that already takes an initial parameter list, just
  * add the configuration parameters after the list of generators, names, or generator/name pairs, as in:
  * </p>
- * 
+ *
  * <pre class="stHighlight">
  * // If providing argument names
  * forAll ("n", "d", minSuccessful(500), maxDiscarded(300)) {
@@ -576,14 +439,14 @@ import org.scalactic._
  * <p>
  * For more information, see the documentation for supertrait <a href="Configuration.html"><code>Configuration</code></a>.
  * </p>
- * 
+ *
  * @author Bill Venners
  */
-trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
+trait GeneratorDrivenPropertyChecks extends CommonGenerators with Whenever with Configuration {
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
    * <code>PropertyGenConfig</code> object with explicitly passed parameter values.
    *
    * <p>
@@ -626,7 +489,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
 
   /**
    * Performs a configured property checks by applying property check functions passed to its <code>apply</code> methods to arguments
-   * supplied by implicitly passed generators, modifying the values in the 
+   * supplied by implicitly passed generators, modifying the values in the
    * <code>PropertyGenConfig</code> object passed implicitly to its <code>apply</code> methods with parameter values passed to its constructor.
    *
    * <p>
@@ -688,8 +551,8 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -705,35 +568,20 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, ASSERTION](fun: (A) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check1(fun, genA, param, prettifier, pos, List.empty)
     }
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -749,36 +597,21 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, B, ASSERTION](fun: (A, B) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        arbB: Arbitrary[B], shrB: Shrink[B],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        genB: org.scalatest.prop.Generator[B],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A, b: B) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a, b)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check2(fun, genA, genB, param, prettifier, pos, List.empty)
     }
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -794,37 +627,22 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, B, C, ASSERTION](fun: (A, B, C) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        arbB: Arbitrary[B], shrB: Shrink[B],
-        arbC: Arbitrary[C], shrC: Shrink[C],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        genB: org.scalatest.prop.Generator[B],
+        genC: org.scalatest.prop.Generator[C],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A, b: B, c: C) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a, b, c)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check3(fun, genA, genB, genC, param, prettifier, pos, List.empty)
     }
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -840,38 +658,23 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, B, C, D, ASSERTION](fun: (A, B, C, D) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        arbB: Arbitrary[B], shrB: Shrink[B],
-        arbC: Arbitrary[C], shrC: Shrink[C],
-        arbD: Arbitrary[D], shrD: Shrink[D],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        genB: org.scalatest.prop.Generator[B],
+        genC: org.scalatest.prop.Generator[C],
+        genD: org.scalatest.prop.Generator[D],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A, b: B, c: C, d: D) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a, b, c, d)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check4(fun, genA, genB, genC, genD, param, prettifier, pos, List.empty)
     }
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -887,39 +690,24 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, B, C, D, E, ASSERTION](fun: (A, B, C, D, E) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        arbB: Arbitrary[B], shrB: Shrink[B],
-        arbC: Arbitrary[C], shrC: Shrink[C],
-        arbD: Arbitrary[D], shrD: Shrink[D],
-        arbE: Arbitrary[E], shrE: Shrink[E],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        genB: org.scalatest.prop.Generator[B],
+        genC: org.scalatest.prop.Generator[C],
+        genD: org.scalatest.prop.Generator[D],
+        genE: org.scalatest.prop.Generator[E],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A, b: B, c: C, d: D, e: E) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a, b, c, d, e)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check5(fun, genA, genB, genC, genD, genE, param, prettifier, pos, List.empty)
     }
 
   /**
    * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators, modifying the values in the implicitly passed 
-   * <code>PropertyGenConfig</code> object with parameter values passed to this object's constructor.
+   * supplied by implicitly passed generators, modifying the values in the implicitly passed
+   * <code>PropertyCheckConfiguration</code> object with parameter values passed to this object's constructor.
    *
    * <p>
    * Here's an example:
@@ -935,264 +723,157 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    */
     def apply[A, B, C, D, E, F, ASSERTION](fun: (A, B, C, D, E, F) => ASSERTION)
       (implicit
-        config: PropertyCheckConfigurable,
-        arbA: Arbitrary[A], shrA: Shrink[A],
-        arbB: Arbitrary[B], shrB: Shrink[B],
-        arbC: Arbitrary[C], shrC: Shrink[C],
-        arbD: Arbitrary[D], shrD: Shrink[D],
-        arbE: Arbitrary[E], shrE: Shrink[E],
-        arbF: Arbitrary[F], shrF: Shrink[F],
-        asserting: CheckerAsserting[ASSERTION],
+        config: PropertyCheckConfiguration,
+        genA: org.scalatest.prop.Generator[A],
+        genB: org.scalatest.prop.Generator[B],
+        genC: org.scalatest.prop.Generator[C],
+        genD: org.scalatest.prop.Generator[D],
+        genE: org.scalatest.prop.Generator[E],
+        genF: org.scalatest.prop.Generator[F],
+        asserting: PropCheckerAsserting[ASSERTION],
         prettifier: Prettifier,
         pos: source.Position
       ): asserting.Result = {
-        val propF = { (a: A, b: B, c: C, d: D, e: E, f: F) =>
-          val (unmetCondition, exception) =
-            try {
-              fun(a, b, c, d, e, f)
-              (false, None)
-            }
-            catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
-            }
-          propBoolean(!unmetCondition) ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
-        }
-        val prop = Prop.forAll(propF)
-        val params = getScalaCheckParams(configParams, config)
-        asserting.check(prop, params, prettifier, pos)
+      val param = getParameter(configParams, config)
+      asserting.check6(fun, genA, genB, genC, genD, genE, genF, param, prettifier, pos, List.empty)
     }
   }
+
+  import GeneratorDrivenPropertyChecks.prettyArgs
+
 """
 
-val propertyCheckForAllTemplate = """
-  /**
-   * Performs a property check by applying the specified property check function to arguments
-   * supplied by implicitly passed generators.
-   *
-   * <p>
-   * Here's an example:
-   * </p>
-   *
-   * <pre class="stHighlight">
-   * forAll { ($namesAndTypes$) =>
-   *   $sumOfArgLengths$ should equal (($sumOfArgs$).length)
-   * }
-   * </pre>
-   *
-   * @param fun the property check function to apply to the generated arguments
-   */
+  val propertyCheckForAllTemplate = """
   def forAll[$alphaUpper$, ASSERTION](fun: ($alphaUpper$) => ASSERTION)
+  (implicit
+    config: PropertyCheckConfiguration,
+    $gens$,
+    prettifier: Prettifier,
+    pos: source.Position,
+    asserting: PropCheckerAsserting[ASSERTION]
+  ): asserting.Result =
+    asserting.check$n$(fun, $genRefs$, getParameter(List.empty, config), prettifier, pos, List.empty)
+
+  def forAll[$alphaUpper$, ASSERTION]($namesAndTypes$)(fun: ($alphaUpper$) => ASSERTION)
     (implicit
-      config: PropertyCheckConfigurable,
-$arbShrinks$,
-        asserting: CheckerAsserting[ASSERTION],
-        prettifier: Prettifier,
-        pos: source.Position
+      config: PropertyCheckConfiguration,
+$gens$,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
+    ): asserting.Result =
+      asserting.check$n$(fun, $genRefs$, getParameter(List.empty, config), prettifier, pos, List($alphaLower$))
+
+  def forAll[$alphaUpper$, ASSERTION]($namesAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
+    (implicit
+      config: PropertyCheckConfiguration,
+$gens$,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
+    ): asserting.Result =
+      asserting.check$n$(fun, $genRefs$, getParameter(configParams, config), prettifier, pos, List($alphaLower$))
+
+  def forAll[$alphaUpper$, ASSERTION]($gens$)(fun: ($alphaUpper$) => ASSERTION)
+    (implicit
+      config: PropertyCheckConfiguration,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
+    ): asserting.Result =
+    asserting.check$n$(fun, $genRefs$, getParameter(List.empty, config), prettifier, pos, List.empty)
+
+  def forAll[$alphaUpper$, ASSERTION]($gens$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
+    (implicit
+      config: PropertyCheckConfiguration,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
+    ): asserting.Result =
+    asserting.check$n$(fun, $genRefs$, getParameter(configParams, config), prettifier, pos, List.empty)
+
+  def forAll[$alphaUpper$, ASSERTION]($gensAndNames$)(fun: ($alphaUpper$) => ASSERTION)
+    (implicit
+      config: PropertyCheckConfiguration,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
     ): asserting.Result = {
-      val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
-          try {
-            fun($alphaLower$)
-            (false, None)
-          }
-          catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
-          }
-        propBoolean(!unmetCondition) ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-        )
-      }
-      val prop = Prop.forAll(propF)
-      val params = getScalaCheckParams(Seq(), config)
-      asserting.check(prop, params, prettifier, pos)
+    $tupleBusters$
+    asserting.check$n$(fun, $genRefs$, getParameter(List.empty, config), prettifier, pos, List($argNameNames$))
   }
 
-  /**
-   * Performs a property check by applying the specified property check function with the specified
-   * argument names to arguments supplied by implicitly passed generators.
-   *
-   * <p>
-   * Here's an example:
-   * </p>
-   *
-   * <pre class="stHighlight">
-   * forAll ($argNames$) { ($namesAndTypes$) =>
-   *   $sumOfArgLengths$ should equal (($sumOfArgs$).length)
-   * }
-   * </pre>
-   *
-   * @param fun the property check function to apply to the generated arguments
-   */
-  def forAll[$alphaUpper$, ASSERTION]($argNameNamesAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
+  def forAll[$alphaUpper$, ASSERTION]($gensAndNames$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
     (implicit
-      config: PropertyCheckConfigurable,
-$arbShrinks$,
-        asserting: CheckerAsserting[ASSERTION],
-        prettifier: Prettifier,
-        pos: source.Position
+      config: PropertyCheckConfiguration,
+      prettifier: Prettifier,
+      pos: source.Position,
+      asserting: PropCheckerAsserting[ASSERTION]
     ): asserting.Result = {
-      val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
-          try {
-            fun($alphaLower$)
-            (false, None)
-          }
-          catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
-          }
-        propBoolean(!unmetCondition) ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-        )
-      }
-      val prop = Prop.forAll(propF)
-      val params = getScalaCheckParams(configParams, config)
-      asserting.check(prop, params, prettifier, pos, Some(List($argNameNames$)))
-  }
+      $tupleBusters$
+      asserting.check$n$(fun, $genRefs$, getParameter(configParams, config), prettifier, pos, List($argNameNames$))
+    }
 
-  /**
-   * Performs a property check by applying the specified property check function to arguments
-   * supplied by the specified generators.
-   *
-   * <p>
-   * Here's an example:
-   * </p>
-   *
-   * <pre class="stHighlight">
-   * import org.scalacheck.Gen
-   *
-   * // Define your own string generator:
-   * val famousLastWords = for {
-   *   s <- Gen.oneOf("the", "program", "compiles", "therefore", "it", "should", "work")
-   * } yield s
-   * 
-   * forAll ($famousArgs$) { ($namesAndTypes$) =>
-   *   $sumOfArgLengths$ should equal (($sumOfArgs$).length)
-   * }
-   * </pre>
-   *
-   * @param fun the property check function to apply to the generated arguments
-   */
-  def forAll[$alphaUpper$, ASSERTION]($genArgsAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
-    (implicit
-      config: PropertyCheckConfigurable,
-$shrinks$,
-        asserting: CheckerAsserting[ASSERTION],
-        prettifier: Prettifier,
-        pos: source.Position
-    ): asserting.Result = {
-      val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
-          try {
-            fun($alphaLower$)
-            (false, None)
-          }
-          catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
-          }
-        propBoolean(!unmetCondition) ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-        )
-      }
-      val prop = Prop.forAll($genArgs$)(propF)
-      val params = getScalaCheckParams(configParams, config)
-      asserting.check(prop, params, prettifier, pos)
-  }
-
-  /**
-   * Performs a property check by applying the specified property check function to named arguments
-   * supplied by the specified generators.
-   *
-   * <p>
-   * Here's an example:
-   * </p>
-   *
-   * <pre class="stHighlight">
-   * import org.scalacheck.Gen
-   *
-   * // Define your own string generator:
-   * val famousLastWords = for {
-   *   s <- Gen.oneOf("the", "program", "compiles", "therefore", "it", "should", "work")
-   * } yield s
-   * 
-   * forAll ($nameGenTuples$) { ($namesAndTypes$) =>
-   *   $sumOfArgLengths$ should equal (($sumOfArgs$).length)
-   * }
-   * </pre>
-   *
-   * @param fun the property check function to apply to the generated arguments
-   */
-  def forAll[$alphaUpper$, ASSERTION]($nameAndGenArgsAndTypes$, configParams: PropertyCheckConfigParam*)(fun: ($alphaUpper$) => ASSERTION)
-    (implicit
-      config: PropertyCheckConfigurable,
-$shrinks$,
-        asserting: CheckerAsserting[ASSERTION],
-        prettifier: Prettifier,
-        pos: source.Position
-    ): asserting.Result = {
-
-$tupleBusters$
-
-      val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
-          try {
-            fun($alphaLower$)
-            (false, None)
-          }
-          catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
-          }
-        propBoolean(!unmetCondition) ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-        )
-      }
-      val prop = Prop.forAll($genArgs$)(propF)
-      val params = getScalaCheckParams(configParams, config)
-      asserting.check(prop, params, prettifier, pos, Some(List($argNameNames$)))
-  }
 """
 
-val generatorDrivenPropertyChecksCompanionObjectVerbatimString = """
+  val generatorDrivenPropertyChecksCompanionObjectVerbatimString = """
 
-object GeneratorDrivenPropertyChecks extends GeneratorDrivenPropertyChecks
+object GeneratorDrivenPropertyChecks extends GeneratorDrivenPropertyChecks {
+
+  import FailureMessages.decorateToStringValue
+  private def prettyArgs(args: List[Any], prettifier: Prettifier) = {
+    val strs = for((a, i) <- args.zipWithIndex) yield (
+      "    " +
+      (
+        a match {
+          case PropertyArgument(Some(label), value) => label + " = " + decorateToStringValue(prettifier, value)
+          case PropertyArgument(None, value) => "arg" + i + " = " + decorateToStringValue(prettifier, value)
+          case other => "arg" + i + " = " + decorateToStringValue(prettifier, other)
+        }
+      ) +
+      (if (i < args.length - 1) "," else "") // +
+      // (if (a.shrinks > 0) " // " + a.shrinks + (if (a.shrinks == 1) " shrink" else " shrinks") else "")
+    )
+    strs.mkString("\n")
+  }
+
+}
 """
 
-val generatorSuitePreamble = """
+  val generatorSuitePreamble = """
 
 import org.scalatest.Matchers
 import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
-import org.scalacheck.Gen
 """
 
-val generatorSuitePostamble = """
+  val generatorSuitePostamble = """
   val famousLastWords = for {
-    s <- Gen.oneOf("the", "program", "compiles", "therefore", "it", "should", "work")
+    s <- org.scalatest.prop.CommonGenerators.specificValues("the", "program", "compiles", "therefore", "it", "should", "work")
   } yield s
 
-  val sevenEleven: Gen[String] =
-    Gen.sized { (size: Int) =>
-      if (size >= 7 && size <= 11)
-        Gen.const("OKAY")
-      else
-        throw new Exception("expected 7 <= size <= 11 but got " + size)
+  val sevenEleven: Generator[String] =
+    new Generator[String] {
+      def next(szp: SizeParam, edges: List[String], rnd: Randomizer): (String, List[String], Randomizer) = {
+        if (szp.size.value >= 7 && szp.size.value <= 11)
+          ("OKAY", edges, rnd)
+        else
+          throw new Exception("expected 7 <= size <= 11 but got " + szp.size)
+      }
     }
 
-  val fiveFive: Gen[String] =
-    Gen.sized { (size: Int) =>
-      if (size == 5)
-        Gen.const("OKAY")
-      else
-        throw new Exception("expected size 5 but got " + size)
+
+  val fiveFive: Generator[String] =
+    new Generator[String] {
+      def next(szp: SizeParam, edges: List[String], rnd: Randomizer): (String, List[String], Randomizer) = {
+        if (szp.size.value == 5)
+          ("OKAY", edges, rnd)
+        else
+          throw new Exception("expected size 5 but got " + szp.size)
+      }
     }
 """
 
-val generatorSuiteTemplate = """
+  val generatorSuiteAssertTemplate = """
 
   it("generator-driven property that takes $n$ args, which succeeds") {
 
@@ -1873,7 +1554,7 @@ $lengthAssertions$
 $lengthAssertions$
     }
   }
- 
+
   // set minSize == maxSize with (param, param) (ensure always passed with that size)
   it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
 
@@ -2031,508 +1712,2241 @@ $okayAssertions$
   }
 """
 
-val checkersSuiteTemplate = """
+  val generatorSuiteFutureAssertTemplate = """
 
-  it("ScalaCheck property that takes $n$ args, which succeeds") {
-
-    check { ($namesAndTypes$) =>
-      $sumOfArgLengths$ == (($sumOfArgs$).length)
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      check { ($namesAndTypes$) =>
-        $sumOfArgLengths$ < 0
+  it("generator-driven property that takes $n$ args, which succeeds") {
+    forAll { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
       }
     }
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds") {
-
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      $sumOfArgLengths$ == (($sumOfArgs$).length)
+  it("generator-driven property that takes $n$ args, which fails in future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
     }
-    check(prop)
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which fails") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        $sumOfArgLengths$ < 0
+  it("generator-driven property that takes $n$ args, which fails before future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
       }
-      check(prop)
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds") {
+    forAll ($argNames$) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails in future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails before future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds") {
+    forAll ($famousArgs$) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails in future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds") {
+    forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
     }
   }
 
   // Same thing, but with config params
-  it("ScalaCheck property that takes $n$ args, which succeeds, with config params") {
-
-    check(
-      ($namesAndTypes$) => $sumOfArgLengths$ == (($sumOfArgs$).length),
-      minSize(10),
-      maxSize(20)
-    )
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails, with config params") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      check(
-        ($namesAndTypes$) => $sumOfArgLengths$ < 0,
-        minSize(10),
-        maxSize(20)
-      )
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds, with config params") {
-
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      $sumOfArgLengths$ == (($sumOfArgs$).length)
-    }
-    check(prop, minSize(10), maxSize(20))
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which fails, with config params") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        $sumOfArgLengths$ < 0
+  it("generator-driven property that takes $n$ args, which succeeds, with config params") {
+    forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
       }
-      check(prop, minSize(10), maxSize(20))
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails in future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails before future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with config params") {
+    forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails in future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails before future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with config params") {
+    forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails in future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with config params") {
+    forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+      Future {
+        assert($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        Future {
+          assert($sumOfArgLengths$ < 0)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block, with config params") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        assert($sumOfArgLengths$ < 0)
+        Future {
+          assert(true)
+        }
+      }
     }
   }
 
   // Same thing, but set minSuccessful to 5 with param, prop fails after 5
-  it("ScalaCheck property that takes $n$ args, which succeeds, with minSuccessful param set to 5") {
-
+  it("generator-driven property that takes $n$ args, which succeeds, with minSuccessful param set to 5") {
     var i = 0
-    check(
-      ($namesAndTypes$) => {
-        val res = i != 5
+    forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+      Future {
         i += 1
-        res
-      },
-      minSuccessful(5)
-    )
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails, with minSuccessful param set to 5") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      check(
-        ($namesAndTypes$) => {
-          val res = i != 4
-          i += 1
-        res
-        },
-        minSuccessful(5)
-      ) 
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5") {
-
-    var i = 0
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      val res = i != 5
-      i += 1
-      res
-    }
-    check(prop, minSuccessful(5))
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which fails, with minSuccessful param set to 5") {
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        val res = i != 4
-        i += 1
-        res
+        assert(i != 6)
       }
-      check(prop, minSuccessful(5))
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails in future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails before future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails in future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails before future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails in future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block, with minSuccessful param set to 5") {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
     }
   }
 
   // Same thing, but set default minSuccessful to 5, prop fails after 5
-  it("ScalaCheck property that takes $n$ args, which succeeds, with default minSuccessful param set to 5") {
+  it("generator-driven property that takes $n$ args, which succeeds, with default minSuccessful param set to 5") {
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    forAll { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails in future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails before future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default minSuccessful param set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
 
     var i = 0
-    check { ($namesAndTypes$) =>
-      val res = i != 5
-      i += 1
-      res
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails, with default minSuccessful param set to 5") {
-
-    // Hides the member
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      check { ($namesAndTypes$) =>
-        val res = i != 4
+    forAll ($argNames$) { ($namesAndTypes$) =>
+      Future {
         i += 1
-        res
+        assert(i != 6)
       }
     }
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5") {
+  it("generator-driven property that takes $n$ named args, which fails in future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
 
     var i = 0
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      val res = i != 5
-      i += 1
-      res
+    forAll ($famousArgs$) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
     }
-    check(prop)
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which fails, with default minSuccessful param set to 5") {
+  it("generator-driven property that takes $n$ args and generators, which fails in future block, with default minSuccessful param set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
 
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
       var i = 0
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        val res = i != 4
-        i += 1
-        res
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
       }
-      check(prop)
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        assert(i != 6)
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          assert(i != 5)
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        assert(i != 5)
+        Future {
+          assert(true)
+        }
+      }
     }
   }
 
   // Same thing, but set maxDiscarded to 5 with param, prop fails after 5
-  it("ScalaCheck property that takes $n$ args, which succeeds, with maxDiscarded param set to 5") {
+  it("generator-driven property that takes $n$ args, which succeeds, with maxDiscarded param set to 5") {
 
     var i = 0
-    check(
-      ($namesAndTypes$) => {
+    forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+      Future {
         i += 1
-        (i > 5) ==> { 1 + 1 == (2) }
-      },
-      maxDiscarded(5)
-    )
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails, with maxDiscarded param set to 5") {
-
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      check(
-        ($namesAndTypes$) => {
-          i += 1
-          (i > 7) ==> { 1 + 1 == (2) }
-        },
-        maxDiscarded(5)
-      ) 
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5") {
-
-    var i = 0
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      i += 1
-      (i > 5) ==> { 1 + 1 == (2) }
-    }
-    check(prop, maxDiscarded(5))
-  }
-
-  it("ScalaCheck property that takes $n$ args and generators, which fails, with maxDiscarded param set to 5") {
-
-    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        i += 1
-        (i > 7) ==> { 1 + 1 == (2) }
+        whenever (i > 5) { assert(1 + 1 === (2)) }
       }
-      check(prop, maxDiscarded(5))
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails in future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails before future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with maxDiscarded param set to 5") {
+    var i = 0
+    forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails in future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails before future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails in future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
     }
   }
 
   // Same thing, but set default maxDiscarded to 5, prop fails after 5
-  it("ScalaCheck property that takes $n$ args, which succeeds, with default maxDiscarded set to 5") {
+  it("generator-driven property that takes $n$ args, which succeeds, with default maxDiscarded set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
 
     var i = 0
-    check { ($namesAndTypes$) =>
-      i += 1
-      (i > 5) ==> { 1 + 1 == (2) }
-    }
-  }
-
-  it("ScalaCheck property that takes $n$ args, which fails, with default maxDiscarded set to 5") {
-
-    // Hides the member
-    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
-
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
-      var i = 0
-      check { ($namesAndTypes$) =>
+    forAll { ($namesAndTypes$) =>
+      Future {
         i += 1
-        (i > 7) ==> { 1 + 1 == (2) }
+        whenever (i > 5) { assert(1 + 1 === (2)) }
       }
     }
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5") {
+  it("generator-driven property that takes $n$ args, which fails in future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args, which fails before future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default maxDiscarded set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
 
     var i = 0
-    val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-      i += 1
-      (i > 5) ==> { 1 + 1 == (2) }
+    forAll ($argNames$) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
     }
-    check(prop)
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which fails, with default maxDiscarded set to 5") {
+  it("generator-driven property that takes $n$ named args, which fails in future block, with default maxDiscarded set to 5") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
 
-    intercept[GeneratorDrivenPropertyCheckFailedException] {
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
       var i = 0
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        i += 1
-        (i > 7) ==> { 1 + 1 == (2) }
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
       }
-      check(prop)
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails before future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    forAll ($famousArgs$) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails in future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails before future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+      Future {
+        i += 1
+        whenever (i > 5) { assert(1 + 1 === (2)) }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails in future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        Future {
+          i += 1
+          whenever (i > 7) { assert(1 + 1 === (2)) }
+        }
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails before future block, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    recoverToSucceededIf[GeneratorDrivenPropertyCheckFailedException] {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { assert(1 + 1 === (2)) }
+        Future {
+          whenever (i > 7) { assert(true) }
+        }
+      }
     }
   }
 
   // set minSize > maxSize with (param, param) (intercept IAE)
-  it("ScalaCheck property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
-
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
     intercept[IllegalArgumentException] {
-      check(
-        ($namesAndTypes$) => {
-          1 + 1 == (2)
-        },
-        minSize(5),
-        maxSize(4)
-      ) 
+      forAll (minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
     }
+    succeed
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
-
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
     intercept[IllegalArgumentException] {
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        1 + 1 == (2)
+      forAll ($argNames$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
       }
-      check(prop, minSize(5), maxSize(4))
     }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
   }
 
   // set minSize > maxSize with (param, default) (intercept IAE)
-  it("ScalaCheck property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
 
     intercept[IllegalArgumentException] {
-      check(
-        ($namesAndTypes$) => {
-          1 + 1 == (2)
-        },
-        minSize(5)
-      )
+      forAll (minSize(5)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
     }
+    succeed
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
 
     intercept[IllegalArgumentException] {
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        1 + 1 == (2)
+      forAll ($argNames$, minSize(5)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
       }
-      check(prop, minSize(5))
     }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
   }
 
   // set minSize > maxSize with (default, param) (intercept IAE)
-  it("ScalaCheck property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
 
     intercept[IllegalArgumentException] {
-      check(
-        ($namesAndTypes$) => {
-          1 + 1 == (2)
-        },
-        maxSize(4)
-      )
+      forAll (maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
     }
+    succeed
   }
 
-  it("ScalaCheck property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
 
     intercept[IllegalArgumentException] {
-      val prop = forAll ($famousArgs$) { ($namesAndTypes$) =>
-        1 + 1 == (2)
+      forAll ($argNames$, maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
       }
-      check(prop, maxSize(4))
     }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, maxSize(4)) { ($namesAndTypes$) =>
+        Future {
+          assert(1 + 1 === (2))
+        }
+      }
+    }
+    succeed
   }
 
   // set maxSize with param (ensure always passed with a size less than maxSize)
-  it("ScalaCheck property that takes $n$ args, with maxSize specified as param") {
+  it("generator-driven property that takes $n$ args, with maxSize specified as param") {
 
-    check(
-      ($namesAndTypes$) => {
-$lengthExpressions$
-      },
-      maxSize(5)
-    ) 
+    forAll (maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$lengthAssertions$
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as param") {
+
+    forAll ($argNames$, maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$lengthAssertions$
+      }
+    }
   }
 
   // set maxSize with default (ensure always passed with a size less than maxSize)
-  it("ScalaCheck property that takes $n$ args, with maxSize specified as default") {
+  it("generator-driven property that takes $n$ args, with maxSize specified as default") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
 
-    check { ($namesAndTypes$) =>
-$lengthExpressions$
+    forAll { ($namesAndTypes$) =>
+      Future {
+$lengthAssertions$
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as default") {
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    forAll ($argNames$) { ($namesAndTypes$) =>
+      Future {
+$lengthAssertions$
+      }
     }
   }
 
   // set minSize == maxSize with (param, param) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
-
-    val prop = forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
+    forAll ($fiveFiveArgs$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, minSize(5), maxSize(5))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, param)") {
+    forAll ($fiveFiveNameGenTuples$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize == maxSize with (param, default) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize == maxSize, specified as (param, default)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
 
-    val prop = forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($fiveFiveArgs$, minSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, minSize(5))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    forAll ($fiveFiveNameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize == maxSize with (default, param) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize == maxSize, specified as (default, param)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, param)") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
 
-    val prop = forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($fiveFiveArgs$, maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, maxSize(5))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    forAll ($fiveFiveNameGenTuples$, maxSize(5)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize == maxSize with (default, default) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize == maxSize, specified as (default, default)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
 
-    val prop = forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    forAll ($fiveFiveNameGenTuples$) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize to 7 and maxSize to 11 with (param, param) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
 
-    val prop = forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($sevenElevenArgs$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, minSize(7), maxSize(11))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    forAll ($sevenElevenNameGenTuples$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize to 7 and maxSize to 11 with (param, default) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
 
-    val prop = forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($sevenElevenArgs$, minSize(7)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, minSize(7))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    forAll ($sevenElevenNameGenTuples$, minSize(7)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize to 7 and maxSize to 11 with (default, param) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
 
     // Hides the member
     implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
 
-    val prop = forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($sevenElevenArgs$, maxSize(11)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop, maxSize(11))
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    forAll ($sevenElevenNameGenTuples$, maxSize(11)) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 
   // set minSize to 7 and maxSize to 11 with (default, default) (ensure always passed with that size)
-  it("ScalaCheck property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
 
     // Hides the member
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
 
-    val prop = forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
-$okayExpressions$
+    forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
     }
-    check(prop)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    forAll ($sevenElevenNameGenTuples$) { ($namesAndTypes$) =>
+      Future {
+$okayAssertions$
+      }
+    }
   }
 """
-// 1712  2205
 
-// For some reason that I don't understand, I need to leave off the stars before the <pre> when 
-// they are next to ST commands. So I say  "   <pre>" sometimes instead of " * <pre>".
+  val generatorSuiteExpectTemplate = """
+
+  it("generator-driven property that takes $n$ args, which succeeds") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but with config params
+  it("generator-driven property that takes $n$ args, which succeeds, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set minSuccessful to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default minSuccessful to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default minSuccessful param set to 5") {
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set maxDiscarded to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default maxDiscarded to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // set minSize > maxSize with (param, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (param, default) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (default, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll (maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set maxSize with param (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as param") {
+    val result =
+    forAll (maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as param") {
+    val result =
+    forAll ($argNames$, maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set maxSize with default (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($argNames$) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenArgs$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, returns VacuousYes should be considered discarded evaluation") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        val x = -1
+        expect(x > 0) implies expect(x > -1)
+      }
+    assert(result.isNo)
+  }
+"""
+
+  // 1712  2205
+
+  // For some reason that I don't understand, I need to leave off the stars before the <pre> when
+  // they are next to ST commands. So I say  "   <pre>" sometimes instead of " * <pre>".
 
   val thisYear = Calendar.getInstance.get(Calendar.YEAR)
 
   def genPropertyChecks(targetDir: File): Seq[File] = {
     targetDir.mkdirs()
+
     val targetFile = new File(targetDir, "GeneratorDrivenPropertyChecks.scala")
 
     if (!targetFile.exists || generatorSource.lastModified > targetFile.lastModified) {
       val bw = new BufferedWriter(new FileWriter(targetFile))
+
       try {
         val st = new org.antlr.stringtemplate.StringTemplate(copyrightTemplate)
         st.setAttribute("year", thisYear);
@@ -2551,6 +3965,31 @@ $okayExpressions$
           val shrinks = alpha.take(i).toUpperCase.map(
             c => "      shr" + c + ": Shrink[" + c + "]"
           ).mkString(",\n")
+
+          val gens = alpha.take(i).toUpperCase.map(
+            c => "      gen" + c + ": org.scalatest.prop.Generator[" + c + "]"
+          ).mkString(",\n")
+
+          val genRefs = alpha.take(i).toUpperCase.map(
+            c => "gen" + c
+          ).mkString(", ")
+
+          val gensAndNames = alpha.take(i).toUpperCase.map(
+            c => "      genAndName" + c + ": (org.scalatest.prop.Generator[" + c + "], String)"
+          ).mkString(",\n")
+
+          val stepToStepToResult =
+            "        val (a, ar) = genA.next(10, nextRandomizer)" + "\n" +
+              (if (i > 1)
+                alpha.take(i).sliding(2).map {
+                  ab =>
+                    val a = ab.charAt(0)
+                    val b = ab.charAt(1)
+                    "      val (" + b + ", " + b + "r) = gen" + b.toString.toUpperCase + ".next(10, " + a + "r)"
+                }.mkString("\n")
+              else
+                "")
+
           val sumOfArgLengths = alpha.take(i).map(_ + ".length").mkString(" + ")
           val namesAndTypes = alpha.take(i).map(_ + ": String").mkString(", ")
           val sumOfArgs = alpha.take(i).mkString(" + ")
@@ -2567,8 +4006,13 @@ $okayExpressions$
           st.setAttribute("argType", argType)
           st.setAttribute("arbShrinks", arbShrinks)
           st.setAttribute("shrinks", shrinks)
+          st.setAttribute("gens", gens)
+          st.setAttribute("genRefs", genRefs)
+          st.setAttribute("gensAndNames", gensAndNames)
+          st.setAttribute("stepToStepToResult", stepToStepToResult)
           st.setAttribute("alphaLower", alphaLower)
           st.setAttribute("alphaUpper", alphaUpper)
+          st.setAttribute("alphaLast", alpha.take(i).last.toString)
           st.setAttribute("strings", strings)
           st.setAttribute("sumOfArgLengths", sumOfArgLengths)
           st.setAttribute("namesAndTypes", namesAndTypes)
@@ -2584,33 +4028,114 @@ $okayExpressions$
           st.setAttribute("argNameNamesAndTypes", argNameNamesAndTypes)
           bw.write(st.toString)
         }
-
         bw.write("}\n")
         bw.write(generatorDrivenPropertyChecksCompanionObjectVerbatimString)
       }
       finally {
-        bw.flush()
         bw.close()
-        println("###Generated: " + targetFile.getAbsolutePath)
       }
     }
 
     Seq(targetFile)
   }
 
+  val generatorTemplate =
+    """private[prop] class GeneratorFor$arity$[$alphaUpper$](
+      |  $initToLastName$: $initType$ => $lastType$,
+      |  $lastToInitName$: $lastType$ => $initType$
+      |)(
+      |  $initGensDecls$
+      |) extends Generator[$lastType$] { thisGenerator =>
+      |
+      |  private val underlying: Generator[$lastType$] = {
+      |    for {
+      |      $initGenArrows$
+      |    } yield $initToLastName$($initLower$)
+      |  }
+      |
+      |  def next(szp: SizeParam, edges: List[$lastType$], rnd: Randomizer): ($lastType$, List[$lastType$], Randomizer) = underlying.next(szp, edges, rnd)
+      |  override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[$lastType$], Randomizer) = underlying.initEdges(maxLength, rnd)
+      |  override def map[Z](f: ($lastType$) => Z): Generator[Z] = underlying.map(f)
+      |  override def flatMap[Z](f: ($lastType$) => Generator[Z]): Generator[Z] = underlying.flatMap(f)
+      |  override def canonicals(rnd: Randomizer): (Iterator[$lastType$], Randomizer) = underlying.canonicals(rnd)
+      |  override def shrink(lastValue: $lastType$, rnd0: Randomizer): (Iterator[$lastType$], Randomizer) = {
+      |    val ($initLower$) = $lastToInitName$(lastValue)
+      |    $initShrinks$
+      |    $initStreams$
+      |    val streamOf$lastType$: Stream[$lastType$] = // TODO: check about the problem with streams and memory leaks, or do this a different way
+      |      for {
+      |        $initStreamArrows$
+      |      } yield $initToLastName$($initLower$)
+      |    (streamOf$lastType$.iterator, rnd$arity$)
+      |  }
+      |}
+    """.stripMargin
+
+  def genGenerators(targetDir: File): Seq[File] = {
+    targetDir.mkdirs()
+
+    val alphaAll = "abcdefghijklmnopqrstuvw"
+
+    for (i <- 1 to 22) yield {
+
+      val alpha = alphaAll.take(i + 1)
+      val alphaLower = alpha.mkString(", ")
+      val initLower = alpha.init.mkString(", ")
+      val alphaUpper = alpha.toUpperCase.mkString(", ")
+      val initToLastName = alpha.init.head + alpha.init.tail.toUpperCase + "To" + alpha.last.toString.toUpperCase
+      val lastToInitName = alpha.last.toString + "To" + alpha.init.toUpperCase
+      val initType = if (i > 1) "(" + alpha.init.mkString(", ").toUpperCase + ")" else alpha.init.mkString(", ").toUpperCase
+      val lastType = alphaUpper.last.toString
+      val initGensDecls = alpha.init.map(a => "genOf" + a.toString.toUpperCase + ": Generator[" + a.toString.toUpperCase + "]").mkString(", \n")
+      val initGenArrows = alpha.init.map(a => a + " <- genOf" + a.toString.toUpperCase).mkString("\n")
+      val initShrinks = alpha.init.zipWithIndex.map { case (a, idx) =>
+        "val (itOf" + a.toString.toUpperCase + ", rnd" + (idx + 1) + ") = genOf" + a.toString.toUpperCase + ".shrink(" + a + ", rnd" + idx + ")"
+      }.mkString("\n")
+      val initStreams = alpha.init.map(a => "val streamOf" + a.toString.toUpperCase + ": Stream[" + a.toString.toUpperCase + "] = itOf" + a.toString.toUpperCase + ".toStream").mkString("\n")
+      val initStreamArrows = alpha.init.map(a => a + " <- streamOf" + a.toString.toUpperCase).mkString("\n")
+
+      val targetFile = new File(targetDir, "GeneratorFor" + i + ".scala")
+
+      if (!targetFile.exists || generatorSource.lastModified > targetFile.lastModified) {
+        val bw = new BufferedWriter(new FileWriter(targetFile))
+        val stCopyRight = new org.antlr.stringtemplate.StringTemplate(copyrightTemplate)
+        stCopyRight.setAttribute("year", thisYear)
+        bw.write(stCopyRight.toString)
+
+        val st = new org.antlr.stringtemplate.StringTemplate(generatorTemplate)
+        st.setAttribute("arity", i)
+        st.setAttribute("alphaUpper", alphaUpper)
+        st.setAttribute("initLower", initLower)
+        st.setAttribute("initToLastName", initToLastName)
+        st.setAttribute("lastToInitName", lastToInitName)
+        st.setAttribute("initType", initType)
+        st.setAttribute("lastType", lastType)
+        st.setAttribute("initGensDecls", initGensDecls)
+        st.setAttribute("initGenArrows", initGenArrows)
+        st.setAttribute("initShrinks", initShrinks)
+        st.setAttribute("initStreams", initStreams)
+        st.setAttribute("initStreamArrows", initStreamArrows)
+
+        bw.write(st.toString)
+
+        bw.flush()
+        bw.close()
+      }
+
+      targetFile
+    }
+  }
+
   // Invitation style indicates how GeneratorDrivenPropertyChecks is imported
-  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, doItForCheckers: Boolean): Seq[File] = {
+  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, generatorSuiteTemplate: String, checkMethod: String, async: Boolean): Seq[File] = {
 
     targetDir.mkdirs()
-    
-    val traitOrObjectName =
-      if (doItForCheckers)
-        "Checkers"
-      else {
-        if (withTables) "PropertyChecks" else "GeneratorDrivenPropertyChecks"
-      }
-    val suiteClassName = traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite" 
-    val fileName = suiteClassName + ".scala" 
+
+    val traitOrObjectName = if (withTables) "PropertyChecks" else "GeneratorDrivenPropertyChecks"
+
+    val asyncPrefix = if (async) "Async" else ""
+    val suiteClassName = asyncPrefix + traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite"
+    val fileName = checkMethod.capitalize + suiteClassName + ".scala"
 
     val targetFile = new File(targetDir, fileName)
 
@@ -2622,23 +4147,19 @@ $okayExpressions$
         st.setAttribute("year", thisYear);
         bw.write(st.toString)
         bw.write(generatorSuitePreamble)
-        if (doItForCheckers) {
-          bw.write("import org.scalacheck.Prop.{Exception => _, _}\n")
-        }
         if (!mixinInvitationStyle)
           bw.write("import " + traitOrObjectName + "._\n")
+        bw.write("import org.scalatest.Expectations._\n")
+        if (async)
+          bw.write("import scala.concurrent.Future\n")
         bw.write("\n")
         bw.write(
-          "class " + suiteClassName + " extends FunSpec " +
+          "class " + checkMethod.capitalize + suiteClassName + " extends " + asyncPrefix + "FunSpec " +
             (if (mixinInvitationStyle) "with " + traitOrObjectName else "") + " {\n")
         bw.write(generatorSuitePostamble)
         val alpha = "abcdefghijklmnopqrstuv"
         for (i <- 1 to 6) {
-          val st =
-            if (doItForCheckers)
-              new org.antlr.stringtemplate.StringTemplate(checkersSuiteTemplate)
-            else
-              new org.antlr.stringtemplate.StringTemplate(generatorSuiteTemplate)
+          val st = new org.antlr.stringtemplate.StringTemplate(generatorSuiteTemplate)
           val rowOfOnes = List.fill(i)("  1").mkString(", ")
           val rowOfTwos = List.fill(i)("  2").mkString(", ")
           val listOfIs = List.fill(i)("i").mkString(", ")
@@ -2660,8 +4181,8 @@ $okayExpressions$
           val nameGenTuples = alpha.take(i).map("(famousLastWords, \"" + _ + "\")").mkString(", ")
           val fiveFiveNameGenTuples = alpha.take(i).map("(fiveFive, \"" + _ + "\")").mkString(", ")
           val sevenElevenNameGenTuples = alpha.take(i).map("(sevenEleven, \"" + _ + "\")").mkString(", ")
-          val lengthAssertions = alpha.take(i).map("      assert(" + _ + ".length <= 5)").mkString("\n")
-          val okayAssertions = alpha.take(i).map("        assert(" + _ + " === (\"OKAY\"))").mkString("\n")
+          val lengthAssertions = alpha.take(i).map("      " + checkMethod + "(" + _ + ".length <= 5)").mkString("\n")
+          val okayAssertions = alpha.take(i).map("        " + checkMethod + "(" + _ + " === (\"OKAY\"))").mkString("\n")
           val lengthExpressions = alpha.take(i).map("      " + _ + ".length <= 5").mkString("\n")
           val okayExpressions = alpha.take(i).map("        " + _ + " == (\"OKAY\")").mkString("\n")
           st.setAttribute("n", i)
@@ -2688,18 +4209,15 @@ $okayExpressions$
         }
 
         bw.write("}\n")
-
-        println("Generated " + targetFile.getAbsolutePath)
       }
       finally {
-        bw.flush()
         bw.close()
       }
     }
 
     Seq(targetFile)
   }
-  
+
   def main(args: Array[String]) {
     val targetDir = args(0)
     val version = args(1)
@@ -2707,23 +4225,30 @@ $okayExpressions$
     val mainDir = new File(targetDir + "/main/scala/org/scalatest/prop")
     mainDir.mkdirs()
     genMain(mainDir, version, scalaVersion)
-    
+
     val testDir = new File("gentests/" + targetDir + "/test/scala/org/scalatest/prop")
     testDir.mkdirs()
     genTest(testDir, version, scalaVersion)
   }
-  
+
   def genMain(dir: File, version: String, scalaVersion: String): Seq[File] = {
-    genPropertyChecks(dir)
+    genPropertyChecks(dir) ++
+    genGenerators(dir)
   }
-  
+
   def genTest(dir: File, version: String, scalaVersion: String): Seq[File] = {
-    genGeneratorDrivenSuite(dir, true, false, false) ++
-    genGeneratorDrivenSuite(dir, false, false, false) ++
-    genGeneratorDrivenSuite(dir, true, true, false) ++
-    genGeneratorDrivenSuite(dir, false, true, false) ++
-    genGeneratorDrivenSuite(dir, true, true, true) ++
-    genGeneratorDrivenSuite(dir, false, true, true)
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteFutureAssertTemplate, "assert", true) /*++
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteExpectTemplate, "expect", false)*/
+
   }
 }
-

--- a/project/GenScalaCheckGen.scala
+++ b/project/GenScalaCheckGen.scala
@@ -53,7 +53,7 @@ import org.scalatest.enablers.CheckerAsserting
 import org.scalactic._
 
 /**
- * Trait containing methods that faciliate property checks against generated data using ScalaCheck.
+ * Trait containing methods that faciliate property checks against generated data.
  *
  * <p>
  * This trait contains <code>forAll</code> methods that provide various ways to check properties using
@@ -581,17 +581,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -626,18 +633,25 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
-          !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
+            !unmetCondition ==> (
+              if (exception.isEmpty) {
+                if (succeeded)
+                  Prop.passed
+                else
+                  Prop.falsified
+              }
+              else
+                Prop.exception(exception.get)
+            )
         }
         val prop = Prop.forAll(propF)
         val params = getScalaCheckParams(configParams, config)
@@ -672,18 +686,25 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
-          !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
-          )
+            !unmetCondition ==> (
+              if (exception.isEmpty) {
+                if (succeeded)
+                  Prop.passed
+                else
+                  Prop.falsified
+              }
+              else
+                Prop.exception(exception.get)
+            )
         }
         val prop = Prop.forAll(propF)
         val params = getScalaCheckParams(configParams, config)
@@ -719,17 +740,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -767,17 +795,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D, e: E) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d, e)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d, e))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -816,17 +851,24 @@ trait ScalaCheckDrivenPropertyChecks extends Whenever with Configuration {
         pos: source.Position
       ): asserting.Result = {
         val propF = { (a: A, b: B, c: C, d: D, e: E, f: F) =>
-          val (unmetCondition, exception) =
+          val (unmetCondition, succeeded, exception) =
             try {
-              fun(a, b, c, d, e, f)
-              (false, None)
+              val (succeeded, cause) = asserting.succeed(fun(a, b, c, d, e, f))
+              (false, succeeded, cause)
             }
             catch {
-              case e: DiscardedEvaluationException => (true, None)
-              case e: Throwable => (false, Some(e))
+              case e: DiscardedEvaluationException => (true, false, None)
+              case e: Throwable => (false, false, Some(e))
             }
           !unmetCondition ==> (
-            if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+            if (exception.isEmpty) {
+              if (succeeded)
+                Prop.passed
+              else
+                Prop.falsified
+            }
+            else
+              Prop.exception(exception.get)
           )
         }
         val prop = Prop.forAll(propF)
@@ -862,17 +904,24 @@ $arbShrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll(propF)
@@ -905,17 +954,24 @@ $arbShrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll(propF)
@@ -955,17 +1011,24 @@ $shrinks$,
         pos: source.Position
     ): asserting.Result = {
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll($genArgs$)(propF)
@@ -1008,17 +1071,24 @@ $shrinks$,
 $tupleBusters$
 
       val propF = { ($argType$) =>
-        val (unmetCondition, exception) =
+        val (unmetCondition, succeeded, exception) =
           try {
-            fun($alphaLower$)
-            (false, None)
+            val (succeeded, cause) = asserting.succeed(fun($alphaLower$))
+            (false, succeeded, cause)
           }
           catch {
-            case e: DiscardedEvaluationException => (true, None)
-            case e: Throwable => (false, Some(e))
+            case e: DiscardedEvaluationException => (true, false, None)
+            case e: Throwable => (false, false, Some(e))
           }
         !unmetCondition ==> (
-          if (exception.isEmpty) Prop.passed else Prop.exception(exception.get)
+          if (exception.isEmpty) {
+            if (succeeded)
+              Prop.passed
+            else
+              Prop.falsified
+          }
+          else
+            Prop.exception(exception.get)
         )
       }
       val prop = Prop.forAll($genArgs$)(propF)
@@ -1061,7 +1131,7 @@ import org.scalacheck.Gen
     }
                                 """
 
-  val generatorSuiteTemplate = """
+  val generatorSuiteAssertTemplate = """
 
   it("generator-driven property that takes $n$ args, which succeeds") {
 
@@ -1900,6 +1970,915 @@ $okayAssertions$
   }
                                """
 
+  val generatorSuiteExpectTemplate = """
+
+  it("generator-driven property that takes $n$ args, which succeeds") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails") {
+    val result =
+      forAll { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails") {
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails") {
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails") {
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but with config params
+  it("generator-driven property that takes $n$ args, which succeeds, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with config params") {
+    val result =
+      forAll (minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with config params") {
+    val result =
+      forAll ($argNames$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with config params") {
+    val result =
+      forAll ($famousArgs$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ === (($sumOfArgs$).length))
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with config params") {
+    val result =
+      forAll ($nameGenTuples$, minSize(10), maxSize(20)) { ($namesAndTypes$) =>
+        expect($sumOfArgLengths$ < 0)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set minSuccessful to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll (minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($argNames$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($famousArgs$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with minSuccessful param set to 5") {
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, minSuccessful(5)) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default minSuccessful to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default minSuccessful param set to 5") {
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 6)
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default minSuccessful param set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        expect(i != 5)
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set maxDiscarded to 5 with param, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll (maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with maxDiscarded param set to 5") {
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with maxDiscarded param set to 5") {
+
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$, maxDiscarded(5)) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // Same thing, but set default maxDiscarded to 5, prop fails after 5
+  it("generator-driven property that takes $n$ args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($argNames$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($famousArgs$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which succeeds, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5)
+
+    var i = 0
+    val result =
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 5) { expect(1 + 1 === (2)) }
+      }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which fails, with default maxDiscarded set to 5") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxDiscarded = 5, minSuccessful = 5)
+
+    val result = {
+      var i = 0
+      forAll ($nameGenTuples$) { ($namesAndTypes$) =>
+        i += 1
+        whenever (i > 7) { expect(1 + 1 === (2)) }
+      }
+    }
+    assert(result.isNo)
+  }
+
+  // set minSize > maxSize with (param, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, param)") {
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5), maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (param, default) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll (minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 4)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set minSize > maxSize with (default, param) (intercept IAE)
+  it("generator-driven property that takes $n$ args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll (maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($argNames$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($famousArgs$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, which should throw IAE because maxSize > maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    intercept[IllegalArgumentException] {
+      forAll ($nameGenTuples$, maxSize(4)) { ($namesAndTypes$) =>
+        expect(1 + 1 === (2))
+      }
+    }
+  }
+
+  // set maxSize with param (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as param") {
+    val result =
+    forAll (maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as param") {
+    val result =
+    forAll ($argNames$, maxSize(5)) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set maxSize with default (ensure always passed with a size less than maxSize)
+  it("generator-driven property that takes $n$ args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args, with maxSize specified as default") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($argNames$) { ($namesAndTypes$) =>
+$lengthAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, param)") {
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5), maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, minSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$, maxSize(5)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize == maxSize with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize == maxSize, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 5, maxSize = 5)
+
+    val result =
+    forAll ($fiveFiveNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, param)") {
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7), maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (param, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (param, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, minSize(7)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, param) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenArgs$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, param)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSize = 7)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$, maxSize(11)) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  // set minSize to 7 and maxSize to 11 with (default, default) (ensure always passed with that size)
+  it("generator-driven property that takes $n$ args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenArgs$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+
+  it("generator-driven property that takes $n$ named args and generators, with minSize to 7 and maxSize to 11, specified as (default, default)") {
+
+    // Hides the member
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfig(minSize = 7, maxSize = 11)
+
+    val result =
+    forAll ($sevenElevenNameGenTuples$) { ($namesAndTypes$) =>
+$okayAssertions$
+    }
+    assert(result.isYes)
+  }
+                                     """
+
   val checkersSuiteTemplate = """
 
   it("ScalaCheck property that takes $n$ args, which succeeds") {
@@ -2398,6 +3377,7 @@ $okayExpressions$
 
   def genPropertyChecks(targetDir: File): Seq[File] = {
     targetDir.mkdirs()
+
     val targetFile = new File(targetDir, "ScalaCheckDrivenPropertyChecks.scala")
 
     if (!targetFile.exists || generatorSource.lastModified > targetFile.lastModified) {
@@ -2466,7 +3446,7 @@ $okayExpressions$
   }
 
   // Invitation style indicates how GeneratorDrivenPropertyChecks is imported
-  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, doItForCheckers: Boolean): Seq[File] = {
+  def genGeneratorDrivenSuite(targetDir: File, mixinInvitationStyle: Boolean, withTables: Boolean, doItForCheckers: Boolean, generatorSuiteTemplate: String, checkMethod: String): File = {
 
     targetDir.mkdirs()
 
@@ -2474,10 +3454,10 @@ $okayExpressions$
       if (doItForCheckers)
         "Checkers"
       else {
-        if (withTables) "PropertyChecks" else "ScalaCheckDrivenPropertyChecks"
+        if (withTables) "ScalaCheckPropertyChecks" else "ScalaCheckDrivenPropertyChecks"
       }
     val suiteClassName = traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite"
-    val fileName = suiteClassName + ".scala"
+    val fileName = checkMethod.capitalize + suiteClassName + ".scala"
 
     val targetFile = new File(targetDir, fileName)
 
@@ -2494,9 +3474,11 @@ $okayExpressions$
         }
         if (!mixinInvitationStyle)
           bw.write("import " + traitOrObjectName + "._\n")
+        if (checkMethod == "expect")
+          bw.write("import org.scalatest.Expectations._\n")
         bw.write("\n")
         bw.write(
-          "class " + suiteClassName + " extends FunSpec " +
+          "class " + checkMethod.capitalize + suiteClassName + " extends FunSpec " +
             (if (mixinInvitationStyle) "with " + traitOrObjectName else "") + " {\n")
         bw.write(generatorSuitePostamble)
         val alpha = "abcdefghijklmnopqrstuv"
@@ -2527,8 +3509,8 @@ $okayExpressions$
           val nameGenTuples = alpha.take(i).map("(famousLastWords, \"" + _ + "\")").mkString(", ")
           val fiveFiveNameGenTuples = alpha.take(i).map("(fiveFive, \"" + _ + "\")").mkString(", ")
           val sevenElevenNameGenTuples = alpha.take(i).map("(sevenEleven, \"" + _ + "\")").mkString(", ")
-          val lengthAssertions = alpha.take(i).map("      assert(" + _ + ".length <= 5)").mkString("\n")
-          val okayAssertions = alpha.take(i).map("        assert(" + _ + " === (\"OKAY\"))").mkString("\n")
+          val lengthAssertions = alpha.take(i).map("      " + checkMethod + "(" + _ + ".length <= 5)").mkString("\n")
+          val okayAssertions = alpha.take(i).map("        " + checkMethod + "(" + _ + " === (\"OKAY\"))").mkString("\n")
           val lengthExpressions = alpha.take(i).map("      " + _ + ".length <= 5").mkString("\n")
           val okayExpressions = alpha.take(i).map("        " + _ + " == (\"OKAY\")").mkString("\n")
           st.setAttribute("n", i)
@@ -2560,7 +3542,8 @@ $okayExpressions$
         bw.close()
       }
     }
-    Seq(targetFile)
+
+    targetFile
   }
 
   def main(args: Array[String]) {
@@ -2581,11 +3564,20 @@ $okayExpressions$
   }
 
   def genTest(dir: File, version: String, scalaVersion: String): Seq[File] = {
-    genGeneratorDrivenSuite(dir, true, false, false) ++
-    genGeneratorDrivenSuite(dir, false, false, false) ++
-    genGeneratorDrivenSuite(dir, true, true, false) ++
-    genGeneratorDrivenSuite(dir, false, true, false) ++
-    genGeneratorDrivenSuite(dir, true, true, true) ++
-    genGeneratorDrivenSuite(dir, false, true, true)
+    Seq(
+      genGeneratorDrivenSuite(dir, true, false, false, generatorSuiteAssertTemplate, "assert"),
+      genGeneratorDrivenSuite(dir, false, false, false, generatorSuiteAssertTemplate, "assert"),
+      genGeneratorDrivenSuite(dir, true, true, false, generatorSuiteAssertTemplate, "assert"),
+      genGeneratorDrivenSuite(dir, false, true, false, generatorSuiteAssertTemplate, "assert"),
+      genGeneratorDrivenSuite(dir, true, true, true, generatorSuiteAssertTemplate, "assert"),
+      genGeneratorDrivenSuite(dir, false, true, true, generatorSuiteAssertTemplate, "assert"),
+
+      genGeneratorDrivenSuite(dir, true, false, false, generatorSuiteExpectTemplate, "expect"),
+      genGeneratorDrivenSuite(dir, false, false, false, generatorSuiteExpectTemplate, "expect"),
+      genGeneratorDrivenSuite(dir, true, true, false, generatorSuiteExpectTemplate, "expect"),
+      genGeneratorDrivenSuite(dir, false, true, false, generatorSuiteExpectTemplate, "expect"),
+      genGeneratorDrivenSuite(dir, true, true, true, generatorSuiteExpectTemplate, "expect"),
+      genGeneratorDrivenSuite(dir, false, true, true, generatorSuiteExpectTemplate, "expect")
+    )
   }
 }

--- a/project/GenScalaTestNative.scala
+++ b/project/GenScalaTestNative.scala
@@ -303,6 +303,8 @@ object GenScalaTestNative {
         "EntrySpec.scala",    // skipped because Entry extends java.util.Map
         "ExampleBeforeAfterParallelSpec.scala",
         "EveryShouldContainAllElementsOfSpec.scala", // skipped because causing crash
+        "EveryShouldContainAtLeastOneElementOfSpec.scala", // skipped because causing crash
+        "EveryShouldContainNoneOfSpec.scala", // skipped because causing crash
         "ExampleParallelSpec.scala",
         "ExampleStackSpec.scala",
         "ExampleSuiteTimeoutSpec.scala",
@@ -408,6 +410,7 @@ object GenScalaTestNative {
         "RandomTestOrderSpec.scala",
         "RecoverMethodsSpec.scala",
         "RefSpecSpec.scala",          // skipped because depends on java reflections.
+        "ResultOfAtLeastOneOfApplication.scala", // skipped because causing crash
         "RetriesSpec.scala",
         "RunningTestSpec.scala",
         "SavesConfigMapSuite.scala",    // skipped because depends on java reflection
@@ -594,6 +597,8 @@ object GenScalaTestNative {
     copyDir("scalatest-test/src/test/scala/org/scalatest/events/examples", "org/scalatest/events/examples", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/events", "org/scalatest/events", targetDir,
       List(
+        "DeprecatedLocationFunctionSuiteProp.scala",
+        "DeprecatedScopePendingProp.scala", 
         "TestLocationJUnit3Suite.scala",
         "TestLocationJUnitSuite.scala",
         "TestLocationTestNGSuite.scala",
@@ -607,15 +612,23 @@ object GenScalaTestNative {
     copyDir("scalatest-test/src/test/scala/org/scalatest/fixture", "org/scalatest/fixture", targetDir,
       List(
         "SpecSpec.scala",     // skipped because depends on java reflections
-        "SuiteSpec.scala"    // skipped because depends on java reflections,
+        "SuiteSpec.scala"    // skipped because depends on java reflections
       ) ++ asyncs("scalatest-test/src/test/scala/org/scalatest/fixture")) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
-    copyDir("scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, List.empty) ++
+    copyDir("scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir,
+      List(
+        "AsyncGeneratorDrivenPropertyChecksSpec.scala"
+      )
+    ) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/check", "org/scalatest/check", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/suiteprop", "org/scalatest/suiteprop", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/matchers", "org/scalatest/matchers", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/time", "org/scalatest/time", targetDir, List.empty) ++
-    copyDir("scalatest-test/src/test/scala/org/scalatest/words", "org/scalatest/words", targetDir, List.empty) ++
+    copyDir("scalatest-test/src/test/scala/org/scalatest/words", "org/scalatest/words", targetDir,
+      List(
+        "ResultOfNotWordForAnySpec.scala"
+      )
+    ) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/tools", "org/scalatest/tools", targetDir,
       List(
         "DashboardReporterSpec.scala",
@@ -637,7 +650,8 @@ object GenScalaTestNative {
         "StringReporterSuite.scala",
         "StringReporterSummarySpec.scala",
         "SuiteDiscoveryHelperSuite.scala",
-        "XmlSocketReporterSpec.scala"
+        "XmlSocketReporterSpec.scala",
+        "ArgsParserSpec.scala"   // skipped because it is causing crash
       )
     )
   }

--- a/scalactic-macro/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2001-2017 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalactic.source
+
+import org.scalactic.{MacroOwnerRepair, Resources}
+
+import scala.reflect.macros.Context
+
+/**
+  * Helper class for Position macro. (Will be removed from the public API if possible in a subsequent 3.0.0-RCx release.)
+  */
+object TypeInfoMacro {
+
+  /**
+    * Helper method for TypeInfo macro.
+    */
+  def genTypeInfo[T: context.WeakTypeTag](context: Context) = {
+    import context.universe._
+
+    val TypeApply(_, List(typeTree)) = context.macroApplication
+
+    val expandedCode =
+    context.Expr(
+      Apply(
+        TypeApply(
+          Select(
+            Select(
+              Select(
+                Select(
+                  Select(
+                    Ident(newTermName("_root_")),
+                    newTermName("org")
+                  ),
+                  newTermName("scalactic")
+                ),
+                newTermName("source")
+              ),
+              newTermName("TypeInfo")
+            ),
+            newTermName("apply")
+          ),
+          List(typeTree.duplicate)
+        ),
+        List(
+          Literal(Constant(typeTree.toString()))
+        )
+      )
+    )
+
+    val ownerRepair = new MacroOwnerRepair[context.type](context)
+    ownerRepair.repairOwners(expandedCode)
+  }
+
+}

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
@@ -33,16 +31,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.NumberCompatHelper
 
 trait NegDoubleSpecSupport {
-
-  val negZDoubleGen: Gen[NegZDouble] =
-    for {i <- choose(Double.MinValue, 0.0)} yield NegZDouble.ensuringValid(i)
-
-  implicit val arbNegZDouble: Arbitrary[NegZDouble] = Arbitrary(negZDoubleGen)
-
-  val negDoubleGen: Gen[NegDouble] =
-    for {i <- choose(Double.MinValue, -Double.MinPositiveValue)} yield NegDouble.ensuringValid(i)
-
-  implicit val arbNegDouble: Arbitrary[NegDouble] = Arbitrary(negDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
@@ -33,16 +31,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.NumberCompatHelper
 
 trait NegFiniteDoubleSpecSupport {
-
-  val negZFiniteDoubleGen: Gen[NegZFiniteDouble] =
-    for {i <- choose(Double.MinValue, 0.0)} yield NegZFiniteDouble.ensuringValid(i)
-
-  implicit val arbNegZFiniteDouble: Arbitrary[NegZFiniteDouble] = Arbitrary(negZFiniteDoubleGen)
-
-  val negFiniteDoubleGen: Gen[NegFiniteDouble] =
-    for {i <- choose(Double.MinValue, -Double.MinPositiveValue)} yield NegFiniteDouble.ensuringValid(i)
-
-  implicit val arbNegFiniteDouble: Arbitrary[NegFiniteDouble] = Arbitrary(negFiniteDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
@@ -32,16 +30,6 @@ import org.scalactic.NumberCompatHelper
 
 trait NegFiniteFloatSpecSupport {
 
-  val negZFiniteFloatGen: Gen[NegZFiniteFloat] =
-    for {i <- choose(Float.MinValue, 0.0f)} yield NegZFiniteFloat.ensuringValid(i)
-
-  implicit val arbNegZFiniteFloat: Arbitrary[NegZFiniteFloat] = Arbitrary(negZFiniteFloatGen)
-
-  val negFiniteFloatGen: Gen[NegFiniteFloat] =
-    for {i <- choose(Float.MinValue, -Float.MinPositiveValue)} yield NegFiniteFloat.ensuringValid(i)
-
-  implicit val arbNegFiniteFloat: Arbitrary[NegFiniteFloat] = Arbitrary(negFiniteFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
@@ -50,6 +38,11 @@ trait NegFiniteFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
@@ -32,16 +30,6 @@ import org.scalactic.NumberCompatHelper
 
 trait NegFloatSpecSupport {
 
-  val negZFloatGen: Gen[NegZFloat] =
-    for {i <- choose(Float.MinValue, 0.0f)} yield NegZFloat.ensuringValid(i)
-
-  implicit val arbNegZFloat: Arbitrary[NegZFloat] = Arbitrary(negZFloatGen)
-
-  val negFloatGen: Gen[NegFloat] =
-    for {i <- choose(Float.MinValue, -Float.MinPositiveValue)} yield NegFloat.ensuringValid(i)
-
-  implicit val arbNegFloat: Arbitrary[NegFloat] = Arbitrary(negFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
@@ -50,6 +38,11 @@ trait NegFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
@@ -15,8 +15,6 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen._
 import org.scalactic.Equality
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -27,11 +25,6 @@ import org.scalactic.{Validation, Pass, Fail}
 import org.scalactic.{Or, Good, Bad}
 
 trait NegIntSpecSupport {
-
-  val negIntGen: Gen[NegInt] =
-    for {i <- choose(Int.MinValue, -1)} yield NegInt.from(i).get
-
-  implicit val arbNegInt: Arbitrary[NegInt] = Arbitrary(negIntGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
@@ -30,11 +28,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 
 trait NegLongSpecSupport {
-
-  val negLongGen: Gen[NegLong] =
-    for {i <- choose(Long.MinValue, -1L)} yield NegLong.from(i).get
-
-  implicit val arbNegLong: Arbitrary[NegLong] = Arbitrary(negLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -33,16 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait NegZDoubleSpecSupport {
-
-  val negZDoubleGen: Gen[NegZDouble] =
-    for {i <- choose(Double.MinValue, 0.0)} yield NegZDouble.from(i).get
-
-  implicit val arbNegZDouble: Arbitrary[NegZDouble] = Arbitrary(negZDoubleGen)
-
-  val negDoubleGen: Gen[NegDouble] =
-    for {i <- choose(Double.MinValue, -Double.MinPositiveValue)} yield NegDouble.from(i).get
-
-  implicit val arbNegDouble: Arbitrary[NegDouble] = Arbitrary(negDoubleGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -33,16 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait NegZFiniteDoubleSpecSupport {
-
-  val negZFiniteDoubleGen: Gen[NegZFiniteDouble] =
-    for {i <- choose(Double.MinValue, 0.0)} yield NegZFiniteDouble.from(i).get
-
-  implicit val arbNegZFiniteDouble: Arbitrary[NegZFiniteDouble] = Arbitrary(negZFiniteDoubleGen)
-
-  val negFiniteDoubleGen: Gen[NegFiniteDouble] =
-    for {i <- choose(Double.MinValue, -Double.MinPositiveValue)} yield NegFiniteDouble.from(i).get
-
-  implicit val arbNegFiniteDouble: Arbitrary[NegFiniteDouble] = Arbitrary(negFiniteDoubleGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
@@ -33,11 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait NegZFiniteFloatSpecSupport {
-
-  val negZFiniteFloatGen: Gen[NegZFiniteFloat] =
-    for {i <- choose(Float.MinValue, 0.0f)} yield NegZFiniteFloat.from(i).get
-
-  implicit val arbNegZFiniteFloat: Arbitrary[NegZFiniteFloat] = Arbitrary(negZFiniteFloatGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {
@@ -65,6 +58,11 @@ trait NegZFiniteFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
@@ -33,11 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait NegZFloatSpecSupport {
-
-  val negZFloatGen: Gen[NegZFloat] =
-    for {i <- choose(Float.MinValue, 0.0f)} yield NegZFloat.from(i).get
-
-  implicit val arbNegZFloat: Arbitrary[NegZFloat] = Arbitrary(negZFloatGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {
@@ -65,6 +58,11 @@ trait NegZFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
@@ -15,8 +15,6 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen._
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
@@ -28,11 +26,6 @@ import OptionValues._
 import scala.util.{Failure, Success, Try}
 
 trait NegZIntSpecSupport {
-
-  val negZIntGen: Gen[NegZInt] =
-    for {i <- choose(Int.MinValue, -1)} yield NegZInt.from(i).get
-
-  implicit val arbNegZInt: Arbitrary[NegZInt] = Arbitrary(negZIntGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
@@ -31,11 +29,6 @@ import OptionValues._
 import scala.util.{Failure, Success, Try}
 
 trait NegZLongSpecSupport {
-
-  val negZLongGen: Gen[NegZLong] =
-    for {i <- choose(Long.MinValue, 0L)} yield NegZLong.from(i).get
-
-  implicit val arbNegZLong: Arbitrary[NegZLong] = Arbitrary(negZLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
@@ -15,12 +15,11 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen.choose
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.check.ScalaCheckGenerators
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -33,15 +32,6 @@ import org.scalactic.{Good, Bad}
 import org.scalactic.NumberCompatHelper
 
 trait NonZeroDoubleSpecSupport {
-  val nonZeroDoubleGen: Gen[NonZeroDouble] =
-    for {i <- choose(Double.MinValue, Double.MaxValue)} yield {
-      if (i == 0.0)
-        NonZeroDouble.ensuringValid(1.0)
-      else
-        NonZeroDouble.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroDouble: Arbitrary[NonZeroDouble] = Arbitrary(nonZeroDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
@@ -15,8 +15,6 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen.choose
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
@@ -33,15 +31,6 @@ import org.scalactic.{Good, Bad}
 import org.scalactic.NumberCompatHelper
 
 trait NonZeroFiniteDoubleSpecSupport {
-  val nonZeroFiniteDoubleGen: Gen[NonZeroFiniteDouble] =
-    for {i <- choose(Double.MinValue, Double.MaxValue)} yield {
-      if (i == 0.0)
-        NonZeroFiniteDouble.ensuringValid(1.0)
-      else
-        NonZeroFiniteDouble.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroFiniteDouble: Arbitrary[NonZeroFiniteDouble] = Arbitrary(nonZeroFiniteDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
@@ -33,16 +31,6 @@ import org.scalactic.Equality
 
 trait NonZeroFiniteFloatSpecSupport {
 
-  val nonZeroFiniteFloatGen: Gen[NonZeroFiniteFloat] =
-    for {i <- choose(Float.MinValue, Float.MaxValue)} yield {
-      if (i == 0.0f)
-        NonZeroFiniteFloat.ensuringValid(1.0f)
-      else
-        NonZeroFiniteFloat.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroFiniteFloat: Arbitrary[NonZeroFiniteFloat] = Arbitrary(nonZeroFiniteFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
@@ -51,6 +39,11 @@ trait NonZeroFiniteFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
@@ -17,10 +17,9 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.check.ScalaCheckGenerators
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -33,21 +32,16 @@ import org.scalactic.Equality
 
 trait NonZeroFloatSpecSupport {
 
-  val nonZeroFloatGen: Gen[NonZeroFloat] =
-    for {i <- choose(Float.MinValue, Float.MaxValue)} yield {
-      if (i == 0.0f)
-        NonZeroFloat.ensuringValid(1.0f)
-      else
-        NonZeroFloat.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroFloat: Arbitrary[NonZeroFloat] = Arbitrary(nonZeroFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
       // [info] - should offer a '%' method that is consistent with Int *** FAILED ***
       // [info]   Success(NaN) did not equal Success(NaN) (PosIntExperiment.scala:498)
+      case Success(double: Double) if double.isNaN =>  
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
+          case _ => false
+        }
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
@@ -15,37 +15,16 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen._
 import org.scalactic.Equality
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.check.ScalaCheckGenerators
 import OptionValues._
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 import scala.util.{Failure, Success, Try}
 
 trait NonZeroIntSpecSupport {
-
-  val nonZeroIntGen: Gen[NonZeroInt] =
-    for {i <- choose(Int.MinValue, Int.MaxValue)} yield {
-      if (i == 1)
-        NonZeroInt.ensuringValid(1)
-      else
-        NonZeroInt.ensuringValid(i)
-    }
-
-  val nonZeroLongGen: Gen[NonZeroLong] =
-    for {i <- choose(Long.MinValue, Long.MaxValue)} yield {
-      if (i == 1L)
-        NonZeroLong.ensuringValid(1)
-      else
-        NonZeroLong.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroInt: Arbitrary[NonZeroInt] = Arbitrary(nonZeroIntGen)
-
-  implicit val arbNonZeroLong: Arbitrary[NonZeroLong] = Arbitrary(nonZeroLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
@@ -17,10 +17,9 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.check.ScalaCheckGenerators
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 
@@ -30,16 +29,6 @@ import scala.collection.immutable.NumericRange
 import scala.util.{Failure, Success, Try}
 
 trait NonZeroLongSpecSupport {
-
-  val nonZeroLongGen: Gen[NonZeroLong] =
-    for {i <- choose(Long.MinValue, Long.MaxValue)} yield {
-      if (i == 1L)
-        NonZeroLong.ensuringValid(1)
-      else
-        NonZeroLong.ensuringValid(i)
-    }
-
-  implicit val arbNonZeroLong: Arbitrary[NonZeroLong] = Arbitrary(nonZeroLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
@@ -18,6 +18,8 @@ package org.scalactic.anyvals
 import org.scalactic.Equality
 import org.scalatest._
 import org.scalatest.prop._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen.choose
 import OptionValues._
 import java.nio.charset.Charset
 import scala.collection.mutable.ArrayBuffer
@@ -31,7 +33,6 @@ import org.scalactic.ColCompatHelper.aggregate
 
 class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
 
-/*
   import prop._
 
   implicit val numericStringGen: Generator[NumericString] =
@@ -39,22 +40,6 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
       if (cs.isEmpty) NumericString("000")
       else NumericString.ensuringValid(cs.mkString)
     }
-*/
-
-  import org.scalacheck.Gen._
-  import org.scalacheck.{Arbitrary, Gen}
-
-  val numericStringGen: Gen[NumericString] =
-    for (cs <- Gen.containerOf[List, Char](Gen.oneOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) yield {
-      if (cs.isEmpty) NumericString("000")
-      else NumericString.ensuringValid(cs.mkString)
-    }
-
-  implicit val numericStringArb: Arbitrary[NumericString] = Arbitrary(numericStringGen)
-
-  val posIntGen: Gen[PosInt] = Gen.posNum[Int].map(i => PosInt.ensuringValid(i))
-
-  implicit val posIntArb: Arbitrary[PosInt] = Arbitrary(posIntGen)
 
   val numericCharGen: Gen[NumericChar] =
     for {i <- choose(0, 9)} yield NumericChar.from(i.toString.charAt(0)).get

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
@@ -33,16 +31,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.NumberCompatHelper
 
 trait PosDoubleSpecSupport {
-
-  val posZDoubleGen: Gen[PosZDouble] =
-    for {i <- choose(0, Double.MaxValue)} yield PosZDouble.ensuringValid(i)
-
-  implicit val arbPosZDouble: Arbitrary[PosZDouble] = Arbitrary(posZDoubleGen)
-
-  val posDoubleGen: Gen[PosDouble] =
-    for {i <- choose(1, Double.MaxValue)} yield PosDouble.ensuringValid(i)
-
-  implicit val arbPosDouble: Arbitrary[PosDouble] = Arbitrary(posDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
@@ -33,16 +31,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.NumberCompatHelper
 
 trait PosFiniteDoubleSpecSupport {
-
-  val posZFiniteDoubleGen: Gen[PosZFiniteDouble] =
-    for {i <- choose(0, Double.MaxValue)} yield PosZFiniteDouble.ensuringValid(i)
-
-  implicit val arbPosZFiniteDouble: Arbitrary[PosZFiniteDouble] = Arbitrary(posZFiniteDoubleGen)
-
-  val posFiniteDoubleGen: Gen[PosFiniteDouble] =
-    for {i <- choose(1, Double.MaxValue)} yield PosFiniteDouble.ensuringValid(i)
-
-  implicit val arbPosFiniteDouble: Arbitrary[PosFiniteDouble] = Arbitrary(posFiniteDoubleGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
@@ -32,16 +30,6 @@ import org.scalactic.NumberCompatHelper
 
 trait PosFiniteFloatSpecSupport {
 
-  val posZFiniteFloatGen: Gen[PosZFiniteFloat] =
-    for {i <- choose(0, Float.MaxValue)} yield PosZFiniteFloat.ensuringValid(i)
-
-  implicit val arbPosZFiniteFloat: Arbitrary[PosZFiniteFloat] = Arbitrary(posZFiniteFloatGen)
-
-  val posFiniteFloatGen: Gen[PosFiniteFloat] =
-    for {i <- choose(1, Float.MaxValue)} yield PosFiniteFloat.ensuringValid(i)
-
-  implicit val arbPosFiniteFloat: Arbitrary[PosFiniteFloat] = Arbitrary(posFiniteFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
@@ -50,6 +38,11 @@ trait PosFiniteFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
@@ -32,16 +30,6 @@ import org.scalactic.NumberCompatHelper
 
 trait PosFloatSpecSupport {
 
-  val posZFloatGen: Gen[PosZFloat] =
-    for {i <- choose(0, Float.MaxValue)} yield PosZFloat.ensuringValid(i)
-
-  implicit val arbPosZFloat: Arbitrary[PosZFloat] = Arbitrary(posZFloatGen)
-
-  val posFloatGen: Gen[PosFloat] =
-    for {i <- choose(1, Float.MaxValue)} yield PosFloat.ensuringValid(i)
-
-  implicit val arbPosFloat: Arbitrary[PosFloat] = Arbitrary(posFloatGen)
-
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {
       // I needed this because with GenDrivenPropertyChecks, got:
@@ -50,6 +38,11 @@ trait PosFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
@@ -15,8 +15,6 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen._
 import org.scalactic.Equality
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -27,11 +25,6 @@ import org.scalactic.{Validation, Pass, Fail}
 import org.scalactic.{Or, Good, Bad}
 
 trait PosIntSpecSupport {
-
-  val posIntGen: Gen[PosInt] =
-    for {i <- choose(1, Int.MaxValue)} yield PosInt.from(i).get
-
-  implicit val arbPosInt: Arbitrary[PosInt] = Arbitrary(posIntGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
@@ -17,8 +17,6 @@ package org.scalactic.anyvals
 
 import org.scalatest._
 import OptionValues._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
@@ -30,11 +28,6 @@ import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 
 trait PosLongSpecSupport {
-
-  val posLongGen: Gen[PosLong] =
-    for {i <- choose(1, Long.MaxValue)} yield PosLong.from(i).get
-
-  implicit val arbPosLong: Arbitrary[PosLong] = Arbitrary(posLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -33,16 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait PosZDoubleSpecSupport {
-
-  val posZDoubleGen: Gen[PosZDouble] =
-    for {i <- choose(0, Double.MaxValue)} yield PosZDouble.from(i).get
-
-  implicit val arbPosZDouble: Arbitrary[PosZDouble] = Arbitrary(posZDoubleGen)
-
-  val posDoubleGen: Gen[PosDouble] =
-    for {i <- choose(1, Double.MaxValue)} yield PosDouble.from(i).get
-
-  implicit val arbPosDouble: Arbitrary[PosDouble] = Arbitrary(posDoubleGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -33,16 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait PosZFiniteDoubleSpecSupport {
-
-  val posZFiniteDoubleGen: Gen[PosZFiniteDouble] =
-    for {i <- choose(0, Double.MaxValue)} yield PosZFiniteDouble.from(i).get
-
-  implicit val arbPosZFiniteDouble: Arbitrary[PosZFiniteDouble] = Arbitrary(posZFiniteDoubleGen)
-
-  val posFiniteDoubleGen: Gen[PosFiniteDouble] =
-    for {i <- choose(1, Double.MaxValue)} yield PosFiniteDouble.from(i).get
-
-  implicit val arbPosFiniteDouble: Arbitrary[PosFiniteDouble] = Arbitrary(posFiniteDoubleGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
@@ -33,11 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait PosZFiniteFloatSpecSupport {
-
-  val posZFiniteFloatGen: Gen[PosZFiniteFloat] =
-    for {i <- choose(0, Float.MaxValue)} yield PosZFiniteFloat.from(i).get
-
-  implicit val arbPosZFiniteFloat: Arbitrary[PosZFiniteFloat] = Arbitrary(posZFiniteFloatGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {
@@ -65,6 +58,11 @@ trait PosZFiniteFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
@@ -33,11 +31,6 @@ import scala.util.{Try, Success, Failure}
 import org.scalactic.NumberCompatHelper
 
 trait PosZFloatSpecSupport {
-
-  val posZFloatGen: Gen[PosZFloat] =
-    for {i <- choose(0, Float.MaxValue)} yield PosZFloat.from(i).get
-
-  implicit val arbPosZFloat: Arbitrary[PosZFloat] = Arbitrary(posZFloatGen)
 
   implicit val doubleEquality: Equality[Double] =
     new Equality[Double] {
@@ -65,6 +58,11 @@ trait PosZFloatSpecSupport {
       case Success(float: Float) if float.isNaN =>
         b match {
           case Success(bFloat: Float) if bFloat.isNaN => true
+          case _ => false
+        }
+      case Success(double: Double) if double.isNaN => 
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
           case _ => false
         }
       case _: Success[_] => a == b

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
@@ -15,8 +15,6 @@
  */
 package org.scalactic.anyvals
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen._
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
@@ -30,11 +28,6 @@ import scala.util.{Failure, Success, Try}
 //import org.scalactic.StrictCheckedEquality
 
 trait PosZIntSpecSupport {
-
-  val posZIntGen: Gen[PosZInt] =
-    for {i <- choose(0, Int.MaxValue)} yield PosZInt.from(i).get
-
-  implicit val arbPosZInt: Arbitrary[PosZInt] = Arbitrary(posZIntGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
@@ -16,8 +16,6 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalacheck.Gen._
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
@@ -33,11 +31,6 @@ import scala.util.{Failure, Success, Try}
 //import org.scalactic.StrictCheckedEquality
 
 trait PosZLongSpecSupport {
-
-  val posZLongGen: Gen[PosZLong] =
-    for {i <- choose(0, Long.MaxValue)} yield PosZLong.from(i).get
-
-  implicit val arbPosZLong: Arbitrary[PosZLong] = Arbitrary(posZLongGen)
 
   implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
     override def areEqual(a: Try[T], b: Any): Boolean = a match {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
@@ -25,22 +25,8 @@ import java.util.Locale
 // SKIP-SCALATESTJS,NATIVE-END
 
 
-class RegexStringSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with PosIntSpecSupport {
+class RegexStringSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
 
-  val regexStringGen: Gen[RegexString] =
-    Gen.oneOf(
-      RegexString(""),
-      RegexString("."),
-      RegexString(".*"),
-      RegexString("^Now is the time for all good men$"),
-      RegexString("(a|b)"),
-      RegexString("""^\\(&amp;|\W|\p{Alpha}+\*?|_)"""),
-      RegexString("[abc]")
-    )
-
-  implicit val arbRegexString: Arbitrary[RegexString] = Arbitrary(regexStringGen)
-
-/*
   import prop._
 
   implicit val RegexStringGen: Generator[RegexString] =
@@ -52,7 +38,6 @@ class RegexStringSpec extends FunSpec with Matchers with GeneratorDrivenProperty
       RegexString("(a|b)"),
       RegexString("""^\\(&amp;|\W|\p{Alpha}+\*?|_)"""),
       RegexString("[abc]"))
-*/
 
   describe("A RegexString") {
 

--- a/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
+++ b/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2001-2017 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalactic.source
+
+class TypeInfo[T](val name: String)
+
+/**
+  * Companion object for <code>Position</code> that defines an implicit
+  * method that uses a macro to grab the enclosing position.
+  */
+object TypeInfo {
+
+  import scala.language.experimental.macros
+
+  def apply[T](name: String): TypeInfo[T] = new TypeInfo[T](name)
+
+  implicit def gen[T]: TypeInfo[T] = macro TypeInfoMacro.genTypeInfo[T]
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/check/ScalaCheckGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/check/ScalaCheckGeneratorsSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.check
+
+import org.scalacheck._
+import org.scalatest._
+import Arbitrary._
+import Prop._
+import org.scalatest.Matchers._
+import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
+import org.scalacheck.util.Pretty
+import org.scalatest.SharedHelpers.thisLineNumber
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.prop.PropertyChecks
+
+class ScalaCheckGeneratorsSpec extends FunSpec with PropertyChecks {
+
+  describe("The ScalaCheckGenerators trait") {
+    it("should provide an implicit Generator for a type given an implicit Arbitrary and Shrink for that type") {
+      import ScalaCheckGenerators._
+      case class Person(name: String, age: Int)
+      val personGen: Gen[Person] =
+        for {
+          name <- implicitly[Arbitrary[String]].arbitrary
+          age <- implicitly[Arbitrary[Int]].arbitrary
+        } yield Person(name, age)
+
+      implicit val personArb: Arbitrary[Person] = Arbitrary(personGen)
+      forAll { (p: Person) =>
+        p shouldEqual p
+      }
+    }
+  }
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2001-2017 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalatest.AsyncFunSpec
+import org.scalatest.exceptions.TestFailedException
+
+import scala.concurrent.Future
+
+class AsyncGeneratorDrivenPropertyChecksSpec extends AsyncFunSpec with GeneratorDrivenPropertyChecks {
+
+  describe("GeneratorDrivenPropertyChecks") {
+
+    it("should do nothing when non-blocking 1 argument block assertion passed") {
+      forAll { (i: Int) =>
+        Future { assert(i == i) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 1 argument block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i: Int) =>
+          Future {
+            assert(i != i)
+          }
+        }
+      }
+    }
+
+    it("should do nothing when non-blocking 2 arguments block assertion passed") {
+      forAll { (i1: Int, i2: Long) =>
+        Future { assert(i1 == i1 && i2 == i2) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 2 arguments block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i1: Int, i2: Long) =>
+          Future {
+            assert(i1 == i1 && i2 != i2)
+          }
+        }
+      }
+    }
+
+    it("should do nothing when non-blocking 3 arguments block assertion passed") {
+      forAll { (i1: Int, i2: Long, i3: String) =>
+        Future { assert(i1 == i1 && i2 == i2 && i3 == i3) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 3 arguments block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i1: Int, i2: Long, i3: String) =>
+          Future {
+            assert(i1 == i1 && i2 == i2 && i3 != i3)
+          }
+        }
+      }
+    }
+
+    it("should do nothing when non-blocking 4 arguments block assertion passed") {
+      forAll { (i1: Int, i2: Long, i3: String, i4: Short) =>
+        Future { assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 == i4) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 4 arguments block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i1: Int, i2: Long, i3: String, i4: Short) =>
+          Future {
+            assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 != i4)
+          }
+        }
+      }
+    }
+
+    it("should do nothing when non-blocking 5 arguments block assertion passed") {
+      forAll { (i1: Int, i2: Long, i3: String, i4: Short, i5: Float) =>
+        Future { assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 == i4 && i5 == i5) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 5 arguments block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i1: Int, i2: Long, i3: String, i4: Short, i5: Float) =>
+          Future {
+            assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 == i4 && i5 != i5)
+          }
+        }
+      }
+    }
+
+    it("should do nothing when non-blocking 6 arguments block assertion passed") {
+      forAll { (i1: Int, i2: Long, i3: String, i4: Short, i5: Float, i6: Double) =>
+        Future { assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 == i4 && i5 == i5 && i6 == i6) }
+      }
+    }
+
+    it("should fail with TestFailedException when non-blocking 6 arguments block assertion failed") {
+      recoverToSucceededIf[TestFailedException] {
+        forAll { (i1: Int, i2: Long, i3: String, i4: Short, i5: Float, i6: Double) =>
+          Future {
+            assert(i1 == i1 && i2 == i2 && i3 == i3 && i4 == i4 && i5 == i5 && i6 != i6)
+          }
+        }
+      }
+    }
+
+  }
+
+}

--- a/scalatest-test/src/test/scala/org/scalatest/prop/ClassificationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/ClassificationSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalatest._
+import org.scalactic.anyvals._
+
+class ClassificationSpec extends WordSpec with Matchers {
+  "A Classification" should {
+    "round to the nearest Int in its percentages method" in {
+      val c =
+        Classification(
+          10000,
+          Map(
+            "one point eight" -> 180,
+            "one point five" -> 150,
+            "one point three" -> 130
+          )
+        )
+      c.percentages shouldEqual Map(
+        "one point eight" -> PosZInt(2),
+        "one point five" -> PosZInt(2),
+        "one point three" -> PosZInt(1)
+      )
+    }
+    "handle percentages of 0" in {
+      val c =
+        Classification(
+          10000,
+          Map(
+            "zero" -> 0
+          )
+        )
+      c.percentages shouldEqual Map(
+        "zero" -> PosZInt(0)
+      )
+    }
+    "include the Int percentage in the toString" in {
+      val c =
+        Classification(
+          100,
+          Map(
+            "ten" -> 10
+          )
+        )
+      c.toString shouldBe "10% ten"
+    }
+  }
+}

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -1,0 +1,5307 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import org.scalatest.exceptions.TestFailedException
+import scala.annotation.tailrec
+import org.scalatest.Resources
+import org.scalatest.matchers.BeMatcher
+import org.scalatest.matchers.MatchResult
+import scala.collection.immutable.SortedSet
+import scala.collection.immutable.SortedMap
+
+class CommonGeneratorsSpec extends WordSpec with Matchers {
+  import CommonGenerators._
+  "The CommonGenerators object" should {
+    "offer a first1000Primes method" that {
+      "produces the first 1000 prime numbers a Ints" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        def isPrime(n: Int): Boolean = {
+          if (n <= 1) false
+          else if (n <= 3) true
+          else if (n % 2 == 0 || n % 3 == 0) false
+          else {
+            var i = 5
+            while (i * i <= n) {
+              if (n % i == 0 || n % (i + 2) == 0)
+                return false
+              i += 6
+            }
+            true
+          }
+        }
+
+        val aPrimeNumber =
+          new BeMatcher[Int] {
+            def apply(left: Int) =
+              MatchResult(
+                isPrime(left),
+                left.toString + " was not prime",
+                left.toString + " was prime"
+              )
+          }
+
+        forAll (first1000Primes) { i =>
+          i shouldBe aPrimeNumber
+        }
+      }
+    }
+
+    "offer a bytesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- bytesBetween(Byte.MinValue, Byte.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- bytesBetween((lo + 1).toByte, Byte.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            bytesBetween(hi, lo)
+          }
+        }
+      }
+      "produces Bytes between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Byte, Byte)] =
+          for {
+            min <- bytesBetween(Byte.MinValue, Byte.MaxValue - 1)
+            max <- bytesBetween(min, Byte.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Byte] = bytesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Byte, Byte)] =
+          for {
+            min <- bytesBetween(Byte.MinValue, Byte.MaxValue - 1)
+            max <- bytesBetween(min, Byte.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Byte] = bytesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Int edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = bytes.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Byte, to: Byte): List[Byte] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Byte] = bytesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a shortsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- shortsBetween(Short.MinValue, Short.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- shortsBetween((lo + 1).toShort, Short.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            shortsBetween(hi, lo)
+          }
+        }
+      }
+      "produces Shorts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Short, Short)] =
+          for {
+            min <- shortsBetween(Short.MinValue, Short.MaxValue - 1)
+            max <- shortsBetween(min, Short.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Short] = shortsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Short, Short)] =
+          for {
+            min <- shortsBetween(Short.MinValue, Short.MaxValue - 1)
+            max <- shortsBetween(min, Short.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Short] = shortsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Int edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = shorts.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Short, to: Short): List[Short] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Short] = shortsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer an intsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- intsBetween(Int.MinValue, Int.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- intsBetween(lo + 1, Int.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            intsBetween(hi, lo)
+          }
+        }
+      }
+      "produces Ints between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Int, Int)] = 
+          for {
+            min <- intsBetween(Int.MinValue, Int.MaxValue - 1)
+            max <- intsBetween(min, Int.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Int] = intsBetween(min, max) 
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Int, Int)] = 
+          for {
+            min <- intsBetween(Int.MinValue, Int.MaxValue - 1)
+            max <- intsBetween(min, Int.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Int] = intsBetween(min, max) 
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Int edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = ints.initEdges(100, Randomizer.default)
+        // sortedEdges: List[Int] = List(-2147483648, -1, 0, 1, 2147483647)
+        val sortedEdges = edges.sorted
+        // res5: List[List[Int]] = List(List(-2147483648, -1), List(-2147483648, 0), List(-2147483648, 1),
+        //   List(-2147483648, 2147483647), List(-1, 0), List(-1, 1), List(-1, 2147483647), List(0, 1),
+        //   List(0, 2147483647), List(1, 2147483647))
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Int, to: Int): List[Int] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Int] = intsBetween(from, to) 
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a longsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- longsBetween(Long.MinValue, Long.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- longsBetween(lo + 1, Long.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            longsBetween(hi, lo)
+          }
+        }
+      }
+      "produces Longs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Long, Long)] =
+          for {
+            min <- longsBetween(Long.MinValue, Long.MaxValue - 1)
+            max <- longsBetween(min, Long.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Long] = longsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Long, Long)] =
+          for {
+            min <- longsBetween(Long.MinValue, Long.MaxValue - 1)
+            max <- longsBetween(min, Long.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Long] = longsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Int edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = longs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Long, to: Long): List[Long] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Long] = longsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a charsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- charsBetween(Char.MinValue, Char.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- charsBetween((lo + 1).toChar, Char.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            charsBetween(hi, lo)
+          }
+        }
+      }
+      "produces Chars between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Char, Char)] =
+          for {
+            min <- charsBetween(Char.MinValue, Char.MaxValue - 1)
+            max <- charsBetween(min, Char.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Char] = charsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Char, Char)] =
+          for {
+            min <- charsBetween(Char.MinValue, Char.MaxValue - 1)
+            max <- charsBetween(min, Char.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Char] = charsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Char edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = chars.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Char, to: Char): List[Char] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Char] = charsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a floatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- floatsBetween(Float.MinValue, Float.MaxValue - 1E32f) // Hmm. Using the method to test itself
+            hi <- floatsBetween((lo + 1E32f), Float.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            floatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces Floats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Float, Float)] =
+          for {
+            min <- floatsBetween(Float.MinValue, Float.MaxValue - 1E32f)
+            max <- floatsBetween(min, Float.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Float] = floatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Float, Float)] =
+          for {
+            min <- floatsBetween(Float.MinValue, Float.MaxValue - 1E32f)
+            max <- floatsBetween(min, Float.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Float] = floatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Float edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = floats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Float, to: Float): List[Float] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Float] = floatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a doublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- doublesBetween(Double.MinValue, Double.MaxValue - 1E292) // Hmm. Using the method to test itself
+            hi <- doublesBetween((lo + 1E292), Double.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            doublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces Doubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Double, Double)] =
+          for {
+            min <- doublesBetween(Double.MinValue, Double.MaxValue - 1E292)
+            max <- doublesBetween(min, Double.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Double] = doublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(Double, Double)] =
+          for {
+            min <- doublesBetween(Double.MinValue, Double.MaxValue - 1E292)
+            max <- doublesBetween(min, Double.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[Double] = doublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal Double edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = doubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: Double, to: Double): List[Double] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[Double] = doublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posIntsBetween method" that {
+      val PosIntMaxValueMinusOne = PosInt(2147483646)
+
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- intsBetween(PosInt.MinValue, PosInt.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- intsBetween(lo + 1, PosInt.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            intsBetween(hi, lo)
+          }
+        }
+      }
+
+      "produces PosInts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosInt, PosInt)] = 
+          for {
+            min <- posIntsBetween(PosInt.MinValue, PosIntMaxValueMinusOne)
+            max <- posIntsBetween(min, PosInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosInt] = posIntsBetween(min, max) 
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosInt, PosInt)] = 
+          for {
+            min <- posIntsBetween(PosInt.MinValue, PosIntMaxValueMinusOne)
+            max <- posIntsBetween(min, PosInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosInt] = posIntsBetween(min, max) 
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should (have length 1 or have length 2)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosInt edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posInts.initEdges(100, Randomizer.default)
+        // sortedEdges: List[Int] = List(-2147483648, -1, 0, 1, 2147483647)
+        val sortedEdges = edges.sorted
+        // res5: List[List[Int]] = List(List(-2147483648, -1), List(-2147483648, 0), List(-2147483648, 1),
+        //   List(-2147483648, 2147483647), List(-1, 0), List(-1, 1), List(-1, 2147483647), List(0, 1),
+        //   List(0, 2147483647), List(1, 2147483647))
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosInt, to: PosInt): List[PosInt] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosInt] = posIntsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posLongsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posLongsBetween(PosLong.MinValue, PosLong.ensuringValid(PosLong.MaxValue - 1)) // Hmm. Using the method to test itself
+            hi <- posLongsBetween(PosLong.ensuringValid(lo + 1), PosLong.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            posLongsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosLongs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosLong, PosLong)] =
+          for {
+            min <- posLongsBetween(PosLong.MinValue, PosLong.ensuringValid(PosLong.MaxValue - 1))
+            max <- posLongsBetween(min, PosLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosLong] = posLongsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosLong, PosLong)] =
+          for {
+            min <- posLongsBetween(PosLong.MinValue, PosLong.ensuringValid(PosLong.MaxValue - 1))
+            max <- posLongsBetween(min, PosLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosLong] = posLongsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosLong edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posLongs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosLong, to: PosLong): List[PosLong] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosLong] = posLongsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posFloatsBetween(PosFloat.MinValue, PosFloat.ensuringValid(PosFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
+            hi <- posFloatsBetween(PosFloat.ensuringValid(lo + 1E32f), PosFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFloat, PosFloat)] =
+          for {
+            min <- posFloatsBetween(PosFloat.MinValue, PosFloat.ensuringValid(PosFloat.MaxValue - 1E32f))
+            max <- posFloatsBetween(min, PosFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFloat] = posFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFloat, PosFloat)] =
+          for {
+            min <- posFloatsBetween(PosFloat.MinValue, PosFloat.ensuringValid(PosFloat.MaxValue - 1E32f))
+            max <- posFloatsBetween(min, PosFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFloat] = posFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosFloat, to: PosFloat): List[PosFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosFloat] = posFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posFiniteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posFiniteFloatsBetween(PosFiniteFloat.MinValue, PosFiniteFloat.ensuringValid(PosFiniteFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
+            hi <- posFiniteFloatsBetween(PosFiniteFloat.ensuringValid(lo + 1E32f), PosFiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posFiniteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosFiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFiniteFloat, PosFiniteFloat)] =
+          for {
+            min <- posFiniteFloatsBetween(PosFiniteFloat.MinValue, PosFiniteFloat.ensuringValid(PosFiniteFloat.MaxValue - 1E32f))
+            max <- posFiniteFloatsBetween(min, PosFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFiniteFloat] = posFiniteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFiniteFloat, PosFiniteFloat)] =
+          for {
+            min <- posFiniteFloatsBetween(PosFiniteFloat.MinValue, PosFiniteFloat.ensuringValid(PosFiniteFloat.MaxValue - 1E32f))
+            max <- posFiniteFloatsBetween(min, PosFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFiniteFloat] = posFiniteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosFiniteFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posFiniteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosFiniteFloat, to: PosFiniteFloat): List[PosFiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosFiniteFloat] = posFiniteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posDoublesBetween(PosDouble.MinValue, PosDouble.ensuringValid(PosDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- posDoublesBetween(PosDouble.ensuringValid(lo + 1E292), PosDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosDouble, PosDouble)] =
+          for {
+            min <- posDoublesBetween(PosDouble.MinValue, PosDouble.ensuringValid(PosDouble.MaxValue - 1E292))
+            max <- posDoublesBetween(min, PosDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosDouble] = posDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosDouble, PosDouble)] =
+          for {
+            min <- posDoublesBetween(PosDouble.MinValue, PosDouble.ensuringValid(PosDouble.MaxValue - 1E292))
+            max <- posDoublesBetween(min, PosDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosDouble] = posDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal PosDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosDouble, to: PosDouble): List[PosDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosDouble] = posDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posFiniteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posFiniteDoublesBetween(PosFiniteDouble.MinValue, PosFiniteDouble.ensuringValid(PosFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- posFiniteDoublesBetween(PosFiniteDouble.ensuringValid(lo + 1E292), PosFiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posFiniteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosFiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFiniteDouble, PosFiniteDouble)] =
+          for {
+            min <- posFiniteDoublesBetween(PosFiniteDouble.MinValue, PosFiniteDouble.ensuringValid(PosFiniteDouble.MaxValue - 1E292))
+            max <- posFiniteDoublesBetween(min, PosFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFiniteDouble] = posFiniteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosFiniteDouble, PosFiniteDouble)] =
+          for {
+            min <- posFiniteDoublesBetween(PosFiniteDouble.MinValue, PosFiniteDouble.ensuringValid(PosDouble.MaxValue - 1E292))
+            max <- posFiniteDoublesBetween(min, PosFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosFiniteDouble] = posFiniteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal PosFiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posFiniteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosFiniteDouble, to: PosFiniteDouble): List[PosFiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosFiniteDouble] = posFiniteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZIntsBetween method" that {
+      val PosZIntMaxValueMinusOne = PosZInt(2147483646)
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- intsBetween(PosZInt.MinValue, PosZInt.MaxValue - 1) // Hmm. Using the method to test itself
+            hi <- intsBetween(lo + 1, PosZInt.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            intsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosZInts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZInt, PosZInt)] =
+          for {
+            min <- posZIntsBetween(PosZInt.MinValue, PosZIntMaxValueMinusOne)
+            max <- posZIntsBetween(min, PosZInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZInt] = posZIntsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZInt, PosZInt)] =
+          for {
+            min <- posZIntsBetween(PosZInt.MinValue, PosZIntMaxValueMinusOne)
+            max <- posZIntsBetween(min, PosZInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZInt] = posZIntsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should (have length 1 or have length 2 or have length 3)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosZInt edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZInts.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZInt, to: PosZInt): List[PosZInt] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZInt] = posZIntsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZLongsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posZLongsBetween(PosZLong.MinValue, PosZLong.ensuringValid(PosLong.MaxValue - 1)) // Hmm. Using the method to test itself
+            hi <- posZLongsBetween(PosZLong.ensuringValid(lo + 1), PosZLong.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            posZLongsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosZLongs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZLong, PosZLong)] =
+          for {
+            min <- posZLongsBetween(PosZLong.MinValue, PosZLong.ensuringValid(PosLong.MaxValue - 1))
+            max <- posZLongsBetween(min, PosZLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZLong] = posZLongsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZLong, PosZLong)] =
+          for {
+            min <- posZLongsBetween(PosZLong.MinValue, PosZLong.ensuringValid(PosZLong.MaxValue - 1))
+            max <- posZLongsBetween(min, PosZLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZLong] = posZLongsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosZLong edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZLongs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZLong, to: PosZLong): List[PosZLong] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZLong] = posZLongsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posZFloatsBetween(PosZFloat.MinValue, PosZFloat.ensuringValid(PosZFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
+            hi <- posZFloatsBetween(PosZFloat.ensuringValid(lo + 1E32f), PosZFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posZFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosZFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFloat, PosZFloat)] =
+          for {
+            min <- posZFloatsBetween(PosZFloat.MinValue, PosZFloat.ensuringValid(PosZFloat.MaxValue - 1E32f))
+            max <- posZFloatsBetween(min, PosZFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFloat] = posZFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFloat, PosZFloat)] =
+          for {
+            min <- posZFloatsBetween(PosZFloat.MinValue, PosZFloat.ensuringValid(PosZFloat.MaxValue - 1E32f))
+            max <- posZFloatsBetween(min, PosZFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFloat] = posZFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZFloat, to: PosZFloat): List[PosZFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZFloat] = posZFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZFiniteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posZFiniteFloatsBetween(PosZFiniteFloat.MinValue, PosZFiniteFloat.ensuringValid(PosZFiniteFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
+            hi <- posZFiniteFloatsBetween(PosZFiniteFloat.ensuringValid(lo + 1E32f), PosZFiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posZFiniteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosZFiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFiniteFloat, PosZFiniteFloat)] =
+          for {
+            min <- posZFiniteFloatsBetween(PosZFiniteFloat.MinValue, PosZFiniteFloat.ensuringValid(PosZFiniteFloat.MaxValue - 1E32f))
+            max <- posZFiniteFloatsBetween(min, PosZFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFiniteFloat] = posZFiniteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFiniteFloat, PosZFiniteFloat)] =
+          for {
+            min <- posZFiniteFloatsBetween(PosZFiniteFloat.MinValue, PosZFiniteFloat.ensuringValid(PosZFiniteFloat.MaxValue - 1E32f))
+            max <- posZFiniteFloatsBetween(min, PosZFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFiniteFloat] = posZFiniteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal PosFiniteFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZFiniteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZFiniteFloat, to: PosZFiniteFloat): List[PosZFiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZFiniteFloat] = posZFiniteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posZDoublesBetween(PosZDouble.MinValue, PosZDouble.ensuringValid(PosZDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- posZDoublesBetween(PosZDouble.ensuringValid(lo + 1E292), PosZDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posZDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZDouble, PosZDouble)] =
+          for {
+            min <- posZDoublesBetween(PosZDouble.MinValue, PosZDouble.ensuringValid(PosZDouble.MaxValue - 1E292))
+            max <- posZDoublesBetween(min, PosZDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZDouble] = posZDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZDouble, PosZDouble)] =
+          for {
+            min <- posZDoublesBetween(PosZDouble.MinValue, PosZDouble.ensuringValid(PosZDouble.MaxValue - 1E292))
+            max <- posZDoublesBetween(min, PosZDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZDouble] = posZDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal PosZDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZDouble, to: PosZDouble): List[PosZDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZDouble] = posZDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a posZFiniteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- posZFiniteDoublesBetween(PosZFiniteDouble.MinValue, PosZFiniteDouble.ensuringValid(PosZFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- posZFiniteDoublesBetween(PosZFiniteDouble.ensuringValid(lo + 1E292), PosZFiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            posZFiniteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosFiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFiniteDouble, PosZFiniteDouble)] =
+          for {
+            min <- posZFiniteDoublesBetween(PosZFiniteDouble.MinValue, PosZFiniteDouble.ensuringValid(PosZDouble.MaxValue - 1E292))
+            max <- posZFiniteDoublesBetween(min, PosZFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFiniteDouble] = posZFiniteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(PosZFiniteDouble, PosZFiniteDouble)] =
+          for {
+            min <- posZFiniteDoublesBetween(PosZFiniteDouble.MinValue, PosZFiniteDouble.ensuringValid(PosZFiniteDouble.MaxValue - 1E292))
+            max <- posZFiniteDoublesBetween(min, PosZFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[PosZFiniteDouble] = posZFiniteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal PosZFiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = posZFiniteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: PosZFiniteDouble, to: PosZFiniteDouble): List[PosZFiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[PosZFiniteDouble] = posZFiniteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negIntsBetween method" that {
+      val NegIntMaxValueMinusOne = NegInt(-2)
+
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negIntsBetween(NegInt.MinValue, NegInt.ensuringValid(NegInt.MaxValue - 1)) // Hmm. Using the method to test itself
+            hi <- negIntsBetween(NegInt.ensuringValid(lo + 1), NegInt.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            negIntsBetween(hi, lo)
+          }
+        }
+      }
+
+      "produces NegInts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegInt, NegInt)] =
+          for {
+            min <- negIntsBetween(NegInt.MinValue, NegIntMaxValueMinusOne)
+            max <- negIntsBetween(min, NegInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegInt] = negIntsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegInt, NegInt)] =
+          for {
+            min <- negIntsBetween(NegInt.MinValue, NegIntMaxValueMinusOne)
+            max <- negIntsBetween(min, NegInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegInt] = negIntsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should (have length 1 or have length 2)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegInt edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negInts.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegInt, to: NegInt): List[NegInt] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegInt] = negIntsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negLongsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negLongsBetween(NegLong.MinValue, NegLong.ensuringValid(NegLong.MaxValue - 1)) // Hmm. Using the method to test itself
+            hi <- negLongsBetween(NegLong.ensuringValid(lo + 1), NegLong.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            negLongsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegLongs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegLong, NegLong)] =
+          for {
+            min <- negLongsBetween(NegLong.MinValue, NegLong.ensuringValid(NegLong.MaxValue - 1))
+            max <- negLongsBetween(min, NegLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegLong] = negLongsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegLong, NegLong)] =
+          for {
+            min <- negLongsBetween(NegLong.MinValue, NegLong.ensuringValid(NegLong.MaxValue - 1))
+            max <- negLongsBetween(min, NegLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegLong] = negLongsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegLong edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negLongs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegLong, to: NegLong): List[NegLong] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegLong] = negLongsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negFloatsBetween(NegFloat.MinValue, NegFloat.ensuringValid(NegFloat.MaxValue - 1E32f - 1E32f))
+            hi <- negFloatsBetween(NegFloat.ensuringValid(lo + 1E32f), NegFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFloat, NegFloat)] =
+          for {
+            min <- negFloatsBetween(NegFloat.MinValue, NegFloat.ensuringValid(NegFloat.MaxValue - 1E32f))
+            max <- negFloatsBetween(min, NegFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFloat] = negFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFloat, NegFloat)] =
+          for {
+            min <- negFloatsBetween(NegFloat.MinValue, NegFloat.ensuringValid(NegFloat.MaxValue - 1E32f))
+            max <- negFloatsBetween(min, NegFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFloat] = negFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegFloat, to: NegFloat): List[NegFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegFloat] = negFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negFiniteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negFiniteFloatsBetween(NegFiniteFloat.MinValue, NegFiniteFloat.ensuringValid(NegFiniteFloat.MaxValue - 1E32f - 1E32f))
+            hi <- negFiniteFloatsBetween(NegFiniteFloat.ensuringValid(lo + 1E32f), NegFiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negFiniteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegFiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFiniteFloat, NegFiniteFloat)] =
+          for {
+            min <- negFiniteFloatsBetween(NegFiniteFloat.MinValue, NegFiniteFloat.ensuringValid(NegFiniteFloat.MaxValue - 1E32f))
+            max <- negFiniteFloatsBetween(min, NegFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFiniteFloat] = negFiniteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFiniteFloat, NegFiniteFloat)] =
+          for {
+            min <- negFiniteFloatsBetween(NegFiniteFloat.MinValue, NegFiniteFloat.ensuringValid(NegFiniteFloat.MaxValue - 1E32f))
+            max <- negFiniteFloatsBetween(min, NegFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFiniteFloat] = negFiniteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negFiniteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegFiniteFloat, to: NegFiniteFloat): List[NegFiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegFiniteFloat] = negFiniteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negDoublesBetween(NegDouble.MinValue, NegDouble.ensuringValid(NegDouble.MaxValue - 1E292 - 1E292)) // Hmm. Using the method to test itself
+            hi <- negDoublesBetween(NegDouble.ensuringValid(lo + 1E292), NegDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegDouble, NegDouble)] =
+          for {
+            min <- negDoublesBetween(NegDouble.MinValue, NegDouble.ensuringValid(NegDouble.MaxValue - 1E292 - 1E292))
+            max <- negDoublesBetween(min, NegDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegDouble] = negDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegDouble, NegDouble)] =
+          for {
+            min <- negDoublesBetween(NegDouble.MinValue, NegDouble.ensuringValid(NegDouble.MaxValue - 1E292 - 1E292))
+            max <- negDoublesBetween(min, NegDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegDouble] = negDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NegDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegDouble, to: NegDouble): List[NegDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegDouble] = negDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negFiniteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negFiniteDoublesBetween(NegFiniteDouble.MinValue, NegFiniteDouble.ensuringValid(NegFiniteDouble.MaxValue - 1E292 - 1E292)) // Hmm. Using the method to test itself
+            hi <- negFiniteDoublesBetween(NegFiniteDouble.ensuringValid(lo + 1E292), NegFiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negFiniteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegFiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFiniteDouble, NegFiniteDouble)] =
+          for {
+            min <- negFiniteDoublesBetween(NegFiniteDouble.MinValue, NegFiniteDouble.ensuringValid(NegFiniteDouble.MaxValue - 1E292 - 1E292))
+            max <- negFiniteDoublesBetween(min, NegFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFiniteDouble] = negFiniteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegFiniteDouble, NegFiniteDouble)] =
+          for {
+            min <- negFiniteDoublesBetween(NegFiniteDouble.MinValue, NegFiniteDouble.ensuringValid(NegFiniteDouble.MaxValue - 1E292 - 1E292))
+            max <- negFiniteDoublesBetween(min, NegFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegFiniteDouble] = negFiniteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NegFiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negFiniteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegFiniteDouble, to: NegFiniteDouble): List[NegFiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegFiniteDouble] = negFiniteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZIntsBetween method" that {
+      val NegZIntMaxValueMinusOne = NegZInt(-1)
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZIntsBetween(NegZInt.MinValue, NegZInt.ensuringValid(NegZInt.MaxValue - 1))
+            hi <- negZIntsBetween(NegZInt.ensuringValid(lo + 1), NegZInt.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            negZIntsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegZInts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZInt, NegZInt)] =
+          for {
+            min <- negZIntsBetween(NegZInt.MinValue, NegZIntMaxValueMinusOne)
+            max <- negZIntsBetween(min, NegZInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZInt] = negZIntsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZInt, NegZInt)] =
+          for {
+            min <- negZIntsBetween(NegZInt.MinValue, NegZIntMaxValueMinusOne)
+            max <- negZIntsBetween(min, NegZInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZInt] = negZIntsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should (have length 1 or have length 2 or have length 3)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegZInt edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZInts.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZInt, to: NegZInt): List[NegZInt] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZInt] = negZIntsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZLongsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZLongsBetween(NegZLong.MinValue, NegZLong.ensuringValid(NegLong.MaxValue - 1)) // Hmm. Using the method to test itself
+            hi <- negZLongsBetween(NegZLong.ensuringValid(lo + 1), NegZLong.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            negZLongsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegZLongs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZLong, NegZLong)] =
+          for {
+            min <- negZLongsBetween(NegZLong.MinValue, NegZLong.ensuringValid(NegLong.MaxValue - 1))
+            max <- negZLongsBetween(min, NegZLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZLong] = negZLongsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZLong, NegZLong)] =
+          for {
+            min <- negZLongsBetween(NegZLong.MinValue, NegZLong.ensuringValid(NegZLong.MaxValue - 1))
+            max <- negZLongsBetween(min, NegZLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZLong] = negZLongsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegZLong edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZLongs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZLong, to: NegZLong): List[NegZLong] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZLong] = negZLongsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZFloatsBetween(NegZFloat.MinValue, NegZFloat.ensuringValid(NegZFloat.MaxValue - 1E32f - 1E32f)) // Hmm. Using the method to test itself
+            hi <- negZFloatsBetween(NegZFloat.ensuringValid(lo + 1E32f), NegZFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negZFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegZFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFloat, NegZFloat)] =
+          for {
+            min <- negZFloatsBetween(NegZFloat.MinValue, NegZFloat.ensuringValid(NegZFloat.MaxValue - 1E32f - 1E32f))
+            max <- negZFloatsBetween(min, NegZFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFloat] = negZFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFloat, NegZFloat)] =
+          for {
+            min <- negZFloatsBetween(NegZFloat.MinValue, NegZFloat.ensuringValid(NegZFloat.MaxValue - 1E32f))
+            max <- negZFloatsBetween(min, NegZFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFloat] = negZFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegZFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZFloat, to: NegZFloat): List[NegZFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZFloat] = negZFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZFiniteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZFiniteFloatsBetween(NegZFiniteFloat.MinValue, NegZFiniteFloat.ensuringValid(NegZFiniteFloat.MaxValue - 1E32f - 1E32f)) // Hmm. Using the method to test itself
+            hi <- negZFiniteFloatsBetween(NegZFiniteFloat.ensuringValid(lo + 1E32f), NegZFiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negZFiniteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegZFiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFiniteFloat, NegZFiniteFloat)] =
+          for {
+            min <- negZFiniteFloatsBetween(NegZFiniteFloat.MinValue, NegZFiniteFloat.ensuringValid(NegZFiniteFloat.MaxValue - 1E32f - 1E32f))
+            max <- negZFiniteFloatsBetween(min, NegZFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFiniteFloat] = negZFiniteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFiniteFloat, NegZFiniteFloat)] =
+          for {
+            min <- negZFiniteFloatsBetween(NegZFiniteFloat.MinValue, NegZFiniteFloat.ensuringValid(NegZFiniteFloat.MaxValue - 1E32f))
+            max <- negZFiniteFloatsBetween(min, NegZFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFiniteFloat] = negZFiniteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NegZFiniteFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZFiniteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZFiniteFloat, to: NegZFiniteFloat): List[NegZFiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZFiniteFloat] = negZFiniteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZDoublesBetween(NegZDouble.MinValue, NegZDouble.ensuringValid(NegZDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- negZDoublesBetween(NegZDouble.ensuringValid(lo + 1E292), NegZDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negZDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZDouble, NegZDouble)] =
+          for {
+            min <- negZDoublesBetween(NegZDouble.MinValue, NegZDouble.ensuringValid(NegZDouble.MaxValue - 1E292))
+            max <- negZDoublesBetween(min, NegZDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZDouble] = negZDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZDouble, NegZDouble)] =
+          for {
+            min <- negZDoublesBetween(NegZDouble.MinValue, NegZDouble.ensuringValid(NegZDouble.MaxValue - 1E292))
+            max <- negZDoublesBetween(min, NegZDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZDouble] = negZDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NegZDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZDouble, to: NegZDouble): List[NegZDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZDouble] = negZDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a negZFiniteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- negZFiniteDoublesBetween(NegZFiniteDouble.MinValue, NegZFiniteDouble.ensuringValid(NegZFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
+            hi <- negZFiniteDoublesBetween(NegZFiniteDouble.ensuringValid(lo + 1E292), NegZFiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            negZFiniteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NegZFiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFiniteDouble, NegZFiniteDouble)] =
+          for {
+            min <- negZFiniteDoublesBetween(NegZFiniteDouble.MinValue, NegZFiniteDouble.ensuringValid(NegZFiniteDouble.MaxValue - 1E292))
+            max <- negZFiniteDoublesBetween(min, NegZFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFiniteDouble] = negZFiniteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NegZFiniteDouble, NegZFiniteDouble)] =
+          for {
+            min <- negZFiniteDoublesBetween(NegZFiniteDouble.MinValue, NegZFiniteDouble.ensuringValid(NegZFiniteDouble.MaxValue - 1E292))
+            max <- negZFiniteDoublesBetween(min, NegZFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NegZFiniteDouble] = negZFiniteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NegZFiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = negZFiniteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NegZFiniteDouble, to: NegZFiniteDouble): List[NegZFiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NegZFiniteDouble] = negZFiniteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroIntsBetween method" that {
+      val NonZeroIntMaxValueMinusOne = PosInt(2147483646)
+
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroIntsBetween(NonZeroInt.MinValue, NonZeroInt.ensuringValid(NonZeroInt.MaxValue - 1))
+            hi <- nonZeroIntsBetween(if (lo.value == -1) NonZeroInt(1) else NonZeroInt.ensuringValid(lo + 1), NonZeroInt.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            nonZeroIntsBetween(hi, lo)
+          }
+        }
+      }
+
+      "produces NonZeroInts between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroInt, NonZeroInt)] =
+          for {
+            min <- nonZeroIntsBetween(NonZeroInt.MinValue, NonZeroIntMaxValueMinusOne)
+            max <- nonZeroIntsBetween(min, NonZeroInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroInt] = nonZeroIntsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroInt, NonZeroInt)] =
+          for {
+            min <- nonZeroIntsBetween(NonZeroInt.MinValue, NonZeroIntMaxValueMinusOne)
+            max <- nonZeroIntsBetween(min, NonZeroInt.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroInt] = nonZeroIntsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should (have length 1 or have length 2 or have length 3 or have length 4)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NonZeroInt edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroInts.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroInt, to: NonZeroInt): List[NonZeroInt] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroInt] = nonZeroIntsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroLongsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroLongsBetween(NonZeroLong.MinValue, NonZeroLong.ensuringValid(NonZeroLong.MaxValue - 1L)) // Hmm. Using the method to test itself
+            hi <- nonZeroLongsBetween(if (lo.value == -1L) NonZeroLong(1L) else NonZeroLong.ensuringValid(lo + 1L), NonZeroLong.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an [IllegalArgumentException] should be thrownBy {
+            nonZeroLongsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NonZeroLongs between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroLong, NonZeroLong)] =
+          for {
+            min <- nonZeroLongsBetween(NonZeroLong.MinValue, NonZeroLong.ensuringValid(NonZeroLong.MaxValue - 1))
+            max <- nonZeroLongsBetween(min, NonZeroLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroLong] = nonZeroLongsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroLong, NonZeroLong)] =
+          for {
+            min <- nonZeroLongsBetween(NonZeroLong.MinValue, NonZeroLong.ensuringValid(NonZeroLong.MaxValue - 1L))
+            max <- nonZeroLongsBetween(min, NonZeroLong.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroLong] = nonZeroLongsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NonZeroLong edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroLongs.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroLong, to: NonZeroLong): List[NonZeroLong] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroLong] = nonZeroLongsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroFloatsBetween(NonZeroFloat.MinValue, NonZeroFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
+            hi <- nonZeroFloatsBetween(if (lo + 1E32f == 0.0f) NonZeroFloat(1.0f) else NonZeroFloat.ensuringValid(lo + 1E32f), NonZeroFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            nonZeroFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces PosFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFloat, NonZeroFloat)] =
+          for {
+            min <- nonZeroFloatsBetween(NonZeroFloat.MinValue, NonZeroFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
+            max <- nonZeroFloatsBetween(min, NonZeroFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFloat] = nonZeroFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFloat, NonZeroFloat)] =
+          for {
+            min <- nonZeroFloatsBetween(NonZeroFloat.MinValue, NonZeroFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
+            max <- nonZeroFloatsBetween(min, NonZeroFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFloat] = nonZeroFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NonZeroFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroFloat, to: NonZeroFloat): List[NonZeroFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroFloat] = nonZeroFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroFiniteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroFiniteFloatsBetween(NonZeroFiniteFloat.MinValue, NonZeroFiniteFloat.ensuringValid(NonZeroFiniteFloat.MaxValue - 1E32f))
+            hi <- nonZeroFiniteFloatsBetween(if (lo + 1E32f == 0.0f) NonZeroFiniteFloat(1.0f) else NonZeroFiniteFloat.ensuringValid(lo + 1E32f), NonZeroFiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            nonZeroFiniteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces NonZeroFiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFiniteFloat, NonZeroFiniteFloat)] =
+          for {
+/*
+TODO: The following ensuringValid call is occassionally failing with a passed Infinity:
+This may be fixed by https://github.com/scalatest/scalatest/pull/1129/files
+If it doesn't show up for a while, please delete this comment.
+[info] CommonGeneratorsSpec:
+[info] The CommonGenerators object should offer a nonZeroFiniteFloatsBetween method that 
+[info] - returns a generator whose initEdges method includes min and max *** FAILED *** (5 milliseconds)
+[info]   java.lang.AssertionError: Infinity was not a valid NonZeroFiniteFloat
+[info]   at org.scalactic.anyvals.NonZeroFiniteFloat$.ensuringValid(NonZeroFiniteFloat.scala:541)
+[info]   at org.scalatest.prop.Randomizer.chooseNonZeroFiniteFloat(Randomizer.scala:1141)
+[info]   at org.scalatest.prop.CommonGenerators$$anon$35.next(CommonGenerators.scala:781)
+[info]   at org.scalatest.prop.Generator$$anon$9.next(Generator.scala:44)
+[info]   at org.scalatest.prop.Generator$$anon$10.next(Generator.scala:82)
+[info]   at org.scalatest.enablers.UnitPropCheckerAsserting$PropCheckerAssertingImpl.loop$1(PropCheckerAsserting.scala:152)
+[info]   at org.scalatest.enablers.UnitPropCheckerAsserting$PropCheckerAssertingImpl.checkForAll(PropCheckerAsserting.scala:194)
+[info]   at org.scalatest.enablers.UnitPropCheckerAsserting$PropCheckerAssertingImpl.check1(PropCheckerAsserting.scala:627)
+[info]   at org.scalatest.prop.GeneratorDrivenPropertyChecks$class.forAll(GeneratorDrivenPropertyChecks.scala:755)
+[info]   at org.scalatest.prop.GeneratorDrivenPropertyChecks$.forAll(GeneratorDrivenPropertyChecks.scala:1281)
+[info]   ...
+*/
+            min <- nonZeroFiniteFloatsBetween(NonZeroFiniteFloat.MinValue, NonZeroFiniteFloat.ensuringValid(NonZeroFiniteFloat.MaxValue - 1E32f))
+            max <- nonZeroFiniteFloatsBetween(min, NonZeroFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFiniteFloat] = nonZeroFiniteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFiniteFloat, NonZeroFiniteFloat)] =
+          for {
+            min <- nonZeroFiniteFloatsBetween(NonZeroFiniteFloat.MinValue, NonZeroFiniteFloat.ensuringValid(NonZeroFiniteFloat.MaxValue - 1E32f))
+            max <- nonZeroFiniteFloatsBetween(min, NonZeroFiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFiniteFloat] = nonZeroFiniteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal NonZeroFiniteFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroFiniteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat): List[NonZeroFiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroFiniteFloat] = nonZeroFiniteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroDoublesBetween(NonZeroDouble.MinValue, NonZeroDouble.ensuringValid(NonZeroDouble.MaxValue - 1E292))
+            hi <- nonZeroDoublesBetween(if (lo + 1E292 == 0.0) NonZeroDouble(1.0) else NonZeroDouble.ensuringValid(lo + 1E292), NonZeroDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            nonZeroDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NonZeroDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroDouble, NonZeroDouble)] =
+          for {
+            min <- nonZeroDoublesBetween(NonZeroDouble.MinValue, NonZeroDouble.ensuringValid(NonZeroDouble.MaxValue - 1E292))
+            max <- nonZeroDoublesBetween(min, NonZeroDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroDouble] = nonZeroDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroDouble, NonZeroDouble)] =
+          for {
+            min <- nonZeroDoublesBetween(NonZeroDouble.MinValue, NonZeroDouble.ensuringValid(NonZeroDouble.MaxValue - 1E292))
+            max <- nonZeroDoublesBetween(min, NonZeroDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroDouble] = nonZeroDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NonZeroDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroDouble, to: NonZeroDouble): List[NonZeroDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroDouble] = nonZeroDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a nonZeroFiniteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- nonZeroFiniteDoublesBetween(NonZeroFiniteDouble.MinValue, NonZeroFiniteDouble.ensuringValid(NonZeroFiniteDouble.MaxValue - 1E292))
+            hi <- nonZeroFiniteDoublesBetween(if (lo + 1E292 == 0.0) NonZeroFiniteDouble(1.0) else NonZeroFiniteDouble.ensuringValid(lo + 1E292), NonZeroFiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            nonZeroFiniteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces NonZeroFiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFiniteDouble, NonZeroFiniteDouble)] =
+          for {
+            min <- nonZeroFiniteDoublesBetween(NonZeroFiniteDouble.MinValue, NonZeroFiniteDouble.ensuringValid(NonZeroFiniteDouble.MaxValue - 1E292))
+            max <- nonZeroFiniteDoublesBetween(min, NonZeroFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFiniteDouble] = nonZeroFiniteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(NonZeroFiniteDouble, NonZeroFiniteDouble)] =
+          for {
+            min <- nonZeroFiniteDoublesBetween(NonZeroFiniteDouble.MinValue, NonZeroFiniteDouble.ensuringValid(NonZeroFiniteDouble.MaxValue - 1E292))
+            max <- nonZeroFiniteDoublesBetween(min, NonZeroFiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[NonZeroFiniteDouble] = nonZeroFiniteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal NonZeroFiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = nonZeroFiniteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble): List[NonZeroFiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[NonZeroFiniteDouble] = nonZeroFiniteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a finiteFloatsBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- finiteFloatsBetween(FiniteFloat.MinValue, FiniteFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
+            hi <- finiteFloatsBetween(FiniteFloat.ensuringValid(lo + 1E32f), FiniteFloat.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            finiteFloatsBetween(hi, lo)
+          }
+        }
+      }
+      "produces FiniteFloats between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(FiniteFloat, FiniteFloat)] =
+          for {
+            min <- finiteFloatsBetween(FiniteFloat.MinValue, FiniteFloat.ensuringValid(FiniteFloat.MaxValue - 1E32f))
+            max <- finiteFloatsBetween(min, FiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[FiniteFloat] = finiteFloatsBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(FiniteFloat, FiniteFloat)] =
+          for {
+            min <- finiteFloatsBetween(FiniteFloat.MinValue, FiniteFloat.ensuringValid(FiniteFloat.MaxValue - 1E32f))
+            max <- finiteFloatsBetween(min, FiniteFloat.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[FiniteFloat] = finiteFloatsBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+      "returns a generator whose initEdges method includes normal FiniteFloat edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = finiteFloats.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: FiniteFloat, to: FiniteFloat): List[FiniteFloat] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[FiniteFloat] = finiteFloatsBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a finiteDoublesBetween method" that {
+      "throws IAE if max is less than min" in {
+        val loHiPairs =
+          for {
+            lo <- finiteDoublesBetween(FiniteDouble.MinValue, FiniteDouble.ensuringValid(FiniteDouble.MaxValue - 1E292))
+            hi <- finiteDoublesBetween(FiniteDouble.ensuringValid(lo + 1E292), FiniteDouble.MaxValue)
+          } yield (lo, hi)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (loHiPairs) { case (lo, hi) =>
+          an[IllegalArgumentException] should be thrownBy {
+            finiteDoublesBetween(hi, lo)
+          }
+        }
+      }
+      "produces FiniteDoubles between min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(FiniteDouble, FiniteDouble)] =
+          for {
+            min <- finiteDoublesBetween(FiniteDouble.MinValue, FiniteDouble.ensuringValid(FiniteDouble.MaxValue - 1E292))
+            max <- finiteDoublesBetween(min, FiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[FiniteDouble] = finiteDoublesBetween(min, max)
+          val samples = minMaxGen.samples(10)
+          import org.scalatest.Inspectors._
+          forAll (samples) { i =>
+            i should be >= min
+            i should be <= max
+          }
+        }
+      }
+      "returns a generator whose initEdges method includes min and max" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minMaxPairs: Generator[(FiniteDouble, FiniteDouble)] =
+          for {
+            min <- finiteDoublesBetween(FiniteDouble.MinValue, FiniteDouble.ensuringValid(FiniteDouble.MaxValue - 1E292))
+            max <- finiteDoublesBetween(min, FiniteDouble.MaxValue)
+          } yield (min, max)
+
+        forAll (minMaxPairs) { case (min, max) =>
+          val minMaxGen: Generator[FiniteDouble] = finiteDoublesBetween(min, max)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges.length should (be >= 1 or be <= 7)
+          edges should contain (min)
+          edges should contain (max)
+        }
+      }
+
+      "returns a generator whose initEdges method includes normal FiniteDouble edges only if they are between min and max, inclusive" in {
+
+        import org.scalatest.Inspectors._
+
+        val (edges, rnd1) = finiteDoubles.initEdges(100, Randomizer.default)
+        val sortedEdges = edges.sorted
+        val combos = sortedEdges.combinations(2).toList
+
+        def included(from: FiniteDouble, to: FiniteDouble): List[FiniteDouble] = {
+          val fromIdx = sortedEdges.indexOf(from)
+          val toIdx = sortedEdges.indexOf(to)
+          sortedEdges.drop(fromIdx).take(toIdx - fromIdx + 1)
+        }
+
+        forAll (combos) { case List(from, to) =>
+          val requiredEdges = included(from, to)
+          val minMaxGen: Generator[FiniteDouble] = finiteDoublesBetween(from, to)
+          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          edges should contain allElementsOf requiredEdges
+          val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
+          edges should contain noElementsOf outOfBoundsEdges
+        }
+      }
+    }
+
+    "offer a specificValues method" that {
+      "returns a generator that produces from a given set of specific objects for any type T" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val values123 = specificValues(1, 2, 3)
+        // forAll (values123) { x => x should be oneOf (1, 2, 3) }
+        forAll (values123) { x => x should (be (1) or be (2) or be (3)) }
+        forAll (specificValues("nice", "warm", "fireplace")) { x =>
+          x should (be ("nice") or be ("warm") or be ("fireplace"))
+        }
+      }
+      "requires at least two values be passed to it" in {
+        """specificValues()""" shouldNot compile
+        """specificValues(1)""" shouldNot compile
+        """specificValues(1, 2)""" should compile
+      }
+    }
+    "offer a specificValue method" that {
+      "returns a generator that produces from a given single specific object for any type T" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val specificValue42 = specificValue(42)
+        forAll (specificValue42) { x => x shouldBe (42) }
+        forAll (specificValue("nice")) { x =>
+          x should (be ("nice"))
+        }
+      }
+    }
+    "offer a frequency method that takes a varargs of Int weights to generators and produces a generator" that {
+      "returns values from each specific generator with a probability determined by the weights" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        // import specificValue
+        val evenInts = for { i <- intsBetween(2, 100000) } yield 2 * i
+        val oddInts = for { i <- intsBetween(0, 100000) } yield 2 * i + 1
+        val oddAndEvenInts =
+          frequency(
+            1 -> oddInts,
+            2 -> evenInts,
+            4 -> specificValue(0)
+          )
+
+        val classification: Classification =
+          classify(10000, oddAndEvenInts) {
+            case 0 => "zero"
+            case i if i % 2 == 0 => "even"
+            case _ => "odd"
+          }
+ 
+        val percentages: Map[String, PosZInt] = classification.percentages
+
+        val totalWeight = 1 + 2 + 4
+        percentages("zero").value shouldBe (4.0 / totalWeight * 100).toInt +- 1
+        percentages("even").value shouldBe (2.0 / totalWeight * 100).toInt +- 1
+        percentages("odd").value shouldBe (1.0 / totalWeight * 100).toInt +- 1
+      }
+      "throws IllegalArgumentException if passed less than two arguments" in {
+        "frequency()" shouldNot compile
+        "frequency(1 -> ints)" shouldNot compile
+        "frequency(1 -> intsBetween(1, 10), 5 -> specificValue(0))" should compile
+      }
+    }
+    "offer an evenly method that takes a varargs of generators and produces a generator" that {
+      "returns values from each specific generator with an equal probability" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        sealed trait Numero extends Product with Serializable {
+          val value: Int
+        }
+        case class Uno(value: Int) extends Numero
+        case class Dos(value: Int) extends Numero
+        case class Tres(value: Int) extends Numero
+	case class Quatro(value: Int) extends Numero
+        case class Cinco(value: Int) extends Numero
+
+        val unos = instancesOf(Uno) { uno => uno.value }
+        val doses = instancesOf(Dos) { dos => dos.value }
+        val treses = instancesOf(Tres) { tres => tres.value }
+        val quatros = instancesOf(Quatro) { quatro => quatro.value }
+        val cincos = instancesOf(Cinco) { cinco => cinco.value }
+
+        // val numeros: Generator[Numero] = evenly(unos, doses, treses, quatros, cincos)
+        val numeros = evenly(unos, doses, treses, quatros, cincos)
+
+        val classification: Classification =
+          classify(10000, numeros) {
+            case _: Uno => "uno"
+            case _: Dos => "dos"
+            case _: Tres => "tres"
+            case _: Quatro => "quatro"
+            case _: Cinco => "cinco"
+          }
+ 
+        val percentages: Map[String, PosZInt] = classification.percentages
+
+        percentages("uno").value shouldBe 20 +- 1
+        percentages("dos").value shouldBe 20 +- 1
+        percentages("tres").value shouldBe 20 +- 1
+        percentages("quatro").value shouldBe 20 +- 1
+        percentages("cinco").value shouldBe 20 +- 1
+      }
+      "throws IllegalArgumentException if passed less than two arguments" in {
+        "evenly()" shouldNot compile
+        "evenly(ints)" shouldNot compile
+        "evenly(intsBetween(1, 10), specificValue(0))" should compile
+      }
+    }
+    def samplesForGen[T](genOfT: Generator[T], desiredLength: PosInt, originalRnd: Randomizer): List[T] = {         
+      @tailrec                                       
+      def samplesLoop(count: Int, rnd: Randomizer, acc: List[T]): List[T] = {
+        if (count == desiredLength.value) acc
+        else {
+          val maxSize = PosZInt(100)
+          val (size, nextRnd) = rnd.chooseInt(1, maxSize)
+          val (value, _, nextNextRnd) = genOfT.next(SizeParam(PosZInt(0), maxSize, PosZInt.ensuringValid(size)), Nil, rnd)
+          samplesLoop(count + 1, nextNextRnd, value :: acc)
+        } 
+      }
+      samplesLoop(100, originalRnd, Nil)
+    }
+
+    "offer a bytes method" that {
+      "returns the default implicit generator that produces arbitrary Bytes" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Byte]]
+        val namedGen = bytes
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a shorts method" that {
+      "returns the default implicit generator that produces arbitrary Shorts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Short]]
+        val namedGen = shorts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer an ints method" that {
+      "returns the default implicit generator that produces arbitrary Ints" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Int]]
+        val namedGen = ints
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a longs method" that {
+      "returns the default implicit generator that produces arbitrary Longs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Long]]
+        val namedGen = longs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a chars method" that {
+      "returns the default implicit generator that produces arbitrary Chars" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Char]]
+        val namedGen = chars
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a floats method" that {
+      "returns the default implicit generator that produces arbitrary Floats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Float]]
+        val namedGen = floats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a doubles method" that {
+      "returns the default implicit generator that produces arbitrary Doubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Double]]
+        val namedGen = doubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a strings method" that {
+      "returns the default implicit generator that produces arbitrary Strings" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[String]]
+        val namedGen = strings
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a lists method" that {
+      "returns the default implicit generator that produces arbitrary Lists" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[List[Int]]]
+        val namedGen = lists[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+      "returns a type that also offers a havingLength method that provides a generator for lists of a specific length" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (posIntsBetween(1, 100)) { len => 
+          forAll (lists[Int].havingLength(len)) { xs => xs.length shouldEqual len.value }
+        }
+      }
+      "returns a type that also offers a havingLengthsBetween method that provides a generator for lists of a range of lengths" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minsAndMaxes: Generator[(PosZInt, PosZInt)] =
+          for {
+            min <- posZIntsBetween(0, 99)
+            max <- posZIntsBetween(min.ensuringValid(_ + 1), 100)
+          } yield (min, max)
+
+        forAll (minsAndMaxes) { case (min, max) => 
+          forAll (lists[Int].havingLengthsBetween(min, max)) { xs => xs.length should (be >= min.value and be <= max.value) }
+        }
+
+        the [IllegalArgumentException] thrownBy {
+          lists[Int].havingLengthsBetween(2, 1)
+        } should have message "requirement failed: " + Resources.fromGreaterThanToHavingLengthsBetween(PosZInt(2), PosZInt(1))
+        the [IllegalArgumentException] thrownBy {
+          lists[Int].havingLengthsBetween(1, 1)
+        } should have message "requirement failed: " + Resources.fromEqualToToHavingLengthsBetween(PosZInt(1))
+      }
+      "returns a type that also offers a havingLengthsDeterminedBy method that provides a generator for lists whose length is determined by a function" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val upperLimits: Generator[PosZInt] = posZIntsBetween(0, 99)
+
+        forAll (upperLimits) { upperLimit => 
+          def limitedSize(szp: SizeParam): SizeParam = {
+            val sz = if (szp.maxSize < upperLimit) szp.maxSize else upperLimit
+            szp.copy(size = sz)
+          }
+          val lengthlimitedLists = lists[Int].havingLengthsDeterminedBy(limitedSize)
+          forAll (lengthlimitedLists) { xs => xs.length should be <= upperLimit.value }
+        }
+      }
+      "returns a type that also offers a havingSize method that provides a generator for lists of a specific size" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (posIntsBetween(1, 100)) { sz => 
+          forAll (lists[Int].havingSize(sz)) { xs => xs.size shouldEqual sz.value }
+        }
+      }
+      "returns a type that also offers a havingSizesBetween method that provides a generator for lists of a range of sizes" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val minsAndMaxes: Generator[(PosZInt, PosZInt)] =
+          for {
+            min <- posZIntsBetween(0, 99)
+            max <- posZIntsBetween(min.ensuringValid(_ + 1), 100)
+          } yield (min, max)
+
+        forAll (minsAndMaxes) { case (min, max) => 
+          forAll (lists[Int].havingSizesBetween(min, max)) { xs => xs.size should (be >= min.value and be <= max.value) }
+        }
+
+        the [IllegalArgumentException] thrownBy {
+          lists[Int].havingSizesBetween(2, 1)
+        } should have message "requirement failed: " + Resources.fromGreaterThanToHavingSizesBetween(PosZInt(2), PosZInt(1))
+        the [IllegalArgumentException] thrownBy {
+          lists[Int].havingSizesBetween(1, 1)
+        } should have message "requirement failed: " + Resources.fromEqualToToHavingSizesBetween(PosZInt(1))
+      }
+      "returns a type that also offers a havingSizesDeterminedBy method that provides a generator for lists whose size is determined by a function" in {
+
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+        val upperLimits: Generator[PosZInt] = posZIntsBetween(0, 99)
+
+        forAll (upperLimits) { upperLimit => 
+          def limitedSize(szp: SizeParam): SizeParam = {
+            val sz = if (szp.maxSize < upperLimit) szp.maxSize else upperLimit
+            szp.copy(size = sz)
+          }
+          val sizelimitedLists = lists[Int].havingSizesDeterminedBy(limitedSize)
+          forAll (sizelimitedLists) { xs => xs.size should be <= upperLimit.value }
+        }
+      }
+    }
+    "offer a posInts method" that {
+      "returns the default implicit generator that produces arbitrary PosInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosInt]]
+        val namedGen = posInts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZInts method" that {
+      "returns the default implicit generator that produces arbitrary PosZInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZInt]]
+        val namedGen = posZInts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posLongs method" that {
+      "returns the default implicit generator that produces arbitrary PosLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosLong]]
+        val namedGen = posLongs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZLongs method" that {
+      "returns the default implicit generator that produces arbitrary PosZLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZLong]]
+        val namedGen = posZLongs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFloats method" that {
+      "returns the default implicit generator that produces arbitrary PosFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFloat]]
+        val namedGen = posFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFiniteFloats method" that {
+      "returns the default implicit generator that produces arbitrary PosFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFiniteFloat]]
+        val namedGen = posFiniteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFloats method" that {
+      "returns the default implicit generator that produces arbitrary PosZFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFloat]]
+        val namedGen = posZFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFiniteFloats method" that {
+      "returns the default implicit generator that produces arbitrary PosZFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFiniteFloat]]
+        val namedGen = posZFiniteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posDoubles method" that {
+      "returns the default implicit generator that produces arbitrary PosDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosDouble]]
+        val namedGen = posDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFiniteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary PosFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFiniteDouble]]
+        val namedGen = posFiniteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZDoubles method" that {
+      "returns the default implicit generator that produces arbitrary PosZDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZDouble]]
+        val namedGen = posZDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFiniteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary PosZFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFiniteDouble]]
+        val namedGen = posZFiniteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a posIntValues method" that {
+      "returns the default implicit generator that produces arbitrary positive Ints" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosInt]]
+        val namedGen = posIntValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZIntValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and positive Ints" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZInt]]
+        val namedGen = posZIntValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posLongValues method" that {
+      "returns the default implicit generator that produces arbitrary positive Longs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosLong]]
+        val namedGen = posLongValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZLongValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and positive Longs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZLong]]
+        val namedGen = posZLongValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary positive Floats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFloat]]
+        val namedGen = posFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFiniteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary PosFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFiniteFloat]]
+        val namedGen = posFiniteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and positive Floats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFloat]]
+        val namedGen = posZFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFiniteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and PosZFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFiniteFloat]]
+        val namedGen = posZFiniteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary positive Doubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosDouble]]
+        val namedGen = posDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posFiniteDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary PosFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosFiniteDouble]]
+        val namedGen = posFiniteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and positive Doubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZDouble]]
+        val namedGen = posZDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a posZFiniteDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and PosZFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[PosZFiniteDouble]]
+        val namedGen = posZFiniteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negInts method" that {
+      "returns the default implicit generator that produces arbitrary NegInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegInt]]
+        val namedGen = negInts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZInts method" that {
+      "returns the default implicit generator that produces arbitrary NegZInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZInt]]
+        val namedGen = negZInts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negLongs method" that {
+      "returns the default implicit generator that produces arbitrary NegLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegLong]]
+        val namedGen = negLongs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZLongs method" that {
+      "returns the default implicit generator that produces arbitrary NegZLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZLong]]
+        val namedGen = negZLongs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFloats method" that {
+      "returns the default implicit generator that produces arbitrary NegFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFloat]]
+        val namedGen = negFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFiniteFloats method" that {
+      "returns the default implicit generator that produces arbitrary NegFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFiniteFloat]]
+        val namedGen = negFiniteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFloats method" that {
+      "returns the default implicit generator that produces arbitrary NegZFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFloat]]
+        val namedGen = negZFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFiniteFloats method" that {
+      "returns the default implicit generator that produces arbitrary NegZFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFiniteFloat]]
+        val namedGen = negZFiniteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NegDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegDouble]]
+        val namedGen = negDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFiniteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NegFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFiniteDouble]]
+        val namedGen = negFiniteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NegZDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZDouble]]
+        val namedGen = negZDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFiniteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NegZFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFiniteDouble]]
+        val namedGen = negZFiniteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a negIntValues method" that {
+      "returns the default implicit generator that produces arbitrary NegInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegInt]]
+        val namedGen = negIntValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZIntValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZInt]]
+        val namedGen = negZIntValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negLongValues method" that {
+      "returns the default implicit generator that produces arbitrary NegLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegLong]]
+        val namedGen = negLongValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZLongValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZLong]]
+        val namedGen = negZLongValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary NegFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFloat]]
+        val namedGen = negFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFiniteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary NegFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFiniteFloat]]
+        val namedGen = negFiniteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFloat]]
+        val namedGen = negZFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFiniteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFiniteFloat]]
+        val namedGen = negZFiniteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary NegDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegDouble]]
+        val namedGen = negDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negFiniteDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary NegFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegFiniteDouble]]
+        val namedGen = negFiniteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZDouble]]
+        val namedGen = negZDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a negZFiniteDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary zero and NegZFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NegZFiniteDouble]]
+        val namedGen = negZFiniteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroInts method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroInt]]
+        val namedGen = nonZeroInts
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroLongs method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroLong]]
+        val namedGen = nonZeroLongs
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFloats method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFloat]]
+        val namedGen = nonZeroFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFiniteFloats method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFiniteFloat]]
+        val namedGen = nonZeroFiniteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroDouble]]
+        val namedGen = nonZeroDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFiniteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFiniteDouble]]
+        val namedGen = nonZeroFiniteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroIntValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroInts" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroInt]]
+        val namedGen = nonZeroIntValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroLongValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroLongs" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroLong]]
+        val namedGen = nonZeroLongValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFloat]]
+        val namedGen = nonZeroFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFiniteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFiniteFloat]]
+        val namedGen = nonZeroFiniteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroDouble]]
+        val namedGen = nonZeroDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a nonZeroFiniteDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary NonZeroFiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NonZeroFiniteDouble]]
+        val namedGen = nonZeroFiniteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a finiteFloats method" that {
+      "returns the default implicit generator that produces arbitrary FiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[FiniteFloat]]
+        val namedGen = finiteFloats
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a finiteDoubles method" that {
+      "returns the default implicit generator that produces arbitrary FiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[FiniteDouble]]
+        val namedGen = finiteDoubles
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a numericChars method" that {
+      "returns the default implicit generator that produces arbitrary NumericChars" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NumericChar]]
+        val namedGen = numericChars
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a finiteFloatValues method" that {
+      "returns the default implicit generator that produces arbitrary FiniteFloats" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[FiniteFloat]]
+        val namedGen = finiteFloatValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a finiteZeroDoubleValues method" that {
+      "returns the default implicit generator that produces arbitrary FiniteDoubles" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[FiniteDouble]]
+        val namedGen = finiteDoubleValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+    "offer a numericCharValues method" that {
+      "returns the default implicit generator that produces arbitrary NumericChars" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[NumericChar]]
+        val namedGen = numericCharValues
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples.map(_.value) shouldEqual namedGenSamples
+      }
+    }
+
+    "offer a tuple2s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple2s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int)]]
+        val namedGen = tuple2s[String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple3s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple3s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long)]]
+        val namedGen = tuple3s[String, Int, Long]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple4s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple4s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float)]]
+        val namedGen = tuple4s[String, Int, Long, Float]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple5s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple5s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double)]]
+        val namedGen = tuple5s[String, Int, Long, Float, Double]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple6s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple6s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String)]]
+        val namedGen = tuple6s[String, Int, Long, Float, Double, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple7s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple7s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int)]]
+        val namedGen = tuple7s[String, Int, Long, Float, Double, String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple8s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple8s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long)]]
+        val namedGen = tuple8s[String, Int, Long, Float, Double, String, Int, Long]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple9s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple9s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float)]]
+        val namedGen = tuple9s[String, Int, Long, Float, Double, String, Int, Long, Float]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple10s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple10s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
+        val namedGen = tuple10s[String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple11s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple11s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
+        val namedGen = tuple11s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple12s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple12s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
+        val namedGen = tuple12s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple13s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple13s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long)]]
+        val namedGen = tuple13s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple14s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple14s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float)]]
+        val namedGen = tuple14s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple15s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple15s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
+        val namedGen = tuple15s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple16s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple16s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
+        val namedGen = tuple16s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple17s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple17s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
+        val namedGen = tuple17s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple18s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple18s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long)]]
+        val namedGen = tuple18s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple19s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple19s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float)]]
+        val namedGen = tuple19s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple20s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple20s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
+        val namedGen = tuple20s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple21s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple21s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
+        val namedGen = tuple21s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a tuple22s method" that {
+      "returns the default implicit generator that produces arbitrary Tuple22s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
+        val namedGen = tuple22s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a function0s method" that {
+      "returns the default implicit generator that produces arbitrary Function0s" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[() => Int]]
+        val namedGen = function0s[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a function1s method" that {
+      "should use the implicit provider that uses hashCode to tweak a seed and has a pretty toString" in {
+        val implicitGen = implicitly[Generator[Long => Int]]
+        val namedGen = function1s[Long, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a function2s method" that {
+      "should use the implicit provider that uses hashCode to tweak a seed and has a pretty toString" in {
+        val implicitGen = implicitly[Generator[(Long, String) => Int]]
+        val namedGen = function2s[Long, String, Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a vectors method" that {
+      "returns the default implicit generator that produces arbitrary Vectors" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Vector[Int]]]
+        val namedGen = vectors[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a sets method" that {
+      "returns the default implicit generator that produces arbitrary Sets" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Set[Int]]]
+        val namedGen = sets[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a sortedSets method" that {
+      "returns the default implicit generator that produces arbitrary Sets" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[SortedSet[Int]]]
+        val namedGen = sortedSets[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a maps method" that {
+      "returns the default implicit generator that produces arbitrary Maps" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Map[Int, String]]]
+        val namedGen = maps[Int, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a sortedMaps method" that {
+      "returns the default implicit generator that produces arbitrary SortedMaps" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[SortedMap[Int, String]]]
+        val namedGen = sortedMaps[Int, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+    "offer a classify method" that {
+      "takes a partial function and returns an object containing a Map of String classifications to Int totals" in {
+        val classification: Classification =
+          classify(1000, ints) {
+            case 0 => "zero"
+            case i if i > 0 => "positive"
+            case _ => "negative"
+          }
+ 
+        val totals: Map[String, PosZInt] = classification.totals
+        totals should have size 3
+        totals should (contain key "zero" and contain key "positive" and contain key "negative")
+      }
+      "allows users to leave some values unclassified" in {
+        val classification: Classification =
+          classify(1000, ints) {
+            case 0 => "zero"
+            case i if i > 0 => "positive"
+            // case _ => "negative" will leave negative ones unclassified
+          }
+ 
+        val totals: Map[String, PosZInt] = classification.totals
+        totals should have size 2
+        totals should (contain key "zero" and contain key "positive")
+      }
+      "offer a method that gives back the total number of trials performed" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (posIntsBetween(100, 1000)) { (count: PosInt) =>
+          val fullClassification: Classification =
+            classify(count, ints) {
+              case 0 => "zero"
+              case i if i > 0 => "positive"
+              case _ => "negative"
+            }
+          fullClassification.totalGenerated shouldEqual count
+ 
+          val partialClassification: Classification =
+            classify(count, ints) {
+              case 0 => "zero"
+              case i if i > 0 => "positive"
+              // case _ => "negative" will leave negative ones unclassified
+            }
+          partialClassification.totalGenerated shouldEqual count
+        }
+      }
+      "offers a method returning a Map of String classification names to Double portions (between 0.0 and 1.0)" in {
+        val classification: Classification =
+          classify(1000, ints) {
+            case 0 => "zero"
+            case i if i > 0 => "positive"
+            case _ => "negative"
+          }
+ 
+        val portions: Map[String, Double] = classification.portions
+        portions should have size 3
+        portions should (contain key "zero" and contain key "positive" and contain key "negative")
+        portions.values.sum shouldEqual 1.0
+      }
+      "offers a method returning a Map of String classification names to Int percentages (between 0 and 100)" in {
+        val classification: Classification =
+          classify(1000, ints) {
+            case 0 => "zero"
+            case i if i > 0 => "positive"
+            case _ => "negative"
+          }
+ 
+        val percentages: Map[String, PosZInt] = classification.percentages
+        percentages should have size 3
+        percentages should (contain key "zero" and contain key "positive" and contain key "negative")
+        percentages.values.map(_.value).sum shouldEqual 100 +- 1
+      }
+      "has a toString method that prints percentages and classifications on individual lines" in {
+        val classification: Classification =
+          classify(1000, ints) {
+            case 0 => "zero"
+            case i if i > 0 => "positive"
+            case _ => "negative"
+          }
+ 
+        val output: String = classification.toString
+        output.count(_ == '\n') shouldEqual 2
+        val lines: List[String] = output.split('\n').toList
+        lines.length shouldEqual 3
+        all (lines) should contain ('%')
+        exactly (1, lines) should include ("zero")
+        exactly (1, lines) should include ("positive")
+        exactly (1, lines) should include ("negative")
+      }
+    }
+    "offer a gen method" that {
+      "produces generators given construct and deconstruct functions for 1 type" in {
+        case class Person(age: Int)
+        val persons = instancesOf(Person) { p => p.age } (posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(ag) => ag should be >= 0 } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 2 types" in {
+        case class Person(name: String, age: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age)
+        } (strings, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag) => ag should be >= 0 } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 3 types" in {
+        case class Person(name: String, age: Int, attr3: Long)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3)
+        } (strings, posZIntValues, posZLongValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 4 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 5 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 6 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 7 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 8 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 9 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 10 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 11 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 12 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 13 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 14 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 15 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 16 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 17 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 18 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float, attr18: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+          attr18 should be >= 0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 19 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float, attr18: Int, attr19: Long)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+          attr18 should be >= 0
+          attr19 should be >= 0L
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 20 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+          attr18 should be >= 0
+          attr19 should be >= 0L
+          attr20 should be >= 0.0
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 21 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+          attr18 should be >= 0
+          attr19 should be >= 0L
+          attr20 should be >= 0.0
+          attr21 should be >= 0.0f
+        } // A contrived property check to do something with the generator
+      }
+      "produces generators given construct and deconstruct functions for 22 types" in {
+        case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
+                          attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float, attr22: Int)
+        val persons = instancesOf(Person) { p =>
+          (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21, p.attr22)
+        } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
+          posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21, attr22) =>
+          ag should be >= 0
+          attr3 should be >= 0L
+          attr4 should be >= 0.0
+          attr5 should be >= 0.0f
+          attr6 should be >= 0
+          attr7 should be >= 0L
+          attr8 should be >= 0.0
+          attr9 should be >= 0.0f
+          attr10 should be >= 0
+          attr11 should be >= 0L
+          attr12 should be >= 0.0
+          attr13 should be >= 0.0f
+          attr14 should be >= 0
+          attr15 should be >= 0L
+          attr16 should be >= 0.0
+          attr17 should be >= 0.0f
+          attr18 should be >= 0
+          attr19 should be >= 0L
+          attr20 should be >= 0.0
+          attr21 should be >= 0.0f
+          attr22 should be >= 0
+        } // A contrived property check to do something with the generator
+      }
+    }
+  }
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest._
+
+class ConfigurationSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  describe("Configuration.Parameter") {
+    implicit val configGen: Generator[Configuration.Parameter] =
+      for {
+        minSuccessful <- posInts
+        maxDiscardedFactor <- posZDoubles
+        minSize <- posZInts
+        sizeRange <- posZIntsBetween(0, PosZInt.ensuringValid(PosZInt.MaxValue - minSize))
+        workers <- posInts
+      } yield Configuration.Parameter(minSuccessful, maxDiscardedFactor, minSize, sizeRange, workers)
+
+    it("should offer a maxSize method that is minSize + SizeRange") {
+      forAll { (param: Configuration.Parameter) =>
+        param.maxSize.value shouldEqual (param.minSize + param.sizeRange)
+      }
+    }
+
+    it("should throw IllegalArgumentException when the result of minSize + sizeRange goes out of range") {
+      assertThrows[IllegalArgumentException] {
+        Configuration.Parameter(PosInt(5), PosZDouble(0.5), PosZInt.MaxValue, PosZInt(1), PosInt(1))
+      }
+    }
+  }
+}

--- a/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1,0 +1,2579 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.scalatest.exceptions.TestFailedException
+import scala.collection.immutable.SortedSet
+import scala.collection.immutable.SortedMap
+
+class GeneratorSpec extends FunSpec with Matchers {
+  describe("A Generator") {
+    it("should offer a map and flatMap method that composes the next methods") {
+      import Generator._
+      def pairGen(): Generator[(Int, Double)] =
+        // doubleGen().flatMap(d => intGen().map(i => (i, d)))
+        for {
+          d <- doubleGenerator
+          i <- intGenerator
+        } yield (i, d)
+      val aGen = pairGen()
+      val bGen = pairGen()
+      val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+      val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+      val (a3, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+      a1._1 should not equal a2._1
+      a1._2 should not equal a2._2
+      val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+      val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+      val (b3, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+      a1 shouldEqual b1
+      a2 shouldEqual b2
+      a3 shouldEqual b3
+    }
+    it("should offer a map method that composes canonicals methods and offers a shrink that uses the canonicals methods") {
+
+      import Generator._
+
+      val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+      val expectedTupCanonicals = intCanonicalsIt.map(i => ('A', i)).toList
+
+      val tupGen = for (i <- intGenerator) yield ('A', i)
+      val (tupShrinkIt, _) = tupGen.shrink(('A', 100), Randomizer.default)
+      val (tupCanonicalsIt, _) = tupGen.canonicals(Randomizer.default)
+      val tupShrink = tupShrinkIt.toList
+      val tupCanonicals = tupCanonicalsIt.toList
+
+      tupShrink shouldBe expectedTupCanonicals
+      tupCanonicals shouldBe expectedTupCanonicals
+    }
+    it("should offer a flatMap method that composes canonicals methods and offers a shrink that uses the canonicals methods") {
+
+      import Generator._
+
+      val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+      val intCanonicals = intCanonicalsIt.toList
+      val (doubleCanonicalsIt, _) = doubleGenerator.canonicals(Randomizer.default)
+      val doubleCanonicals = doubleCanonicalsIt.toList
+      val expectedTupCanonicals: List[(Int, Double)] =
+        for {
+          i <- intCanonicals
+          d <- doubleCanonicals
+        } yield (i, d)
+
+      val tupGen =
+        for {
+          i <- intGenerator
+          d <- doubleGenerator
+        }  yield (i, d)
+      val (tupShrinkIt, _) = tupGen.shrink((100, 100.0), Randomizer.default)
+      val (tupCanonicalsIt, _) = tupGen.canonicals(Randomizer.default)
+      val tupShrink = tupShrinkIt.toList
+      val tupCanonicals = tupCanonicalsIt.toList
+
+      tupShrink shouldBe expectedTupCanonicals
+      tupCanonicals shouldBe expectedTupCanonicals
+    }
+    it("should offer a filter method so that pattern matching can be used in for expressions with Generator generators") {
+      """for ((a, b) <- CommonGenerators.tuple2s[String, Int]) yield (b, a)""" should compile
+      case class Person(name: String, age: Int)
+      val persons = CommonGenerators.instancesOf(Person) { p => (p.name, p.age) }
+      """for (Person(a, b) <- persons) yield (b, a)""" should compile
+    }
+    it("should offer a filter method that throws an exception if too many objects are filtered out") {
+      val doNotDoThisAtHome = CommonGenerators.ints.filter(i => i == 0) // Only keep zero
+      a [IllegalStateException] should be thrownBy {
+        doNotDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default())
+      }
+      val okToDoThisAtHome = CommonGenerators.ints.filter(i => i != 0) // Only keep non-zeros
+      noException should be thrownBy {
+        okToDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default())
+      }
+    }
+    it("should mix up both i and d when used in a for expression") {
+      import Generator._
+      def pairGen(): Generator[(Int, Double)] =
+        // doubleGen().flatMap(d => intGen().map(i => (i, d)))
+        for {
+          i <- intGenerator
+          d <- doubleGenerator
+        } yield (i, d)
+      val aGen = pairGen()
+      val bGen = pairGen()
+      val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+      val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+      val (a3, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+      a1._1 should not equal a2._1
+      a1._2 should not equal a2._2
+      val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+      val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+      val (b3, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+      a1 shouldEqual b1
+      a2 shouldEqual b2
+      a3 shouldEqual b3
+    }
+    it("should be usable in a forAll") {
+      import GeneratorDrivenPropertyChecks._
+      forAll { (i: Int) => 
+        i + i shouldEqual i * 2
+      }
+      a [TestFailedException] should be thrownBy {
+        forAll { (i: Int) => 
+          i + i shouldEqual i * 3
+        }
+      }
+    }
+    it("should be used at least minSuccessful times in a forAll") {
+      import GeneratorDrivenPropertyChecks._
+      var count = 0
+      forAll { (i: Int) => 
+        count += 1
+        i + i shouldEqual i * 2
+      }
+      count shouldEqual generatorDrivenConfig.minSuccessful.value
+
+      {
+        implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 10)
+        count = 0
+        forAll { (i: Int) => 
+          count += 1
+          i + i shouldEqual i * 2
+        }
+        count shouldEqual generatorDrivenConfig.minSuccessful.value
+      }
+    }
+    it("should be used at least maxDiscarded times in a forAll") {
+      import GeneratorDrivenPropertyChecks._
+      var count = 0
+      a [TestFailedException] should be thrownBy {
+        forAll { (i: Int) => 
+          count += 1
+          whenever(false) {
+            i + i shouldEqual i * 3
+          }
+        }
+      }
+      val maxDiscarded = PropertyCheckConfiguration.calculateMaxDiscarded(generatorDrivenConfig.maxDiscardedFactor, generatorDrivenConfig.minSuccessful)
+      count shouldEqual maxDiscarded
+
+      {
+        val expectedTestDiscarded = 49
+        val maxDiscardedFactor = PosZDouble.ensuringValid(PropertyCheckConfiguration.calculateMaxDiscardedFactor(10, expectedTestDiscarded))
+        implicit val generatorDrivenConfig = PropertyCheckConfiguration(maxDiscardedFactor = maxDiscardedFactor)
+        info(s"What is this one: ${generatorDrivenConfig.maxDiscardedFactor}")
+        count = 0
+        a [TestFailedException] should be thrownBy {
+          forAll { (i: Int) => 
+            count += 1
+            whenever(false) {
+              i + i shouldEqual i * 3
+            }
+          }
+        }
+        count shouldEqual expectedTestDiscarded
+      }
+    }
+    it("mapping and flatMapping a Generator should compose the edges") {
+      // import prop._
+      import Generator._
+
+      val intGenerator1 = intGenerator
+      val intGenerator2 = intGenerator
+
+      val (initEdges1, ir1) = intGenerator1.initEdges(100, Randomizer.default)
+      val (initEdges2, ir2) = intGenerator2.initEdges(100, ir1)
+
+      initEdges1 should contain theSameElementsAs initEdges2
+
+      def pairGen(): Generator[(Int, Int)] =
+        for {
+          i <- intGenerator1
+          j <- intGenerator2
+        } yield (i, j)
+
+      val gen = pairGen()
+      val (initEdges, ier) = gen.initEdges(100, ir2)
+
+      initEdges.length should equal (initEdges1.length * initEdges2.length)
+
+      val comboLists: List[List[Int]] = initEdges1.combinations(2).toList
+      val comboPairs: List[(Int, Int)] = comboLists.map(xs => (xs(0), xs(1)))
+      val plusReversedPairs: List[(Int, Int)] = comboPairs flatMap { case (x, y) => List((x, y), (y, x)) }
+      val sameValuePairs: List[(Int, Int)] = initEdges1.map(i => (i, i))
+      val expectedInitEdges: List[(Int, Int)] = plusReversedPairs ++ sameValuePairs
+
+      initEdges should contain theSameElementsAs expectedInitEdges
+
+      val (tup1, e1, r1) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+      val (tup2, e2, r2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e1, rnd = r1)
+      val (tup3, e3, r3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e2, rnd = r2)
+      val (tup4, e4, r4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e3, rnd = r3)
+      val (tup5, e5, r5) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e4, rnd = r4)
+      val (tup6, e6, r6) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e5, rnd = r5)
+      val (tup7, e7, r7) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e6, rnd = r6)
+      val (tup8, e8, r8) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e7, rnd = r7)
+      val (tup9, e9, r9) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e8, rnd = r8)
+      val (tup10, e10, r10) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e9, rnd = r9)
+      val (tup11, e11, r11) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e10, rnd = r10)
+      val (tup12, e12, r12) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e11, rnd = r11)
+      val (tup13, e13, r13) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e12, rnd = r12)
+      val (tup14, e14, r14) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e13, rnd = r13)
+      val (tup15, e15, r15) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e14, rnd = r14)
+      val (tup16, e16, r16) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e15, rnd = r15)
+      val (tup17, e17, r17) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e16, rnd = r16)
+      val (tup18, e18, r18) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e17, rnd = r17)
+      val (tup19, e19, r19) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e18, rnd = r18)
+      val (tup20, e20, r20) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e19, rnd = r19)
+      val (tup21, e21, r21) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e20, rnd = r20)
+      val (tup22, e22, r22) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e21, rnd = r21)
+      val (tup23, e23, r23) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e22, rnd = r22)
+      val (tup24, e24, r24) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e23, rnd = r23)
+      val (tup25, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e24, rnd = r24)
+      val values = List(tup1, tup2, tup3, tup4, tup5, tup6, tup7, tup8, tup9, tup10,
+          tup11, tup12, tup13, tup14, tup15, tup16, tup17, tup18, tup19, tup20,
+          tup21, tup22, tup23, tup24, tup25)
+      values should contain theSameElementsAs expectedInitEdges
+    }
+    it("should be able to use a ScalaCheck Arbitary and Shrink") {
+      import org.scalacheck.{Arbitrary, Gen, Shrink}
+      import org.scalacheck.rng.Seed
+      val intShrink = implicitly[Shrink[Int]] 
+      val intArbitrary = implicitly[Arbitrary[Int]]
+      val intGen = intArbitrary.arbitrary
+      val intGenerator = Generator.scalaCheckArbitaryGenerator(intArbitrary, intShrink)
+      val (edges, er) = intGenerator.initEdges(100, Randomizer.default)
+      edges should equal (Nil) // A ScalaCheck-backed generator would have no edges
+      val scalaCheckShrinkList = intShrink.shrink(100)
+      val (scalaTestShrinkIt, _) = intGenerator.shrink(100, Randomizer.default)
+      val scalaTestShrinkList = scalaTestShrinkIt.toList
+      scalaTestShrinkList shouldEqual scalaCheckShrinkList.reverse
+    }
+
+    describe("for Bytes") {
+      it("should produce the same Byte values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = byteGenerator
+        val bGen = byteGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Byte edge values first in random order") {
+        import Generator._
+        val gen = byteGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: Byte, ae1: List[Byte], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (0)
+        edges should contain (1)
+        edges should contain (-1)
+        edges should contain (Byte.MaxValue)
+        edges should contain (Byte.MinValue)
+      }
+      it("should produce Byte canonical values") {
+        import Generator._
+        val gen = byteGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3).map(_.toByte)
+      }
+      it("should shrink Bytes by repeatedly halving and negating") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (b: Byte) =>
+          val generator = implicitly[Generator[Byte]]
+          val (shrinkIt, _) = generator.shrink(b, Randomizer.default)
+          val shrinks: List[Byte] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (b == 0)
+            shrinks shouldBe empty
+          else {
+            if (b > 1.toByte)
+              shrinks.last should be > 0.toByte
+            else if (b < -1.toByte)
+              shrinks.last should be < 0.toByte
+            import org.scalatest.Inspectors._
+            val pairs: List[(Byte, Byte)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0 || x == -y || x.abs == y.abs / 2)
+            }
+          }
+        }
+      }
+    }
+    describe("for Shorts") {
+      it("should produce the same Short values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= shortGenerator
+        val bGen = shortGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Short edge values first in random order") {
+        import Generator._
+        val gen = shortGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: Short, ae1: List[Short], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (0)
+        edges should contain (1)
+        edges should contain (-1)
+        edges should contain (Short.MaxValue)
+        edges should contain (Short.MinValue)
+      }
+      it("should produce Short canonical values") {
+        import Generator._
+        val gen = shortGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3).map(_.toShort)
+      }
+      it("should shrink Shorts by repeatedly halving and negating") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (n: Short) =>
+          val generator = implicitly[Generator[Short]]
+          val (shrinkIt, _) = generator.shrink(n, Randomizer.default)
+          val shrinks: List[Short] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (n == 0)
+            shrinks shouldBe empty
+          else {
+            if (n > 1.toShort)
+              shrinks.last should be > 0.toShort
+            else if (n < -1.toShort)
+              shrinks.last should be < 0.toShort
+            import org.scalatest.Inspectors._
+            val pairs: List[(Short, Short)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0 || x == -y || x.abs == y.abs / 2)
+            }
+          }
+        }
+      }
+    }
+    describe("for Ints") {
+      it("should produce the same Int values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= intGenerator
+        val bGen = intGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Int edge values first in random order") {
+        import Generator._
+        val gen = intGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: Int, ae1: List[Int], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (0)
+        edges should contain (1)
+        edges should contain (-1)
+        edges should contain (Int.MaxValue)
+        edges should contain (Int.MinValue)
+      }
+      it("should produce Int canonical values") {
+        import Generator._
+        val gen = intGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3)
+      }
+      it("should shrink Ints by repeatedly halving and negating") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (i: Int) =>
+          val generator = implicitly[Generator[Int]]
+          val (shrinkIt, _) = generator.shrink(i, Randomizer.default)
+          val shrinks: List[Int] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (i == 0)
+            shrinks shouldBe empty
+          else {
+            if (i > 1)
+              shrinks.last should be > 0
+            else if (i < -1)
+              shrinks.last should be < 0
+            import org.scalatest.Inspectors._
+            val pairs: List[(Int, Int)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0 || x == -y || x.abs == y.abs / 2)
+            }
+          }
+        }
+      }
+    }
+    describe("for Longs") {
+      it("should produce the same Long values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= longGenerator
+        val bGen = longGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Long edge values first in random order") {
+        import Generator._
+        val gen = longGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: Long, ae1: List[Long], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (0)
+        edges should contain (1)
+        edges should contain (-1)
+        edges should contain (Long.MaxValue)
+        edges should contain (Long.MinValue)
+      }
+      it("should produce Long canonical values") {
+        import Generator._
+        val gen = longGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0L, 1L, -1L, 2L, -2L, 3L, -3L)
+      }
+      it("should shrink Longs by repeatedly halving and negating") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (n: Long) =>
+          val generator = implicitly[Generator[Long]]
+          val (shrinkIt, _) = generator.shrink(n, Randomizer.default)
+          val shrinks: List[Long] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (n == 0)
+            shrinks shouldBe empty
+          else {
+            if (n > 1L)
+              shrinks.last should be > 0L
+            else if (n < -1L)
+              shrinks.last should be < 0L
+            import org.scalatest.Inspectors._
+            val pairs: List[(Long, Long)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0 || x == -y || x.abs == y.abs / 2)
+            }
+  /*
+            all (pairs) should satisfy { case (x, y) =>
+              y == 0 || y == -x || y.abs == x.abs / 2
+            }
+  */
+          }
+        }
+      }
+    }
+    describe("for Chars") {
+      it("should produce the same Char values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= charGenerator
+        val bGen = charGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Char edge values first in random order") {
+        import Generator._
+        val gen = charGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: Char, ae1: List[Char], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (Char.MinValue)
+        edges should contain (Char.MaxValue)
+      }
+      it("should produce Char canonical values") {
+        import Generator._
+        val gen = charGenerator
+        val (canonicalsIt, _) = gen.canonicals(Randomizer.default)
+        val canonicals = canonicalsIt.toList
+        canonicals(0) should (be >= 'a' and be <= 'z')
+        canonicals(1) should (be >= 'A' and be <= 'Z')
+        canonicals(2) should (be >= '0' and be <= '9')
+      }
+      it("should shrink Chars by trying selected printable characters") {
+        import GeneratorDrivenPropertyChecks._
+        val expectedChars = "abcdefghikjlmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toList
+        val generator = implicitly[Generator[Char]]
+        forAll { (c: Char) =>
+          val (shrinkIt, _) = generator.shrink(c, Randomizer.default)
+          val shrinks: List[Char] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z')
+            shrinks shouldBe empty
+          else
+            shrinks shouldEqual expectedChars
+        }
+        import org.scalatest.Inspectors
+        Inspectors.forAll (expectedChars) { (c: Char) => 
+          val (shrinkIt, _) = generator.shrink(c, Randomizer.default)
+          val shrinks: List[Char] = shrinkIt.toList
+          shrinks shouldBe empty
+        }
+      }
+    }
+    describe("for Floats") {
+      it("should produce the same Float values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = floatGenerator
+        val bGen = floatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        a1 shouldEqual b1
+        a2 shouldEqual b2
+        a3 shouldEqual b3
+      }
+      it("should produce the Float edge value first") {
+        import Generator._
+        val gen = floatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        a1 shouldEqual 0.0f
+      }
+      it("should produce Float canonical values") {
+        import Generator._
+        val gen = floatGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0.0f, 1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f)
+      }
+      it("should shrink Floats by dropping the fraction part then repeatedly 'square-rooting' and negating") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (f: Float) =>
+          val generator = implicitly[Generator[Float]]
+          val (shrinkIt, _) = generator.shrink(f, Randomizer.default)
+          val shrinks: List[Float] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (f == 0.0f) {
+            shrinks shouldBe empty
+          } else {
+            if (f > 1.0f)
+              shrinks.last should be > 0.0f
+            else if (f < -1.0f)
+              shrinks.last should be < 0.0f
+            import org.scalatest.Inspectors._
+            if (!f.isWhole) {
+              shrinks.last shouldEqual (if (f > 0.0f) f.floor else f.ceil)
+            }
+            val pairs: List[(Float, Float)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0.0f || x == -y || x.abs < y.abs)
+            }
+          }
+        }
+      }
+    }
+    describe("for Doubles") {
+      it("should produce the same Double values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = doubleGenerator
+        val bGen = doubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        a1 shouldEqual b1
+        a2 shouldEqual b2
+        a3 shouldEqual b3
+      }
+      it("should produce the Double edge value first") {
+        import Generator._
+        val gen = doubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        a1 shouldEqual 0.0
+      }
+      it("should produce Double canonical values") {
+        import Generator._
+        val gen = doubleGenerator
+        val (canonicals, _) = gen.canonicals(Randomizer.default)
+        canonicals.toList shouldBe List(0.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0)
+      }
+      it("should shrink Doubles by dropping the fraction part then repeatedly 'square-rooting' and negating") {
+        import GeneratorDrivenPropertyChecks._
+  // try with -173126.1489439121
+        forAll { (d: Double) =>
+          val generator = implicitly[Generator[Double]]
+          val (shrinkIt, _) = generator.shrink(d, Randomizer.default)
+          val shrinks: List[Double] = shrinkIt.toList
+          shrinks.distinct.length shouldEqual shrinks.length
+          if (d == 0.0) {
+            shrinks shouldBe empty
+          }
+          else {
+            import org.scalatest.Inspectors._
+            if (d > 1.0)
+              shrinks.last should be > 0.0
+            else if (d < -1.0)
+              shrinks.last should be < 0.0
+            if (!d.isWhole) {
+              shrinks.last shouldEqual (if (d > 0.0) d.floor else d.ceil)
+            }
+            val pairs: List[(Double, Double)] = shrinks.zip(shrinks.tail)
+            forAll (pairs) { case (x, y) =>
+              assert(x == 0.0 || x == -y || x.abs < y.abs)
+            }
+          }
+        }
+      }
+    }
+    describe("for PosInts") {
+      it("should produce the same PosInt values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posIntGenerator
+        val bGen = posIntGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosInt edge values first in random order") {
+        import Generator._
+        val gen = posIntGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosInt, ae1: List[PosInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosInt(1))
+        edges should contain (PosInt.MaxValue)
+      }
+    }
+    describe("for PosZInts") {
+      it("should produce the same PosZInt values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZIntGenerator
+        val bGen = posZIntGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZInt edge values first in random order") {
+        import Generator._
+        val gen = posZIntGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZInt, ae1: List[PosZInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZInt(0))
+        edges should contain (PosZInt(1))
+        edges should contain (PosZInt.MaxValue)
+      }
+    }
+    describe("for PosLongs") {
+      it("should produce the same PosLong values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posLongGenerator
+        val bGen = posLongGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosLong edge values first in random order") {
+        import Generator._
+        val gen = posLongGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosLong, ae1: List[PosLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosLong(1L))
+        edges should contain (PosLong.MaxValue)
+      }
+    }
+    describe("for PosZLongs") {
+      it("should produce the same PosZLong values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZLongGenerator
+        val bGen = posZLongGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZLong edge values first in random order") {
+        import Generator._
+        val gen = posZLongGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZLong, ae1: List[PosZLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZLong(0L))
+        edges should contain (PosZLong(1L))
+        edges should contain (PosZLong.MaxValue)
+      }
+    }
+    describe("for PosFloat") {
+      it("should produce the same PosFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posFloatGenerator
+        val bGen = posFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosFloat edge values first in random order") {
+        import Generator._
+        val gen = posFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosFloat, ae1: List[PosFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosFloat(1.0f))
+        edges should contain (PosFloat.MaxValue)
+      }
+    }
+    describe("for PosFiniteFloat") {
+      it("should produce the same PosFiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posFiniteFloatGenerator
+        val bGen = posFiniteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosFiniteFloat edge values first in random order") {
+        import Generator._
+        val gen = posFiniteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosFiniteFloat, ae1: List[PosFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosFiniteFloat(1.0f))
+        edges should contain (PosFiniteFloat.MaxValue)
+      }
+    }
+    describe("for PosZFloat") {
+      it("should produce the same PosZFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZFloatGenerator
+        val bGen = posZFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZFloat edge values first in random order") {
+        import Generator._
+        val gen = posZFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZFloat, ae1: List[PosZFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZFloat(0.0f))
+        edges should contain (PosZFloat(1.0f))
+        edges should contain (PosZFloat.MaxValue)
+      }
+    }
+    describe("for PosZFiniteFloat") {
+      it("should produce the same PosZFiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZFiniteFloatGenerator
+        val bGen = posZFiniteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZFiniteFloat edge values first in random order") {
+        import Generator._
+        val gen = posZFiniteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZFiniteFloat, ae1: List[PosZFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZFiniteFloat(0.0f))
+        edges should contain (PosZFiniteFloat(1.0f))
+        edges should contain (PosZFiniteFloat.MaxValue)
+      }
+    }
+    describe("for PosDouble") {
+      it("should produce the same PosDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posDoubleGenerator
+        val bGen = posDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosDouble edge values first in random order") {
+        import Generator._
+        val gen = posDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosDouble, ae1: List[PosDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosDouble(1.0))
+        edges should contain (PosDouble.MaxValue)
+      }
+    }
+    describe("for PosFiniteDouble") {
+      it("should produce the same PosFiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posFiniteDoubleGenerator
+        val bGen = posFiniteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosFiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = posFiniteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosFiniteDouble, ae1: List[PosFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (PosFiniteDouble(1.0))
+        edges should contain (PosFiniteDouble.MaxValue)
+      }
+    }
+    describe("for PosZDouble") {
+      it("should produce the same PosZDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZDoubleGenerator
+        val bGen = posZDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZDouble edge values first in random order") {
+        import Generator._
+        val gen = posZDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZDouble, ae1: List[PosZDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZDouble(0.0))
+        edges should contain (PosZDouble(1.0))
+        edges should contain (PosZDouble.MaxValue)
+      }
+    }
+    describe("for PosZFiniteDouble") {
+      it("should produce the same PosZFiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= posZFiniteDoubleGenerator
+        val bGen = posZFiniteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce PosZFiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = posZFiniteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: PosZFiniteDouble, ae1: List[PosZFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (PosZFiniteDouble(0.0))
+        edges should contain (PosZFiniteDouble(1.0))
+        edges should contain (PosZFiniteDouble.MaxValue)
+      }
+    }
+    describe("for NegInts") {
+      it("should produce the same NegInt values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negIntGenerator
+        val bGen = negIntGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegInt edge values first in random order") {
+        import Generator._
+        val gen = negIntGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegInt, ae1: List[NegInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (NegInt(-1))
+        edges should contain (NegInt.MaxValue)
+      }
+    }
+    describe("for NegZInts") {
+      it("should produce the same NegZInt values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZIntGenerator
+        val bGen = negZIntGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZInt edge values first in random order") {
+        import Generator._
+        val gen = negZIntGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZInt, ae1: List[NegZInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegZInt(0))
+        edges should contain (NegZInt(-1))
+        edges should contain (NegZInt.MaxValue)
+      }
+    }
+    describe("for NegLongs") {
+      it("should produce the same NegLong values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negLongGenerator
+        val bGen = negLongGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegLong edge values first in random order") {
+        import Generator._
+        val gen = negLongGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegLong, ae1: List[NegLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val edges = List(a1, a2)
+        edges should contain (NegLong(-1L))
+        edges should contain (NegLong.MaxValue)
+      }
+    }
+    describe("for NegZLongs") {
+      it("should produce the same NegZLong values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZLongGenerator
+        val bGen = negZLongGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZLong edge values first in random order") {
+        import Generator._
+        val gen = negZLongGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZLong, ae1: List[NegZLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegZLong(0L))
+        edges should contain (NegZLong(-1L))
+        edges should contain (NegZLong.MaxValue)
+      }
+    }
+    describe("for NegFloat") {
+      it("should produce the same NegFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negFloatGenerator
+        val bGen = negFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegFloat edge values first in random order") {
+        import Generator._
+        val gen = negFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegFloat, ae1: List[NegFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegFloat(-1.0f))
+        edges should contain (NegFloat.MaxValue)
+        edges should contain (NegFloat.MinValue)
+      }
+    }
+    describe("for NegFiniteFloat") {
+      it("should produce the same NegFiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negFiniteFloatGenerator
+        val bGen = negFiniteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegFiniteFloat edge values first in random order") {
+        import Generator._
+        val gen = negFiniteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegFiniteFloat, ae1: List[NegFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegFiniteFloat(-1.0f))
+        edges should contain (NegFiniteFloat.MaxValue)
+        edges should contain (NegFiniteFloat.MinValue)
+      }
+    }
+    describe("for NegZFloat") {
+      it("should produce the same NegZFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZFloatGenerator
+        val bGen = negZFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZFloat edge values first in random order") {
+        import Generator._
+        val gen = negZFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZFloat, ae1: List[NegZFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NegZFloat.MinValue)
+        edges should contain (NegZFloat(-1.0f))
+        edges should contain (NegZFloat.MaxValue)
+        edges should contain (NegZFloat.ensuringValid(-Float.MinPositiveValue))
+      }
+    }
+    describe("for NegZFiniteFloat") {
+      it("should produce the same NegZFiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZFiniteFloatGenerator
+        val bGen = negZFiniteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZFiniteFloat edge values first in random order") {
+        import Generator._
+        val gen = negZFiniteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZFiniteFloat, ae1: List[NegZFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NegZFiniteFloat.MinValue)
+        edges should contain (NegZFiniteFloat(-1.0f))
+        edges should contain (NegZFiniteFloat.MaxValue)
+        edges should contain (NegZFiniteFloat.ensuringValid(-Float.MinPositiveValue))
+      }
+    }
+    describe("for NegDouble") {
+      it("should produce the same NegDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negDoubleGenerator
+        val bGen = negDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegDouble edge values first in random order") {
+        import Generator._
+        val gen = negDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegDouble, ae1: List[NegDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegDouble(-1.0))
+        edges should contain (NegDouble.MinValue)
+        edges should contain (NegDouble.MaxValue)
+      }
+    }
+    describe("for NegFiniteDouble") {
+      it("should produce the same NegFiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negFiniteDoubleGenerator
+        val bGen = negFiniteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegFiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = negFiniteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegFiniteDouble, ae1: List[NegFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (NegFiniteDouble(-1.0))
+        edges should contain (NegFiniteDouble.MinValue)
+        edges should contain (NegFiniteDouble.MaxValue)
+      }
+    }
+    describe("for NegZDouble") {
+      it("should produce the same NegZDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZDoubleGenerator
+        val bGen = negZDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZDouble edge values first in random order") {
+        import Generator._
+        val gen = negZDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZDouble, ae1: List[NegZDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NegZDouble.MinValue)
+        edges should contain (NegZDouble(-1.0))
+        edges should contain (NegZDouble.MaxValue)
+        edges should contain (NegZDouble.ensuringValid(-Double.MinPositiveValue))
+      }
+    }
+    describe("for NegZFiniteDouble") {
+      it("should produce the same NegZFiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= negZFiniteDoubleGenerator
+        val bGen = negZFiniteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NegZFiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = negZFiniteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NegZFiniteDouble, ae1: List[NegZFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NegZFiniteDouble.MinValue)
+        edges should contain (NegZFiniteDouble(-1.0))
+        edges should contain (NegZFiniteDouble.MaxValue)
+        edges should contain (NegZFiniteDouble.ensuringValid(-Double.MinPositiveValue))
+      }
+    }
+    describe("for NonZeroInts") {
+      it("should produce the same NonZeroInt values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroIntGenerator
+        val bGen = nonZeroIntGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroInt edge values first in random order") {
+        import Generator._
+        val gen = nonZeroIntGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroInt, ae1: List[NonZeroInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroInt(-1))
+        edges should contain (NonZeroInt.MaxValue)
+        edges should contain (NonZeroInt(1))
+        edges should contain (NonZeroInt.MinValue)
+      }
+    }
+    describe("for NonZeroLongs") {
+      it("should produce the same NonZeroLong values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroLongGenerator
+        val bGen = nonZeroLongGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroLong edge values first in random order") {
+        import Generator._
+        val gen = nonZeroLongGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroLong, ae1: List[NonZeroLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroLong(-1L))
+        edges should contain (NonZeroLong.MaxValue)
+        edges should contain (NonZeroLong(1L))
+        edges should contain (NonZeroLong.MinValue)
+      }
+    }
+    describe("for NonZeroFloat") {
+      it("should produce the same NonZeroFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroFloatGenerator
+        val bGen = nonZeroFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroFloat edge values first in random order") {
+        import Generator._
+        val gen = nonZeroFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroFloat, ae1: List[NonZeroFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroFloat(-1.0f))
+        edges should contain (NonZeroFloat(1.0f))
+        edges should contain (NonZeroFloat.MaxValue)
+        edges should contain (NonZeroFloat.MinValue)
+      }
+    }
+    describe("for NonZeroFiniteFloat") {
+      it("should produce the same NonZeroFiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroFiniteFloatGenerator
+        val bGen = nonZeroFiniteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroFiniteFloat edge values first in random order") {
+        import Generator._
+        val gen = nonZeroFiniteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroFiniteFloat, ae1: List[NonZeroFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroFiniteFloat(-1.0f))
+        edges should contain (NonZeroFiniteFloat(1.0f))
+        edges should contain (NonZeroFiniteFloat.MaxValue)
+        edges should contain (NonZeroFiniteFloat.MinValue)
+      }
+    }
+    describe("for NonZeroDouble") {
+      it("should produce the same NonZeroDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroDoubleGenerator
+        val bGen = nonZeroDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroDouble edge values first in random order") {
+        import Generator._
+        val gen = nonZeroDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroDouble, ae1: List[NonZeroDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroDouble(-1.0))
+        edges should contain (NonZeroDouble(1.0))
+        edges should contain (NonZeroDouble.MinValue)
+        edges should contain (NonZeroDouble.MaxValue)
+      }
+    }
+    describe("for NonZeroFiniteDouble") {
+      it("should produce the same NonZeroFiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen= nonZeroFiniteDoubleGenerator
+        val bGen = nonZeroFiniteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NonZeroFiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = nonZeroFiniteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: NonZeroFiniteDouble, ae1: List[NonZeroFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val edges = List(a1, a2, a3, a4)
+        edges should contain (NonZeroFiniteDouble(-1.0))
+        edges should contain (NonZeroFiniteDouble(1.0))
+        edges should contain (NonZeroFiniteDouble.MinValue)
+        edges should contain (NonZeroFiniteDouble.MaxValue)
+      }
+    }
+    describe("for FiniteFloat") {
+      it("should produce the same FiniteFloat values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = finiteFloatGenerator
+        val bGen = finiteFloatGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce finiteFloat edge values first in random order") {
+        import Generator._
+        val gen = finiteFloatGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: FiniteFloat, ae1: List[FiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (FiniteFloat(0.0f))
+        edges should contain (FiniteFloat(-1.0f))
+        edges should contain (FiniteFloat(1.0f))
+        edges should contain (FiniteFloat.MaxValue)
+        edges should contain (FiniteFloat.MinValue)
+      }
+    }
+    describe("for FiniteDouble") {
+      it("should produce the same FiniteDouble values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = finiteDoubleGenerator
+        val bGen = finiteDoubleGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce FiniteDouble edge values first in random order") {
+        import Generator._
+        val gen = finiteDoubleGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1: FiniteDouble, ae1: List[FiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
+        val (a5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae4, rnd = ar4)
+        val edges = List(a1, a2, a3, a4, a5)
+        edges should contain (FiniteDouble(0.0))
+        edges should contain (FiniteDouble(-1.0))
+        edges should contain (FiniteDouble(1.0))
+        edges should contain (FiniteDouble.MinValue)
+        edges should contain (FiniteDouble.MaxValue)
+      }
+    }
+    describe("for NumericChar") {
+      it("should produce the same NumericChar values in the same order given the same Randomizer") {
+        import Generator._
+        val aGen = numericCharGenerator
+        val bGen = numericCharGenerator
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce NumericChar edge values first in random order") {
+        import Generator._
+        val gen = numericCharGenerator
+        val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
+        val (a1, ae1, ar1) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a2, _, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        List(a1, a2) should contain theSameElementsAs List(NumericChar('0'), NumericChar('9'))
+      }
+    }
+
+    describe("for Strings") {
+      it("should offer a String generator that returns a string whose length equals the passed size") {
+  
+        import Generator._
+        val gen = stringGenerator
+  
+        val (s1, _, r1) = gen.next(szp = SizeParam(PosZInt(0), 100, 0), edges = Nil, rnd = Randomizer(100))
+        s1.length shouldBe 0
+  
+        val (s2, _, r2) = gen.next(szp = SizeParam(PosZInt(0), 100, 3), edges = Nil, rnd = r1)
+        s2.length shouldBe 3
+  
+        val (s3, _, r3) = gen.next(szp = SizeParam(PosZInt(0), 100, 38), edges = Nil, rnd = r2)
+        s3.length shouldBe 38
+  
+        val (s4, _, r4) = gen.next(szp = SizeParam(PosZInt(0), 100, 88), edges = Nil, rnd = r3)
+        s4.length shouldBe 88
+  
+        val (s5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = r4)
+        s5.length shouldBe 100
+      }
+      it("should shrink Strings using strategery") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (s: String) =>
+          val generator = implicitly[Generator[String]]
+          val (shrinkIt, _) = generator.shrink(s, Randomizer.default)
+          val shrinks: List[String] = shrinkIt.toList
+          if (s.isEmpty)
+            shrinks shouldBe empty
+          else {
+            shrinks(0) shouldBe ""
+            shrinks(1) should have length 1
+            shrinks(1).head should (be >= 'a' and be <= 'z')
+            shrinks(2) should have length 1
+            shrinks(2).head should (be >= 'A' and be <= 'Z')
+            shrinks(3) should have length 1
+            shrinks(3).head should (be >= '0' and be <= '9')
+  
+            val theChars = shrinks.drop(4)
+            val distincts: List[String] = s.distinct.toList.map(_.toString)
+            theChars.take(distincts.length).toList shouldEqual distincts
+  
+            val theHalves = shrinks.drop(4 + distincts.length)
+            if (theHalves.length > 1) {
+              import org.scalatest.Inspectors
+              val zipped = theHalves.zip(theHalves.tail) 
+              Inspectors.forAll (zipped) { case (s, t) => 
+                s.length should be < t.length
+              }
+            } else succeed
+          }
+        }
+      }
+      it("should offer a String generator that offers cononicals based on Char canonicals") {
+        import Generator._
+        val gen = stringGenerator
+        val (canonicalsIt, _) = gen.canonicals(Randomizer.default)
+        val canonicals = canonicalsIt.toList
+        canonicals(0) shouldBe empty
+        canonicals(1) should have length 1
+        canonicals(1).head should (be >= 'a' and be <= 'z')
+        canonicals(2) should have length 1
+        canonicals(2).head should (be >= 'A' and be <= 'Z')
+        canonicals(3) should have length 1
+        canonicals(3).head should (be >= '0' and be <= '9')
+      }
+    }
+    describe("for Lists") {
+      it("should offer a List[T] generator that returns a List[T] whose length equals the passed size") {
+  
+        import Generator._
+        val gen = listGenerator[Int]
+  
+        val (l1, _, r1) = gen.next(szp = SizeParam(PosZInt(0), 100, 0), edges = Nil, rnd = Randomizer(100))
+        l1.length shouldBe 0
+  
+        val (l2, _, r2) = gen.next(szp = SizeParam(PosZInt(0), 100, 3), edges = Nil, rnd = r1)
+        l2.length shouldBe 3
+  
+        val (l3, _, r3) = gen.next(szp = SizeParam(PosZInt(0), 100, 38), edges = Nil, rnd = r2)
+        l3.length shouldBe 38
+  
+        val (l4, _, r4) = gen.next(szp = SizeParam(PosZInt(0), 100, 88), edges = Nil, rnd = r3)
+        l4.length shouldBe 88
+  
+        val (l5, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = r4)
+        l5.length shouldBe 100
+      }
+      it("should not exhibit this bug in List shrinking") {
+        val lstGen = implicitly[Generator[List[List[Int]]]]
+        val xss = List(List(100, 200, 300, 400, 300))
+        lstGen.shrink(xss, Randomizer.default)._1.toList should not contain xss
+      }
+      it("should shrink Lists using strategery") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        forAll { (xs: List[Int]) =>
+          val generator = implicitly[Generator[List[Int]]]
+          val (shrinkIt, _) = generator.shrink(xs, Randomizer.default)
+          val shrinks: List[List[Int]] = shrinkIt.toList
+          if (xs.isEmpty)
+            shrinks shouldBe empty
+          else {
+  
+            // First one should be the empty list
+            shrinks(0) shouldBe Nil
+  
+            // Then should come one-element Lists of the canonicals of the type
+            val phase2 = shrinks.drop(1).take(intCanonicals.length)
+            phase2 shouldEqual (intCanonicals.map(i => List(i)))
+  
+            // Phase 3 should be one-element lists of all distinct values in the value passed to shrink
+            // If xs already is a one-element list, then we don't do this, because then xs would appear in the output.
+            val xsDistincts = if (xs.length > 1) xs.distinct else Nil
+            val phase3 = shrinks.drop(1 + intCanonicals.length).take(xsDistincts.length)
+            phase3 shouldEqual (xsDistincts.map(i => List(i)))
+  
+            // Phase 4 should be n-element lists that are prefixes cut in half
+            val theHalves = shrinks.drop(1 + intCanonicals.length + xsDistincts.length)
+            theHalves should not contain xs // This was a bug I noticed
+            if (theHalves.length > 1) {
+              import org.scalatest.Inspectors
+              val zipped = theHalves.zip(theHalves.tail) 
+              Inspectors.forAll (zipped) { case (s, t) => 
+                s.length should be < t.length
+              }
+            } else succeed
+          }
+        }
+      }
+      it("should return an empty Iterator when asked to shrink a List of size 0") {
+        val lstGen = implicitly[Generator[List[Int]]]
+        val xs = List.empty[Int]
+        lstGen.shrink(xs, Randomizer.default)._1.toList shouldBe empty
+      }
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a List of size 1") {
+        val lstGen = implicitly[Generator[List[Int]]]
+        val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
+        val expectedLists = List(List.empty[Int]) ++ canonicalLists
+        val nonCanonical = List(99)
+        lstGen.shrink(nonCanonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+        val canonical = List(3)
+        // Ensure 3 (an Int canonical value) does not show up twice in the output
+        lstGen.shrink(canonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+      }
+      it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
+        val lstGen = implicitly[Generator[List[Int]]]
+        val shrinkees = lstGen.shrink(List(3, 99), Randomizer.default)._1.toList
+        shrinkees.distinct should contain theSameElementsAs shrinkees
+      }
+      it("should return an Iterator that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
+        // Since the last batch of lists produced by the list shrinker start at length 2 and then double in size each time,
+        // they lengths will be powers of two: 2, 4, 8, 16, etc... So make sure that if the original length has length 16,
+        // for example, that that one doesn't show up in the shrinks output, because it would be the original list-to-shrink.
+        val lstGen = implicitly[Generator[List[Int]]]
+        val listToShrink = List.fill(16)(99)
+        val shrinkees = lstGen.shrink(listToShrink, Randomizer.default)._1.toList
+        shrinkees.distinct should not contain listToShrink
+      }
+      it("should offer a list generator whose canonical method uses the canonical method of the underlying T") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        val listOfIntGenerator = Generator.listGenerator[Int]
+        val (listOfIntCanonicalsIt, _) = listOfIntGenerator.canonicals(Randomizer.default)
+        val listOfIntCanonicals = listOfIntCanonicalsIt.toList
+        listOfIntCanonicals shouldEqual intCanonicals.map(i => List(i))
+      }
+    }
+    describe("for Function0s") {
+      it("should offer an implicit provider for constant function0's with a pretty toString") {
+        val function0s = Generator.function0Generator[Int]
+        import GeneratorDrivenPropertyChecks._
+        forAll (function0s) { (f: () => Int) =>
+          val constantResult = f()
+          import org.scalactic.TimesOnInt._
+          10 times { f() shouldEqual constantResult }
+          f.toString shouldBe s"() => $constantResult"
+        }
+      }
+      it("should offer an implicit provider for constant function0's that returns the edges of the result type") {
+        val ints = Generator.intGenerator
+        val function0s = Generator.function0Generator[Int]
+        val (intEdgesIt, rnd1) = ints.initEdges(100, Randomizer.default)
+        val (function0EdgesIt, _) = function0s.initEdges(100, rnd1)
+        val intEdges = intEdgesIt.toList
+        val function0Edges = function0EdgesIt.toList
+        function0Edges.map(f => f()) should contain theSameElementsAs intEdges
+      }
+      it("should offer an implicit provider for constant function0's that returns the canonicals of the result type") {
+        val ints = Generator.intGenerator
+        val function0s = Generator.function0Generator[Int]
+        val (intCanonicalsIt, rnd1) = ints.canonicals(Randomizer.default)
+        val (function0CanonicalsIt, _) = function0s.canonicals(rnd1)
+        val intCanonicals = intCanonicalsIt.toList
+        val function0Canonicals = function0CanonicalsIt.toList
+        function0Canonicals.map(f => f()) should contain theSameElementsAs intCanonicals
+      }
+      it("should offer an implicit provider for constant function0's that returns the shrinks of the result type") {
+        val ints = Generator.intGenerator
+        val function0s = Generator.function0Generator[Int]
+        import GeneratorDrivenPropertyChecks._
+        forAll (ints) { (i: Int) =>
+          val (intShrinksIt, rnd1) = ints.shrink(i, Randomizer.default)
+          val (function0ShrinksIt, _) = function0s.shrink(() => i, rnd1)
+          val intShrinks = intShrinksIt.toList
+          val function0Shrinks = function0ShrinksIt.toList
+          function0Shrinks.map(f => f()) should contain theSameElementsAs intShrinks
+        }
+      }
+    }
+    describe("for arbitrary Function1s") {
+      it("should offer an implicit provider that uses hashCode to tweak a seed and has a pretty toString") {
+        val gen = implicitly[Generator[Option[Int] => List[Int]]]
+        val sample = gen.sample
+        sample.toString should include ("Option[Int]")
+        sample.toString should include ("List[Int]")
+      }
+    }
+    describe("for Tuple2s") {
+      it("should offer a tuple2 generator") {
+        val gen = implicitly[Generator[(Int, Int)]]
+        val intGen = implicitly[Generator[Int]]
+        val (it8, rnd1) = intGen.shrink(8, Randomizer.default())
+        val (it18, rnd2)= intGen.shrink(18, rnd1)
+        val list8 = it8.toList
+        val list18 = it18.toList
+        val listTup =
+          for {
+            x <- list8
+            y <- list18
+          } yield (x, y)
+        gen.shrink((8, 18), rnd2)._1.toList shouldEqual listTup
+      }
+      it("should be able to transform a tuple generator to a case class generator") {
+        val tupGen: Generator[(String, Int)] = Generator.tuple2Generator[String, Int]
+        case class Person(name: String, age: Int)
+        val persons = for (tup <- tupGen) yield Person(tup._1, tup._2)
+        val (it, _) = persons.shrink(Person("Harry Potter", 32), Randomizer.default())
+        it.toList should not be empty
+      }
+    }
+    describe("for Int => Ints") {
+      it("should have toString and simpleName that doesn't include org.scalatest.prop.valueOf") {
+        import GeneratorDrivenPropertyChecks._
+        forAll { (f: Int => Int) =>
+          f.toString should startWith ("(i: Int) => ")
+          f.toString should not include "org.scalatest.prop.valueOf"
+        }
+      }
+    }
+    describe("for Vector[T]s") {
+      it("should produce the same Vector[T] values in the same order given the same Randomizer") {
+        val aGen= Generator.vectorGenerator[Int]
+        val bGen = Generator.vectorGenerator[Int]
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Vector[T] edge values first in random order") {
+        val gen = Generator.vectorGenerator[Int]
+        val (a1: Vector[Int], ae1: List[Vector[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Vector.empty[Int], Vector(1, 2), Vector(3, 4, 5)), rnd = Randomizer.default)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (Vector.empty[Int])
+        edges should contain (Vector(1, 2))
+        edges should contain (Vector(3, 4, 5))
+      }
+      it("should produce Vector[T] following size determined by havingSize method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.size shouldBe 3
+        }
+      }
+      it("should produce Vector[T] following length determined by havingLength method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingLength(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.length shouldBe 3
+        }
+      }
+      it("should produce Vector[T] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.vectorGenerator[Int]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce Vector[T] following lengths determined by havingLengthBetween method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.length should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingLengthBetween is called with invalid from and to pair") {
+        val aGen= Generator.vectorGenerator[Int]
+        aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingLengthsBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingLengthsBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce Vector[T] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.size shouldBe 5
+        }
+      }
+      it("should produce Vector[T] following sizes determined by havingLengthsDeterminedBy method") {
+        val aGen= Generator.vectorGenerator[Int]
+        implicit val sGen = aGen.havingLengthsDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { v: Vector[Int] =>
+          v.length shouldBe 5
+        }
+      }
+    }
+
+    describe("for Set[T]s") {
+      it("should produce the same Set[T] values in the same order given the same Randomizer") {
+        val aGen= Generator.setGenerator[Int]
+        val bGen = Generator.setGenerator[Int]
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Set[T] edge values first in random order") {
+        val gen = Generator.setGenerator[Int]
+        val (a1: Set[Int], ae1: List[Set[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Set.empty[Int], Set(1, 2), Set(3, 4, 5)), rnd = Randomizer.default)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (Set.empty[Int])
+        edges should contain (Set(1, 2))
+        edges should contain (Set(3, 4, 5))
+      }
+      it("should produce Set[T] following size determined by havingSize method") {
+        val aGen= Generator.setGenerator[Int]
+        implicit val sGen = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Set[Int] =>
+          s.size shouldBe 3
+        }
+      }
+      it("should produce Set[T] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.setGenerator[Int]
+        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Set[Int] =>
+          s.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.setGenerator[Int]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce Set[T] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.setGenerator[Int]
+        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Set[Int] =>
+          s.size shouldBe 5
+        }
+      }
+    }
+
+    describe("for SortedSet[T]s") {
+      it("should produce the same SortedSet[T] values in the same order given the same Randomizer") {
+        val aGen= Generator.sortedSetGenerator[Int]
+        val bGen = Generator.sortedSetGenerator[Int]
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce SortedSet[T] edge values first in random order") {
+        val gen = Generator.sortedSetGenerator[Int]
+        val (a1: SortedSet[Int], ae1: List[SortedSet[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(SortedSet.empty[Int], SortedSet(1, 2), SortedSet(3, 4, 5)), rnd = Randomizer.default)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (SortedSet.empty[Int])
+        edges should contain (SortedSet(1, 2))
+        edges should contain (SortedSet(3, 4, 5))
+      }
+      it("should produce Set[T] following size determined by havingSize method") {
+        val aGen= Generator.sortedSetGenerator[Int]
+        implicit val sGen = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedSet[Int] =>
+          s.size shouldBe 3
+        }
+      }
+      it("should produce Set[T] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.sortedSetGenerator[Int]
+        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedSet[Int] =>
+          s.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.sortedSetGenerator[Int]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce Set[T] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.sortedSetGenerator[Int]
+        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedSet[Int] =>
+          s.size shouldBe 5
+        }
+      }
+    }
+
+    describe("for Map[K, V]s") {
+      it("should produce the same Map[K, V] values in the same order given the same Randomizer") {
+        val aGen= Generator.mapGenerator[Int, String]
+        val bGen = Generator.mapGenerator[Int, String]
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce Map[K, V] edge values first in random order") {
+        val gen = Generator.mapGenerator[Int, String]
+        val (a1: Map[Int, String], ae1: List[Map[Int, String]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Map.empty[Int, String], Map(1 -> "one", 2 -> "two"), Map(3 -> "three", 4 -> "four", 5 -> "five")), rnd = Randomizer.default)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (Map.empty[Int, String])
+        edges should contain (Map(1 -> "one", 2 -> "two"))
+        edges should contain (Map(3 -> "three", 4 -> "four", 5 -> "five"))
+      }
+      it("should produce Map[K, V] following size determined by havingSize method") {
+        val aGen= Generator.mapGenerator[Int, String]
+        implicit val sGen = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Map[Int, String] =>
+          s.size shouldBe 3
+        }
+      }
+      it("should produce Map[K, V] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.mapGenerator[Int, String]
+        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Map[Int, String] =>
+          s.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.mapGenerator[Int, String]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce Map[K, V] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.mapGenerator[Int, String]
+        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: Map[Int, String] =>
+          s.size shouldBe 5
+        }
+      }
+    }
+
+    describe("for SortedMaps") {
+      it("should produce the same SortedMap[K, V] values in the same order given the same Randomizer") {
+        val aGen= Generator.sortedMapGenerator[Int, String]
+        val bGen = Generator.sortedMapGenerator[Int, String]
+        val (a1, _, ar1) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (a2, _, ar2) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar1)
+        val (a3, _, ar3) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar2)
+        val (a4, _, ar4) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar3)
+        val (a5, _, ar5) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar4)
+        val (a6, _, ar6) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar5)
+        val (a7, _, _) = aGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = ar6)
+        val (b1, _, br1) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = Randomizer(100))
+        val (b2, _, br2) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br1)
+        val (b3, _, br3) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br2)
+        val (b4, _, br4) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br3)
+        val (b5, _, br5) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br4)
+        val (b6, _, br6) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br5)
+        val (b7, _, _) = bGen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = Nil, rnd = br6)
+        List(a1, a2, a3, a4, a5) should contain theSameElementsAs List(b1, b2, b3, b4, b5)
+        a6 shouldEqual b6
+        a7 shouldEqual b7
+      }
+      it("should produce SortedMap[K, V] edge values first in random order") {
+        val gen = Generator.sortedMapGenerator[Int, String]
+        val (a1: SortedMap[Int, String], ae1: List[SortedMap[Int, String]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(SortedMap.empty[Int, String], SortedMap(1 -> "one", 2 -> "two"), SortedMap(3 -> "three", 4 -> "four", 5 -> "five")), rnd = Randomizer.default)
+        val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
+        val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
+        val edges = List(a1, a2, a3)
+        edges should contain (SortedMap.empty[Int, String])
+        edges should contain (SortedMap(1 -> "one", 2 -> "two"))
+        edges should contain (SortedMap(3 -> "three", 4 -> "four", 5 -> "five"))
+      }
+      it("should produce SortedMap[K, V] following size determined by havingSize method") {
+        val aGen= Generator.sortedMapGenerator[Int, String]
+        implicit val sGen = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedMap[Int, String] =>
+          s.size shouldBe 3
+        }
+      }
+      it("should produce SortedMap[K, V] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.sortedMapGenerator[Int, String]
+        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedMap[Int, String] =>
+          s.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.sortedMapGenerator[Int, String]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce SortedMap[K, V] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.sortedMapGenerator[Int, String]
+        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { s: SortedMap[Int, String] =>
+          s.size shouldBe 5
+        }
+      }
+    }
+  }
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.scalatest.exceptions.TestFailedException
+
+class HavingLengthsBetweenSpec extends FunSpec with Matchers {
+  describe("A HavingLengthsBetween Generator for Lists") {
+    describe("where from is 0") {
+      it("should offer a List[T] generator that returns a List[T] whose length equals the passed size") {
+  
+        import Generator._
+        import CommonGenerators.lists
+        val gen = lists[Int].havingLengthsBetween(0, 100)
+  
+        val (l1, _, r1) = gen.next(szp = SizeParam(PosZInt(0), 100, 0), edges = Nil, rnd = Randomizer(100))
+        l1.length shouldBe 0
+  
+        val (l2, _, r2) = gen.next(szp = SizeParam(PosZInt(0), 100, 3), edges = Nil, rnd = r1)
+        l2.length shouldBe 3
+  
+        val (l3, _, r3) = gen.next(szp = SizeParam(PosZInt(0), 100, 38), edges = Nil, rnd = r2)
+        l3.length shouldBe 38
+  
+        val (l4, _, r4) = gen.next(szp = SizeParam(PosZInt(0), 100, 88), edges = Nil, rnd = r3)
+        l4.length shouldBe 88 +- 1 // TODO: Why is this coming out as 87?
+      }
+      it("should not exhibit this bug in List shrinking") {
+        import CommonGenerators.lists
+        val lstGen = lists[List[Int]].havingLengthsBetween(0, 77)
+        val xss = List(List(100, 200, 300, 400, 300))
+        lstGen.shrink(xss, Randomizer.default)._1.toList should not contain xss
+      }
+      it("should shrink Lists using strategery") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        forAll (lists[Int].havingLengthsBetween(0, 78)) { (xs: List[Int]) =>
+          val generator = lists[Int]
+          val (shrinkIt, _) = generator.shrink(xs, Randomizer.default)
+          val shrinks: List[List[Int]] = shrinkIt.toList
+          if (xs.isEmpty)
+            shrinks shouldBe empty
+          else {
+  
+            // First one should be the empty list
+            shrinks(0) shouldBe Nil
+  
+            // Then should come one-element Lists of the canonicals of the type
+            val phase2 = shrinks.drop(1).take(intCanonicals.length)
+            phase2 shouldEqual (intCanonicals.map(i => List(i)))
+  
+            // Phase 3 should be one-element lists of all distinct values in the value passed to shrink
+            // If xs already is a one-element list, then we don't do this, because then xs would appear in the output.
+            val xsDistincts = if (xs.length > 1) xs.distinct else Nil
+            val phase3 = shrinks.drop(1 + intCanonicals.length).take(xsDistincts.length)
+            phase3 shouldEqual (xsDistincts.map(i => List(i)))
+  
+            // Phase 4 should be n-element lists that are prefixes cut in half
+            val theHalves = shrinks.drop(1 + intCanonicals.length + xsDistincts.length)
+            theHalves should not contain xs // This was a bug I noticed
+            if (theHalves.length > 1) {
+              import org.scalatest.Inspectors
+              val zipped = theHalves.zip(theHalves.tail) 
+              Inspectors.forAll (zipped) { case (s, t) => 
+                s.length should be < t.length
+              }
+            } else succeed
+          }
+        }
+      }
+      it("should return an empty Iterator when asked to shrink a List of size 0") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(0, 99)
+        val xs = List.empty[Int]
+        lstGen.shrink(xs, Randomizer.default)._1.toList shouldBe empty
+      }
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a List of size 1") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(0, 88)
+        val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
+        val expectedLists = List(List.empty[Int]) ++ canonicalLists
+        val nonCanonical = List(99)
+        lstGen.shrink(nonCanonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+        val canonical = List(3)
+        // Ensure 3 (an Int canonical value) does not show up twice in the output
+        lstGen.shrink(canonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+      }
+      it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(0, 66)
+        val shrinkees = lstGen.shrink(List(3, 99), Randomizer.default)._1.toList
+        shrinkees.distinct should contain theSameElementsAs shrinkees
+      }
+      it("should return an Iterator that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
+        // Since the last batch of lists produced by the list shrinker start at length 2 and then double in size each time,
+        // they lengths will be powers of two: 2, 4, 8, 16, etc... So make sure that if the original length has length 16,
+        // for example, that that one doesn't show up in the shrinks output, because it would be the original list-to-shrink.
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(0, 77)
+        val listToShrink = List.fill(16)(99)
+        val shrinkees = lstGen.shrink(listToShrink, Randomizer.default)._1.toList
+        shrinkees.distinct should not contain listToShrink
+      }
+      it("should offer a list generator whose canonical method uses the canonical method of the underlying T if min is 0 or 1") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        val listOfIntGenerator = lists[Int].havingLengthsBetween(0, 50)
+        val (listOfIntCanonicalsIt, _) = listOfIntGenerator.canonicals(Randomizer.default)
+        val listOfIntCanonicals = listOfIntCanonicalsIt.toList
+        listOfIntCanonicals shouldEqual intCanonicals.map(i => List(i))
+      }
+    }
+    describe("where from is 1") {
+      it("should offer a list generator whose canonical method uses the canonical method of the underlying T if min is 0 or 1") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        val listOfIntGenerator = lists[Int].havingLengthsBetween(1, 50)
+        val (listOfIntCanonicalsIt, _) = listOfIntGenerator.canonicals(Randomizer.default)
+        val listOfIntCanonicals = listOfIntCanonicalsIt.toList
+        listOfIntCanonicals shouldEqual intCanonicals.map(i => List(i))
+      }
+    }
+    describe("where from is greater than 1") {
+      it("should offer a List[T] generator that returns a List[T] whose length equals the passed size") {
+  
+        import Generator._
+        import CommonGenerators.lists
+        val maxSize = PosZInt(100)
+        val from = PosZInt(5)
+        val to = PosZInt(88)
+        val gen = lists[Int].havingLengthsBetween(from, to)
+        def expectedSize(size: Int): Int = {
+          val candidate: Int = (from + (size.toFloat * (to - from).toFloat / (maxSize + 1).toFloat)).round
+          if (candidate > to) to
+          else if (candidate < from) from
+          else candidate
+        }
+
+        val (l1, _, r1) = gen.next(szp = SizeParam(PosZInt(0), maxSize, 0), edges = Nil, rnd = Randomizer(100))
+        l1.length shouldBe expectedSize(0)
+  
+        val (l2, _, r2) = gen.next(szp = SizeParam(PosZInt(0), maxSize, 3), edges = Nil, rnd = r1)
+        l2.length shouldBe expectedSize(3)
+  
+        val (l3, _, r3) = gen.next(szp = SizeParam(PosZInt(0), maxSize, 38), edges = Nil, rnd = r2)
+        l3.length shouldBe expectedSize(38)
+  
+        val (l4, _, r4) = gen.next(szp = SizeParam(PosZInt(0), maxSize, 88), edges = Nil, rnd = r3)
+        l4.length shouldBe expectedSize(88)
+  
+        val (l5, _, r5) = gen.next(szp = SizeParam(PosZInt(0), maxSize, 89), edges = Nil, rnd = r3)
+        l5.length shouldBe expectedSize(89)
+      }
+      it("should not exhibit this bug in List shrinking") {
+        import CommonGenerators.lists
+        val lstGen = lists[List[Int]].havingLengthsBetween(5, 77)
+        val xss = List(List(100, 200, 300, 400, 300))
+        lstGen.shrink(xss, Randomizer.default)._1.toList should not contain xss
+      }
+      it("should shrink Lists using strategery") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        forAll (lists[Int].havingLengthsBetween(5, 78)) { (xs: List[Int]) =>
+          val generator = lists[Int]
+          val (shrinkIt, _) = generator.shrink(xs, Randomizer.default)
+          val shrinks: List[List[Int]] = shrinkIt.toList
+          if (xs.isEmpty)
+            shrinks shouldBe empty
+          else {
+  
+            // First one should be the empty list
+            shrinks(0) shouldBe Nil
+  
+            // Then should come one-element Lists of the canonicals of the type
+            val phase2 = shrinks.drop(1).take(intCanonicals.length)
+            phase2 shouldEqual (intCanonicals.map(i => List(i)))
+  
+            // Phase 3 should be one-element lists of all distinct values in the value passed to shrink
+            // If xs already is a one-element list, then we don't do this, because then xs would appear in the output.
+            val xsDistincts = if (xs.length > 1) xs.distinct else Nil
+            val phase3 = shrinks.drop(1 + intCanonicals.length).take(xsDistincts.length)
+            phase3 shouldEqual (xsDistincts.map(i => List(i)))
+  
+            // Phase 4 should be n-element lists that are prefixes cut in half
+            val theHalves = shrinks.drop(1 + intCanonicals.length + xsDistincts.length)
+            theHalves should not contain xs // This was a bug I noticed
+            if (theHalves.length > 1) {
+              import org.scalatest.Inspectors
+              val zipped = theHalves.zip(theHalves.tail) 
+              Inspectors.forAll (zipped) { case (s, t) => 
+                s.length should be < t.length
+              }
+            } else succeed
+          }
+        }
+      }
+      it("should return an empty Iterator when asked to shrink a List of size 0") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(5, 99)
+        val xs = List.empty[Int]
+        lstGen.shrink(xs, Randomizer.default)._1.toList shouldBe empty
+      }
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a List of size 1") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(5, 88)
+        val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
+        val expectedLists = List(List.empty[Int]) ++ canonicalLists
+        val nonCanonical = List(99)
+        lstGen.shrink(nonCanonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+        val canonical = List(3)
+        // Ensure 3 (an Int canonical value) does not show up twice in the output
+        lstGen.shrink(canonical, Randomizer.default)._1.toList should contain theSameElementsAs expectedLists
+      }
+      it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(5, 66)
+        val shrinkees = lstGen.shrink(List(3, 99), Randomizer.default)._1.toList
+        shrinkees.distinct should contain theSameElementsAs shrinkees
+      }
+      it("should return an Iterator that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
+        // Since the last batch of lists produced by the list shrinker start at length 2 and then double in size each time,
+        // they lengths will be powers of two: 2, 4, 8, 16, etc... So make sure that if the original length has length 16,
+        // for example, that that one doesn't show up in the shrinks output, because it would be the original list-to-shrink.
+        import CommonGenerators.lists
+        val lstGen = lists[Int].havingLengthsBetween(5, 77)
+        val listToShrink = List.fill(16)(99)
+        val shrinkees = lstGen.shrink(listToShrink, Randomizer.default)._1.toList
+        shrinkees.distinct should not contain listToShrink
+      }
+      it("should offer a list generator whose canonical method is empty if from is greater than 1") {
+        import GeneratorDrivenPropertyChecks._
+        val intGenerator = Generator.intGenerator
+        val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
+        val intCanonicals = intCanonicalsIt.toList
+        val listOfIntGenerator = lists[Int].havingLengthsBetween(5, 50)
+        val (listOfIntCanonicalsIt, _) = listOfIntGenerator.canonicals(Randomizer.default)
+        val listOfIntCanonicals = listOfIntCanonicalsIt.toList
+        listOfIntCanonicals shouldBe empty
+      }
+      // TODO: I'd like some better tests here for the behavior of size in havingLengthsBetween. If you say,
+      // 150 to 175, and maxSize still is 100, then it should only generate between 150 and 175. Can whip
+      // up a forAll test.
+    }
+  }
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import org.scalatest.exceptions.TestFailedException
+import scala.annotation.tailrec
+import org.scalatest.Resources
+
+class OrgScalaTestPropSpec extends WordSpec with Matchers {
+
+  def samplesForGen[T](genOfT: Generator[T], desiredLength: PosInt, originalRnd: Randomizer): List[(T, Randomizer)] = {
+    @tailrec
+    def samplesLoop(count: Int, rnd: Randomizer, acc: List[(T, Randomizer)]): List[(T, Randomizer)] = {
+      if (count == desiredLength.value) acc
+      else {
+        val maxSize = PosZInt(100)
+        val (size, nextRnd) = rnd.chooseInt(1, maxSize)
+        val (value, _, nextNextRnd) = genOfT.next(SizeParam(PosZInt(0), maxSize, PosZInt.ensuringValid(size)), Nil, rnd)
+        samplesLoop(count + 1, nextNextRnd, (value, rnd) :: acc)
+      }
+    }
+    samplesLoop(0, originalRnd, Nil)
+  }
+
+/*
+  // TODO: I can't follow the test anymore. Need to just rethink how to test the valueOf methods.
+  "The org.scalatest.prop package object" should {
+
+    "offer a valueOf method that takes 1 input arguments" in {
+      val implicitGen = implicitly[Generator[String => Long]] // implicit String to Long function gen
+
+      val rnd = Randomizer.default // rnd
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd) // List of (String => Long, Randomizer)
+      val stringGen = CommonGenerators.strings
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) => // For each specific function, and RND
+        val (s, _, nextRnd) = stringGen.next(5, List.empty, rnd) // Get a string and a nextRnd
+        val result1 = fun(s) // pass the string to the specific function and get a Long
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd) // ah, generate an IntToInt with the same RND. Should get back the same function
+        val result2 = org.scalatest.prop.valueOf[Long](s, intToInt) // call valueOf with function from String => Long
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 2 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple2Gen = CommonGenerators.tuple2s[String, Int]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((s, i), _, nextRnd) = tuple2Gen.next(5, List.empty, rnd)
+        val result1 = fun(s, i)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](s, i, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 3 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple3Gen = CommonGenerators.tuple3s[String, Int, Long]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3), _, nextRnd) = tuple3Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 4 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple4Gen = CommonGenerators.tuple4s[String, Int, Long, Float]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4), _, nextRnd) = tuple4Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 5 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple5Gen = CommonGenerators.tuple5s[String, Int, Long, Float, Double]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5), _, nextRnd) = tuple5Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 6 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple6Gen = CommonGenerators.tuple6s[String, Int, Long, Float, Double, String]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6), _, nextRnd) = tuple6Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 7 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple7Gen = CommonGenerators.tuple7s[String, Int, Long, Float, Double, String, Int]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7), _, nextRnd) = tuple7Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 8 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple8Gen = CommonGenerators.tuple8s[String, Int, Long, Float, Double, String, Int, Long]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8), _, nextRnd) = tuple8Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 9 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple9Gen = CommonGenerators.tuple9s[String, Int, Long, Float, Double, String, Int, Long, Float]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9), _, nextRnd) = tuple9Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 10 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple10Gen = CommonGenerators.tuple10s[String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10), _, nextRnd) = tuple10Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 11 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple11Gen = CommonGenerators.tuple11s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11), _, nextRnd) = tuple11Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, intToInt)
+        result1 shouldEqual result2
+      }
+
+
+    }
+
+    "offer a valueOf method that takes 12 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple12Gen = CommonGenerators.tuple12s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12), _, nextRnd) = tuple12Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 13 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple13Gen = CommonGenerators.tuple13s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13), _, nextRnd) = tuple13Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 14 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple14Gen = CommonGenerators.tuple14s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14), _, nextRnd) = tuple14Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 15 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple15Gen = CommonGenerators.tuple15s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15), _, nextRnd) = tuple15Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 16 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple16Gen = CommonGenerators.tuple16s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16), _, nextRnd) = tuple16Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 17 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple17Gen = CommonGenerators.tuple17s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17), _, nextRnd) = tuple17Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 18 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple18Gen = CommonGenerators.tuple18s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18), _, nextRnd) = tuple18Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 19 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple19Gen = CommonGenerators.tuple19s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19), _, nextRnd) = tuple19Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 20 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple20Gen = CommonGenerators.tuple20s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20), _, nextRnd) = tuple20Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 21 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple21Gen = CommonGenerators.tuple21s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val ((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21), _, nextRnd) = tuple21Gen.next(5, List.empty, rnd)
+        val result1 = fun(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+
+    "offer a valueOf method that takes 22 input arguments" in {
+      val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int) => Long]]
+
+      val rnd = Randomizer.default
+
+      val samples = samplesForGen(implicitGen, PosInt(100), rnd)
+      val tuple22Gen = CommonGenerators.tuple22s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
+
+      val intToIntGen: Generator[Int => Int] = Generator.function1IntToIntGenerator
+
+      samples.foreach { case (fun, rnd) =>
+        val (t22, _, nextRnd) = tuple22Gen.next(5, List.empty, rnd)
+        val result1 = fun(t22._1, t22._2, t22._3, t22._4, t22._5, t22._6, t22._7, t22._8, t22._9, t22._10, t22._11, t22._12, t22._13, t22._14, t22._15, t22._16, t22._17, t22._18, t22._19, t22._20, t22._21, t22._22)
+
+        val (intToInt, _, _) = intToIntGen.next(10, Nil, rnd)
+        val result2 = org.scalatest.prop.valueOf[Long](t22._1, t22._2, t22._3, t22._4, t22._5, t22._6, t22._7, t22._8, t22._9, t22._10, t22._11, t22._12, t22._13, t22._14, t22._15, t22._16, t22._17, t22._18, t22._19, t22._20, t22._21, t22._22, intToInt)
+        result1 shouldEqual result2
+      }
+    }
+  }
+*/
+}

--- a/scalatest-test/src/test/scala/org/scalatest/prop/OverrideImplicitConfigurationSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/OverrideImplicitConfigurationSuite.scala
@@ -1,5 +1,6 @@
-package org.scalatest
-package prop
+package org.scalatest.prop
+
+import org.scalatest._
 
 trait GetImplicitConfig { self: Configuration =>
   def getImplicitConfig()(implicit config: PropertyCheckConfigurable): PropertyCheckConfiguration = config.asPropertyCheckConfiguration

--- a/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.scalatest.exceptions.TestFailedException
+
+class PrettyFunction0Spec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+  describe("A PrettyFunction0") {
+    it("should return the constant passed to its constructor") {
+      forAll { (i: Int) =>
+        val f = new PrettyFunction0(i)
+        f() shouldBe i
+      }
+    }
+    it("should have a pretty toString") {
+      forAll { (i: Int) =>
+        val f = new PrettyFunction0(i)
+        f.toString shouldBe s"() => $i"
+      }
+    }
+    it("should offer an apply method in its companion object") {
+      forAll { (i: Int) =>
+        val f = PrettyFunction0(i)
+        f() shouldBe i
+        f.toString shouldBe s"() => $i"
+      }
+    }
+    it("should offer an equals method that compares the constant result") {
+      forAll { (i: Int) =>
+        val f = PrettyFunction0(i)
+        val g = PrettyFunction0(i)
+        f shouldEqual g
+      }
+    }
+    it("should offer a hashCode method that returns the hashCode of the constant result") {
+      forAll { (i: Int) =>
+        val f = PrettyFunction0(i)
+        val g = PrettyFunction0(i)
+        f.hashCode shouldEqual g.hashCode
+      }
+    }
+  }
+}

--- a/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+
+class RandomizerSpec extends FunSpec with Matchers {
+
+  describe("A Randomizer") {
+    it("should offer a nextInt method that produces the same values as java.util.Random given the same seed") {
+      val jr = new java.util.Random(100)
+      val ja = jr.nextInt()
+      val jb = jr.nextInt()
+      val jc = jr.nextInt()
+
+      val sr = Randomizer(100)
+      val (ia, ra) = sr.nextInt
+      val (ib, rb) = ra.nextInt
+      val (ic, _) = rb.nextInt
+
+      ja shouldEqual ia
+      jb shouldEqual ib
+      jc shouldEqual ic
+    }
+
+    it("should offer a nextLong method that produces the same values as java.util.Random given the same seed") {
+      val jr = new java.util.Random(100)
+      val ja = jr.nextLong()
+      val jb = jr.nextLong()
+      val jc = jr.nextLong()
+
+      val sr = Randomizer(100)
+      val (ia, ra) = sr.nextLong
+      val (ib, rb) = ra.nextLong
+      val (ic, _) = rb.nextLong
+
+      ja shouldEqual ia
+      jb shouldEqual ib
+      jc shouldEqual ic
+    }
+
+    it("should offer a nextFloatBetween0And1 method that produces the same values as java.util.Random given the same seed") {
+      val jr = new java.util.Random(100)
+      val ja = jr.nextFloat()
+      val jb = jr.nextFloat()
+      val jc = jr.nextFloat()
+
+      val sr = Randomizer(100)
+      val (ia, ra) = sr.nextFloatBetween0And1
+      val (ib, rb) = ra.nextFloatBetween0And1
+      val (ic, _) = rb.nextFloatBetween0And1
+
+      ja shouldEqual ia
+      jb shouldEqual ib
+      jc shouldEqual ic
+    }
+
+    it("should offer a nextDoubleBetween0And1 method that produces the same values as java.util.Random given the same seed") {
+      val jr = new java.util.Random(100)
+      val ja = jr.nextDouble()
+      val jb = jr.nextDouble()
+      val jc = jr.nextDouble()
+
+      val sr = Randomizer(100)
+      val (ia, ra) = sr.nextDoubleBetween0And1
+      val (ib, rb) = ra.nextDoubleBetween0And1
+      val (ic, _) = rb.nextDoubleBetween0And1
+
+      ja shouldEqual ia
+      jb shouldEqual ib
+      jc shouldEqual ic
+    }
+
+    it("should offer a chooseInt method that initially produces Int values between from and to") {
+      import GeneratorDrivenPropertyChecks._
+      var rnd = Randomizer.default
+      forAll { (i: Int, j: Int) =>
+        val (k, nextRandomizer) = rnd.chooseInt(i, j)
+        val min = i.min(j)
+        val max = i.max(j)
+        k should be <= max
+        k should be >= min
+        rnd = nextRandomizer
+        succeed
+      }
+    }
+    it("should offer a chooseLong method that initially produces Long values between from and to") {
+      import GeneratorDrivenPropertyChecks._
+      var rnd = Randomizer.default
+      forAll { (i: Long, j: Long) =>
+        val (k, nextRandomizer) = rnd.chooseLong(i, j)
+        val min = i.min(j)
+        val max = i.max(j)
+        k should be <= max
+        k should be >= min
+        rnd = nextRandomizer
+        succeed
+      }
+    }
+    it("should offer a nextString method that produces a String of the requested 0 or greater size") {
+
+      
+      an [IllegalArgumentException] should be thrownBy { Randomizer(100).nextString(-1) }
+
+      val (sa, ra) = Randomizer(100).nextString(0)
+      sa should have length 0
+
+      val (sb, rb) = ra.nextString(1)
+      sb should have length 1
+
+      val (sc, rc) = rb.nextString(10)
+      sc should have length 10
+
+      val (sd, _) = rc.nextString(100)
+      sd should have length 100
+
+      // Ensure not all chars are the same (because initially it did that, because
+      // I was using calling nextChar on the initial Randomizer only)
+      sd.distinct shouldNot have size 1
+    }
+    it("should offer a nextList[T] method that produces a List[T] of the requested 0 or greater size") {
+
+      an [IllegalArgumentException] should be thrownBy { Randomizer(100).nextList[Int](-1) }
+
+      val (la, ra) = Randomizer(100).nextList[Int](0)
+      la should have length 0
+
+      val (lb, rb) = ra.nextString(1)
+      lb should have length 1
+
+      val (lc, rc) = rb.nextString(10)
+      lc should have length 10
+
+      val (ld, _) = rc.nextString(100)
+      ld should have length 100
+
+      ld.distinct shouldNot have size 1
+    }
+    it("should offer a shuffle method in its companion object that shuffles a list.") {
+      import GeneratorDrivenPropertyChecks._
+      var nextRnd = Randomizer.default
+      forAll { (xs: List[Int]) =>
+        val (shuffled, nr) = Randomizer.shuffle(xs, nextRnd)
+        nextRnd = nr
+        shuffled should contain theSameElementsAs xs
+      }
+    }
+  }
+}
+

--- a/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
@@ -21,7 +21,7 @@ import org.scalactic.anyvals._
 /*
 It looks like sizeRange = maxSize - minSize
 */
-class SizeParamSpec extends WordSpec with Matchers {
+class SizeParamSpec extends WordSpec with Matchers with PropertyChecks {
   "A SizeParam" should {
     "have a minimum, range, and size" in {
       val sp = SizeParam(33, 20, 35)
@@ -34,12 +34,29 @@ class SizeParamSpec extends WordSpec with Matchers {
       noException should be thrownBy SizeParam(0, 10, 10)
       noException should be thrownBy SizeParam(1, 10, 1)
       noException should be thrownBy SizeParam(1, 10, 11)
-      an [IllegalArgumentException] should be thrownBy SizeParam(0, 10, 11) // minSize 0, maxSize 10 
-      an [IllegalArgumentException] should be thrownBy SizeParam(1, 10, 0) // minSize 1, maxSize 11, 
+      an [IllegalArgumentException] should be thrownBy SizeParam(0, 10, 11) // minSize 0, maxSize 10
+      an [IllegalArgumentException] should be thrownBy SizeParam(1, 10, 0) // minSize 1, maxSize 11,
       an [IllegalArgumentException] should be thrownBy SizeParam(1, 10, 12)
+    }
+    "offer a maxSize methods" in {
+     
+       val params =
+        for {
+          minSz <- posZInts
+          maxSz <- posZIntsBetween(minSz, PosZInt.MaxValue)
+          sz <- posZIntsBetween(minSz, maxSz)
+        } yield (minSz, maxSz, sz)
+  
+      forAll (params) { case (minSize, sizeRange, size) => 
+        whenever(minSize + sizeRange >= 0) {
+          val sp = SizeParam(minSize, sizeRange, size)
+          sp.sizeRange shouldBe PosZInt.ensuringValid(sp.maxSize - sp.minSize)
+        }
+      }
     }
   }
 }
+
 
 
 

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -485,6 +485,7 @@ occurredOnValues=Occurred when passed generated values (
 propCheckLabel=Label of failing property:
 propCheckLabels=Labels of failing property:
 suiteAndTestNamesFormattedForDisplay={0}, {1}
+initSeed=Init Seed: {0}
 notLoneElement=Expected {0} to contain exactly 1 element, but it has size {1}
 testNGConfigFailed=TestNG configuration failed
 jUnitTestFailed=A JUnit test failed
@@ -715,6 +716,12 @@ rightParensCommaAnd={0}, and ({1})
 bothParensCommaAnd=({0}), and ({1})
 
 assertionWasTrue=Assertion was true
+
+fromEqualToToHavingLengthsBetween=The from and to values passed to havingLengthsBetween must not be equal, but were both {0}. Please use the havingLength method instead.
+fromGreaterThanToHavingLengthsBetween=The from value passed to havingLengthsBetween, which was {0}, must be less than the to value, which was {1}. Please swap the order of the arguments.
+
+fromEqualToToHavingSizesBetween=The from and to values passed to havingSizesBetween must not be equal, but were both {0}. Please use the havingLength method instead.
+fromGreaterThanToHavingSizesBetween=The from value passed to havingSizesBetween, which was {0}, must be less than the to value, which was {1}. Please swap the order of the arguments.
 
 analysis=Analysis:
 

--- a/scalatest/src/main/scala/org/scalatest/check/ScalaCheckGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/check/ScalaCheckGenerators.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.check
+
+import org.scalatest.prop.{Generator, Randomizer, SizeParam}
+
+trait ScalaCheckGenerators {
+
+  import org.scalacheck.{Arbitrary, Gen, Shrink}
+  import org.scalacheck.rng.Seed
+
+  implicit def scalaCheckArbitaryGenerator[T](implicit arb: Arbitrary[T], shrk: Shrink[T]): Generator[T] =
+    new Generator[T] {
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            arb.arbitrary.apply(Gen.Parameters.default.withSize(szp.size), Seed(rnd.seed)) match {
+              case Some(nextT) => (nextT, Nil, rnd.nextRandomizer)
+              case None => throw new IllegalStateException("Unable to generate value using ScalaCheck Arbitary.")
+            }
+        }
+      }
+      override def shrink(value: T, rnd: Randomizer): (Iterator[T], Randomizer) = {
+        (shrk.shrink(value).take(10000).reverse.toIterator, rnd)
+      }
+    }
+}
+
+object ScalaCheckGenerators extends ScalaCheckGenerators 

--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -22,6 +22,8 @@ import org.scalacheck.Prop.Arg
 import org.scalacheck.Test
 import org.scalacheck.util.Pretty
 import org.scalatest.Assertion
+import org.scalatest.Expectation
+import org.scalatest.Fact
 import org.scalatest.FailureMessages
 import org.scalatest.Resources
 import org.scalatest.Succeeded
@@ -45,6 +47,8 @@ trait CheckerAsserting[T] {
    * The result type of the <code>check</code> method.
    */
   type Result
+
+  def succeed(result: T): (Boolean, Option[Throwable])
 
   /**
    * Perform the property check using the given <code>Prop</code> and <code>Test.Parameters</code>.
@@ -175,6 +179,7 @@ abstract class UnitCheckerAsserting {
   implicit def assertingNatureOfT[T]: CheckerAsserting[T] { type Result = Unit } =
     new CheckerAssertingImpl[T] {
       type Result = Unit
+      def succeed(result: T) = (true, None)
       private[scalatest] def indicateSuccess(message: => String): Unit = ()
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Unit = {
         throw new GeneratorDrivenPropertyCheckFailedException(
@@ -195,21 +200,37 @@ abstract class UnitCheckerAsserting {
  * Abstract class that in the future will hold an intermediate priority <code>CheckerAsserting</code> implicit, which will enable inspector expressions
  * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
  */
-/*abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
+abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
 
-  implicit def assertingNatureOfExpectation: CheckerAsserting[Expectation] { type Result = Expectation } = {
-    new CheckerAsserting[Expectation] {
+  implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): CheckerAsserting[Expectation] { type Result = Expectation } = {
+    new CheckerAssertingImpl[Expectation] {
       type Result = Expectation
+      def succeed(result: Expectation) = (result.isYes, result.cause)
+      private[scalatest] def indicateSuccess(message: => String): Expectation = Fact.Yes(message)(prettifier)
+      private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Expectation = {
+        val gdpcfe =
+          new GeneratorDrivenPropertyCheckFailedException(
+            messageFun,
+            optionalCause,
+            pos,
+            None,
+            undecoratedMessage,
+            scalaCheckArgs,
+            None,
+            scalaCheckLabels.toList
+          )
+        val message: String = gdpcfe.getMessage
+        Fact.No(message)(prettifier)
+      }
     }
   }
-
-}*/
+}
 
 /**
  * Companion object to <code>CheckerAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
  * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
  */
-object CheckerAsserting extends UnitCheckerAsserting /*ExpectationCheckerAsserting*/ {
+object CheckerAsserting extends ExpectationCheckerAsserting {
 
   /**
     * Provides support of [[org.scalatest.enablers.CheckerAsserting CheckerAsserting]] for Assertion.  Returns [[org.scalatest.Succeeded Succeeded]] when the check succeeds,
@@ -219,6 +240,7 @@ object CheckerAsserting extends UnitCheckerAsserting /*ExpectationCheckerAsserti
   implicit def assertingNatureOfAssertion: CheckerAsserting[Assertion] { type Result = Assertion } = {
     new CheckerAssertingImpl[Assertion] {
       type Result = Assertion
+      def succeed(result: Assertion) = (true, None)
       private[scalatest] def indicateSuccess(message: => String): Assertion = Succeeded
       private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
         throw new GeneratorDrivenPropertyCheckFailedException(

--- a/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -1,0 +1,1610 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.enablers
+
+import org.scalactic.{Prettifier, source}
+import org.scalatest.exceptions.{StackDepth, StackDepthException, GeneratorDrivenPropertyCheckFailedException}
+import org.scalatest.prop.{Configuration, PropertyArgument, PropertyCheckResult}
+import org.scalatest.{FailureMessages, Resources, UnquotedString, Fact, Expectation, Assertion, Succeeded}
+import FailureMessages.decorateToStringValue
+import org.scalactic.anyvals.PosZInt
+import org.scalatest.prop.Randomizer
+import scala.annotation.tailrec
+import org.scalatest.prop.Configuration.Parameter
+import org.scalatest.prop.{SizeParam}
+import scala.util.{Try, Success, Failure}
+import org.scalatest.exceptions.DiscardedEvaluationException
+import scala.concurrent.Future
+import scala.compat.Platform.EOL
+
+trait PropCheckerAsserting[T] {
+
+  /**
+    * The result type of the <code>check</code> method.
+    */
+  type Result
+
+  type S
+
+  def discard(result: S): Boolean
+
+  def succeed(result: S): (Boolean, Option[Throwable])
+
+  //private[scalatest] def indicateSuccess(message: => String): Result
+
+  //private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Result
+
+  /**
+    * Perform the property check using the given function, generator and <code>Configuration.Parameters</code>.
+    *
+    * @param fun the function to be used to check
+    * @param genA the generator of type <code>A</code>
+    * @param prms the <code>Configuration.Parameters</code> to be used to check
+    * @param prettifier the <code>Prettifier</code> to be used to prettify error message
+    * @param pos the <code>Position</code> of the caller site
+    * @param names the list of names
+    * @param argNames the list of argument names
+    * @return the <code>Result</code> of the property check.
+    */
+  def check1[A](fun: (A) => T,
+               genA: org.scalatest.prop.Generator[A],
+               prms: Configuration.Parameter,
+               prettifier: Prettifier,
+               pos: source.Position,
+               names: List[String],
+               argNames: Option[List[String]] = None): Result
+
+  def check2[A, B](fun: (A, B) => T,
+                   genA: org.scalatest.prop.Generator[A],
+                   genB: org.scalatest.prop.Generator[B],
+                   prms: Configuration.Parameter,
+                   prettifier: Prettifier,
+                   pos: source.Position,
+                   names: List[String],
+                   argNames: Option[List[String]] = None): Result
+
+  def check3[A, B, C](fun: (A, B, C) => T,
+                      genA: org.scalatest.prop.Generator[A],
+                      genB: org.scalatest.prop.Generator[B],
+                      genC: org.scalatest.prop.Generator[C],
+                      prms: Configuration.Parameter,
+                      prettifier: Prettifier,
+                      pos: source.Position,
+                      names: List[String],
+                      argNames: Option[List[String]] = None): Result
+
+  def check4[A, B, C, D](fun: (A, B, C, D) => T,
+                         genA: org.scalatest.prop.Generator[A],
+                         genB: org.scalatest.prop.Generator[B],
+                         genC: org.scalatest.prop.Generator[C],
+                         genD: org.scalatest.prop.Generator[D],
+                         prms: Configuration.Parameter,
+                         prettifier: Prettifier,
+                         pos: source.Position,
+                         names: List[String],
+                         argNames: Option[List[String]] = None): Result
+
+  def check5[A, B, C, D, E](fun: (A, B, C, D, E) => T,
+                            genA: org.scalatest.prop.Generator[A],
+                            genB: org.scalatest.prop.Generator[B],
+                            genC: org.scalatest.prop.Generator[C],
+                            genD: org.scalatest.prop.Generator[D],
+                            genE: org.scalatest.prop.Generator[E],
+                            prms: Configuration.Parameter,
+                            prettifier: Prettifier,
+                            pos: source.Position,
+                            names: List[String],
+                            argNames: Option[List[String]] = None): Result
+
+  def check6[A, B, C, D, E, F](fun: (A, B, C, D, E, F) => T,
+                               genA: org.scalatest.prop.Generator[A],
+                               genB: org.scalatest.prop.Generator[B],
+                               genC: org.scalatest.prop.Generator[C],
+                               genD: org.scalatest.prop.Generator[D],
+                               genE: org.scalatest.prop.Generator[E],
+                               genF: org.scalatest.prop.Generator[F],
+                               prms: Configuration.Parameter,
+                               prettifier: Prettifier,
+                               pos: source.Position,
+                               names: List[String],
+                               argNames: Option[List[String]] = None): Result
+
+}
+
+/**
+  * Class holding lowest priority <code>CheckerAsserting</code> implicit, which enables [[org.scalatest.prop.GeneratorDrivenPropertyChecks GeneratorDrivenPropertyChecks]] expressions that have result type <code>Unit</code>.
+  */
+abstract class UnitPropCheckerAsserting {
+
+  import PropCheckerAsserting._
+
+  abstract class PropCheckerAssertingImpl[T] extends PropCheckerAsserting[T] {
+
+    type S = T
+
+    private def checkForAll[A](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A])(fun: (A) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextEdges, nextNextRnd) = genA.next(SizeParam(PosZInt(0), maxSize, size), edges, nextRnd) // TODO: Move PosZInt farther out
+
+        val result: Try[T] = Try { fun(a) }
+        val argsPassed = List(if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a))
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextEdges, nextNextRnd, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      // ensuringValid will always succeed because /ing a PosInt by a positive number will always yield a positive or zero
+      val (initEdges, afterEdgesRnd) = genA.initEdges(PosZInt.ensuringValid(config.minSuccessful / 5), afterSizesRnd)
+      loop(0, 0, initEdges, afterEdgesRnd, initialSizes, initSeed) // We may need to be able to pass in a oh, pass in a key? Or grab it from the outside via cmd ln parm?
+    }
+
+    private def checkForAll[A, B](names: List[String], config: Parameter,
+                          genA: org.scalatest.prop.Generator[A],
+                          genB: org.scalatest.prop.Generator[B])
+                         (fun: (A, B) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, rnd1) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1) // TODO: See if PosZInt can be moved farther out
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val result: Try[T] = Try { fun(a, b) }
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b)
+          )
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, rnd3, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      loop(0, 0, initAEdges, initBEdges, afterBEdgesRnd, initialSizes, initSeed)
+    }
+
+    private def checkForAll[A, B, C](names: List[String], config: Parameter,
+                             genA: org.scalatest.prop.Generator[A],
+                             genB: org.scalatest.prop.Generator[B],
+                             genC: org.scalatest.prop.Generator[C])
+                            (fun: (A, B, C) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, rnd1) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val result: Try[T] = Try { fun(a, b, c) }
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c)
+          )
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, rnd4, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      loop(0, 0, initAEdges, initBEdges, initCEdges, afterCEdgesRnd, initialSizes, initSeed)
+    }
+
+    private def checkForAll[A, B, C, D](names: List[String], config: Parameter,
+                                genA: org.scalatest.prop.Generator[A],
+                                genB: org.scalatest.prop.Generator[B],
+                                genC: org.scalatest.prop.Generator[C],
+                                genD: org.scalatest.prop.Generator[D])
+                               (fun: (A, B, C, D) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, rnd1) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, rnd5) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+        val result: Try[T] = Try { fun(a, b, c, d) }
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d)
+          )
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, rnd5, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, afterDEdgesRnd, initialSizes, initSeed)
+    }
+
+    private def checkForAll[A, B, C, D, E](names: List[String], config: Parameter,
+                                   genA: org.scalatest.prop.Generator[A],
+                                   genB: org.scalatest.prop.Generator[B],
+                                   genC: org.scalatest.prop.Generator[C],
+                                   genD: org.scalatest.prop.Generator[D],
+                                   genE: org.scalatest.prop.Generator[E])
+                                  (fun: (A, B, C, D, E) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, rnd1) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, rnd5) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+        val (e, nextEEdges, rnd6) = genE.next(SizeParam(PosZInt(0), maxSize, size), eEdges, rnd5)
+        val result: Try[T] = Try { fun(a, b, c, d, e) }
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d),
+            if (names.isDefinedAt(4)) PropertyArgument(Some(names(4)), e) else PropertyArgument(None, e)
+          )
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, rnd6, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+      val (initEEdges, afterEEdgesRnd) = genE.initEdges(maxEdges, afterDEdgesRnd)
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, initEEdges, afterEEdgesRnd, initialSizes, initSeed)
+    }
+
+    private def checkForAll[A, B, C, D, E, F](names: List[String], config: Parameter,
+                                      genA: org.scalatest.prop.Generator[A],
+                                      genB: org.scalatest.prop.Generator[B],
+                                      genC: org.scalatest.prop.Generator[C],
+                                      genD: org.scalatest.prop.Generator[D],
+                                      genE: org.scalatest.prop.Generator[E],
+                                      genF: org.scalatest.prop.Generator[F])
+                                     (fun: (A, B, C, D, E, F) => T): PropertyCheckResult = {
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      @tailrec
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+        val (size, nextInitialSizes, rnd1) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, rnd5) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+        val (e, nextEEdges, rnd6) = genE.next(SizeParam(PosZInt(0), maxSize, size), eEdges, rnd5)
+        val (f, nextFEdges, rnd7) = genF.next(SizeParam(PosZInt(0), maxSize, size), fEdges, rnd6)
+        val result: Try[T] = Try { fun(a, b, c, d, e, f) }
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d),
+            if (names.isDefinedAt(4)) PropertyArgument(Some(names(4)), e) else PropertyArgument(None, e),
+            if (names.isDefinedAt(5)) PropertyArgument(Some(names(5)), f) else PropertyArgument(None, f)
+          )
+        result match {
+          case Success(r) =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes, initSeed)
+              else
+                new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  loop(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes, initSeed)
+                else
+                  PropertyCheckResult.Success(argsPassed, initSeed)
+              }
+              else {
+                new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)
+              }
+            }
+
+          case Failure(ex: DiscardedEvaluationException) =>
+            val nextDiscardedCount = discardedCount + 1
+            if (nextDiscardedCount < maxDiscarded)
+              loop(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, rnd7, nextInitialSizes, initSeed)
+            else
+              new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
+          case Failure(ex) =>
+            new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+      val (initEEdges, afterEEdgesRnd) = genE.initEdges(maxEdges, afterDEdgesRnd)
+      val (initFEdges, afterFEdgesRnd) = genF.initEdges(maxEdges, afterEEdgesRnd)
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, initEEdges, initFEdges, afterFEdgesRnd, initialSizes, initSeed)
+    }
+
+    private def checkResult(result: PropertyCheckResult, prettifier: Prettifier, pos: source.Position, argNames: Option[List[String]] = None): Result = {
+      val (args, labels) = argsAndLabels(result)
+      result match {
+        case PropertyCheckResult.Exhausted(succeeded, discarded, names, argsPassed, initSeed) =>
+          val failureMsg =
+            if (succeeded == 1)
+              FailureMessages.propCheckExhaustedAfterOne(prettifier, discarded) + EOL + FailureMessages.initSeed(prettifier, initSeed)
+            else
+              FailureMessages.propCheckExhausted(prettifier, succeeded, discarded) + EOL + FailureMessages.initSeed(prettifier, initSeed)
+
+          indicateFailure(
+            sde => failureMsg,
+            failureMsg,
+            args,
+            labels,
+            None,
+            pos
+          )
+
+        case PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
+          indicateFailure(
+            sde => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + EOL +
+              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + EOL +
+              "  " + FailureMessages.propertyFailed(prettifier, succeeded) + EOL +
+              (
+                sde match {
+                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + EOL
+                  case _ => ""
+                }
+                ) +
+              "  " + FailureMessages.occurredOnValues + EOL +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, argsPassed), prettifier) + EOL +
+              "  )" +
+              getLabelDisplay(labels.toSet) + EOL +
+              "  " + FailureMessages.initSeed(prettifier, initSeed),
+            FailureMessages.propertyFailed(prettifier, succeeded),
+            argsPassed,
+            labels,
+            None,
+            pos
+          )
+
+        case _ => indicateSuccess(FailureMessages.propertyCheckSucceeded)
+      }
+    }
+
+    def check1[A](fun: (A) => T,
+                  genA: org.scalatest.prop.Generator[A],
+                  prms: Configuration.Parameter,
+                  prettifier: Prettifier,
+                  pos: source.Position,
+                  names: List[String],
+                  argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    def check2[A, B](fun: (A, B) => T,
+                     genA: org.scalatest.prop.Generator[A],
+                     genB: org.scalatest.prop.Generator[B],
+                     prms: Configuration.Parameter,
+                     prettifier: Prettifier,
+                     pos: source.Position,
+                     names: List[String],
+                     argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA, genB)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    def check3[A, B, C](fun: (A, B, C) => T,
+                        genA: org.scalatest.prop.Generator[A],
+                        genB: org.scalatest.prop.Generator[B],
+                        genC: org.scalatest.prop.Generator[C],
+                        prms: Configuration.Parameter,
+                        prettifier: Prettifier,
+                        pos: source.Position,
+                        names: List[String],
+                        argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA, genB, genC)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    def check4[A, B, C, D](fun: (A, B, C, D) => T,
+                           genA: org.scalatest.prop.Generator[A],
+                           genB: org.scalatest.prop.Generator[B],
+                           genC: org.scalatest.prop.Generator[C],
+                           genD: org.scalatest.prop.Generator[D],
+                           prms: Configuration.Parameter,
+                           prettifier: Prettifier,
+                           pos: source.Position,
+                           names: List[String],
+                           argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA, genB, genC, genD)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    def check5[A, B, C, D, E](fun: (A, B, C, D, E) => T,
+                              genA: org.scalatest.prop.Generator[A],
+                              genB: org.scalatest.prop.Generator[B],
+                              genC: org.scalatest.prop.Generator[C],
+                              genD: org.scalatest.prop.Generator[D],
+                              genE: org.scalatest.prop.Generator[E],
+                              prms: Configuration.Parameter,
+                              prettifier: Prettifier,
+                              pos: source.Position,
+                              names: List[String],
+                              argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA, genB, genC, genD, genE)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    def check6[A, B, C, D, E, F](fun: (A, B, C, D, E, F) => T,
+                                 genA: org.scalatest.prop.Generator[A],
+                                 genB: org.scalatest.prop.Generator[B],
+                                 genC: org.scalatest.prop.Generator[C],
+                                 genD: org.scalatest.prop.Generator[D],
+                                 genE: org.scalatest.prop.Generator[E],
+                                 genF: org.scalatest.prop.Generator[F],
+                                 prms: Configuration.Parameter,
+                                 prettifier: Prettifier,
+                                 pos: source.Position,
+                                 names: List[String],
+                                 argNames: Option[List[String]] = None): Result = {
+      val result = checkForAll(names, prms, genA, genB, genC, genD, genE, genF)(fun)
+      checkResult(result, prettifier, pos, argNames)
+    }
+
+    private[scalatest] def indicateSuccess(message: => String): Result
+
+    private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Result
+
+  }
+
+}
+
+trait FuturePropCheckerAsserting {
+
+  import PropCheckerAsserting._
+
+  abstract class FuturePropCheckerAssertingImpl[T] extends PropCheckerAsserting[Future[T]] {
+
+    implicit val executionContext: scala.concurrent.ExecutionContext
+
+    type Result = Future[Assertion]
+    type S = T
+
+    private def checkForAll[A](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A])(fun: (A) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextEdges, nextNextRnd) = genA.next(SizeParam(PosZInt(0), maxSize, size), edges, nextRnd) // TODO: Move PosZInt farther out
+
+        val argsPassed = List(if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a))
+        try {
+          val future = fun(a)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.edges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.edges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, edges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      // ensuringValid will always succeed because /ing a PosInt by a positive number will always yield a positive or zero
+      val (initEdges, afterEdgesRnd) = genA.initEdges(PosZInt.ensuringValid(config.minSuccessful / 5), afterSizesRnd)
+
+      loop(0, 0, initEdges, afterEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkForAll[A, B](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B])(fun: (A, B) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
+        val (b, nextBEdges, nextNextRnd) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b)
+          )
+        try {
+          val future = fun(a, b)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+
+      loop(0, 0, initAEdges, initBEdges, afterBEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkForAll[A, B, C](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
+                                     genC: org.scalatest.prop.Generator[C])(fun: (A, B, C) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, nextNextRnd) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c)
+          )
+        try {
+          val future = fun(a, b, c)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+
+      loop(0, 0, initAEdges, initBEdges, initCEdges, afterCEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkForAll[A, B, C, D](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
+                                     genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D])(fun: (A, B, C, D) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, nextNextRnd) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d)
+          )
+        try {
+          val future = fun(a, b, c, d)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, afterDEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkForAll[A, B, C, D, E](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
+                                        genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D], genE: org.scalatest.prop.Generator[E])(fun: (A, B, C, D, E) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, rnd5) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+        val (e, nextEEdges, nextNextRnd) = genE.next(SizeParam(PosZInt(0), maxSize, size), eEdges, rnd5)
+
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d),
+            if (names.isDefinedAt(4)) PropertyArgument(Some(names(4)), e) else PropertyArgument(None, e)
+          )
+        try {
+          val future = fun(a, b, c, d, e)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+      val (initEEdges, afterEEdgesRnd) = genE.initEdges(maxEdges, afterDEdgesRnd)
+
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, initEEdges, afterEEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkForAll[A, B, C, D, E, F](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
+                                           genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D], genE: org.scalatest.prop.Generator[E],
+                                           genF: org.scalatest.prop.Generator[F])(fun: (A, B, C, D, E, F) => Future[T]): Future[PropertyCheckResult] = {
+
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult])
+
+      val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
+      val minSize = config.minSize
+      val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
+
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+        val (size, nextInitialSizes, nextRnd) =
+          initialSizes match {
+            case head :: tail => (head, tail, rnd)
+            case Nil =>
+              val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
+              (sz, Nil, nextRnd)
+          }
+        val (a, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
+        val (b, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
+        val (c, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
+        val (d, nextDEdges, rnd5) = genD.next(SizeParam(PosZInt(0), maxSize, size), dEdges, rnd4)
+        val (e, nextEEdges, rnd6) = genE.next(SizeParam(PosZInt(0), maxSize, size), eEdges, rnd5)
+        val (f, nextFEdges, nextNextRnd) = genF.next(SizeParam(PosZInt(0), maxSize, size), fEdges, rnd6)
+
+        val argsPassed =
+          List(
+            if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), a) else PropertyArgument(None, a),
+            if (names.isDefinedAt(1)) PropertyArgument(Some(names(1)), b) else PropertyArgument(None, b),
+            if (names.isDefinedAt(2)) PropertyArgument(Some(names(2)), c) else PropertyArgument(None, c),
+            if (names.isDefinedAt(3)) PropertyArgument(Some(names(3)), d) else PropertyArgument(None, d),
+            if (names.isDefinedAt(4)) PropertyArgument(Some(names(4)), e) else PropertyArgument(None, e),
+            if (names.isDefinedAt(5)) PropertyArgument(Some(names(5)), f) else PropertyArgument(None, f)
+          )
+        try {
+          val future = fun(a, b, c, d, e, f)
+          future.map { r =>
+            if (discard(r)) {
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            }
+            else {
+              val (success, cause) = succeed(r)
+              if (success) {
+                val nextSucceededCount = succeededCount + 1
+                if (nextSucceededCount < config.minSuccessful)
+                  AccumulatedResult(nextSucceededCount, discardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, nextNextRnd, nextInitialSizes, None)
+                else
+                  AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(PropertyCheckResult.Success(argsPassed, initSeed)))
+
+              }
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, cause, names, argsPassed, initSeed)))
+
+            }
+          } recover {
+            case ex: DiscardedEvaluationException =>
+              val nextDiscardedCount = discardedCount + 1
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            case ex =>
+              AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+          } flatMap { result =>
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.fEdges, result.rnd, result.initialSizes, initSeed)
+          }
+        }
+        catch {
+          case ex: DiscardedEvaluationException =>
+            val nextDiscardedCount = discardedCount + 1
+            val result =
+              if (nextDiscardedCount < maxDiscarded)
+                AccumulatedResult(succeededCount, nextDiscardedCount, nextAEdges, nextBEdges, nextCEdges, nextDEdges, nextEEdges, nextFEdges, nextNextRnd, nextInitialSizes, None)
+              else
+                AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)))
+
+            if (result.result.isDefined)
+              Future.successful(result)
+            else
+              loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.fEdges, result.rnd, result.initialSizes, initSeed)
+
+          case ex =>
+            val result = AccumulatedResult(succeededCount, discardedCount, aEdges, bEdges, cEdges, dEdges, eEdges, fEdges, rnd, initialSizes, Some(new PropertyCheckResult.Failure(succeededCount, Some(ex), names, argsPassed, initSeed)))
+            Future.successful(result)
+        }
+      }
+
+      val initRnd = Randomizer.default // Eventually we'll grab this from a global that can be set by a cmd line param.
+      val initSeed = initRnd.seed
+      val (initialSizes, afterSizesRnd) = PropCheckerAsserting.calcSizes(minSize, maxSize, initRnd)
+      val maxEdges = PosZInt.ensuringValid(config.minSuccessful / 5) // Because PosInt / positive Int is always going to be positive
+      val (initAEdges, afterAEdgesRnd) = genA.initEdges(maxEdges, afterSizesRnd)
+      val (initBEdges, afterBEdgesRnd) = genB.initEdges(maxEdges, afterAEdgesRnd)
+      val (initCEdges, afterCEdgesRnd) = genC.initEdges(maxEdges, afterBEdgesRnd)
+      val (initDEdges, afterDEdgesRnd) = genD.initEdges(maxEdges, afterCEdgesRnd)
+      val (initEEdges, afterEEdgesRnd) = genE.initEdges(maxEdges, afterDEdgesRnd)
+      val (initFEdges, afterFEdgesRnd) = genF.initEdges(maxEdges, afterEEdgesRnd)
+
+      loop(0, 0, initAEdges, initBEdges, initCEdges, initDEdges, initEEdges, initFEdges, afterFEdgesRnd, initialSizes, initSeed).map { accResult =>
+        accResult.result.get
+      }
+    }
+
+    private def checkResult(result: PropertyCheckResult, prettifier: Prettifier, pos: source.Position, argNames: Option[List[String]] = None): Assertion = {
+      val (args, labels) = argsAndLabels(result)
+      result match {
+        case PropertyCheckResult.Exhausted(succeeded, discarded, names, argsPassed, initSeed) =>
+          val failureMsg =
+            if (succeeded == 1)
+              FailureMessages.propCheckExhaustedAfterOne(prettifier, discarded) + EOL + FailureMessages.initSeed(prettifier, initSeed)
+            else
+              FailureMessages.propCheckExhausted(prettifier, succeeded, discarded) + EOL + FailureMessages.initSeed(prettifier, initSeed)
+
+          indicateFutureFailure(
+            sde => failureMsg,
+            failureMsg,
+            args,
+            labels,
+            None,
+            pos
+          )
+
+        case PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
+          indicateFutureFailure(
+            sde => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + EOL +
+              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + EOL +
+              "  " + FailureMessages.propertyFailed(prettifier, succeeded) + EOL +
+              (
+                sde match {
+                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + EOL
+                  case _ => ""
+                }
+                ) +
+              "  " + FailureMessages.occurredOnValues + EOL +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, argsPassed), prettifier) + EOL +
+              "  )" +
+              getLabelDisplay(labels.toSet) + EOL +
+              "  " + FailureMessages.initSeed(prettifier, initSeed),
+            FailureMessages.propertyFailed(prettifier, succeeded),
+            argsPassed,
+            labels,
+            None,
+            pos
+          )
+
+        case _ => indicateFutureSuccess(FailureMessages.propertyCheckSucceeded)
+      }
+    }
+
+    def check1[A](fun: (A) => Future[T],
+                  genA: org.scalatest.prop.Generator[A],
+                  prms: Configuration.Parameter,
+                  prettifier: Prettifier,
+                  pos: source.Position,
+                  names: List[String],
+                  argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    def check2[A, B](fun: (A, B) => Future[T],
+                     genA: org.scalatest.prop.Generator[A],
+                     genB: org.scalatest.prop.Generator[B],
+                     prms: Configuration.Parameter,
+                     prettifier: Prettifier,
+                     pos: source.Position,
+                     names: List[String],
+                     argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA, genB)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    def check3[A, B, C](fun: (A, B, C) => Future[T],
+                        genA: org.scalatest.prop.Generator[A],
+                        genB: org.scalatest.prop.Generator[B],
+                        genC: org.scalatest.prop.Generator[C],
+                        prms: Configuration.Parameter,
+                        prettifier: Prettifier,
+                        pos: source.Position,
+                        names: List[String],
+                        argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA, genB, genC)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    def check4[A, B, C, D](fun: (A, B, C, D) => Future[T],
+                           genA: org.scalatest.prop.Generator[A],
+                           genB: org.scalatest.prop.Generator[B],
+                           genC: org.scalatest.prop.Generator[C],
+                           genD: org.scalatest.prop.Generator[D],
+                           prms: Configuration.Parameter,
+                           prettifier: Prettifier,
+                           pos: source.Position,
+                           names: List[String],
+                           argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA, genB, genC, genD)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    def check5[A, B, C, D, E](fun: (A, B, C, D, E) => Future[T],
+                              genA: org.scalatest.prop.Generator[A],
+                              genB: org.scalatest.prop.Generator[B],
+                              genC: org.scalatest.prop.Generator[C],
+                              genD: org.scalatest.prop.Generator[D],
+                              genE: org.scalatest.prop.Generator[E],
+                              prms: Configuration.Parameter,
+                              prettifier: Prettifier,
+                              pos: source.Position,
+                              names: List[String],
+                              argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA, genB, genC, genD, genE)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    def check6[A, B, C, D, E, F](fun: (A, B, C, D, E, F) => Future[T],
+                                 genA: org.scalatest.prop.Generator[A],
+                                 genB: org.scalatest.prop.Generator[B],
+                                 genC: org.scalatest.prop.Generator[C],
+                                 genD: org.scalatest.prop.Generator[D],
+                                 genE: org.scalatest.prop.Generator[E],
+                                 genF: org.scalatest.prop.Generator[F],
+                                 prms: Configuration.Parameter,
+                                 prettifier: Prettifier,
+                                 pos: source.Position,
+                                 names: List[String],
+                                 argNames: Option[List[String]] = None): Result = {
+      val future = checkForAll(names, prms, genA, genB, genC, genD, genE, genF)(fun)
+      future.map { result =>
+        checkResult(result, prettifier, pos, argNames)
+      }
+    }
+
+    private[scalatest] def indicateFutureSuccess(message: => String): Assertion
+
+    private[scalatest] def indicateFutureFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion
+
+  }
+
+}
+
+abstract class ExpectationPropCheckerAsserting extends UnitPropCheckerAsserting {
+
+  implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): PropCheckerAsserting[Expectation] { type Result = Expectation } = {
+    new PropCheckerAssertingImpl[Expectation] {
+      type Result = Expectation
+      def discard(result: Expectation): Boolean = result.isVacuousYes
+      def succeed(result: Expectation): (Boolean, Option[Throwable]) = (result.isYes, result.cause)
+      private[scalatest] def indicateSuccess(message: => String): Expectation = Fact.Yes(message)(prettifier)
+      private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Expectation = {
+        val gdpcfe =
+          new GeneratorDrivenPropertyCheckFailedException(
+            messageFun,
+            optionalCause,
+            pos,
+            None,
+            undecoratedMessage,
+            scalaCheckArgs,
+            None,
+            scalaCheckLabels.toList
+          )
+        val message: String = gdpcfe.getMessage
+        Fact.No(message)(prettifier)
+      }
+    }
+  }
+}
+
+object PropCheckerAsserting extends ExpectationPropCheckerAsserting with FuturePropCheckerAsserting {
+
+  implicit def assertingNatureOfAssertion: PropCheckerAsserting[Assertion] { type Result = Assertion } = {
+    new PropCheckerAssertingImpl[Assertion] {
+      type Result = Assertion
+      def discard(result: Assertion): Boolean = false
+      def succeed(result: Assertion): (Boolean, Option[Throwable]) = (true, None)
+      private[scalatest] def indicateSuccess(message: => String): Assertion = Succeeded
+      private[scalatest] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
+        throw new GeneratorDrivenPropertyCheckFailedException(
+          messageFun,
+          optionalCause,
+          pos,
+          None,
+          undecoratedMessage,
+          scalaCheckArgs,
+          None,
+          scalaCheckLabels.toList
+        )
+      }
+    }
+  }
+
+  implicit def assertingNatureOfFutureAssertion(implicit exeCtx: scala.concurrent.ExecutionContext): PropCheckerAsserting[Future[Assertion]] { type Result = Future[Assertion] } = {
+    new FuturePropCheckerAssertingImpl[Assertion] {
+      implicit val executionContext = exeCtx
+      def discard(result: Assertion): Boolean = false
+      def succeed(result: Assertion): (Boolean, Option[Throwable]) = (true, None)
+      private[scalatest] def indicateFutureSuccess(message: => String): Assertion = Succeeded
+      private[scalatest] def indicateFutureFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
+        throw new GeneratorDrivenPropertyCheckFailedException(
+          messageFun,
+          optionalCause,
+          pos,
+          None,
+          undecoratedMessage,
+          scalaCheckArgs,
+          None,
+          scalaCheckLabels.toList
+        )
+      }
+    }
+  }
+
+  private[enablers] def argsAndLabels(result: PropertyCheckResult): (List[PropertyArgument], List[String]) = {
+
+    val (args: List[PropertyArgument], labels: List[String]) =
+      result match {
+        case PropertyCheckResult.Success(args, _) => (args.toList, List())
+        case PropertyCheckResult.Failure(_, _, names, args, _) => (args.toList, List())
+        case _ => (List(), List())
+      }
+
+    (args, labels)
+  }
+
+  private[enablers] def decorateArgToStringValue(arg: PropertyArgument, prettifier: Prettifier): String =
+    decorateToStringValue(prettifier, arg.value)
+
+  private[enablers] def prettyArgs(args: List[PropertyArgument], prettifier: Prettifier) = {
+    val strs = for((a, i) <- args.zipWithIndex) yield (
+      "    " +
+        (if (a.label == "") "arg" + i else a.label) +
+        " = " + decorateArgToStringValue(a, prettifier) + (if (i < args.length - 1) "," else "") /*+
+        (if (a.shrinks > 0) " // " + a.shrinks + (if (a.shrinks == 1) " shrink" else " shrinks") else "")*/
+      )
+    strs.mkString("\n")
+  }
+
+  private[enablers] def getArgsWithSpecifiedNames(argNames: Option[List[String]], checkArgs: List[PropertyArgument]) = {
+    if (argNames.isDefined) {
+      // length of scalaCheckArgs should equal length of argNames
+      val zipped = argNames.get zip checkArgs
+      zipped map { case (argName, arg) => arg.copy(label = Some(argName)) }
+    }
+    else
+      checkArgs
+  }
+
+  private[enablers] def getLabelDisplay(labels: Set[String]): String =
+    if (labels.size > 0)
+      "\n  " + (if (labels.size == 1) Resources.propCheckLabel else Resources.propCheckLabels) + "\n" + labels.map("    " + _).mkString("\n")
+    else
+      ""
+
+  def calcSizes(minSize: PosZInt, maxSize: PosZInt, initRndm: Randomizer): (List[PosZInt], Randomizer) = {
+    @tailrec
+    def sizesLoop(sizes: List[PosZInt], count: Int, rndm: Randomizer): (List[PosZInt], Randomizer) = {
+      sizes match {
+        case Nil => sizesLoop(List(minSize), 1, rndm)
+        case szs if count < 10 =>
+          val (nextSize, nextRndm) = rndm.choosePosZInt(minSize, maxSize)
+          sizesLoop(nextSize :: sizes, count + 1, nextRndm)
+        case _ => (sizes.sorted, rndm)
+      }
+    }
+    sizesLoop(Nil, 0, initRndm)
+  }
+}

--- a/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2017 Artima, Inc.
+ * Copyright 2001-2016 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,20 @@
 package org.scalatest.prop
 
 import org.scalactic.anyvals.{PosInt,PosZInt}
-import org.scalactic.Requirements._
 
-// 0 + 10 is 10
-// sizeRange = maxSize - minSize
-case class SizeParam(minSize: PosZInt, sizeRange: PosZInt, size: PosZInt) {
-  require(size >= minSize, s"the passed size ($size.value) must be greater than or equal to the passed minSize ($minSize.value)")
-  require(size.value <= minSize + sizeRange, s"the passed size (${size.value}) must be less than or equal to passed minSize plus the passed sizeRange ($minSize + $sizeRange = ${minSize + sizeRange})")
-  val maxSize: PosZInt = PosZInt.ensuringValid(minSize + sizeRange)
+case class Classification(val totalGenerated: PosInt, val totals: Map[String, PosZInt]) {
+
+  def portions: Map[String, Double] =
+    totals.mapValues(count => count.toDouble / totalGenerated.toDouble)
+
+  def percentages: Map[String, PosZInt] =
+    totals mapValues { count =>
+      PosZInt.ensuringValid((count * 100.0 / totalGenerated).round.toInt)
+    }
+
+  override def toString = {
+    val lines = percentages map { case (classification, percentage) => s"${percentage.value}% $classification" }
+    lines.mkString("\n")
+  }
 }
 

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -1,0 +1,1386 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals._
+import scala.annotation.tailrec
+import org.scalactic.source.TypeInfo
+import org.scalactic.Requirements._
+import scala.collection.immutable.SortedSet
+import scala.collection.immutable.SortedMap
+
+trait CommonGenerators {
+
+  def bytesBetween(from: Byte, to: Byte): Generator[Byte] = {
+    require(from <= to)
+    new Generator[Byte] { thisByteGenerator =>
+      private val byteEdges = Generator.byteEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: byteEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Byte], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Byte], rnd: Randomizer): (Byte, List[Byte], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextByte, nextRandomizer) = rnd.chooseByte(from, to)
+            (nextByte, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def shortsBetween(from: Short, to: Short): Generator[Short] = {
+    require(from <= to)
+    new Generator[Short] { thisShortGenerator =>
+      private val shortEdges = List(Short.MinValue, -1.toShort, 0.toShort, 1.toShort, Short.MaxValue).filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: shortEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Short], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Short], rnd: Randomizer): (Short, List[Short], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextShort, nextRandomizer) = rnd.chooseShort(from, to)
+            (nextShort, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def intsBetween(from: Int, to: Int): Generator[Int] = {
+    require(from <= to)
+    new Generator[Int] { thisIntGenerator =>
+      private val intEdges = Generator.intEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Int], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Int], rnd: Randomizer): (Int, List[Int], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRandomizer) = rnd.chooseInt(from, to)
+            (nextInt, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def longsBetween(from: Long, to: Long): Generator[Long] = {
+    require(from <= to)
+    new Generator[Long] { thisLongGenerator =>
+      private val longEdges = Generator.longEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: longEdges).distinct // distinct in case from equals to, and/or overlaps an edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Long], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Long], rnd: Randomizer): (Long, List[Long], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextLong, nextRandomizer) = rnd.chooseLong(from, to)
+            (nextLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def charsBetween(from: Char, to: Char): Generator[Char] = {
+    require(from <= to)
+    new Generator[Char] { thisCharGenerator =>
+      private val charEdges = Generator.charEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: charEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Char], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Char], rnd: Randomizer): (Char, List[Char], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextChar, nextRandomizer) = rnd.chooseChar(from, to)
+            (nextChar, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def floatsBetween(from: Float, to: Float): Generator[Float] = {
+    require(from <= to)
+    new Generator[Float] { thisFloatGenerator =>
+      private val floatEdges = Generator.floatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Float], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Float], rnd: Randomizer): (Float, List[Float], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextFloat, nextRandomizer) = rnd.chooseFloat(from, to)
+            (nextFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def doublesBetween(from: Double, to: Double): Generator[Double] = {
+    require(from <= to)
+    new Generator[Double] { thisDoubleGenerator =>
+      private val doubleEdges = Generator.doubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Double], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Double], rnd: Randomizer): (Double, List[Double], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextDouble, nextRandomizer) = rnd.chooseDouble(from, to)
+            (nextDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posIntsBetween(from: PosInt, to: PosInt): Generator[PosInt] =
+    new Generator[PosInt] { thisPosIntGenerator =>
+      private val intEdges = Generator.posIntEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosInt], rnd: Randomizer): (PosInt, List[PosInt], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosInt, nextRandomizer) = rnd.choosePosInt(from, to)
+            (nextPosInt, Nil, nextRandomizer)
+        }
+      }
+    }
+
+  def posLongsBetween(from: PosLong, to: PosLong): Generator[PosLong] = {
+    require(from <= to)
+    new Generator[PosLong] { thisPosLongGenerator =>
+      private val posLongEdges = List(PosLong(1L), PosLong.MaxValue).filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posLongEdges).distinct // distinct in case from equals to, and/or overlaps an edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosLong], rnd: Randomizer): (PosLong, List[PosLong], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosLong, nextRandomizer) = rnd.choosePosLong(from, to)
+            (nextPosLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posFloatsBetween(from: PosFloat, to: PosFloat): Generator[PosFloat] = {
+    require(from <= to)
+    new Generator[PosFloat] { thisPosFloatGenerator =>
+      private val posFloatEdges = Generator.posFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posFloatEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFloat], rnd: Randomizer): (PosFloat, List[PosFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosFloat, nextRandomizer) = rnd.choosePosFloat(from, to)
+            (nextPosFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posFiniteFloatsBetween(from: PosFiniteFloat, to: PosFiniteFloat): Generator[PosFiniteFloat] = {
+    require(from <= to)
+    new Generator[PosFiniteFloat] { thisPosFiniteFloatGenerator =>
+      private val posFiniteFloatEdges = Generator.posFiniteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posFiniteFloatEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFiniteFloat], rnd: Randomizer): (PosFiniteFloat, List[PosFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosFiniteFloat, nextRandomizer) = rnd.choosePosFiniteFloat(from, to)
+            (nextPosFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posDoublesBetween(from: PosDouble, to: PosDouble): Generator[PosDouble] = {
+    require(from <= to)
+    new Generator[PosDouble] { thisPosDoubleGenerator =>
+      private val posDoubleEdges = Generator.posDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posDoubleEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosDouble], rnd: Randomizer): (PosDouble, List[PosDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosDouble, nextRandomizer) = rnd.choosePosDouble(from, to)
+            (nextPosDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posFiniteDoublesBetween(from: PosFiniteDouble, to: PosFiniteDouble): Generator[PosFiniteDouble] = {
+    require(from <= to)
+    new Generator[PosFiniteDouble] { thisPosFiniteDoubleGenerator =>
+      private val posFiniteDoubleEdges = Generator.posFiniteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posFiniteDoubleEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFiniteDouble], rnd: Randomizer): (PosFiniteDouble, List[PosFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosFiniteDouble, nextRandomizer) = rnd.choosePosFiniteDouble(from, to)
+            (nextPosFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posZIntsBetween(from: PosZInt, to: PosZInt): Generator[PosZInt] =
+    // Probably disallow from >= to, and if =, then say use some alternative? constantValues(x) ?
+    new Generator[PosZInt] { thisPosZIntGenerator =>
+      private val intEdges = Generator.posZIntEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZInt], rnd: Randomizer): (PosZInt, List[PosZInt], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZInt, nextRandomizer) = rnd.choosePosZInt(from, to)
+            (nextPosZInt, Nil, nextRandomizer)
+        }
+      }
+    }
+
+  def posZLongsBetween(from: PosZLong, to: PosZLong): Generator[PosZLong] = {
+    require(from <= to)
+    new Generator[PosZLong] { thisPosZLongGenerator =>
+      private val posZLongEdges = Generator.posZLongEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posZLongEdges).distinct // distinct in case from equals to, and/or overlaps an edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZLong], rnd: Randomizer): (PosZLong, List[PosZLong], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZLong, nextRandomizer) = rnd.choosePosZLong(from, to)
+            (nextPosZLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posZFloatsBetween(from: PosZFloat, to: PosZFloat): Generator[PosZFloat] = {
+    require(from <= to)
+    new Generator[PosZFloat] { thisPosZFloatGenerator =>
+      private val posZFloatEdges = Generator.posZFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posZFloatEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFloat], rnd: Randomizer): (PosZFloat, List[PosZFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZFloat, nextRandomizer) = rnd.choosePosZFloat(from, to)
+            (nextPosZFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posZFiniteFloatsBetween(from: PosZFiniteFloat, to: PosZFiniteFloat): Generator[PosZFiniteFloat] = {
+    require(from <= to)
+    new Generator[PosZFiniteFloat] { thisPosZFiniteFloatGenerator =>
+      private val posZFiniteFloatEdges = Generator.posZFiniteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posZFiniteFloatEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFiniteFloat], rnd: Randomizer): (PosZFiniteFloat, List[PosZFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZFiniteFloat, nextRandomizer) = rnd.choosePosZFiniteFloat(from, to)
+            (nextPosZFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posZDoublesBetween(from: PosZDouble, to: PosZDouble): Generator[PosZDouble] = {
+    require(from <= to)
+    new Generator[PosZDouble] { thisPosZDoubleGenerator =>
+      private val posZDoubleEdges = Generator.posZDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posZDoubleEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZDouble], rnd: Randomizer): (PosZDouble, List[PosZDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZDouble, nextRandomizer) = rnd.choosePosZDouble(from, to)
+            (nextPosZDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def posZFiniteDoublesBetween(from: PosZFiniteDouble, to: PosZFiniteDouble): Generator[PosZFiniteDouble] = {
+    require(from <= to)
+    new Generator[PosZFiniteDouble] { thisPosZFiniteDoubleGenerator =>
+      private val posZFiniteDoubleEdges = Generator.posZFiniteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: posZFiniteDoubleEdges).distinct // distinct in case from equals to, and/or overlaps an Int edge
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFiniteDouble], rnd: Randomizer): (PosZFiniteDouble, List[PosZFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextPosZFiniteDouble, nextRandomizer) = rnd.choosePosZFiniteDouble(from, to)
+            (nextPosZFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negIntsBetween(from: NegInt, to: NegInt): Generator[NegInt] = {
+    require(from <= to)
+    new Generator[NegInt] {
+      thisNegIntGenerator =>
+      private val intEdges = Generator.negIntEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegInt], rnd: Randomizer): (NegInt, List[NegInt], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegInt, nextRandomizer) = rnd.chooseNegInt(from, to)
+            (nextNegInt, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negLongsBetween(from: NegLong, to: NegLong): Generator[NegLong] = {
+    require(from <= to)
+    new Generator[NegLong] {
+      thisNegLongGenerator =>
+      private val longEdges = Generator.negLongEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: longEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegLong], rnd: Randomizer): (NegLong, List[NegLong], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegLong, nextRandomizer) = rnd.chooseNegLong(from, to)
+            (nextNegLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negFloatsBetween(from: NegFloat, to: NegFloat): Generator[NegFloat] = {
+    require(from <= to)
+    new Generator[NegFloat] {
+      thisNegFloatGenerator =>
+      private val floatEdges = Generator.negFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegFloat], rnd: Randomizer): (NegFloat, List[NegFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegFloat, nextRandomizer) = rnd.chooseNegFloat(from, to)
+            (nextNegFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negFiniteFloatsBetween(from: NegFiniteFloat, to: NegFiniteFloat): Generator[NegFiniteFloat] = {
+    require(from <= to)
+    new Generator[NegFiniteFloat] {
+      thisNegFiniteFloatGenerator =>
+      private val floatEdges = Generator.negFiniteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegFiniteFloat], rnd: Randomizer): (NegFiniteFloat, List[NegFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegFiniteFloat, nextRandomizer) = rnd.chooseNegFiniteFloat(from, to)
+            (nextNegFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negDoublesBetween(from: NegDouble, to: NegDouble): Generator[NegDouble] = {
+    require(from <= to)
+    new Generator[NegDouble] {
+      thisNegDoubleGenerator =>
+      private val doubleEdges = Generator.negDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegDouble], rnd: Randomizer): (NegDouble, List[NegDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegDouble, nextRandomizer) = rnd.chooseNegDouble(from, to)
+            (nextNegDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negFiniteDoublesBetween(from: NegFiniteDouble, to: NegFiniteDouble): Generator[NegFiniteDouble] = {
+    require(from <= to)
+    new Generator[NegFiniteDouble] {
+      thisNegFiniteDoubleGenerator =>
+      private val doubleEdges = Generator.negFiniteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegFiniteDouble], rnd: Randomizer): (NegFiniteDouble, List[NegFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegFiniteDouble, nextRandomizer) = rnd.chooseNegFiniteDouble(from, to)
+            (nextNegFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZIntsBetween(from: NegZInt, to: NegZInt): Generator[NegZInt] = {
+    require(from <= to)
+    new Generator[NegZInt] {
+      thisNegZIntGenerator =>
+      private val intEdges = Generator.negZIntEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZInt], rnd: Randomizer): (NegZInt, List[NegZInt], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZInt, nextRandomizer) = rnd.chooseNegZInt(from, to)
+            (nextNegZInt, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZLongsBetween(from: NegZLong, to: NegZLong): Generator[NegZLong] = {
+    require(from <= to)
+    new Generator[NegZLong] {
+      thisNegZLongGenerator =>
+      private val longEdges = Generator.negZLongEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: longEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZLong], rnd: Randomizer): (NegZLong, List[NegZLong], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZLong, nextRandomizer) = rnd.chooseNegZLong(from, to)
+            (nextNegZLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZFloatsBetween(from: NegZFloat, to: NegZFloat): Generator[NegZFloat] = {
+    require(from <= to)
+    new Generator[NegZFloat] {
+      thisNegZFloatGenerator =>
+      private val floatEdges = Generator.negZFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZFloat], rnd: Randomizer): (NegZFloat, List[NegZFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZFloat, nextRandomizer) = rnd.chooseNegZFloat(from, to)
+            (nextNegZFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZFiniteFloatsBetween(from: NegZFiniteFloat, to: NegZFiniteFloat): Generator[NegZFiniteFloat] = {
+    require(from <= to)
+    new Generator[NegZFiniteFloat] {
+      thisNegZFiniteFloatGenerator =>
+      private val floatEdges = Generator.negZFiniteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZFiniteFloat], rnd: Randomizer): (NegZFiniteFloat, List[NegZFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZFiniteFloat, nextRandomizer) = rnd.chooseNegZFiniteFloat(from, to)
+            (nextNegZFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZDoublesBetween(from: NegZDouble, to: NegZDouble): Generator[NegZDouble] = {
+    require(from <= to)
+    new Generator[NegZDouble] {
+      thisNegZDoubleGenerator =>
+      private val doubleEdges = Generator.negZDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZDouble], rnd: Randomizer): (NegZDouble, List[NegZDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZDouble, nextRandomizer) = rnd.chooseNegZDouble(from, to)
+            (nextNegZDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def negZFiniteDoublesBetween(from: NegZFiniteDouble, to: NegZFiniteDouble): Generator[NegZFiniteDouble] = {
+    require(from <= to)
+    new Generator[NegZFiniteDouble] {
+      thisNegZFiniteDoubleGenerator =>
+      private val doubleEdges = Generator.negZFiniteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NegZFiniteDouble], rnd: Randomizer): (NegZFiniteDouble, List[NegZFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNegZFiniteDouble, nextRandomizer) = rnd.chooseNegZFiniteDouble(from, to)
+            (nextNegZFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroIntsBetween(from: NonZeroInt, to: NonZeroInt): Generator[NonZeroInt] = {
+    require(from <= to)
+    new Generator[NonZeroInt] {
+      thisNonZeroIntGenerator =>
+      private val intEdges = Generator.nonZeroIntEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: intEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroInt], rnd: Randomizer): (NonZeroInt, List[NonZeroInt], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroInt, nextRandomizer) = rnd.chooseNonZeroInt(from, to)
+            (nextNonZeroInt, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroLongsBetween(from: NonZeroLong, to: NonZeroLong): Generator[NonZeroLong] = {
+    require(from <= to)
+    new Generator[NonZeroLong] {
+      thisNonZeroLongGenerator =>
+      private val longEdges = Generator.nonZeroLongEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: longEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroLong], rnd: Randomizer): (NonZeroLong, List[NonZeroLong], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroLong, nextRandomizer) = rnd.chooseNonZeroLong(from, to)
+            (nextNonZeroLong, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroFloatsBetween(from: NonZeroFloat, to: NonZeroFloat): Generator[NonZeroFloat] = {
+    require(from <= to)
+    new Generator[NonZeroFloat] {
+      thisNonZeroFloatGenerator =>
+      private val floatEdges = Generator.nonZeroFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroFloat], rnd: Randomizer): (NonZeroFloat, List[NonZeroFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroFloat, nextRandomizer) = rnd.chooseNonZeroFloat(from, to)
+            (nextNonZeroFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroFiniteFloatsBetween(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat): Generator[NonZeroFiniteFloat] = {
+    require(from <= to)
+    new Generator[NonZeroFiniteFloat] {
+      thisNonZeroFiniteFloatGenerator =>
+      private val floatEdges = Generator.nonZeroFiniteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroFiniteFloat], rnd: Randomizer): (NonZeroFiniteFloat, List[NonZeroFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroFiniteFloat, nextRandomizer) = rnd.chooseNonZeroFiniteFloat(from, to)
+            (nextNonZeroFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroDoublesBetween(from: NonZeroDouble, to: NonZeroDouble): Generator[NonZeroDouble] = {
+    require(from <= to)
+    new Generator[NonZeroDouble] {
+      thisNonZeroDoubleGenerator =>
+      private val doubleEdges = Generator.nonZeroDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroDouble], rnd: Randomizer): (NonZeroDouble, List[NonZeroDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroDouble, nextRandomizer) = rnd.chooseNonZeroDouble(from, to)
+            (nextNonZeroDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def nonZeroFiniteDoublesBetween(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble): Generator[NonZeroFiniteDouble] = {
+    require(from <= to)
+    new Generator[NonZeroFiniteDouble] {
+      thisNonZeroFiniteDoubleGenerator =>
+      private val doubleEdges = Generator.nonZeroFiniteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[NonZeroFiniteDouble], rnd: Randomizer): (NonZeroFiniteDouble, List[NonZeroFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextNonZeroFiniteDouble, nextRandomizer) = rnd.chooseNonZeroFiniteDouble(from, to)
+            (nextNonZeroFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def finiteFloatsBetween(from: FiniteFloat, to: FiniteFloat): Generator[FiniteFloat] = {
+    require(from <= to)
+    new Generator[FiniteFloat] {
+      thisFiniteFloatGenerator =>
+      private val floatEdges = Generator.finiteFloatEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: floatEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[FiniteFloat], rnd: Randomizer): (FiniteFloat, List[FiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextFiniteFloat, nextRandomizer) = rnd.chooseFiniteFloat(from, to)
+            (nextFiniteFloat, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def finiteDoublesBetween(from: FiniteDouble, to: FiniteDouble): Generator[FiniteDouble] = {
+    require(from <= to)
+    new Generator[FiniteDouble] {
+      thisFiniteDoubleGenerator =>
+      private val doubleEdges = Generator.finiteDoubleEdges.filter(i => i >= from && i <= to)
+      private val fromToEdges = (from :: to :: doubleEdges).distinct
+
+      // distinct in case from equals to
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(fromToEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[FiniteDouble], rnd: Randomizer): (FiniteDouble, List[FiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            val (nextFiniteDouble, nextRandomizer) = rnd.chooseFiniteDouble(from, to)
+            (nextFiniteDouble, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def specificValues[T](first: T, second: T, rest: T*): Generator[T] =
+    new Generator[T] {
+      private val seq: Seq[T] = first +: second +: rest
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRandomizer) = rnd.chooseInt(0, seq.length - 1)
+            val nextT = seq(nextInt)
+            (nextT, Nil, nextRandomizer)
+        }
+      }
+    }
+
+  def specificValue[T](theValue: T): Generator[T] =
+    new Generator[T] {
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            (theValue, Nil, rnd)
+        }
+      }
+    }
+
+  // TODO: I wonder if I could get rid of the edges pattern match
+  // by moving this to a different method. Then next is just next
+  // in the distributed stuff. I could then do the pattern match
+  // once and forall in a final method, nextEdge.
+  def frequency[T](first: (Int, Generator[T]), second: (Int, Generator[T]), rest: (Int, Generator[T])*): Generator[T] = {
+    val distribution: Vector[(Int, Generator[T])] = (first +: second +: rest).toVector
+    // Take Int not PosInt, because Scala won't apply  multiple implicit
+    // conversions, such as one for PosInt => Int, and another for Int => Generator[Int].
+    // So just do a require.
+/*
+    TODO:
+
+     org.scalactic.Requirements.require {
+       distribution forall { case (w, _) => w >= 1 }
+     }
+
+[error] /Users/bv/nobkp/delus/st-algebra-and-laws-2/scalatest/src/main/scala/org/scalatest/prop/package.scala:154: exception during macro expansion: 
+[error] scala.reflect.macros.TypecheckException: not found: value requirementsHelper
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$typecheck$2$$anonfun$apply$1.apply(Typers.scala:34)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$typecheck$2$$anonfun$apply$1.apply(Typers.scala:28)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$3.apply(Typers.scala:24)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$3.apply(Typers.scala:24)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$withContext$1$1.apply(Typers.scala:25)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$withContext$1$1.apply(Typers.scala:25)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$1.apply(Typers.scala:23)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$1.apply(Typers.scala:23)
+[error] 	at scala.reflect.macros.contexts.Typers$class.withContext$1(Typers.scala:25)
+[error] 	at scala.reflect.macros.contexts.Typers$$anonfun$typecheck$2.apply(Typers.scala:28)
+
+*/
+    // I think we actually need to say org.scalactic.Requirements.requirementsHelper in the thing not requirementsHelper
+    // Oh, maybe that won't work. Anyway, see what's up.
+    import org.scalactic.Requirements._
+    require {
+      distribution forall { case (w, _) => w >= 1 }
+    }
+    new Generator[T] {
+      private val totalWeight: Int = distribution.toMap.keys.sum
+      // gens contains, for each distribution pair, weight generators.
+      private val gens: Vector[Generator[T]] =
+        // TODO: Try dropping toVector. distribution is already a Vector
+        distribution.toVector flatMap { case (w, g) =>
+          Vector.fill(w)(g)
+        }
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRandomizer) = rnd.chooseInt(0, gens.length - 1)
+            val nextGen = gens(nextInt)
+            nextGen.next(szp, Nil, nextRandomizer)
+        }
+      }
+    }
+  }
+
+  def evenly[T](first: Generator[T], second: Generator[T], rest: Generator[T]*): Generator[T] = {
+    val distributees: Vector[Generator[T]] = (first +: second +: rest).toVector
+    new Generator[T] {
+      // gens contains, for each distribution pair, weight generators.
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRandomizer) = rnd.chooseInt(0, distributees.length - 1)
+            val nextGen = distributees(nextInt)
+            nextGen.next(szp, Nil, nextRandomizer) // TODO: Is it correct to pass size and maxSize here?
+        }
+      }
+    }
+  }
+
+  val bytes: Generator[Byte] = Generator.byteGenerator
+  val shorts: Generator[Short] = Generator.shortGenerator
+  val ints: Generator[Int] = Generator.intGenerator
+  val longs: Generator[Long] = Generator.longGenerator
+  val chars: Generator[Char] = Generator.charGenerator
+  val floats: Generator[Float] = Generator.floatGenerator
+  val doubles: Generator[Double] = Generator.doubleGenerator
+  val strings: Generator[String] = Generator.stringGenerator
+  def lists[T](implicit genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] = Generator.listGenerator[T]
+  def tuple2s[A, B](implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[(A, B)] = Generator.tuple2Generator[A, B]
+  def tuple3s[A, B, C](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[(A, B, C)] = Generator.tuple3Generator[A, B, C]
+  def tuple4s[A, B, C, D](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[(A, B, C, D)] = Generator.tuple4Generator[A, B, C, D]
+  def tuple5s[A, B, C, D, E](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[(A, B, C, D, E)] = Generator.tuple5Generator[A, B, C, D, E]
+  def tuple6s[A, B, C, D, E, F](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[(A, B, C, D, E, F)] = Generator.tuple6Generator[A, B, C, D, E, F]
+  def tuple7s[A, B, C, D, E, F, G](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G]): Generator[(A, B, C, D, E, F, G)] = Generator.tuple7Generator[A, B, C, D, E, F, G]
+  def tuple8s[A, B, C, D, E, F, G, H](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H]): Generator[(A, B, C, D, E, F, G, H)] = Generator.tuple8Generator[A, B, C, D, E, F, G, H]
+  def tuple9s[A, B, C, D, E, F, G, H, I](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[(A, B, C, D, E, F, G, H, I)] = Generator.tuple9Generator[A, B, C, D, E, F, G, H, I]
+  def tuple10s[A, B, C, D, E, F, G, H, I, J](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                             genOfJ: Generator[J]): Generator[(A, B, C, D, E, F, G, H, I, J)] = Generator.tuple10Generator[A, B, C, D, E, F, G, H, I, J]
+  def tuple11s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                             genOfJ: Generator[J], genOfK: Generator[K]): Generator[(A, B, C, D, E, F, G, H, I, J, K)] = Generator.tuple11Generator[A, B, C, D, E, F, G, H, I, J, K]
+  def tuple12s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L)] = Generator.tuple12Generator[A, B, C, D, E, F, G, H, I, J, K, L]
+  def tuple13s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                   genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = Generator.tuple13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
+  def tuple14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                      genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = Generator.tuple14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+  def tuple15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                         genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = Generator.tuple15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+  def tuple16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                            genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = Generator.tuple16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+  def tuple17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                               genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = Generator.tuple17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+  def tuple18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                  genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = Generator.tuple18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+  def tuple19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                     genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = Generator.tuple19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+  def tuple20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                           genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
+                                                                           genOfT: Generator[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = Generator.tuple20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+  def tuple21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                           genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
+                                                                           genOfT: Generator[T], genOfU: Generator[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = Generator.tuple21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+  def tuple22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                              genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
+                                                                              genOfT: Generator[T], genOfU: Generator[U], genOfV: Generator[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = Generator.tuple22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+  def function0s[A](implicit genOfA: Generator[A]): Generator[() => A] = Generator.function0Generator[A]
+  def function1s[A, B](implicit genOfB: Generator[B], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B]): Generator[A => B] =
+    Generator.function1Generator[A, B]
+  def function2s[A, B, C](implicit genOfC: Generator[C], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C]): Generator[(A, B) => C] =
+    Generator.function2Generator[A, B, C]
+  def function3s[A, B, C, D](implicit genOfD: Generator[D], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D]): Generator[(A, B, C) => D] =
+    Generator.function3Generator[A, B, C, D]
+  def function4s[A, B, C, D, E](implicit genOfE: Generator[E], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E]): Generator[(A, B, C, D) => E] =
+    Generator.function4Generator[A, B, C, D, E]
+  def function5s[A, B, C, D, E, F](implicit genOfF: Generator[F], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F]): Generator[(A, B, C, D, E) => F] =
+    Generator.function5Generator[A, B, C, D, E, F]
+  def function6s[A, B, C, D, E, F, G](implicit genOfG: Generator[G], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G]): Generator[(A, B, C, D, E, F) => G] =
+    Generator.function6Generator[A, B, C, D, E, F, G]
+  def function7s[A, B, C, D, E, F, G, H](implicit genOfH: Generator[H], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H]): Generator[(A, B, C, D, E, F, G) => H] =
+    Generator.function7Generator[A, B, C, D, E, F, G, H]
+  def function8s[A, B, C, D, E, F, G, H, I](implicit genOfI: Generator[I], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I]): Generator[(A, B, C, D, E, F, G, H) => I] =
+    Generator.function8Generator[A, B, C, D, E, F, G, H, I]
+  def function9s[A, B, C, D, E, F, G, H, I, J](implicit genOfJ: Generator[J], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J]): Generator[(A, B, C, D, E, F, G, H, I) => J] =
+    Generator.function9Generator[A, B, C, D, E, F, G, H, I, J]
+  def function10s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfK: Generator[K], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K]): Generator[(A, B, C, D, E, F, G, H, I, J) => K] =
+    Generator.function10Generator[A, B, C, D, E, F, G, H, I, J, K]
+  def function11s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfL: Generator[L], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] =
+    Generator.function11Generator[A, B, C, D, E, F, G, H, I, J, K, L]
+  def function12s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfM: Generator[M], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] =
+    Generator.function12Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
+  def function13s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfN: Generator[N], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] =
+    Generator.function13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+  def function14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfO: Generator[O], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] =
+    Generator.function14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+  def function15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfP: Generator[P], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] =
+    Generator.function15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+  def function16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfQ: Generator[Q], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] =
+    Generator.function16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+  def function17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfR: Generator[R], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] =
+    Generator.function17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+  def function18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfS: Generator[S], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] =
+    Generator.function18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+  def function19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfT: Generator[T], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] =
+    Generator.function19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+  def function20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfU: Generator[U], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] =
+    Generator.function20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+  def function21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfV: Generator[V], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] =
+    Generator.function21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+  def function22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](implicit genOfW: Generator[W], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V], typeInfoW: TypeInfo[W]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] =
+    Generator.function22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
+
+  val posInts: Generator[PosInt] = Generator.posIntGenerator
+  val posZInts: Generator[PosZInt] = Generator.posZIntGenerator
+  val posLongs: Generator[PosLong] = Generator.posLongGenerator
+  val posZLongs: Generator[PosZLong] = Generator.posZLongGenerator
+  val posFloats: Generator[PosFloat] = Generator.posFloatGenerator
+  val posFiniteFloats: Generator[PosFiniteFloat] = Generator.posFiniteFloatGenerator
+  val posZFloats: Generator[PosZFloat] = Generator.posZFloatGenerator
+  val posZFiniteFloats: Generator[PosZFiniteFloat] = Generator.posZFiniteFloatGenerator
+  val posDoubles: Generator[PosDouble] = Generator.posDoubleGenerator
+  val posFiniteDoubles: Generator[PosFiniteDouble] = Generator.posFiniteDoubleGenerator
+  val posZDoubles: Generator[PosZDouble] = Generator.posZDoubleGenerator
+  val posZFiniteDoubles: Generator[PosZFiniteDouble] = Generator.posZFiniteDoubleGenerator
+  val negInts: Generator[NegInt] = Generator.negIntGenerator
+  val negZInts: Generator[NegZInt] = Generator.negZIntGenerator
+  val negLongs: Generator[NegLong] = Generator.negLongGenerator
+  val negZLongs: Generator[NegZLong] = Generator.negZLongGenerator
+  val negFloats: Generator[NegFloat] = Generator.negFloatGenerator
+  val negFiniteFloats: Generator[NegFiniteFloat] = Generator.negFiniteFloatGenerator
+  val negZFloats: Generator[NegZFloat] = Generator.negZFloatGenerator
+  val negZFiniteFloats: Generator[NegZFiniteFloat] = Generator.negZFiniteFloatGenerator
+  val negDoubles: Generator[NegDouble] = Generator.negDoubleGenerator
+  val negFiniteDoubles: Generator[NegFiniteDouble] = Generator.negFiniteDoubleGenerator
+  val negZDoubles: Generator[NegZDouble] = Generator.negZDoubleGenerator
+  val negZFiniteDoubles: Generator[NegZFiniteDouble] = Generator.negZFiniteDoubleGenerator
+  val nonZeroInts: Generator[NonZeroInt] = Generator.nonZeroIntGenerator
+  val nonZeroLongs: Generator[NonZeroLong] = Generator.nonZeroLongGenerator
+  val nonZeroFloats: Generator[NonZeroFloat] = Generator.nonZeroFloatGenerator
+  val nonZeroFiniteFloats: Generator[NonZeroFiniteFloat] = Generator.nonZeroFiniteFloatGenerator
+  val nonZeroDoubles: Generator[NonZeroDouble] = Generator.nonZeroDoubleGenerator
+  val nonZeroFiniteDoubles: Generator[NonZeroFiniteDouble] = Generator.nonZeroFiniteDoubleGenerator
+  val finiteFloats: Generator[FiniteFloat] = Generator.finiteFloatGenerator
+  val finiteDoubles: Generator[FiniteDouble] = Generator.finiteDoubleGenerator
+  val numericChars: Generator[NumericChar] = Generator.numericCharGenerator
+
+  val posIntValues: Generator[Int] = Generator.posIntGenerator.map(_.value)
+  val posZIntValues: Generator[Int] = Generator.posZIntGenerator.map(_.value)
+  val posLongValues: Generator[Long] = Generator.posLongGenerator.map(_.value)
+  val posZLongValues: Generator[Long] = Generator.posZLongGenerator.map(_.value)
+  val posFloatValues: Generator[Float] = Generator.posFloatGenerator.map(_.value)
+  val posFiniteFloatValues: Generator[Float] = Generator.posFiniteFloatGenerator.map(_.value)
+  val posZFloatValues: Generator[Float] = Generator.posZFloatGenerator.map(_.value)
+  val posZFiniteFloatValues: Generator[Float] = Generator.posZFiniteFloatGenerator.map(_.value)
+  val posDoubleValues: Generator[Double] = Generator.posDoubleGenerator.map(_.value)
+  val posFiniteDoubleValues: Generator[Double] = Generator.posFiniteDoubleGenerator.map(_.value)
+  val posZDoubleValues: Generator[Double] = Generator.posZDoubleGenerator.map(_.value)
+  val posZFiniteDoubleValues: Generator[Double] = Generator.posZFiniteDoubleGenerator.map(_.value)
+  val negIntValues: Generator[Int] = Generator.negIntGenerator.map(_.value)
+  val negZIntValues: Generator[Int] = Generator.negZIntGenerator.map(_.value)
+  val negLongValues: Generator[Long] = Generator.negLongGenerator.map(_.value)
+  val negZLongValues: Generator[Long] = Generator.negZLongGenerator.map(_.value)
+  val negFloatValues: Generator[Float] = Generator.negFloatGenerator.map(_.value)
+  val negFiniteFloatValues: Generator[Float] = Generator.negFiniteFloatGenerator.map(_.value)
+  val negZFloatValues: Generator[Float] = Generator.negZFloatGenerator.map(_.value)
+  val negZFiniteFloatValues: Generator[Float] = Generator.negZFiniteFloatGenerator.map(_.value)
+  val negDoubleValues: Generator[Double] = Generator.negDoubleGenerator.map(_.value)
+  val negFiniteDoubleValues: Generator[Double] = Generator.negFiniteDoubleGenerator.map(_.value)
+  val negZDoubleValues: Generator[Double] = Generator.negZDoubleGenerator.map(_.value)
+  val negZFiniteDoubleValues: Generator[Double] = Generator.negZFiniteDoubleGenerator.map(_.value)
+  val nonZeroIntValues: Generator[Int] = Generator.nonZeroIntGenerator.map(_.value)
+  val nonZeroLongValues: Generator[Long] = Generator.nonZeroLongGenerator.map(_.value)
+  val nonZeroFloatValues: Generator[Float] = Generator.nonZeroFloatGenerator.map(_.value)
+  val nonZeroFiniteFloatValues: Generator[Float] = Generator.nonZeroFiniteFloatGenerator.map(_.value)
+  val nonZeroDoubleValues: Generator[Double] = Generator.nonZeroDoubleGenerator.map(_.value)
+  val nonZeroFiniteDoubleValues: Generator[Double] = Generator.nonZeroFiniteDoubleGenerator.map(_.value)
+  val finiteFloatValues: Generator[Float] = Generator.finiteFloatGenerator.map(_.value)
+  val finiteDoubleValues: Generator[Double] = Generator.finiteDoubleGenerator.map(_.value)
+  val numericCharValues: Generator[Char] = Generator.numericCharGenerator.map(_.value)
+
+  def vectors[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
+  def sets[T](implicit genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] = Generator.setGenerator
+  def sortedSets[T](implicit genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] = Generator.sortedSetGenerator
+  def maps[K, V](implicit genOfTupleKV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] = Generator.mapGenerator
+  def sortedMaps[K, V](implicit genOfTupleKV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] = Generator.sortedMapGenerator
+
+  def instancesOf[A, B](construct: A => B)(deconstruct: B => A)(implicit genOfA: Generator[A]): Generator[B] =
+    new GeneratorFor1[A, B](construct, deconstruct)(genOfA)
+
+  def instancesOf[A, B, C](construct: (A, B) => C)(deconstruct: C => (A, B))(implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[C] =
+    new GeneratorFor2[A, B, C](construct, deconstruct)(genOfA, genOfB)
+
+  def instancesOf[A, B, C, D](construct: (A, B, C) => D)(deconstruct: D => (A, B, C))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[D] =
+    new GeneratorFor3[A, B, C, D](construct, deconstruct)(genOfA, genOfB, genOfC)
+
+  def instancesOf[A, B, C, D, E](construct: (A, B, C, D) => E)(deconstruct: E => (A, B, C, D))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[E] =
+    new GeneratorFor4[A, B, C, D, E](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD)
+
+  def instancesOf[A, B, C, D, E, F](construct: (A, B, C, D, E) => F)(deconstruct: F => (A, B, C, D, E))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[F] =
+    new GeneratorFor5[A, B, C, D, E, F](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE)
+
+  def instancesOf[A, B, C, D, E, F, G](construct: (A, B, C, D, E, F) => G)(deconstruct: G => (A, B, C, D, E, F))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[G] =
+    new GeneratorFor6[A, B, C, D, E, F, G](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF)
+
+  def instancesOf[A, B, C, D, E, F, G, H](construct: (A, B, C, D, E, F, G) => H)(deconstruct: H => (A, B, C, D, E, F, G))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                  genOfG: Generator[G]): Generator[H] =
+    new GeneratorFor7[A, B, C, D, E, F, G, H](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I](construct: (A, B, C, D, E, F, G, H) => I)(deconstruct: I => (A, B, C, D, E, F, G, H))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                  genOfG: Generator[G], genOfH: Generator[H]): Generator[I] =
+    new GeneratorFor8[A, B, C, D, E, F, G, H, I](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J](construct: (A, B, C, D, E, F, G, H, I) => J)(deconstruct: J => (A, B, C, D, E, F, G, H, I))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                           genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[J] =
+    new GeneratorFor9[A, B, C, D, E, F, G, H, I, J](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K](construct: (A, B, C, D, E, F, G, H, I, J) => K)(deconstruct: K => (A, B, C, D, E, F, G, H, I, J))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                    genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J]): Generator[K] =
+    new GeneratorFor10[A, B, C, D, E, F, G, H, I, J, K](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L](construct: (A, B, C, D, E, F, G, H, I, J, K) => L)(deconstruct: L => (A, B, C, D, E, F, G, H, I, J, K))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                             genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K]): Generator[L] =
+    new GeneratorFor11[A, B, C, D, E, F, G, H, I, J, K, L](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M](construct: (A, B, C, D, E, F, G, H, I, J, K, L) => M)(deconstruct: M => (A, B, C, D, E, F, G, H, I, J, K, L))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                      genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[M] =
+    new GeneratorFor12[A, B, C, D, E, F, G, H, I, J, K, L, M](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => N)(deconstruct: N => (A, B, C, D, E, F, G, H, I, J, K, L, M))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                               genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[N] =
+    new GeneratorFor13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O)(deconstruct: O => (A, B, C, D, E, F, G, H, I, J, K, L, M, N))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                 genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                 genOfN: Generator[N]): Generator[O] =
+    new GeneratorFor14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P)(deconstruct: P => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                 genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                 genOfN: Generator[N], genOfO: Generator[O]): Generator[P] =
+    new GeneratorFor15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q)(deconstruct: Q => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                          genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                          genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[Q] =
+    new GeneratorFor16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R)(deconstruct: R => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                   genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                   genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[R] =
+    new GeneratorFor17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S)(deconstruct: S => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                            genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                            genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[S] =
+    new GeneratorFor18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T)(deconstruct: T => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                                     genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                                     genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[T] =
+    new GeneratorFor19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U)(deconstruct: U => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                                              genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                                              genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T]): Generator[U] =
+    new GeneratorFor20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V)(deconstruct: V => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                                                       genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                                                       genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
+                                                                                                                                                                                                                                       genOfU: Generator[U]): Generator[V] =
+    new GeneratorFor21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT, genOfU)
+
+  def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W)(deconstruct: W => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+                                                                                                                                                                                                                                                genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
+                                                                                                                                                                                                                                                genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
+                                                                                                                                                                                                                                                genOfU: Generator[U], genOfV: Generator[V]): Generator[W] =
+    new GeneratorFor22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT, genOfU, genOfV)
+
+  // classify will need to use the same sizing algo as forAll, and same edges approach
+  def classify[A](count: PosInt, genOfA: Generator[A])(pf: PartialFunction[A, String]): Classification = {
+
+    val (initEdges, rnd1) = genOfA.initEdges(100, Randomizer.default())
+    @tailrec
+    def loop(currentCount: Int, edges: List[A], rnd: Randomizer, acc: Map[String, PosZInt]): Map[String, PosZInt] = {
+      if (currentCount >= count) acc
+      else {
+        val (nextA, nextEdges, nextRnd) = genOfA.next(SizeParam(PosZInt(0), PosZInt(100), PosZInt(100)), edges, rnd) // TODO: I think this need to mimic forAll.
+        if (pf.isDefinedAt(nextA)) {
+          val category = pf(nextA)
+          val prevTotal = acc.getOrElse(category, PosZInt(0))
+          val nextAcc = acc + (category -> PosZInt.ensuringValid(prevTotal + 1))
+          loop(currentCount + 1, nextEdges, nextRnd, nextAcc)
+        }
+        else {
+          loop(currentCount + 1, nextEdges, nextRnd, acc)
+        }
+      }
+    }
+    val theMap = loop(0, initEdges, rnd1, Map.empty)
+    Classification(count, theMap)
+  }
+
+  def first1000Primes: Generator[Int] =
+    new Generator[Int] { thisIntGenerator =>
+      def next(szp: SizeParam, edges: List[Int], rnd: Randomizer): (Int, List[Int], Randomizer) = {
+        edges match {
+          case head :: tail => (head, tail, rnd)
+          case _ =>
+            import CommonGenerators.primeNumbers
+            val (index, nextRandomizer) = rnd.chooseInt(0, primeNumbers.length - 1)
+            (primeNumbers(index), Nil, nextRandomizer)
+        }
+      }
+    }
+}
+
+object CommonGenerators extends CommonGenerators {
+  private val primeNumbers =
+    Vector(
+         2,     3,     5,     7,    11,    13,    17,    19,    23,    29,
+        31,    37,    41,    43,    47,    53,    59,    61,    67,    71,
+        73,    79,    83,    89,    97,   101,   103,   107,   109,   113,
+       127,   131,   137,   139,   149,   151,   157,   163,   167,   173,
+       179,   181,   191,   193,   197,   199,   211,   223,   227,   229,
+       233,   239,   241,   251,   257,   263,   269,   271,   277,   281,
+       283,   293,   307,   311,   313,   317,   331,   337,   347,   349,
+       353,   359,   367,   373,   379,   383,   389,   397,   401,   409,
+       419,   421,   431,   433,   439,   443,   449,   457,   461,   463,
+       467,   479,   487,   491,   499,   503,   509,   521,   523,   541,
+       547,   557,   563,   569,   571,   577,   587,   593,   599,   601,
+       607,   613,   617,   619,   631,   641,   643,   647,   653,   659,
+       661,   673,   677,   683,   691,   701,   709,   719,   727,   733,
+       739,   743,   751,   757,   761,   769,   773,   787,   797,   809,
+       811,   821,   823,   827,   829,   839,   853,   857,   859,   863,
+       877,   881,   883,   887,   907,   911,   919,   929,   937,   941,
+       947,   953,   967,   971,   977,   983,   991,   997,  1009,  1013,
+      1019,  1021,  1031,  1033,  1039,  1049,  1051,  1061,  1063,  1069,
+      1087,  1091,  1093,  1097,  1103,  1109,  1117,  1123,  1129,  1151,
+      1153,  1163,  1171,  1181,  1187,  1193,  1201,  1213,  1217,  1223,
+      1229,  1231,  1237,  1249,  1259,  1277,  1279,  1283,  1289,  1291,
+      1297,  1301,  1303,  1307,  1319,  1321,  1327,  1361,  1367,  1373,
+      1381,  1399,  1409,  1423,  1427,  1429,  1433,  1439,  1447,  1451,
+      1453,  1459,  1471,  1481,  1483,  1487,  1489,  1493,  1499,  1511,
+      1523,  1531,  1543,  1549,  1553,  1559,  1567,  1571,  1579,  1583,
+      1597,  1601,  1607,  1609,  1613,  1619,  1621,  1627,  1637,  1657,
+      1663,  1667,  1669,  1693,  1697,  1699,  1709,  1721,  1723,  1733,
+      1741,  1747,  1753,  1759,  1777,  1783,  1787,  1789,  1801,  1811,
+      1823,  1831,  1847,  1861,  1867,  1871,  1873,  1877,  1879,  1889,
+      1901,  1907,  1913,  1931,  1933,  1949,  1951,  1973,  1979,  1987,
+      1993,  1997,  1999,  2003,  2011,  2017,  2027,  2029,  2039,  2053,
+      2063,  2069,  2081,  2083,  2087,  2089,  2099,  2111,  2113,  2129,
+      2131,  2137,  2141,  2143,  2153,  2161,  2179,  2203,  2207,  2213,
+      2221,  2237,  2239,  2243,  2251,  2267,  2269,  2273,  2281,  2287,
+      2293,  2297,  2309,  2311,  2333,  2339,  2341,  2347,  2351,  2357,
+      2371,  2377,  2381,  2383,  2389,  2393,  2399,  2411,  2417,  2423,
+      2437,  2441,  2447,  2459,  2467,  2473,  2477,  2503,  2521,  2531,
+      2539,  2543,  2549,  2551,  2557,  2579,  2591,  2593,  2609,  2617,
+      2621,  2633,  2647,  2657,  2659,  2663,  2671,  2677,  2683,  2687,
+      2689,  2693,  2699,  2707,  2711,  2713,  2719,  2729,  2731,  2741,
+      2749,  2753,  2767,  2777,  2789,  2791,  2797,  2801,  2803,  2819,
+      2833,  2837,  2843,  2851,  2857,  2861,  2879,  2887,  2897,  2903,
+      2909,  2917,  2927,  2939,  2953,  2957,  2963,  2969,  2971,  2999,
+      3001,  3011,  3019,  3023,  3037,  3041,  3049,  3061,  3067,  3079,
+      3083,  3089,  3109,  3119,  3121,  3137,  3163,  3167,  3169,  3181,
+      3187,  3191,  3203,  3209,  3217,  3221,  3229,  3251,  3253,  3257,
+      3259,  3271,  3299,  3301,  3307,  3313,  3319,  3323,  3329,  3331,
+      3343,  3347,  3359,  3361,  3371,  3373,  3389,  3391,  3407,  3413,
+      3433,  3449,  3457,  3461,  3463,  3467,  3469,  3491,  3499,  3511,
+      3517,  3527,  3529,  3533,  3539,  3541,  3547,  3557,  3559,  3571,
+      3581,  3583,  3593,  3607,  3613,  3617,  3623,  3631,  3637,  3643,
+      3659,  3671,  3673,  3677,  3691,  3697,  3701,  3709,  3719,  3727,
+      3733,  3739,  3761,  3767,  3769,  3779,  3793,  3797,  3803,  3821,
+      3823,  3833,  3847,  3851,  3853,  3863,  3877,  3881,  3889,  3907,
+      3911,  3917,  3919,  3923,  3929,  3931,  3943,  3947,  3967,  3989,
+      4001,  4003,  4007,  4013,  4019,  4021,  4027,  4049,  4051,  4057,
+      4073,  4079,  4091,  4093,  4099,  4111,  4127,  4129,  4133,  4139,
+      4153,  4157,  4159,  4177,  4201,  4211,  4217,  4219,  4229,  4231,
+      4241,  4243,  4253,  4259,  4261,  4271,  4273,  4283,  4289,  4297,
+      4327,  4337,  4339,  4349,  4357,  4363,  4373,  4391,  4397,  4409,
+      4421,  4423,  4441,  4447,  4451,  4457,  4463,  4481,  4483,  4493,
+      4507,  4513,  4517,  4519,  4523,  4547,  4549,  4561,  4567,  4583,
+      4591,  4597,  4603,  4621,  4637,  4639,  4643,  4649,  4651,  4657,
+      4663,  4673,  4679,  4691,  4703,  4721,  4723,  4729,  4733,  4751,
+      4759,  4783,  4787,  4789,  4793,  4799,  4801,  4813,  4817,  4831,
+      4861,  4871,  4877,  4889,  4903,  4909,  4919,  4931,  4933,  4937,
+      4943,  4951,  4957,  4967,  4969,  4973,  4987,  4993,  4999,  5003,
+      5009,  5011,  5021,  5023,  5039,  5051,  5059,  5077,  5081,  5087,
+      5099,  5101,  5107,  5113,  5119,  5147,  5153,  5167,  5171,  5179,
+      5189,  5197,  5209,  5227,  5231,  5233,  5237,  5261,  5273,  5279,
+      5281,  5297,  5303,  5309,  5323,  5333,  5347,  5351,  5381,  5387,
+      5393,  5399,  5407,  5413,  5417,  5419,  5431,  5437,  5441,  5443,
+      5449,  5471,  5477,  5479,  5483,  5501,  5503,  5507,  5519,  5521,
+      5527,  5531,  5557,  5563,  5569,  5573,  5581,  5591,  5623,  5639,
+      5641,  5647,  5651,  5653,  5657,  5659,  5669,  5683,  5689,  5693,
+      5701,  5711,  5717,  5737,  5741,  5743,  5749,  5779,  5783,  5791,
+      5801,  5807,  5813,  5821,  5827,  5839,  5843,  5849,  5851,  5857,
+      5861,  5867,  5869,  5879,  5881,  5897,  5903,  5923,  5927,  5939,
+      5953,  5981,  5987,  6007,  6011,  6029,  6037,  6043,  6047,  6053,
+      6067,  6073,  6079,  6089,  6091,  6101,  6113,  6121,  6131,  6133,
+      6143,  6151,  6163,  6173,  6197,  6199,  6203,  6211,  6217,  6221,
+      6229,  6247,  6257,  6263,  6269,  6271,  6277,  6287,  6299,  6301,
+      6311,  6317,  6323,  6329,  6337,  6343,  6353,  6359,  6361,  6367,
+      6373,  6379,  6389,  6397,  6421,  6427,  6449,  6451,  6469,  6473,
+      6481,  6491,  6521,  6529,  6547,  6551,  6553,  6563,  6569,  6571,
+      6577,  6581,  6599,  6607,  6619,  6637,  6653,  6659,  6661,  6673,
+      6679,  6689,  6691,  6701,  6703,  6709,  6719,  6733,  6737,  6761,
+      6763,  6779,  6781,  6791,  6793,  6803,  6823,  6827,  6829,  6833,
+      6841,  6857,  6863,  6869,  6871,  6883,  6899,  6907,  6911,  6917,
+      6947,  6949,  6959,  6961,  6967,  6971,  6977,  6983,  6991,  6997,
+      7001,  7013,  7019,  7027,  7039,  7043,  7057,  7069,  7079,  7103,
+      7109,  7121,  7127,  7129,  7151,  7159,  7177,  7187,  7193,  7207,
+      7211,  7213,  7219,  7229,  7237,  7243,  7247,  7253,  7283,  7297,
+      7307,  7309,  7321,  7331,  7333,  7349,  7351,  7369,  7393,  7411,
+      7417,  7433,  7451,  7457,  7459,  7477,  7481,  7487,  7489,  7499,
+      7507,  7517,  7523,  7529,  7537,  7541,  7547,  7549,  7559,  7561,
+      7573,  7577,  7583,  7589,  7591,  7603,  7607,  7621,  7639,  7643,
+      7649,  7669,  7673,  7681,  7687,  7691,  7699,  7703,  7717,  7723,
+      7727,  7741,  7753,  7757,  7759,  7789,  7793,  7817,  7823,  7829,
+      7841,  7853,  7867,  7873,  7877,  7879,  7883,  7901,  7907,  7919
+    )
+}

--- a/scalatest/src/main/scala/org/scalatest/prop/Configuration.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Configuration.scala
@@ -16,9 +16,9 @@
 package org.scalatest.prop
 
 import org.scalacheck.Test.Parameters
-import org.scalactic.anyvals.{PosZInt, PosZDouble, PosInt}
+import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
 import org.scalacheck.Test.TestCallback
-
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Trait providing methods and classes used to configure property checks provided by the
@@ -36,15 +36,15 @@ trait Configuration {
 
   object PropertyCheckConfiguration {
     private[scalatest] def calculateMaxDiscardedFactor(minSuccessful: Int, maxDiscarded: Int): Double =
-      ((maxDiscarded + 1): Double) / (minSuccessful: Double)
+      (maxDiscarded.toDouble + 1.0) / minSuccessful.toDouble
     private[scalatest] def calculateMaxDiscarded(maxDiscardedRatio: Double, minSuccessful: Int): Double =
-      (maxDiscardedRatio * minSuccessful) - 1
+      (maxDiscardedRatio * minSuccessful.toDouble) - 1.0
   }
 
   case class PropertyCheckConfiguration(minSuccessful: PosInt = PosInt(10),
                                         maxDiscardedFactor: PosZDouble = PosZDouble(5.0),
-                                        minSize: PosZInt = PosZInt(0),
-                                        sizeRange: PosZInt = PosZInt(100),
+                                        minSize: PosZInt = Configuration.minSize.get(),
+                                        sizeRange: PosZInt = Configuration.sizeRange.get(),
                                         workers: PosInt = PosInt(1)) extends PropertyCheckConfigurable {
     @deprecated("Transitional value to ensure upgrade compatibility when mixing PropertyCheckConfig and minSuccessful parameters.  Remove with PropertyCheckConfig class")
     private [scalatest] val legacyMaxDiscarded: Option[Int] = None
@@ -143,11 +143,11 @@ trait Configuration {
   implicit def PropertyCheckConfig2PropertyCheckConfiguration(p: PropertyCheckConfig): PropertyCheckConfiguration = {
     val maxDiscardedFactor = PropertyCheckConfiguration.calculateMaxDiscardedFactor(p.minSuccessful, p.maxDiscarded)
       new PropertyCheckConfiguration(
-        minSuccessful = PosInt.from(p.minSuccessful).get,
-        maxDiscardedFactor = PosZDouble.from(maxDiscardedFactor).get,
-        minSize = PosZInt.from(p.minSize).get,
-        sizeRange = PosZInt.from(p.maxSize - p.minSize).get,
-        workers = PosInt.from(p.workers).get) {
+        minSuccessful = PosInt.ensuringValid(p.minSuccessful),
+        maxDiscardedFactor = PosZDouble.ensuringValid(maxDiscardedFactor),
+        minSize = PosZInt.ensuringValid(p.minSize),
+        sizeRange = PosZInt.ensuringValid(p.maxSize - p.minSize),
+        workers = PosInt.ensuringValid(p.workers)) {
         override private [scalatest]  val legacyMaxDiscarded = Some(p.maxDiscarded)
         override private [scalatest]  val legacyMaxSize      = Some(p.maxSize)
       }
@@ -450,6 +450,111 @@ trait Configuration {
       .withCustomClassLoader(None)
   }
 
+  def getParameter(configParams: Seq[Configuration#PropertyCheckConfigParam], c: PropertyCheckConfiguration): Configuration.Parameter = {
+
+    val config: PropertyCheckConfiguration = c.asPropertyCheckConfiguration
+    var minSuccessful: Option[Int] = None
+    var maxDiscarded: Option[Int] = None
+    var maxDiscardedFactor: Option[Double] = None
+    var pminSize: Option[Int] = None
+    var psizeRange: Option[Int] = None
+    var pmaxSize: Option[Int] = None
+    var pworkers: Option[Int] = None
+
+    var minSuccessfulTotalFound = 0
+    var maxDiscardedTotalFound = 0
+    var maxDiscardedFactorTotalFound = 0
+    var minSizeTotalFound = 0
+    var sizeRangeTotalFound = 0
+    var maxSizeTotalFound = 0
+    var workersTotalFound = 0
+
+    for (configParam <- configParams) {
+      configParam match {
+        case param: MinSuccessful =>
+          minSuccessful = Some(param.value)
+          minSuccessfulTotalFound += 1
+        case param: MaxDiscarded =>
+          maxDiscarded = Some(param.value)
+          maxDiscardedTotalFound += 1
+        case param: MaxDiscardedFactor =>
+          maxDiscardedFactor = Some(param.value)
+          maxDiscardedFactorTotalFound += 1
+        case param: MinSize =>
+          pminSize = Some(param.value)
+          minSizeTotalFound += 1
+        case param: SizeRange =>
+          psizeRange = Some(param.value)
+          sizeRangeTotalFound += 1
+        case param: MaxSize =>
+          pmaxSize = Some(param.value)
+          maxSizeTotalFound += 1
+        case param: Workers =>
+          pworkers = Some(param.value)
+          workersTotalFound += 1
+      }
+    }
+
+    if (minSuccessfulTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MinSuccessful config parameters, but " + minSuccessfulTotalFound + " were passed")
+    val maxDiscardedAndFactorTotalFound = maxDiscardedTotalFound + maxDiscardedFactorTotalFound
+    if (maxDiscardedAndFactorTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MaxDiscarded or MaxDiscardedFactor config parameters, but " + maxDiscardedAndFactorTotalFound + " were passed")
+    if (minSizeTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MinSize config parameters, but " + minSizeTotalFound + " were passed")
+    val maxSizeAndSizeRangeTotalFound = maxSizeTotalFound + sizeRangeTotalFound
+    if (maxSizeAndSizeRangeTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one SizeRange or MaxSize config parameters, but " + maxSizeAndSizeRangeTotalFound + " were passed")
+    if (workersTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one Workers config parameters, but " + workersTotalFound + " were passed")
+
+    val minSuccessfulTests: Int = minSuccessful.getOrElse(config.minSuccessful)
+
+    val minSize: Int = pminSize.getOrElse(config.minSize)
+
+    val maxSize = {
+      (psizeRange, pmaxSize, config.legacyMaxSize) match {
+        case (None, None, Some(legacyMaxSize)) =>
+          legacyMaxSize
+        case (None, Some(maxSize), _) =>
+          maxSize
+        case _ =>
+          psizeRange.getOrElse(config.sizeRange.value) + minSize
+      }
+    }
+
+    val maxDiscardRatio: Float = {
+      (maxDiscardedFactor, maxDiscarded, config.legacyMaxDiscarded, minSuccessful) match {
+        case (None, None, Some(legacyMaxDiscarded), Some(specifiedMinSuccessful)) =>
+          PropertyCheckConfiguration.calculateMaxDiscardedFactor(specifiedMinSuccessful, legacyMaxDiscarded).toFloat
+        case (None, Some(md), _, _) =>
+          if (md < 0) Parameters.default.maxDiscardRatio
+          else PropertyCheckConfiguration.calculateMaxDiscardedFactor(minSuccessfulTests, md).toFloat
+        case _ =>
+          maxDiscardedFactor.getOrElse(config.maxDiscardedFactor.value).toFloat
+      }
+    }
+
+    val param =
+      Configuration.Parameter(
+        PosInt.from(minSuccessfulTests).getOrElse(config.minSuccessful),
+        PosZDouble.from(maxDiscardRatio).getOrElse(config.maxDiscardedFactor),
+        PosZInt.from(minSize).getOrElse(config.minSize),
+        PosZInt.from(maxSize - minSize).getOrElse(config.sizeRange),
+        PosInt.from(pworkers.getOrElse(config.workers)).getOrElse(config.workers)
+      )
+
+    if(
+      param.minSuccessful.value <= 0 ||
+      param.maxDiscardedFactor.value <= 0 ||
+      param.minSize.value < 0 ||
+      maxSize < param.minSize.value ||
+      param.workers.value <= 0
+    ) throw new IllegalArgumentException("Invalid test parameters")
+
+    param
+  }
+
   /**
    * Implicit <code>PropertyCheckConfig</code> value providing default configuration values.
    */
@@ -461,4 +566,29 @@ trait Configuration {
  * an alternative to mixing it in. One use case is to import <code>Configuration</code> members so you can use
  * them in the Scala interpreter.
  */
-object Configuration extends Configuration
+object Configuration extends Configuration {
+
+  private[scalatest] lazy val minSize: AtomicReference[PosZInt] = new AtomicReference(PosZInt(0))
+  private[scalatest] lazy val sizeRange: AtomicReference[PosZInt] = new AtomicReference(PosZInt(100))
+
+  case class Parameter(minSuccessful: PosInt = PosInt(10),
+                       maxDiscardedFactor: PosZDouble = PosZDouble(5.0),
+                       minSize: PosZInt = PosZInt(0),
+                       sizeRange: PosZInt = PosZInt(100),
+                       workers: PosInt = PosInt(1)) {
+
+    import org.scalactic.Requirements._
+
+    require(minSize + sizeRange >= 0)
+
+    lazy val maxSize: PosZInt = {
+      PosZInt.ensuringValid(minSize + sizeRange)
+    }
+  }
+
+  private[scalatest] def calculateMaxDiscardedFactor(minSuccessful: Int, maxDiscarded: Int): Double =
+    ((maxDiscarded + 1): Double) / (minSuccessful: Double)
+  private[scalatest] def calculateMaxDiscarded(maxDiscardedRatio: Double, minSuccessful: Int): Double =
+    (maxDiscardedRatio * minSuccessful) - 1
+
+}

--- a/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2015 Artima, Inc.
+ * Copyright 2001-2016 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,146 +17,2432 @@ package org.scalatest.prop
 
 import scala.collection.mutable.ListBuffer
 import org.scalactic.anyvals._
+import org.scalactic.{Bad, Good, Or}
+import scala.annotation.tailrec
+import org.scalactic.source.TypeInfo
+import org.scalatest.Resources
+import CommonGenerators.first1000Primes
+import scala.collection.immutable.SortedSet
+import scala.collection.immutable.SortedMap
 
-private[prop] trait Generator[T] { thisGeneratorOfT =>
-  def next(size: Int = 100, rnd: Randomizer = Randomizer.default): (T, Randomizer)
+trait Generator[T] { thisGeneratorOfT =>
+
+  def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[T], Randomizer) = (Nil, rnd)
+
+  def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer)
   def map[U](f: T => U): Generator[U] =
+    new Generator[U] { thisGeneratorOfU => 
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[U], Randomizer) = {
+        val (listOfT, nextRnd) = thisGeneratorOfT.initEdges(maxLength, rnd)
+        (listOfT.map(f), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[U], rnd: Randomizer): (U, List[U], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextT, _, nextRandomizer) = thisGeneratorOfT.next(szp, Nil, rnd)
+            (f(nextT), Nil, nextRandomizer)
+        }
+      }
+      override def canonicals(rnd: Randomizer): (Iterator[U], Randomizer) = {
+        val (cansOfT, nextRnd) = thisGeneratorOfT.canonicals(rnd)
+        (cansOfT.map(f), nextRnd)
+      }
+      override def shrink(value: U, rnd: Randomizer): (Iterator[U], Randomizer) = canonicals(rnd)
+    }
+  def flatMap[U](f: T => Generator[U]): Generator[U] = {
     new Generator[U] {
-      def next(size: Int, rnd: Randomizer): (U, Randomizer) = {
-        val (nextT, nextRandomizer) = thisGeneratorOfT.next(size, rnd)
-        (f(nextT), nextRandomizer)
+      thisGeneratorOfU =>
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[U], Randomizer) = {
+        val (listOfT, nextRnd) = thisGeneratorOfT.initEdges(maxLength, rnd)
+        val listOfGenOfU: List[Generator[U]] = listOfT.map(f)
+        val (listOfU, nextNextRnd): (List[U], Randomizer) = {
+          @tailrec
+          def loop(remainingGenOfU: List[Generator[U]], nRnd: Randomizer, acc: Set[U]): (List[U], Randomizer) = {
+            if (acc.size == maxLength.value)
+              (acc.toList, nRnd)
+            else
+              remainingGenOfU match {
+                case head :: tail =>
+                  val (listOfU, nnRnd) = head.initEdges(maxLength, nRnd)
+                  loop(tail, nnRnd, acc ++ listOfU)
+                case _ => (acc.toList, nRnd)
+              }
+          }
+
+          loop(listOfGenOfU, nextRnd, Set.empty)
+        }
+        (listOfU, nextNextRnd)
+      }
+
+      def next(szp: SizeParam, edges: List[U], rnd: Randomizer): (U, List[U], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextT, _, nextRandomizer) = thisGeneratorOfT.next(szp, Nil, rnd)
+            val genOfU: Generator[U] = f(nextT)
+            val (u, _, nextNextRandomizer) = genOfU.next(szp, Nil, nextRandomizer)
+            (u, Nil, nextNextRandomizer)
+        }
+      }
+
+      override def canonicals(rnd: Randomizer): (Iterator[U], Randomizer) = {
+        val (cansOfT, rnd1) = thisGeneratorOfT.canonicals(rnd)
+        var currentRnd = rnd1 // Local var, one thread; TODO: Do this with a tailrec loop
+        def getCanonicals(o: T): Iterator[U] = {
+          val genOfU: Generator[U] = f(o)
+          val (canonicals, nextRnd) = genOfU.canonicals(currentRnd)
+          currentRnd = nextRnd
+          canonicals
+        }
+
+        (cansOfT.flatMap(getCanonicals), currentRnd)
+      }
+
+      override def shrink(value: U, rnd: Randomizer): (Iterator[U], Randomizer) = canonicals(rnd)
+    }
+  }
+  def withFilter(f: T => Boolean): Generator[T] = filter(f)
+  def filter(f: T => Boolean): Generator[T] =
+    new Generator[T] { thisFilteredGeneratorOfT =>
+      private final val MaxLoopCount: Int = 100000
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        @tailrec
+        def loop(count: Int, nextEdges: List[T], nextRnd: Randomizer): (T, List[T], Randomizer) = {
+          if (count > MaxLoopCount)
+            throw new IllegalStateException(s"A Generator produced by calling filter or withFilter on another Generator (possibly by using an 'if' clause in a for expression) has filtered out $MaxLoopCount objects in a row in its next method, so aborting. Please define the Generator without using filter or withFilter.")
+          val candidateResult = thisGeneratorOfT.next(szp, nextEdges, nextRnd)
+          val (nextT, nextNextEdges, nextNextRnd) = candidateResult
+          if (!f(nextT)) loop(count + 1, nextNextEdges, nextNextRnd)
+          else candidateResult
+        }
+        loop(0, edges, rnd)
       }
     }
-  def flatMap[U](f: T => Generator[U]): Generator[U] = 
-    new Generator[U] { thisInnerGenerator =>
-      def next(size: Int, rnd: Randomizer): (U, Randomizer) = {
-        val (nextT, nextRandomizer) = thisGeneratorOfT.next(size, rnd)
-        val (a, b) = f(nextT).next(size, nextRandomizer)
-        (a, b)
+  def shrink(value: T, rnd: Randomizer): (Iterator[T], Randomizer) = (Iterator.empty, rnd)
+  def canonicals(rnd: Randomizer): (Iterator[T], Randomizer) = (Iterator.empty, rnd)
+  def sample: T = {
+    val rnd = Randomizer.default
+    val maxSize = PosZInt(100)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 100, inclusive
+    val (value, _, _) = next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    value
+  }
+  def samples(length: PosInt): List[T] = {
+    @tailrec
+    def loop(count: Int, rnd: Randomizer, acc: List[T]): List[T] = {
+      if (count == length.value) acc
+      else {
+        val maxSize = PosZInt(100)
+        val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 100, inclusive
+        val (value, _, nextNextRnd) = next(SizeParam(PosZInt(0), maxSize, size), Nil, rnd)
+        loop(count + 1, nextNextRnd, value :: acc)
       }
     }
-  def shrink(init: T): Stream[T] = Stream.empty
+    loop(0, Randomizer.default, Nil)
+  }
 }
 
-private[prop] object Generator {
+trait LowerPriorityGeneratorImplicits {
 
-  def chooseInt(from: Int, to: Int): Generator[Int] =
-    new Generator[Int] { thisIntGenerator =>
-      def next(size: Int, rnd: Randomizer): (Int, Randomizer) = {
-        val (nextInt, nextRandomizer) = rnd.chooseInt(from, to)
-        (nextInt, nextRandomizer)
+  import org.scalacheck.{Arbitrary, Gen, Shrink}
+  import org.scalacheck.rng.Seed
+
+  implicit def scalaCheckArbitaryGenerator[T](arb: Arbitrary[T], shrk: Shrink[T]): Generator[T] =
+    new Generator[T] {
+      def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (T, List[T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            arb.arbitrary.apply(Gen.Parameters.default.withSize(szp.size), Seed(rnd.seed)) match {
+              case Some(nextT) => (nextT, Nil, rnd.nextRandomizer)
+              case None => throw new IllegalStateException("Unable to generate value using ScalaCheck Arbitary.")
+            }
+        }
+      }
+      override def shrink(value: T, rnd: Randomizer): (Iterator[T], Randomizer) = {
+        (shrk.shrink(value).take(10000).reverse.toIterator, rnd)
       }
     }
+}
+
+object Generator extends LowerPriorityGeneratorImplicits {
+
+  // I don't want to make Generator covariant, because then an implicit search for a Generator[<supertype>] would
+  // be satisfied if it finds just a Generator[<subtype>], but that would not generate anything except subtypes.
+  // It would be sound, but you would't get a good variety of supertype values.
+  import scala.language.implicitConversions
+  implicit def widen[T, U](genOfT: Generator[T])(implicit ev: T <:< U): Generator[U] = genOfT.map(o => (o: U))
+
+  private[prop] val byteEdges = List(Byte.MinValue, -1.toByte, 0.toByte, 1.toByte, Byte.MaxValue)
+  private[prop] val shortEdges = List(Short.MinValue, -1.toShort, 0.toShort, 1.toShort, Short.MaxValue)
+  private[prop] val charEdges = List(Char.MinValue, Char.MaxValue)
+  private[prop] val intEdges = List(Int.MinValue, -1, 0, 1, Int.MaxValue)
+  private[prop] val longEdges = List(Long.MinValue, -1, 0, 1, Long.MaxValue)
+  private[prop] val floatEdges = List(0.0f)
+  private[prop] val doubleEdges = List(0.0)
+  private[prop] val posIntEdges = List(PosInt(1), PosInt.MaxValue)
+  private[prop] val posZIntEdges = List(PosZInt(0), PosZInt(1), PosZInt.MaxValue)
+  private[prop] val posLongEdges = List(PosLong(1L), PosLong.MaxValue)
+  private[prop] val posZLongEdges = List(PosZLong(0L), PosZLong(1L), PosZLong.MaxValue)
+  private[prop] val posFloatEdges = List(PosFloat(1.0f), PosFloat.MaxValue)
+  private[prop] val posZFloatEdges = List(PosZFloat(0.0f), PosZFloat(1.0f), PosZFloat.MaxValue)
+  private[prop] val posFiniteFloatEdges = List(PosFiniteFloat(1.0f), PosFiniteFloat.MaxValue)
+  private[prop] val posZFiniteFloatEdges = List(PosZFiniteFloat(0.0f), PosZFiniteFloat(1.0f), PosZFiniteFloat.MaxValue)
+  private[prop] val posDoubleEdges = List(PosDouble(1.0), PosDouble.MaxValue)
+  private[prop] val posFiniteDoubleEdges = List(PosFiniteDouble(1.0), PosFiniteDouble.MaxValue)
+  private[prop] val finiteDoubleEdges = List(FiniteDouble.MinValue, FiniteDouble(-1.0), FiniteDouble(0.0), FiniteDouble(1.0), FiniteDouble.MaxValue)
+  private[prop] val finiteFloatEdges = List(FiniteFloat.MinValue, FiniteFloat(-1.0F), FiniteFloat(0.0F), FiniteFloat(1.0F), FiniteFloat.MaxValue)
+  private[prop] val posZDoubleEdges = List(PosZDouble(0.0), PosZDouble(1.0), PosZDouble.MaxValue)
+  private[prop] val posZFiniteDoubleEdges = List(PosZFiniteDouble(0.0), PosZFiniteDouble(1.0), PosZFiniteDouble.MaxValue)
+  private[prop] val nonZeroDoubleEdges = List(NonZeroDouble.MinValue, NonZeroDouble(-1.0), NonZeroDouble(1.0), NonZeroDouble.MaxValue)
+  private[prop] val nonZeroFiniteDoubleEdges = List(NonZeroFiniteDouble.MinValue, NonZeroFiniteDouble(-1.0), NonZeroFiniteDouble(1.0), NonZeroFiniteDouble.MaxValue)
+  private[prop] val nonZeroFloatEdges = List(NonZeroFloat.MinValue, NonZeroFloat(-1.0F), NonZeroFloat(1.0F), NonZeroFloat.MaxValue)
+  private[prop] val nonZeroFiniteFloatEdges = List(NonZeroFiniteFloat.MinValue, NonZeroFiniteFloat(-1.0F), NonZeroFiniteFloat(1.0F), NonZeroFiniteFloat.MaxValue)
+  private[prop] val nonZeroIntEdges = List(NonZeroInt.MinValue, NonZeroInt(-1), NonZeroInt(1), NonZeroInt.MaxValue)
+  private[prop] val nonZeroLongEdges = List(NonZeroLong.MinValue, NonZeroLong(-1L), NonZeroLong(1L), NonZeroLong.MaxValue)
+  private[prop] val negDoubleEdges = List(NegDouble.MinValue, NegDouble(-1.0), NegDouble.MaxValue)
+  private[prop] val negFiniteDoubleEdges = List(NegFiniteDouble.MinValue, NegFiniteDouble(-1.0), NegFiniteDouble.MaxValue)
+  private[prop] val negFloatEdges = List(NegFloat.MinValue, NegFloat(-1.0F), NegFloat.MaxValue)
+  private[prop] val negFiniteFloatEdges = List(NegFiniteFloat.MinValue, NegFiniteFloat(-1.0F), NegFiniteFloat.MaxValue)
+  private[prop] val negIntEdges = List(NegInt.MinValue, NegInt.MaxValue)
+  private[prop] val negLongEdges = List(NegLong.MinValue, NegLong.MaxValue)
+  private[prop] val negZDoubleEdges = List(NegZDouble.MinValue, NegZDouble(-1.0), NegZDouble.ensuringValid(-Double.MinPositiveValue), NegZDouble.MaxValue)
+  private[prop] val negZFiniteDoubleEdges = List(NegZFiniteDouble.MinValue, NegZFiniteDouble(-1.0), NegZFiniteDouble.ensuringValid(-Double.MinPositiveValue), NegZFiniteDouble.MaxValue)
+  private[prop] val negZFloatEdges = List(NegZFloat.MinValue, NegZFloat(-1.0F), NegZFloat.ensuringValid(-Float.MinPositiveValue), NegZFloat.MaxValue)
+  private[prop] val negZFiniteFloatEdges = List(NegZFiniteFloat.MinValue, NegZFiniteFloat(-1.0F), NegZFiniteFloat.ensuringValid(-Float.MinPositiveValue), NegZFiniteFloat.MaxValue)
+  private[prop] val negZIntEdges = List(NegZInt.MinValue, NegZInt(-1), NegZInt.MaxValue)
+  private[prop] val negZLongEdges = List(NegZLong.MinValue, NegZLong(-1L), NegZLong.MaxValue)
+  private[prop] val numericCharEdges = List(NumericChar('0'), NumericChar('9'))
 
   implicit val byteGenerator: Generator[Byte] =
     new Generator[Byte] {
-      def next(size: Int, rnd: Randomizer): (Byte, Randomizer) = rnd.nextByteWithEdges
+
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Byte], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(byteEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Byte], rnd: Randomizer): (Byte, List[Byte], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (b, nextRnd) = rnd.nextByte
+            (b, Nil, nextRnd)
+        }
+      }
+      private val byteCanonicals: List[Byte] = List(0, 1, -1, 2, -2, 3, -3)
+      override def canonicals(rnd: Randomizer): (Iterator[Byte], Randomizer) = (byteCanonicals.iterator, rnd)
+      override def shrink(n: Byte, rnd: Randomizer): (Iterator[Byte], Randomizer) = {
+        @tailrec
+        def shrinkLoop(n: Byte, acc: List[Byte]): List[Byte] = {
+          if (n == 0) acc
+          else {
+            val half: Byte = (n / 2).toByte
+            if (half == 0) 0.toByte :: acc
+            else shrinkLoop(half, (-half).toByte :: half :: acc)
+          }
+        }
+        (shrinkLoop(n, Nil).iterator, rnd)
+      }
       override def toString = "Generator[Byte]"
     }
 
   implicit val shortGenerator: Generator[Short] =
     new Generator[Short] {
-      def next(size: Int, rnd: Randomizer): (Short, Randomizer) = rnd.nextShortWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Short], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(shortEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Short], rnd: Randomizer): (Short, List[Short], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (s, nextRnd) = rnd.nextShort
+            (s, Nil, nextRnd)
+        }
+      }
+      private val shortCanonicals: List[Short] = List(0, 1, -1, 2, -2, 3, -3)
+      override def canonicals(rnd: Randomizer): (Iterator[Short], Randomizer) = (shortCanonicals.iterator, rnd)
+      override def shrink(n: Short, rnd: Randomizer): (Iterator[Short], Randomizer) = {
+        @tailrec
+        def shrinkLoop(n: Short, acc: List[Short]): List[Short] = {
+          if (n == 0) acc
+          else {
+            val half: Short = (n / 2).toShort
+            if (half == 0) 0.toShort :: acc
+            else shrinkLoop(half, (-half).toShort :: half :: acc)
+          }
+        }
+        (shrinkLoop(n, Nil).iterator, rnd)
+      }
       override def toString = "Generator[Short]"
     }
 
   implicit val charGenerator: Generator[Char] =
     new Generator[Char] {
-      def next(size: Int, rnd: Randomizer): (Char, Randomizer) = rnd.nextCharWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Char], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(charEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Char], rnd: Randomizer): (Char, List[Char], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (c, nextRnd) = rnd.nextChar
+            (c, Nil, nextRnd)
+        }
+      }
+      override def canonicals(rnd: Randomizer): (Iterator[Char], Randomizer) = {
+        val lowerAlphaChars = "abcdefghikjlmnopqrstuvwxyz"
+        val upperAlphaChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        val numericChars = "0123456789"
+        val (lowerCharIndex, rnd1) = rnd.chooseInt(0, lowerAlphaChars.length - 1)
+        val (upperCharIndex, rnd2) = rnd1.chooseInt(0, upperAlphaChars.length - 1)
+        val (numericCharIndex, rnd3) = rnd1.chooseInt(0, numericChars.length - 1)
+        val lowerChar = lowerAlphaChars(lowerCharIndex)
+        val upperChar = upperAlphaChars(upperCharIndex)
+        val numericChar = numericChars(numericCharIndex)
+        (Iterator(lowerChar, upperChar, numericChar), rnd3)
+      }
+      override def shrink(c: Char, rnd: Randomizer): (Iterator[Char], Randomizer) = {
+        val userFriendlyChars = "abcdefghikjlmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        if (userFriendlyChars.indexOf(c) >= 0) (Iterator.empty, rnd)
+        else (userFriendlyChars.toIterator, rnd)
+      }
       override def toString = "Generator[Char]"
     }
 
   implicit val intGenerator: Generator[Int] =
     new Generator[Int] {
-      def next(size: Int, rnd: Randomizer): (Int, Randomizer) = rnd.nextIntWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Int], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(intEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Int], rnd: Randomizer): (Int, List[Int], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (i, nextRnd) = rnd.nextInt
+            (i, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[Int]"
-      override def shrink(init: Int): Stream[Int] = 0 #:: 1 #:: -1 #:: Stream.empty
+      private val intCanonicals = List(0, 1, -1, 2, -2, 3, -3)
+      override def canonicals(rnd: Randomizer): (Iterator[Int], Randomizer) = (intCanonicals.iterator, rnd)
+      override def shrink(i: Int, rnd: Randomizer): (Iterator[Int], Randomizer) = {
+        @tailrec
+        def shrinkLoop(i: Int, acc: List[Int]): List[Int] = {
+          if (i == 0) acc
+          else {
+            val half: Int = i / 2
+            if (half == 0) 0 :: acc
+            else shrinkLoop(half, -half :: half :: acc)
+          }
+        }
+        (shrinkLoop(i, Nil).iterator, rnd)
+      }
     }
 
   implicit val longGenerator: Generator[Long] =
     new Generator[Long] {
-      def next(size: Int, rnd: Randomizer): (Long, Randomizer) = rnd.nextLongWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Long], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(longEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Long], rnd: Randomizer): (Long, List[Long], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (n, nextRnd) = rnd.nextLong
+            (n, Nil, nextRnd)
+        }
+      }
+      private val longCanonicals: List[Long] = List(0, 1, -1, 2, -2, 3, -3)
+      override def canonicals(rnd: Randomizer): (Iterator[Long], Randomizer) = (longCanonicals.iterator, rnd)
+      override def shrink(n: Long, rnd: Randomizer): (Iterator[Long], Randomizer) = {
+        @tailrec
+        def shrinkLoop(n: Long, acc: List[Long]): List[Long] = {
+          if (n == 0L) acc
+          else {
+            val half: Long = n / 2
+            if (half == 0L) 0L :: acc
+            else shrinkLoop(half, -half :: half :: acc)
+          }
+        }
+        (shrinkLoop(n, Nil).iterator, rnd)
+      }
       override def toString = "Generator[Long]"
     }
 
   implicit val floatGenerator: Generator[Float] =
     new Generator[Float] {
-      def next(size: Int, rnd: Randomizer): (Float, Randomizer) = rnd.nextFloatWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Float], Randomizer) = {
+        (floatEdges.take(maxLength), rnd)
+      }
+      def next(szp: SizeParam, edges: List[Float], rnd: Randomizer): (Float, List[Float], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (f, nextRnd) = rnd.nextFloat
+            (f, Nil, nextRnd)
+        }
+      }
+      private val floatCanonicals: List[Float] = List(0.0f, 1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f)
+      override def canonicals(rnd: Randomizer): (Iterator[Float], Randomizer) = (floatCanonicals.iterator, rnd)
+      override def shrink(f: Float, rnd: Randomizer): (Iterator[Float], Randomizer) = {
+        @tailrec
+        def shrinkLoop(f: Float, acc: List[Float]): List[Float] = {
+          if (f == 0.0f) acc
+          else if (f <= 1.0f && f >= -1.0f) 0.0f :: acc
+          else if (!f.isWhole) {
+            // Nearest whole numbers closer to zero
+            val (nearest, nearestNeg) = if (f > 0.0f) (f.floor, (-f).ceil) else (f.ceil, (-f).floor)
+            shrinkLoop(nearest, nearestNeg :: nearest :: acc)
+          }
+          else {
+            val sqrt: Float = math.sqrt(f.abs.toDouble).toFloat
+            if (sqrt < 1.0f) 0.0f :: acc
+            else {
+              val whole: Float = sqrt.floor
+              val negWhole: Float = math.rint((-whole).toDouble).toFloat
+              val (first, second) = if (f > 0.0f) (negWhole, whole) else (whole, negWhole)
+              shrinkLoop(first, first :: second :: acc)
+            }
+          }
+        }
+        (shrinkLoop(f, Nil).iterator, rnd)
+      }
       override def toString = "Generator[Float]"
     }
 
   implicit val doubleGenerator: Generator[Double] =
     new Generator[Double] {
-      def next(size: Int, rnd: Randomizer): (Double, Randomizer) = rnd.nextDoubleWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Double], Randomizer) = {
+        (doubleEdges.take(maxLength), rnd)
+      }
+      def next(szp: SizeParam, edges: List[Double], rnd: Randomizer): (Double, List[Double], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (d, nextRnd) = rnd.nextDouble
+            (d, Nil, nextRnd)
+        }
+      }
+      private val doubleCanonicals: List[Double] = List(0.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0)
+      override def canonicals(rnd: Randomizer): (Iterator[Double], Randomizer) = (doubleCanonicals.iterator, rnd)
+      override def shrink(d: Double, rnd: Randomizer): (Iterator[Double], Randomizer) = {
+        @tailrec
+        def shrinkLoop(d: Double, acc: List[Double]): List[Double] = {
+          if (d == 0.0) acc
+          else if (d <= 1.0 && d >= -1.0) 0.0 :: acc
+          else if (!d.isWhole) {
+            // Nearest whole numbers closer to zero
+            val (nearest, nearestNeg) = if (d > 0.0) (d.floor, (-d).ceil) else (d.ceil, (-d).floor)
+            shrinkLoop(nearest, nearestNeg :: nearest :: acc)
+          }
+          else {
+            val sqrt: Double = math.sqrt(d.abs)
+            if (sqrt < 1.0) 0.0 :: acc
+            else {
+              val whole: Double = sqrt.floor
+              // Bill: math.rint behave similarly on js, is it ok we just do -whole instead?  Seems to pass our tests.
+              val negWhole: Double = -whole  //math.rint(-whole)
+              val (first, second) = if (d > 0.0) (negWhole, whole) else (whole, negWhole)
+              shrinkLoop(first, first :: second :: acc)
+            }
+          }
+        }
+        (shrinkLoop(d, Nil).iterator, rnd)
+      }
       override def toString = "Generator[Double]"
     }
 
   implicit val posIntGenerator: Generator[PosInt] =
     new Generator[PosInt] {
-      def next(size: Int, rnd: Randomizer): (PosInt, Randomizer) = rnd.nextPosIntWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posIntEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosInt], rnd: Randomizer): (PosInt, List[PosInt], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posInt, nextRnd) = rnd.nextPosInt
+            (posInt, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosInt]"
     }
 
   implicit val posZIntGenerator: Generator[PosZInt] =
     new Generator[PosZInt] {
-      def next(size: Int, rnd: Randomizer): (PosZInt, Randomizer) = rnd.nextPosZIntWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZIntEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZInt], rnd: Randomizer): (PosZInt, List[PosZInt], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZInt, nextRnd) = rnd.nextPosZInt
+            (posZInt, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosZInt]"
     }
 
   implicit val posLongGenerator: Generator[PosLong] =
     new Generator[PosLong] {
-      def next(size: Int, rnd: Randomizer): (PosLong, Randomizer) = rnd.nextPosLongWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posLongEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosLong], rnd: Randomizer): (PosLong, List[PosLong], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posLong, nextRnd) = rnd.nextPosLong
+            (posLong, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosLong]"
     }
 
   implicit val posZLongGenerator: Generator[PosZLong] =
     new Generator[PosZLong] {
-      def next(size: Int, rnd: Randomizer): (PosZLong, Randomizer) = rnd.nextPosZLongWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZLongEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZLong], rnd: Randomizer): (PosZLong, List[PosZLong], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZLong, nextRnd) = rnd.nextPosZLong
+            (posZLong, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosZLong]"
     }
 
   implicit val posFloatGenerator: Generator[PosFloat] =
     new Generator[PosFloat] {
-      def next(size: Int, rnd: Randomizer): (PosFloat, Randomizer) = rnd.nextPosFloatWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFloat], rnd: Randomizer): (PosFloat, List[PosFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZFloat, nextRnd) = rnd.nextPosFloat
+            (posZFloat, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosFloat]"
+    }
+
+  implicit val posFiniteFloatGenerator: Generator[PosFiniteFloat] =
+    new Generator[PosFiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posFiniteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFiniteFloat], rnd: Randomizer): (PosFiniteFloat, List[PosFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posFiniteFloat, nextRnd) = rnd.nextPosFiniteFloat
+            (posFiniteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[PosFiniteFloat]"
+    }
+
+  implicit val finiteFloatGenerator: Generator[FiniteFloat] =
+    new Generator[FiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(finiteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[FiniteFloat], rnd: Randomizer): (FiniteFloat, List[FiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (finiteFloat, nextRnd) = rnd.nextFiniteFloat
+            (finiteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[FiniteFloat]"
+    }
+
+  implicit val finiteDoubleGenerator: Generator[FiniteDouble] =
+    new Generator[FiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(finiteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[FiniteDouble], rnd: Randomizer): (FiniteDouble, List[FiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (finiteDouble, nextRnd) = rnd.nextFiniteDouble
+            (finiteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[FiniteDouble]"
     }
 
   implicit val posZFloatGenerator: Generator[PosZFloat] =
     new Generator[PosZFloat] {
-      def next(size: Int, rnd: Randomizer): (PosZFloat, Randomizer) = rnd.nextPosZFloatWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFloat], rnd: Randomizer): (PosZFloat, List[PosZFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZFloat, nextRnd) = rnd.nextPosZFloat
+            (posZFloat, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosZFloat]"
+    }
+
+  implicit val posZFiniteFloatGenerator: Generator[PosZFiniteFloat] =
+    new Generator[PosZFiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZFiniteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFiniteFloat], rnd: Randomizer): (PosZFiniteFloat, List[PosZFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZFiniteFloat, nextRnd) = rnd.nextPosZFiniteFloat
+            (posZFiniteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[PosZFiniteFloat]"
     }
 
   implicit val posDoubleGenerator: Generator[PosDouble] =
     new Generator[PosDouble] {
-      def next(size: Int, rnd: Randomizer): (PosDouble, Randomizer) = rnd.nextPosDoubleWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosDouble], rnd: Randomizer): (PosDouble, List[PosDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posDouble, nextRnd) = rnd.nextPosDouble
+            (posDouble, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosDouble]"
+    }
+
+  implicit val posFiniteDoubleGenerator: Generator[PosFiniteDouble] =
+    new Generator[PosFiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posFiniteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosFiniteDouble], rnd: Randomizer): (PosFiniteDouble, List[PosFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posFiniteDouble, nextRnd) = rnd.nextPosFiniteDouble
+            (posFiniteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[PosFiniteDouble]"
     }
 
   implicit val posZDoubleGenerator: Generator[PosZDouble] =
     new Generator[PosZDouble] {
-      def next(size: Int, rnd: Randomizer): (PosZDouble, Randomizer) = rnd.nextPosZDoubleWithEdges
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZDouble], rnd: Randomizer): (PosZDouble, List[PosZDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZDouble, nextRnd) = rnd.nextPosZDouble
+            (posZDouble, Nil, nextRnd)
+        }
+      }
       override def toString = "Generator[PosZDouble]"
+    }
+
+  implicit val posZFiniteDoubleGenerator: Generator[PosZFiniteDouble] =
+    new Generator[PosZFiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(posZFiniteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[PosZFiniteDouble], rnd: Randomizer): (PosZFiniteDouble, List[PosZFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZFiniteDouble, nextRnd) = rnd.nextPosZFiniteDouble
+            (posZFiniteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[PosZFiniteDouble]"
+    }
+
+  implicit val nonZeroDoubleGenerator: Generator[NonZeroDouble] =
+    new Generator[NonZeroDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroDouble], rnd: Randomizer): (NonZeroDouble, List[NonZeroDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroDouble, nextRnd) = rnd.nextNonZeroDouble
+            (nonZeroDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroDouble]"
+    }
+
+  implicit val nonZeroFiniteDoubleGenerator: Generator[NonZeroFiniteDouble] =
+    new Generator[NonZeroFiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFiniteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroFiniteDouble], rnd: Randomizer): (NonZeroFiniteDouble, List[NonZeroFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroFiniteDouble, nextRnd) = rnd.nextNonZeroFiniteDouble
+            (nonZeroFiniteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroFiniteDouble]"
+    }
+
+  implicit val nonZeroFloatGenerator: Generator[NonZeroFloat] =
+    new Generator[NonZeroFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroFloat], rnd: Randomizer): (NonZeroFloat, List[NonZeroFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroFloat, nextRnd) = rnd.nextNonZeroFloat
+            (nonZeroFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroFloat]"
+    }
+
+  implicit val nonZeroFiniteFloatGenerator: Generator[NonZeroFiniteFloat] =
+    new Generator[NonZeroFiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFiniteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroFiniteFloat], rnd: Randomizer): (NonZeroFiniteFloat, List[NonZeroFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroFiniteFloat, nextRnd) = rnd.nextNonZeroFiniteFloat
+            (nonZeroFiniteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroFiniteFloat]"
+    }
+
+  implicit val nonZeroIntGenerator: Generator[NonZeroInt] =
+    new Generator[NonZeroInt] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroIntEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroInt], rnd: Randomizer): (NonZeroInt, List[NonZeroInt], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroInt, nextRnd) = rnd.nextNonZeroInt
+            (nonZeroInt, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroInt]"
+    }
+
+  implicit val nonZeroLongGenerator: Generator[NonZeroLong] =
+    new Generator[NonZeroLong] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroLongEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NonZeroLong], rnd: Randomizer): (NonZeroLong, List[NonZeroLong], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nonZeroLong, nextRnd) = rnd.nextNonZeroLong
+            (nonZeroLong, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NonZeroLong]"
+    }
+
+  implicit val negDoubleGenerator: Generator[NegDouble] =
+    new Generator[NegDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegDouble], rnd: Randomizer): (NegDouble, List[NegDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negDouble, nextRnd) = rnd.nextNegDouble
+            (negDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegDouble]"
+    }
+
+  implicit val negFiniteDoubleGenerator: Generator[NegFiniteDouble] =
+    new Generator[NegFiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negFiniteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegFiniteDouble], rnd: Randomizer): (NegFiniteDouble, List[NegFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negFiniteDouble, nextRnd) = rnd.nextNegFiniteDouble
+            (negFiniteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegFiniteDouble]"
+    }
+
+  implicit val negFloatGenerator: Generator[NegFloat] =
+    new Generator[NegFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegFloat], rnd: Randomizer): (NegFloat, List[NegFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negFloat, nextRnd) = rnd.nextNegFloat
+            (negFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegFloat]"
+    }
+
+  implicit val negFiniteFloatGenerator: Generator[NegFiniteFloat] =
+    new Generator[NegFiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negFiniteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegFiniteFloat], rnd: Randomizer): (NegFiniteFloat, List[NegFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negFiniteFloat, nextRnd) = rnd.nextNegFiniteFloat
+            (negFiniteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegFiniteFloat]"
+    }
+
+  implicit val negIntGenerator: Generator[NegInt] =
+    new Generator[NegInt] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negIntEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegInt], rnd: Randomizer): (NegInt, List[NegInt], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negInt, nextRnd) = rnd.nextNegInt
+            (negInt, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegInt]"
+    }
+
+  implicit val negLongGenerator: Generator[NegLong] =
+    new Generator[NegLong] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negLongEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegLong], rnd: Randomizer): (NegLong, List[NegLong], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negLong, nextRnd) = rnd.nextNegLong
+            (negLong, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegLong]"
+    }
+
+  implicit val negZDoubleGenerator: Generator[NegZDouble] =
+    new Generator[NegZDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZDouble], rnd: Randomizer): (NegZDouble, List[NegZDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZDouble, nextRnd) = rnd.nextNegZDouble
+            (negZDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZDouble]"
+    }
+
+  implicit val negZFiniteDoubleGenerator: Generator[NegZFiniteDouble] =
+    new Generator[NegZFiniteDouble] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteDouble], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZFiniteDoubleEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZFiniteDouble], rnd: Randomizer): (NegZFiniteDouble, List[NegZFiniteDouble], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZFiniteDouble, nextRnd) = rnd.nextNegZFiniteDouble
+            (negZFiniteDouble, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZFiniteDouble]"
+    }
+
+  implicit val negZFloatGenerator: Generator[NegZFloat] =
+    new Generator[NegZFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZFloat], rnd: Randomizer): (NegZFloat, List[NegZFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZFloat, nextRnd) = rnd.nextNegZFloat
+            (negZFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZFloat]"
+    }
+
+  implicit val negZFiniteFloatGenerator: Generator[NegZFiniteFloat] =
+    new Generator[NegZFiniteFloat] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteFloat], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZFiniteFloatEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZFiniteFloat], rnd: Randomizer): (NegZFiniteFloat, List[NegZFiniteFloat], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZFiniteFloat, nextRnd) = rnd.nextNegZFiniteFloat
+            (negZFiniteFloat, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZFiniteFloat]"
+    }
+
+  implicit val negZIntGenerator: Generator[NegZInt] =
+    new Generator[NegZInt] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZInt], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZIntEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZInt], rnd: Randomizer): (NegZInt, List[NegZInt], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZInt, nextRnd) = rnd.nextNegZInt
+            (negZInt, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZInt]"
+    }
+
+  implicit val negZLongGenerator: Generator[NegZLong] =
+    new Generator[NegZLong] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZLong], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(negZLongEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NegZLong], rnd: Randomizer): (NegZLong, List[NegZLong], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (negZLong, nextRnd) = rnd.nextNegZLong
+            (negZLong, Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NegZLong]"
+    }
+
+  implicit val numericCharGenerator: Generator[NumericChar] =
+    new Generator[NumericChar] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NumericChar], Randomizer) = {
+        val (allEdges, nextRnd) = Randomizer.shuffle(numericCharEdges, rnd)
+        (allEdges.take(maxLength), nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[NumericChar], rnd: Randomizer): (NumericChar, List[NumericChar], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (posZInt, nextRnd) = rnd.choosePosZInt(PosZInt.ensuringValid(0), PosZInt.ensuringValid(9))
+            (NumericChar.ensuringValid((posZInt.value + 48).toChar), Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[NumericChar]"
     }
 
   // Should throw IAE on negative size in all generators, even the ones that ignore size.
   implicit val stringGenerator: Generator[String] =
     new Generator[String] {
-      def next(size: Int, rnd: Randomizer): (String, Randomizer) = {
-        require(size >= 0, "; the size passed to next must be >= 0")
-        rnd.nextString(size)
+      private val stringEdges = List("")
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[String], Randomizer) = {
+        (stringEdges.take(maxLength), rnd)
+      }
+      def next(szp: SizeParam, edges: List[String], rnd: Randomizer): (String, List[String], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (s, nextRnd) = rnd.nextString(szp.size)
+            (s, Nil, nextRnd)
+        }
+      }
+      override def canonicals(rnd: Randomizer): (Iterator[String], Randomizer) = {
+        val (canonicalsOfChar, rnd1) = charGenerator.canonicals(rnd)
+        (Iterator("") ++ canonicalsOfChar.map(t => s"$t"), rnd1)
+      }
+      override def shrink(s: String, rnd: Randomizer): (Iterator[String], Randomizer) = {
+
+        val lowerAlphaChars = "abcdefghikjlmnopqrstuvwxyz"
+        val upperAlphaChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        val numericChars = "0123456789"
+        val (lowerCharIndex, rnd1) = rnd.chooseInt(0, lowerAlphaChars.length - 1)
+        val (upperCharIndex, rnd2) = rnd1.chooseInt(0, upperAlphaChars.length - 1)
+        val (numericCharIndex, rnd3) = rnd1.chooseInt(0, numericChars.length - 1)
+        val lowerChar = lowerAlphaChars(lowerCharIndex)
+        val upperChar = upperAlphaChars(upperCharIndex)
+        val numericChar = numericChars(numericCharIndex)
+        val candidateChars: List[Char] = List(lowerChar, upperChar, numericChar) ++ s.distinct.toList
+        val candidateStrings: List[String] = candidateChars.map(_.toString)
+
+        val lastBatch =
+          new Iterator[String] {
+            private var nextString = s.take(2)
+            def hasNext: Boolean = nextString.length < s.length
+            def next: String = {
+              val result = nextString
+              nextString = s.take(result.length * 2)
+              result
+            }
+          }
+
+        if (s.isEmpty) (Iterator.empty, rnd)
+        else (
+          Iterator("") ++ candidateStrings ++ lastBatch,
+          rnd3
+        )
       }
       override def toString = "Generator[String]"
     }
 
   // Should throw IAE on negative size in all generators, even the ones that ignore size.
-  implicit def listGenerator[T](implicit genOfT: Generator[T]): Generator[List[T]] =
-    new Generator[List[T]] {
-      def next(size: Int, rnd: Randomizer): (List[T], Randomizer) = {
-        require(size >= 0, "; the size passed to next must be >= 0")
-        rnd.nextList[T](size)
+  implicit def listGenerator[T](implicit genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] =
+    new Generator[List[T]] with HavingLength[List[T]] { outerGenOfListOfT =>
+      private val listEdges = List(Nil)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[List[T]], Randomizer) = {
+        (listEdges.take(maxLength), rnd)
+      }
+      def next(szp: SizeParam, edges: List[List[T]], rnd: Randomizer): (List[T], List[List[T]], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (listOfT, nextRnd) = rnd.nextList[T](szp.size)
+            (listOfT, Nil, nextRnd)
+        }
+      }
+      override def canonicals(rnd: Randomizer): (Iterator[List[T]], Randomizer) = {
+        val (canonicalsOfT, rnd1) = genOfT.canonicals(rnd)
+        (canonicalsOfT.map(t => List(t)), rnd1)
+      }
+      override def shrink(xs: List[T], rnd: Randomizer): (Iterator[List[T]], Randomizer) = {
+
+        if (xs.isEmpty) (Iterator.empty, rnd)
+        else {
+          val (canonicalTsIt, rnd1) = genOfT.canonicals(rnd)
+          val canonicalTs = canonicalTsIt.toList
+          // Start with Lists of length one each of which contain one of the canonical values
+          // of the element type.
+          val canonicalListOfTsIt: Iterator[List[T]] = canonicalTs.map(t => List(t)).toIterator
+
+          // Only include distinctListsOfTs if the list to shrink (xs) does not contain
+          // just one element itself. If it does, then xs will appear in the output, which
+          // we don't need, since we already know it fails.
+          val distinctListOfTsIt: Iterator[List[T]] =
+            if (xs.nonEmpty && xs.tail.nonEmpty) {
+              val distinctListOfTs: List[List[T]] =
+                for (x <- xs if !canonicalTs.contains(x)) yield List(x)
+              distinctListOfTs.iterator
+            }
+            else Iterator.empty
+
+          // The last batch of candidate shrunken values are just slices of the list starting at
+          // 0 with size doubling each time.
+          val lastBatch =
+            new Iterator[List[T]] {
+              private var nextT = xs.take(2)
+              def hasNext: Boolean = nextT.length < xs.length
+              def next: List[T] = {
+                if (!hasNext)
+                  throw new NoSuchElementException
+                val result = nextT
+                nextT = xs.take(result.length * 2)
+                result
+              }
+            }
+
+          (Iterator(Nil) ++ canonicalListOfTsIt ++ distinctListOfTsIt ++ lastBatch, rnd1)
+        }
       }
       override def toString = "Generator[List[T]]"
+      def havingSize(size: PosZInt): Generator[List[T]] = // TODO: add with HavingLength again
+        // No edges and no shrinking. Since they said they want a list of a particular length,
+        // that is what they'll get.
+        new Generator[List[T]] {
+          override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[List[T]], Randomizer) = (Nil, rnd) // TODO: filter lists's edges by valid size
+          def next(szp: SizeParam, edges: List[List[T]], rnd: Randomizer): (List[T], List[List[T]], Randomizer) =
+            outerGenOfListOfT.next(SizeParam(PosZInt(0), szp.maxSize, size), edges, rnd) // TODO: SizeParam(size, size, size)?
+          override def canonicals(rnd: Randomizer): (Iterator[List[T]], Randomizer) = (Iterator.empty, rnd)
+          override def shrink(xs: List[T], rnd: Randomizer): (Iterator[List[T]], Randomizer) = (Iterator.empty, rnd)
+          override def toString = s"Generator[List[T] /* having length $size */]"
+        }
+      def havingSizesBetween(from: PosZInt, to: PosZInt): Generator[List[T]] = { // TODO: add with HavingLength again
+        require(from != to, Resources.fromEqualToToHavingSizesBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingSizesBetween(from, to))
+        new Generator[List[T]] {
+          // I don't think edges should have one list each of length from and to, because they would
+          // need to have random contents, and that doesn't seem like an edge.
+          override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[List[T]], Randomizer) = (Nil, rnd) // TODO: filter lists's edges by valid size
+          // Specify how size is used.
+          def next(szp: SizeParam, edges: List[List[T]], rnd: Randomizer): (List[T], List[List[T]], Randomizer) = {
+            val nextSize = {
+              val candidate: Int = (from + (szp.size.toFloat * (to - from).toFloat / (szp.maxSize + 1).toFloat)).round
+              if (candidate > to) to
+              else if (candidate < from) from
+              else PosZInt.ensuringValid(candidate)
+            }
+            // TODO: should minSize not be from from now on.
+            outerGenOfListOfT.next(SizeParam(PosZInt(0), to, nextSize), edges, rnd) // This assumes from < to, and i'm not guaranteeing that yet
+          }
+          // If from is either 0 or 1, return the canonicals of the outer Generator.
+          override def canonicals(rnd: Randomizer): (Iterator[List[T]], Randomizer) =
+            if (from <= 1) outerGenOfListOfT.canonicals(rnd) else (Iterator.empty, rnd)
+          // TODO: Shrink can go from from up to xs length
+          override def shrink(xs: List[T], rnd: Randomizer): (Iterator[List[T]], Randomizer) = outerGenOfListOfT.shrink(xs, rnd)
+          override def toString = s"Generator[List[T] /* having lengths between $from and $to (inclusive) */]"
+        }
+      }
+      def havingSizesDeterminedBy(f: SizeParam => SizeParam): Generator[List[T]] = // TODO: add with HavingLength again
+        new Generator[List[T]] {
+          override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[List[T]], Randomizer) = (Nil, rnd)
+          def next(szp: SizeParam, edges: List[List[T]], rnd: Randomizer): (List[T], List[List[T]], Randomizer) =
+            outerGenOfListOfT.next(f(szp), edges, rnd)
+          override def canonicals(rnd: Randomizer): (Iterator[List[T]], Randomizer) = (Iterator.empty, rnd)
+          override def shrink(xs: List[T], rnd: Randomizer): (Iterator[List[T]], Randomizer) = (Iterator.empty, rnd)
+          override def toString = s"Generator[List[T] /* having lengths determined by a function */]"
+        }
     }
+
+  implicit def function0Generator[T](implicit genOfT: Generator[T]): Generator[() => T] = {
+    new Generator[() => T] { thisGeneratorOfFunction0 =>
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[() => T], Randomizer) = {
+        val (edgesOfT, nextRnd) = genOfT.initEdges(maxLength, rnd)
+        val edges = edgesOfT.map(t => PrettyFunction0(t))
+        (edges, nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[() => T], rnd: Randomizer): (() => T, List[() => T], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextT, _, nextRnd) = genOfT.next(szp, Nil, rnd)
+            (PrettyFunction0(nextT), Nil, nextRnd)
+        }
+      }
+      override def canonicals(rnd: Randomizer): (Iterator[() => T], Randomizer) = {
+        val (canonicalsOfT, nextRnd) = genOfT.canonicals(rnd)
+        val canonicals = canonicalsOfT.map(t => PrettyFunction0(t))
+        (canonicals, nextRnd)
+      }
+      override def shrink(f: () => T, rnd: Randomizer): (Iterator[() => T], Randomizer) = {
+        val (shrinksOfT, nextRnd) = genOfT.shrink(f(), rnd)
+        val shrinks = shrinksOfT.map(t => PrettyFunction0(t))
+        (shrinks, nextRnd)
+      }
+    }
+  }
+
+  implicit val function1IntToIntGenerator: Generator[Int => Int] = {
+    object IntToIntIdentity extends (Int => Int) {
+      def apply(i: Int): Int = i
+      override def toString = "(i: Int) => i"
+    }
+    object IntToIntIncr extends (Int => Int) {
+      def apply(i: Int): Int = i + 1
+      override def toString = "(i: Int) => i + 1"
+    }
+    object IntToIntIncrBy2 extends (Int => Int) {
+      def apply(i: Int): Int = i + 2
+      override def toString = "(i: Int) => i + 2"
+    }
+    object IntToIntIncrBy3 extends (Int => Int) {
+      def apply(i: Int): Int = i + 3
+      override def toString = "(i: Int) => i + 3"
+    }
+    object IntToIntIncrByMax extends (Int => Int) {
+      def apply(i: Int): Int = i + Int.MaxValue
+      override def toString = "(i: Int) => i + Int.MaxValue"
+    }
+    object IntToIntIncrByMin extends (Int => Int) {
+      def apply(i: Int): Int = i + Int.MinValue
+      override def toString = "(i: Int) => i + Int.MinValue"
+    }
+    object IntToIntDecr extends (Int => Int) {
+      def apply(i: Int): Int = i - 1
+      override def toString = "(i: Int) => i - 1"
+    }
+    object IntToIntDecrBy2 extends (Int => Int) {
+      def apply(i: Int): Int = i - 2
+      override def toString = "(i: Int) => i - 2"
+    }
+    object IntToIntDecrBy3 extends (Int => Int) {
+      def apply(i: Int): Int = i - 3
+      override def toString = "(i: Int) => i - 3"
+    }
+    object IntToIntDecrByMax extends (Int => Int) {
+      def apply(i: Int): Int = i - Int.MaxValue
+      override def toString = "(i: Int) => i - Int.MaxValue"
+    }
+    object IntToIntDecrByMin extends (Int => Int) {
+      def apply(i: Int): Int = i - Int.MinValue
+      override def toString = "(i: Int) => i - Int.MinValue"
+    }
+    object IntToIntSquare extends (Int => Int) {
+      def apply(i: Int): Int = i * i
+      override def toString = "(i: Int) => i * i"
+    }
+    object IntToIntCube extends (Int => Int) {
+      def apply(i: Int): Int = i * i * i
+      override def toString = "(i: Int) => i * i * i"
+    }
+    object IntToIntHalf extends (Int => Int) {
+      def apply(i: Int): Int = i / 2
+      override def toString = "(i: Int) => i / 2"
+    }
+    object IntToIntThird extends (Int => Int) {
+      def apply(i: Int): Int = i / 3
+      override def toString = "(i: Int) => i / 3"
+    }
+    object IntToIntFourth extends (Int => Int) {
+      def apply(i: Int): Int = i / 3
+      override def toString = "(i: Int) => i / 4"
+    }
+    object IntToIntNegate extends (Int => Int) {
+      def apply(i: Int): Int = -i
+      override def toString = "(i: Int) => -i"
+    }
+    object IntToIntComplement extends (Int => Int) {
+      def apply(i: Int): Int = ~i
+      override def toString = "(i: Int) => ~i"
+    }
+    val funs: Vector[Int => Int] =
+      Vector(
+        IntToIntIdentity,
+        IntToIntIncr,
+        IntToIntIncrBy2,
+        IntToIntIncrBy3,
+        IntToIntIncrByMax,
+        IntToIntIncrByMin,
+        IntToIntDecr,
+        IntToIntDecrBy2,
+        IntToIntDecrBy3,
+        IntToIntDecrByMax,
+        IntToIntDecrByMin,
+        IntToIntSquare,
+        IntToIntCube,
+        IntToIntHalf,
+        IntToIntThird,
+        IntToIntFourth,
+        IntToIntNegate,
+        IntToIntComplement
+      )
+    new Generator[Int => Int] {
+      def next(szp: SizeParam, edges: List[Int => Int], rnd: Randomizer): (Int => Int, List[Int => Int], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRnd) = rnd.nextInt
+            val idx = (if (nextInt == Int.MinValue) Int.MaxValue else nextInt.abs) % funs.length
+            (funs(idx), Nil, nextRnd)
+        }
+      }
+      override def toString = "Generator[Int => Int]"
+    }
+  }
+
+  implicit def function1Generator[A, B](implicit genOfB: Generator[B], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B]): Generator[A => B] = {
+    new Generator[A => B] {
+      def next(szp: SizeParam, edges: List[A => B], rnd: Randomizer): (A => B, List[A => B], Randomizer) = {
+
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object AToB extends (A => B) {
+          def apply(a: A): B = org.scalatest.prop.valueOf[B](a, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            s"(o: $typeOfA) => org.scalatest.prop.valueOf[$typeOfB](o, $multiplier)"
+          }
+        }
+
+        (AToB, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function2Generator[A, B, C](implicit genOfC: Generator[C], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C]): Generator[(A, B) => C] = {
+    new Generator[(A, B) => C] {
+      def next(szp: SizeParam, edges: List[(A, B) => C], rnd: Randomizer): ((A, B) => C, List[(A, B) => C], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABToC extends ((A, B) => C) {
+          def apply(a: A, b: B): C = org.scalatest.prop.valueOf[C](a, b, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            s"(a: $typeOfA, b: $typeOfB) => org.scalatest.prop.valueOf[$typeOfC](a, b, $multiplier)"
+          }
+        }
+
+        (ABToC, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function3Generator[A, B, C, D](implicit genOfD: Generator[D], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D]): Generator[(A, B, C) => D] = {
+    new Generator[(A, B, C) => D] {
+      def next(szp: SizeParam, edges: List[(A, B, C) => D], rnd: Randomizer): ((A, B, C) => D, List[(A, B, C) => D], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCToD extends ((A, B, C) => D) {
+          def apply(a: A, b: B, c: C): D = org.scalatest.prop.valueOf[D](a, b, c, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC) => org.scalatest.prop.valueOf[$typeOfD](a, b, c, $multiplier)"
+          }
+        }
+
+        (ABCToD, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function4Generator[A, B, C, D, E](implicit genOfE: Generator[E], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E]): Generator[(A, B, C, D) => E] = {
+    new Generator[(A, B, C, D) => E] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D) => E], rnd: Randomizer): ((A, B, C, D) => E, List[(A, B, C, D) => E], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDToE extends ((A, B, C, D) => E) {
+          def apply(a: A, b: B, c: C, d: D): E = org.scalatest.prop.valueOf[E](a, b, c, d, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD) => org.scalatest.prop.valueOf[$typeOfE](a, b, c, d, $multiplier)"
+          }
+        }
+
+        (ABCDToE, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function5Generator[A, B, C, D, E, F](implicit genOfF: Generator[F], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F]): Generator[(A, B, C, D, E) => F] = {
+    new Generator[(A, B, C, D, E) => F] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E) => F], rnd: Randomizer): ((A, B, C, D, E) => F, List[(A, B, C, D, E) => F], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEToF extends ((A, B, C, D, E) => F) {
+          def apply(a: A, b: B, c: C, d: D, e: E): F = org.scalatest.prop.valueOf[F](a, b, c, d, e, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE) => org.scalatest.prop.valueOf[$typeOfF](a, b, c, d, e, $multiplier)"
+          }
+        }
+
+        (ABCDEToF, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function6Generator[A, B, C, D, E, F, G](implicit genOfG: Generator[G], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G]): Generator[(A, B, C, D, E, F) => G] = {
+    new Generator[(A, B, C, D, E, F) => G] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F) => G], rnd: Randomizer): ((A, B, C, D, E, F) => G, List[(A, B, C, D, E, F) => G], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFToG extends ((A, B, C, D, E, F) => G) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F): G = org.scalatest.prop.valueOf[G](a, b, c, d, e, f, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF) => org.scalatest.prop.valueOf[$typeOfG](a, b, c, d, e, f, $multiplier)"
+          }
+        }
+
+        (ABCDEFToG, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function7Generator[A, B, C, D, E, F, G, H](implicit genOfH: Generator[H], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H]): Generator[(A, B, C, D, E, F, G) => H] = {
+    new Generator[(A, B, C, D, E, F, G) => H] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G) => H], rnd: Randomizer): ((A, B, C, D, E, F, G) => H, List[(A, B, C, D, E, F, G) => H], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGToH extends ((A, B, C, D, E, F, G) => H) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G): H = org.scalatest.prop.valueOf[H](a, b, c, d, e, f, g, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG) => org.scalatest.prop.valueOf[$typeOfH](a, b, c, d, e, f, g, $multiplier)"
+          }
+        }
+
+        (ABCDEFGToH, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function8Generator[A, B, C, D, E, F, G, H, I](implicit genOfI: Generator[I], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I]): Generator[(A, B, C, D, E, F, G, H) => I] = {
+    new Generator[(A, B, C, D, E, F, G, H) => I] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H) => I], rnd: Randomizer): ((A, B, C, D, E, F, G, H) => I, List[(A, B, C, D, E, F, G, H) => I], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHToI extends ((A, B, C, D, E, F, G, H) => I) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H): I = org.scalatest.prop.valueOf[I](a, b, c, d, e, f, g, h, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH) => org.scalatest.prop.valueOf[$typeOfI](a, b, c, d, e, f, g, h, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHToI, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function9Generator[A, B, C, D, E, F, G, H, I, J](implicit genOfJ: Generator[J], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J]): Generator[(A, B, C, D, E, F, G, H, I) => J] = {
+    new Generator[(A, B, C, D, E, F, G, H, I) => J] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I) => J], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I) => J, List[(A, B, C, D, E, F, G, H, I) => J], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIToJ extends ((A, B, C, D, E, F, G, H, I) => J) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I): J = org.scalatest.prop.valueOf[J](a, b, c, d, e, f, g, h, i, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI) => org.scalatest.prop.valueOf[$typeOfJ](a, b, c, d, e, f, g, h, i, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIToJ, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function10Generator[A, B, C, D, E, F, G, H, I, J, K](implicit genOfK: Generator[K], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K]): Generator[(A, B, C, D, E, F, G, H, I, J) => K] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J) => K] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J) => K], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J) => K, List[(A, B, C, D, E, F, G, H, I, J) => K], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJToK extends ((A, B, C, D, E, F, G, H, I, J) => K) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J): K = org.scalatest.prop.valueOf[K](a, b, c, d, e, f, g, h, i, j, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ) => org.scalatest.prop.valueOf[$typeOfK](a, b, c, d, e, f, g, h, i, j, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJToK, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function11Generator[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfL: Generator[L], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K) => L], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K) => L, List[(A, B, C, D, E, F, G, H, I, J, K) => L], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKToL extends ((A, B, C, D, E, F, G, H, I, J, K) => L) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K): L = org.scalatest.prop.valueOf[L](a, b, c, d, e, f, g, h, i, j, k, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK) => org.scalatest.prop.valueOf[$typeOfL](a, b, c, d, e, f, g, h, i, j, k, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKToL, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function12Generator[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfM: Generator[M], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L) => M], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L) => M, List[(A, B, C, D, E, F, G, H, I, J, K, L) => M], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLToM extends ((A, B, C, D, E, F, G, H, I, J, K, L) => M) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L): M = org.scalatest.prop.valueOf[M](a, b, c, d, e, f, g, h, i, j, k, l, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL) => org.scalatest.prop.valueOf[$typeOfM](a, b, c, d, e, f, g, h, i, j, k, l, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLToM, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfN: Generator[N], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M) => N, List[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMToN extends ((A, B, C, D, E, F, G, H, I, J, K, L, M) => N) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M): N = org.scalatest.prop.valueOf[N](a, b, c, d, e, f, g, h, i, j, k, l, m, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM) => org.scalatest.prop.valueOf[$typeOfN](a, b, c, d, e, f, g, h, i, j, k, l, m, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMToN, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfO: Generator[O], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNToO extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N): O = org.scalatest.prop.valueOf[O](a, b, c, d, e, f, g, h, i, j, k, l, m, n, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN) => org.scalatest.prop.valueOf[$typeOfO](a, b, c, d, e, f, g, h, i, j, k, l, m, n, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNToO, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfP: Generator[P], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOToP extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O): P = org.scalatest.prop.valueOf[P](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO) => org.scalatest.prop.valueOf[$typeOfP](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOToP, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfQ: Generator[Q], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPToQ extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P): Q = org.scalatest.prop.valueOf[Q](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP) => org.scalatest.prop.valueOf[$typeOfQ](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPToQ, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfR: Generator[R], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQToR extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q): R = org.scalatest.prop.valueOf[R](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ) => org.scalatest.prop.valueOf[$typeOfR](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQToR, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfS: Generator[S], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQRToS extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R): S = org.scalatest.prop.valueOf[S](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            val typeOfS = typeInfoS.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ, r: $typeOfR) => org.scalatest.prop.valueOf[$typeOfS](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQRToS, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfT: Generator[T], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQRSToT extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S): T = org.scalatest.prop.valueOf[T](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            val typeOfS = typeInfoS.name
+            val typeOfT = typeInfoT.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ, r: $typeOfR, s: $typeOfS) => org.scalatest.prop.valueOf[$typeOfT](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQRSToT, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfU: Generator[U], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQRSTToU extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T): U = org.scalatest.prop.valueOf[U](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            val typeOfS = typeInfoS.name
+            val typeOfT = typeInfoT.name
+            val typeOfU = typeInfoU.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ, r: $typeOfR, s: $typeOfS, t: $typeOfT) => org.scalatest.prop.valueOf[$typeOfU](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQRSTToU, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfV: Generator[V], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQRSTUToV extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U): V = org.scalatest.prop.valueOf[V](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            val typeOfS = typeInfoS.name
+            val typeOfT = typeInfoT.name
+            val typeOfU = typeInfoU.name
+            val typeOfV = typeInfoV.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ, r: $typeOfR, s: $typeOfS, t: $typeOfT, u: $typeOfU) => org.scalatest.prop.valueOf[$typeOfV](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQRSTUToV, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def function22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](implicit genOfW: Generator[W], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V], typeInfoW: TypeInfo[W]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] = {
+    new Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] {
+      def next(szp: SizeParam, edges: List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W], rnd: Randomizer): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W, List[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W], Randomizer) = {
+        val first1000PrimesGen: Generator[Int] = first1000Primes
+        val (prime, _, rnd1) = first1000PrimesGen.next(szp, Nil, rnd)
+        val multiplier = if (prime == 2) 1 else prime
+
+        object ABCDEFGHIJKLMNOPQRSTUVToW extends ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W) {
+          def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V): W = org.scalatest.prop.valueOf[W](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, multiplier)
+          override def toString = {
+            val typeOfA = typeInfoA.name
+            val typeOfB = typeInfoB.name
+            val typeOfC = typeInfoC.name
+            val typeOfD = typeInfoD.name
+            val typeOfE = typeInfoE.name
+            val typeOfF = typeInfoF.name
+            val typeOfG = typeInfoG.name
+            val typeOfH = typeInfoH.name
+            val typeOfI = typeInfoI.name
+            val typeOfJ = typeInfoJ.name
+            val typeOfK = typeInfoK.name
+            val typeOfL = typeInfoL.name
+            val typeOfM = typeInfoM.name
+            val typeOfN = typeInfoN.name
+            val typeOfO = typeInfoO.name
+            val typeOfP = typeInfoP.name
+            val typeOfQ = typeInfoQ.name
+            val typeOfR = typeInfoR.name
+            val typeOfS = typeInfoS.name
+            val typeOfT = typeInfoT.name
+            val typeOfU = typeInfoU.name
+            val typeOfV = typeInfoV.name
+            val typeOfW = typeInfoW.name
+            s"(a: $typeOfA, b: $typeOfB, c: $typeOfC, d: $typeOfD, e: $typeOfE, f: $typeOfF, g: $typeOfG, h: $typeOfH, i: $typeOfI, j: $typeOfJ, k: $typeOfK, l: $typeOfL, m: $typeOfM, n: $typeOfN, o: $typeOfO, p: $typeOfP, q: $typeOfQ, r: $typeOfR, s: $typeOfS, t: $typeOfT, u: $typeOfU, v: $typeOfV) => org.scalatest.prop.valueOf[$typeOfW](a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, $multiplier)"
+          }
+        }
+
+        (ABCDEFGHIJKLMNOPQRSTUVToW, Nil, rnd1)
+      }
+    }
+  }
+
+  implicit def optionGenerator[T](implicit genOfT: Generator[T]): Generator[Option[T]] =
+    new Generator[Option[T]] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Option[T]], Randomizer) = {
+        // Subtract one from length, and we'll wrap those in Somes. Subtract one so that None can be the first edge.
+        val (edgesOfT, nextRnd) = genOfT.initEdges(if (maxLength > 0) PosZInt.ensuringValid((maxLength - 1)) else 0, rnd)
+        val edges = None :: edgesOfT.map(t => Some(t))
+        (edges, nextRnd)
+      }
+      def next(szp: SizeParam, edges: List[Option[T]], rnd: Randomizer): (Option[T], List[Option[T]], Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val (nextInt, nextRnd) = rnd.nextInt
+            if (nextInt % 10 == 0)
+              (None, Nil, nextRnd)
+            else {
+              val (nextT, _, nextNextRnd) = genOfT.next(szp, Nil, nextRnd)
+              (Some(nextT), Nil, nextNextRnd)
+            }
+        }
+      }
+    }
+
+  implicit def orGenerator[G, B](implicit genOfG: Generator[G], genOfB: Generator[B]): Generator[G Or B] =
+    new Generator[G Or B] {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[G Or B], Randomizer) = {
+        val (edgesOfG, nextRnd) = genOfG.initEdges(maxLength, rnd)
+        val (edgesOfB, nextNextRnd) = genOfB.initEdges(maxLength, nextRnd)
+        // Fill up to maxLength, favoring Good over Bad if maxLength is odd. Else just dividing it
+        // down the middle, half Good, half Bad. And filling in with the other if one side runs out.
+        @tailrec
+        def loop(count: Int, remainingG: List[G], remainingB: List[B], acc: List[G Or B]): List[G Or B] = {
+          (count, remainingG, remainingB) match {
+            case (0, _, _) => acc
+            case (_, Nil, Nil) => acc
+            case (c, gHead :: gTail, Nil) => loop(c - 1, gTail, Nil, Good(gHead) :: acc)
+            case (c, Nil, bHead :: bTail) => loop(c - 1, Nil, bTail, Bad(bHead) :: acc)
+            case (c, gHead :: gTail, _) if c % 2 == 0 => loop(c - 1, gTail, remainingB, Good(gHead) :: acc)
+            case (c, _, bHead :: bTail) => loop(c - 1, remainingG, bTail, Bad(bHead) :: acc)
+          }
+        }
+        (loop(maxLength, edgesOfG, edgesOfB, Nil), nextNextRnd)
+      }
+      def next(szp: SizeParam, edges: List[G Or B], rnd: Randomizer): (G Or B, List[G Or B], Randomizer) = {
+        edges match {
+          case head :: tail => 
+            (head, tail, rnd)
+          case _ => 
+            val (nextInt, nextRnd) = rnd.nextInt
+            if (nextInt % 4 == 0) {
+              val (nextB, _, nextRnd) = genOfB.next(szp, Nil, rnd)
+              (Bad(nextB), Nil, nextRnd)
+            }
+            else {
+              val (nextG, _, nextRnd) = genOfG.next(szp, Nil, rnd)
+              (Good(nextG), Nil, nextRnd)
+            }
+        }
+      }
+    }
+  implicit def tuple2Generator[A, B](implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[(A, B)] =
+    new GeneratorFor2[A, B, (A, B)]((a: A, b: B) => (a, b), (c: (A, B)) => c)(genOfA, genOfB)
+
+  implicit def tuple3Generator[A, B, C](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[(A, B, C)] = {
+    new GeneratorFor3[A, B, C, (A, B, C)]((a: A, b: B, c: C) => (a, b, c), (d: (A, B, C)) => d)(genOfA, genOfB, genOfC)
+  }
+
+  implicit def tuple4Generator[A, B, C, D](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[(A, B, C, D)] = {
+    new GeneratorFor4[A, B, C, D, (A, B, C, D)]((a: A, b: B, c: C, d: D) => (a, b, c, d), (d: (A, B, C, D)) => d)(genOfA, genOfB, genOfC, genOfD)
+  }
+
+  implicit def tuple5Generator[A, B, C, D, E](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[(A, B, C, D, E)] =
+    new GeneratorFor5[A, B, C, D, E, (A, B, C, D, E)]((a: A, b: B, c: C, d: D, e: E) => (a, b, c, d, e), (f: (A, B, C, D, E)) => f)(genOfA, genOfB, genOfC, genOfD, genOfE)
+
+  implicit def tuple6Generator[A, B, C, D, E, F](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[(A, B, C, D, E, F)] =
+    new GeneratorFor6[A, B, C, D, E, F, (A, B, C, D, E, F)]((a: A, b: B, c: C, d: D, e: E, f: F) => (a, b, c, d, e, f), (g: (A, B, C, D, E, F)) => g)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF)
+
+  implicit def tuple7Generator[A, B, C, D, E, F, G](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G]): Generator[(A, B, C, D, E, F, G)] =
+    new GeneratorFor7[A, B, C, D, E, F, G, (A, B, C, D, E, F, G)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G) => (a, b, c, d, e, f, g), (h: (A, B, C, D, E, F, G)) => h)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG)
+
+  implicit def tuple8Generator[A, B, C, D, E, F, G, H](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H]): Generator[(A, B, C, D, E, F, G, H)] =
+    new GeneratorFor8[A, B, C, D, E, F, G, H, (A, B, C, D, E, F, G, H)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => (a, b, c, d, e, f, g, h), (i: (A, B, C, D, E, F, G, H)) => i)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH)
+
+  implicit def tuple9Generator[A, B, C, D, E, F, G, H, I](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[(A, B, C, D, E, F, G, H, I)] =
+    new GeneratorFor9[A, B, C, D, E, F, G, H, I, (A, B, C, D, E, F, G, H, I)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => (a, b, c, d, e, f, g, h, i), (j: (A, B, C, D, E, F, G, H, I)) => j)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI)
+
+  implicit def tuple10Generator[A, B, C, D, E, F, G, H, I, J](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J]): Generator[(A, B, C, D, E, F, G, H, I, J)] =
+    new GeneratorFor10[A, B, C, D, E, F, G, H, I, J, (A, B, C, D, E, F, G, H, I, J)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => (a, b, c, d, e, f, g, h, i, j), (k: (A, B, C, D, E, F, G, H, I, J)) => k)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ)
+
+  implicit def tuple11Generator[A, B, C, D, E, F, G, H, I, J, K](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K]): Generator[(A, B, C, D, E, F, G, H, I, J, K)] =
+    new GeneratorFor11[A, B, C, D, E, F, G, H, I, J, K, (A, B, C, D, E, F, G, H, I, J, K)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K) => (a, b, c, d, e, f, g, h, i, j, k), (l: (A, B, C, D, E, F, G, H, I, J, K)) => l)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK)
+
+  implicit def tuple12Generator[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L)] =
+    new GeneratorFor12[A, B, C, D, E, F, G, H, I, J, K, L, (A, B, C, D, E, F, G, H, I, J, K, L)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L) => (a, b, c, d, e, f, g, h, i, j, k, l), (m: (A, B, C, D, E, F, G, H, I, J, K, L)) => m)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL)
+
+  implicit def tuple13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M)] =
+    new GeneratorFor13[A, B, C, D, E, F, G, H, I, J, K, L, M, (A, B, C, D, E, F, G, H, I, J, K, L, M)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M) => (a, b, c, d, e, f, g, h, i, j, k, l, m), (n: (A, B, C, D, E, F, G, H, I, J, K, L, M)) => n)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM)
+
+  implicit def tuple14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
+    new GeneratorFor14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n), (o: (A, B, C, D, E, F, G, H, I, J, K, L, M, N)) => o)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN)
+
+  implicit def tuple15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
+    new GeneratorFor15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o), (p: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)) => p)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO)
+
+  implicit def tuple16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
+    new GeneratorFor16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p), (q: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)) => q)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP)
+
+  implicit def tuple17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
+    new GeneratorFor17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q), (r: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)) => r)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ)
+
+  implicit def tuple18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    new GeneratorFor18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r), (s: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)) => s)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR)
+
+  implicit def tuple19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    new GeneratorFor19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s), (t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)) => t)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS)
+
+  implicit def tuple20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    new GeneratorFor20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t), (u: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)) => u)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT)
+
+  implicit def tuple21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T], genOfU: Generator[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    new GeneratorFor21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u), (v: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)) => v)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT, genOfU)
+
+  implicit def tuple22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T], genOfU: Generator[U], genOfV: Generator[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    new GeneratorFor22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)]((a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v), (w: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)) => w)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT, genOfU, genOfV)
+
+  implicit def vectorGenerator[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] =
+    new Generator[Vector[T]] with HavingLength[Vector[T]] {
+
+      def generatorWithSize(szp: SizeParam): Generator[Vector[T]] =
+        new Generator[Vector[T]] {
+
+          def next(ignoredSzp: org.scalatest.prop.SizeParam, edges: List[Vector[T]], rnd: org.scalatest.prop.Randomizer): (Vector[T], List[Vector[T]], org.scalatest.prop.Randomizer) = {
+            @scala.annotation.tailrec
+            def loop (targetSize: Int, result: Vector[T], rnd: org.scalatest.prop.Randomizer): (Vector[T], List[Vector[T]], org.scalatest.prop.Randomizer) =
+              if (result.length == targetSize)
+                (result, edges, rnd)
+              else {
+                val (nextT, nextEdges, nextRnd) = genOfT.next (szp, List.empty, rnd)
+                loop (targetSize, result :+ nextT, nextRnd)
+              }
+
+            val (size, nextRnd) = rnd.choosePosZInt(szp.minSize, szp.maxSize)
+            loop (size.value, Vector.empty, nextRnd)
+          }
+        }
+
+      def next(szp: org.scalatest.prop.SizeParam, edges: List[Vector[T]],rnd: org.scalatest.prop.Randomizer): (Vector[T], List[Vector[T]], org.scalatest.prop.Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val gen = generatorWithSize(szp)
+            gen.next(szp, List.empty, rnd)
+        }
+      }
+      // Members declared in org.scalatest.prop.HavingSize
+      def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Vector[T]] = generatorWithSize(SizeParam(len, 0, len))
+      def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Vector[T]] = {
+        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
+      }
+      def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[Vector[T]] =
+        new Generator[Vector[T]] {
+          def next(szp: org.scalatest.prop.SizeParam, edges: List[Vector[T]],rnd: org.scalatest.prop.Randomizer): (Vector[T], List[Vector[T]], org.scalatest.prop.Randomizer) = {
+            edges match {
+              case head :: tail =>
+                (head, tail, rnd)
+              case _ =>
+                val s = f(szp)
+                val gen = generatorWithSize(s)
+                gen.next(s, List.empty, rnd)
+            }
+          }
+        }
+    }
+
+  implicit def setGenerator[T](implicit genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] =
+    new Generator[Set[T]] with HavingSize[Set[T]] {
+
+      def generatorWithSize(szp: SizeParam): Generator[Set[T]] =
+        new Generator[Set[T]] {
+
+          def next(ignoredSzp: org.scalatest.prop.SizeParam, edges: List[Set[T]], rnd: org.scalatest.prop.Randomizer): (Set[T], List[Set[T]], org.scalatest.prop.Randomizer) = {
+            @scala.annotation.tailrec
+            def loop (targetSize: Int, result: Set[T], rnd: org.scalatest.prop.Randomizer): (Set[T], List[Set[T]], org.scalatest.prop.Randomizer) =
+              if (result.size == targetSize)
+                (result, edges, rnd)
+              else {
+                val (nextT, nextEdges, nextRnd) = genOfT.next (szp, List.empty, rnd)
+                loop (targetSize, result + nextT, nextRnd)
+              }
+
+            val (size, nextRnd) = rnd.choosePosZInt(szp.minSize, szp.maxSize)
+            loop (size.value, Set.empty, nextRnd)
+          }
+        }
+
+      def next(szp: org.scalatest.prop.SizeParam, edges: List[Set[T]],rnd: org.scalatest.prop.Randomizer): (Set[T], List[Set[T]], org.scalatest.prop.Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val gen = generatorWithSize(szp)
+            gen.next(szp, List.empty, rnd)
+        }
+      }
+      // Members declared in org.scalatest.prop.HavingSize
+      def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Set[T]] = generatorWithSize(SizeParam(len, 0, len))
+      def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Set[T]] = {
+        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
+      }
+      def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[Set[T]] =
+        new Generator[Set[T]] {
+          def next(szp: org.scalatest.prop.SizeParam, edges: List[Set[T]],rnd: org.scalatest.prop.Randomizer): (Set[T], List[Set[T]], org.scalatest.prop.Randomizer) = {
+            edges match {
+              case head :: tail =>
+                (head, tail, rnd)
+              case _ =>
+                val s = f(szp)
+                val gen = generatorWithSize(s)
+                gen.next(s, List.empty, rnd)
+            }
+          }
+        }
+    }
+
+  implicit def sortedSetGenerator[T](implicit genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] =
+    new Generator[SortedSet[T]] with HavingSize[SortedSet[T]] {
+
+      def generatorWithSize(szp: SizeParam): Generator[SortedSet[T]] =
+        new Generator[SortedSet[T]] {
+
+          def next(ignoredSzp: org.scalatest.prop.SizeParam, edges: List[SortedSet[T]], rnd: org.scalatest.prop.Randomizer): (SortedSet[T], List[SortedSet[T]], org.scalatest.prop.Randomizer) = {
+            @scala.annotation.tailrec
+            def loop (targetSize: Int, result: SortedSet[T], rnd: org.scalatest.prop.Randomizer): (SortedSet[T], List[SortedSet[T]], org.scalatest.prop.Randomizer) =
+              if (result.size == targetSize)
+                (result, edges, rnd)
+              else {
+                val (nextT, nextEdges, nextRnd) = genOfT.next (szp, List.empty, rnd)
+                loop (targetSize, result + nextT, nextRnd)
+              }
+
+            val (size, nextRnd) = rnd.choosePosZInt(szp.minSize, szp.maxSize)
+            loop (size.value, SortedSet.empty, nextRnd)
+          }
+        }
+
+      def next(szp: org.scalatest.prop.SizeParam, edges: List[SortedSet[T]],rnd: org.scalatest.prop.Randomizer): (SortedSet[T], List[SortedSet[T]], org.scalatest.prop.Randomizer) = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+          case _ =>
+            val gen = generatorWithSize(szp)
+            gen.next(szp, List.empty, rnd)
+        }
+      }
+      // Members declared in org.scalatest.prop.HavingSize
+      def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[SortedSet[T]] = generatorWithSize(SizeParam(len, 0, len))
+      def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[SortedSet[T]] = {
+        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
+      }
+      def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[SortedSet[T]] =
+        new Generator[SortedSet[T]] {
+          def next(szp: org.scalatest.prop.SizeParam, edges: List[SortedSet[T]],rnd: org.scalatest.prop.Randomizer): (SortedSet[T], List[SortedSet[T]], org.scalatest.prop.Randomizer) = {
+            edges match {
+              case head :: tail =>
+                (head, tail, rnd)
+              case _ =>
+                val s = f(szp)
+                val gen = generatorWithSize(s)
+                gen.next(s, List.empty, rnd)
+            }
+          }
+        }
+    }
+
+  implicit def mapGenerator[K, V](implicit genOfTuple2KV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] =
+    new Generator[Map[K, V]] with HavingSize[Map[K, V]] {
+
+      def generatorWithSize(szp: SizeParam): Generator[Map[K, V]] =
+        new Generator[Map[K, V]] {
+
+          def next(ignoredSzp: org.scalatest.prop.SizeParam, edges: List[Map[K, V]], rnd: org.scalatest.prop.Randomizer): (Map[K, V], List[Map[K, V]], org.scalatest.prop.Randomizer) = {
+            @scala.annotation.tailrec
+            def loop (targetSize: Int, result: Map[K, V], rnd: org.scalatest.prop.Randomizer): (Map[K, V], List[Map[K, V]], org.scalatest.prop.Randomizer) =
+              if (result.size == targetSize)
+                (result, edges, rnd)
+              else {
+                val (nextT, nextEdges, nextRnd) = genOfTuple2KV.next (szp, List.empty, rnd)
+                loop (targetSize, result + nextT, nextRnd)
+              }
+
+            val (size, nextRnd) = rnd.choosePosZInt(szp.minSize, szp.maxSize)
+            loop (size.value, Map.empty, nextRnd)
+          }
+        }
+
+      def next(szp: org.scalatest.prop.SizeParam, edges: List[Map[K, V]], rnd: org.scalatest.prop.Randomizer): Tuple3[Map[K, V], List[Map[K, V]], org.scalatest.prop.Randomizer] = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+
+          case _ =>
+            val gen = generatorWithSize(szp)
+            gen.next(szp, List.empty, rnd)
+        }
+      }
+      // Members declared in org.scalatest.prop.HavingSize
+      def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Map[K, V]] = generatorWithSize(SizeParam(len, 0, len))
+      def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Map[K, V]] = {
+        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
+      }
+      def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[Map[K, V]] =
+        new Generator[Map[K, V]] {
+          def next(szp: org.scalatest.prop.SizeParam, edges: List[Map[K, V]],rnd: org.scalatest.prop.Randomizer): (Map[K, V], List[Map[K, V]], org.scalatest.prop.Randomizer) = {
+            edges match {
+              case head :: tail =>
+                (head, tail, rnd)
+              case _ =>
+                val s = f(szp)
+                val gen = generatorWithSize(s)
+                gen.next(s, List.empty, rnd)
+            }
+          }
+        }
+    }
+
+  implicit def sortedMapGenerator[K, V](implicit genOfTuple2KV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] =
+    new Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] {
+
+      def generatorWithSize(szp: SizeParam): Generator[SortedMap[K, V]] =
+        new Generator[SortedMap[K, V]] {
+
+          def next(ignoredSzp: org.scalatest.prop.SizeParam, edges: List[SortedMap[K, V]], rnd: org.scalatest.prop.Randomizer): (SortedMap[K, V], List[SortedMap[K, V]], org.scalatest.prop.Randomizer) = {
+            @scala.annotation.tailrec
+            def loop (targetSize: Int, result: SortedMap[K, V], rnd: org.scalatest.prop.Randomizer): (SortedMap[K, V], List[SortedMap[K, V]], org.scalatest.prop.Randomizer) =
+              if (result.size == targetSize)
+                (result, edges, rnd)
+              else {
+                val (nextT, nextEdges, nextRnd) = genOfTuple2KV.next (szp, List.empty, rnd)
+                loop (targetSize, result + nextT, nextRnd)
+              }
+
+            val (size, nextRnd) = rnd.choosePosZInt(szp.minSize, szp.maxSize)
+            loop (size.value, SortedMap.empty[K, V], nextRnd)
+          }
+        }
+
+      def next(szp: org.scalatest.prop.SizeParam, edges: List[SortedMap[K, V]], rnd: org.scalatest.prop.Randomizer): Tuple3[SortedMap[K, V], List[SortedMap[K, V]], org.scalatest.prop.Randomizer] = {
+        edges match {
+          case head :: tail =>
+            (head, tail, rnd)
+
+          case _ =>
+            val gen = generatorWithSize(szp)
+            gen.next(szp, List.empty, rnd)
+        }
+      }
+      // Members declared in org.scalatest.prop.HavingSize
+      def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[SortedMap[K, V]] = generatorWithSize(SizeParam(len, 0, len))
+      def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[SortedMap[K, V]] = {
+        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
+      }
+      def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[SortedMap[K, V]] =
+        new Generator[SortedMap[K, V]] {
+          def next(szp: org.scalatest.prop.SizeParam, edges: List[SortedMap[K, V]],rnd: org.scalatest.prop.Randomizer): (SortedMap[K, V], List[SortedMap[K, V]], org.scalatest.prop.Randomizer) = {
+            edges match {
+              case head :: tail =>
+                (head, tail, rnd)
+              case _ =>
+                val s = f(szp)
+                val gen = generatorWithSize(s)
+                gen.next(s, List.empty, rnd)
+            }
+          }
+        }
+    }
+
 }
+
 

--- a/scalatest/src/main/scala/org/scalatest/prop/HavingLength.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/HavingLength.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+import org.scalactic.anyvals.PosZInt
+import org.scalatest.Resources
+
+trait HavingLength[T] extends HavingSize[T] {
+  final def havingLength(len: PosZInt): Generator[T] = havingSize(len)
+  final def havingLengthsBetween(from: PosZInt, to: PosZInt): Generator[T] = {
+    require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
+    require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+    havingSizesBetween(from, to)
+  }
+  final def havingLengthsDeterminedBy(f: SizeParam => SizeParam): Generator[T] = havingSizesDeterminedBy(f)
+}
+

--- a/scalatest/src/main/scala/org/scalatest/prop/HavingSize.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/HavingSize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2015 Artima, Inc.
+ * Copyright 2001-2016 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,11 @@
  */
 package org.scalatest.prop
 
-import org.scalatest.FunSpec
-import org.scalatest.Matchers
-import org.scalatest.exceptions.TestFailedException
+import org.scalactic.anyvals.PosZInt
 
-class ShrinkerSpec extends FunSpec with Matchers {
-  describe("A shrinker Stream") {
-    it("should be offered by a the default Int Generator") {
-      import Generator._
-      val is = intGenerator.shrink(100)
-      val xs = is.toList
-      xs(0) shouldBe 0
-      xs(1) shouldBe 1
-      xs(2) shouldBe -1
-    }
-  }
+trait HavingSize[T] {
+  def havingSize(len: PosZInt): Generator[T]
+  def havingSizesBetween(from: PosZInt, to: PosZInt): Generator[T]
+  def havingSizesDeterminedBy(f: SizeParam => SizeParam): Generator[T]
 }
 

--- a/scalatest/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2001-2015 Artima, Inc.
  *
@@ -16,22 +15,18 @@
  */
 package org.scalatest.prop
 
-import org.scalactic.anyvals._
+class PrettyFunction0[A](private val result: A) extends (() => A) {
+  def apply(): A = result
+  override def toString = s"() => $result"
+  override def hashCode: Int = result.hashCode
+  override def equals(o: Any): Boolean = {
+    o match {
+      case that: PrettyFunction0[_] => that.result == this.result
+      case _ => false
+    }
+  }
+}
 
-private[prop] case class Edges(
-  byteEdges: List[Byte],
-  shortEdges: List[Short],
-  charEdges: List[Char],
-  intEdges: List[Int],
-  longEdges: List[Long],
-  floatEdges: List[Float],
-  doubleEdges: List[Double],
-  posIntEdges: List[PosInt],
-  posZIntEdges: List[PosZInt],
-  posLongEdges: List[PosLong],
-  posZLongEdges: List[PosZLong],
-  posFloatEdges: List[PosFloat],
-  posZFloatEdges: List[PosZFloat],
-  posDoubleEdges: List[PosDouble],
-  posZDoubleEdges: List[PosZDouble]
-)
+object PrettyFunction0 {
+  def apply[A](a: A): PrettyFunction0[A] = new PrettyFunction0[A](a)
+}

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyArgument.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyArgument.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.prop
+
+case class PropertyArgument(label: Option[String], value: Any)

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
@@ -15,14 +15,14 @@
  */
 package org.scalatest.prop
 
-import org.scalactic.anyvals.{PosInt,PosZInt}
-import org.scalactic.Requirements._
+sealed trait PropertyCheckResult
 
-// 0 + 10 is 10
-// sizeRange = maxSize - minSize
-case class SizeParam(minSize: PosZInt, sizeRange: PosZInt, size: PosZInt) {
-  require(size >= minSize, s"the passed size ($size.value) must be greater than or equal to the passed minSize ($minSize.value)")
-  require(size.value <= minSize + sizeRange, s"the passed size (${size.value}) must be less than or equal to passed minSize plus the passed sizeRange ($minSize + $sizeRange = ${minSize + sizeRange})")
-  val maxSize: PosZInt = PosZInt.ensuringValid(minSize + sizeRange)
+object PropertyCheckResult {
+
+  case class Success(args: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
+
+  case class Exhausted(succeeded: Long, discarded: Long, names: List[String], argsPassed: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
+
+  case class Failure(succeeded: Long, ex: Option[Throwable], names: List[String], argsPassed: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
+
 }
-

--- a/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -24,15 +24,15 @@ import org.scalactic.Requirements._
 // Maybe this should be a trait, so that people can, hmm. Could 
 // make subclasses with extra methods, like nextSmallInt or something,
 // and in a pattern match narrow the type and call that method.
-private[prop] class Randomizer(seed: Long, edges: Edges) { thisRandomizer =>
+class Randomizer(private[scalatest] val seed: Long) { thisRandomizer =>
   def nextRandomizer: Randomizer = {
     val newSeed = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
-    new Randomizer(newSeed, edges)
+    new Randomizer(newSeed)
   }
   def next(bits: Int): (Int, Randomizer) = {
     val newSeed = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
     val newInt = (newSeed >>> (48 - bits)).toInt
-    (newInt, new Randomizer(newSeed, edges))
+    (newInt, new Randomizer(newSeed))
   }
   def nextByte: (Byte, Randomizer) = {
     val (i, r) = next(8) 
@@ -47,7 +47,7 @@ private[prop] class Randomizer(seed: Long, edges: Edges) { thisRandomizer =>
   // common in practice anyway. So this generator does favor slightly
   // the first code block.
   def nextChar: (Char, Randomizer) = {
-    val (i, r) = nextRandomizer.next(16) 
+    val (i, r) = thisRandomizer.next(16) 
     if (i >= 0xD800 && i <= 0xDFFF) (((i - 0xD800) & 0xFF).toChar, r)
     else (i.toChar, r)
   }
@@ -56,36 +56,6 @@ private[prop] class Randomizer(seed: Long, edges: Edges) { thisRandomizer =>
     val (ia, ra) = thisRandomizer.next(32)
     val (ib, rb) = ra.next(32)
     ((ia.toLong << 32) + ib, rb)
-  }
-  def nextByteWithEdges: (Byte, Randomizer) = {
-    edges.byteEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(byteEdges = tail)))
-      case Nil => nextByte
-    }
-  }
-  def nextShortWithEdges: (Short, Randomizer) = {
-    edges.shortEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(shortEdges = tail)))
-      case Nil => nextShort
-    }
-  }
-  def nextCharWithEdges: (Char, Randomizer) = {
-    edges.charEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(charEdges = tail)))
-      case Nil => nextChar
-    }
-  }
-  def nextIntWithEdges: (Int, Randomizer) = {
-    edges.intEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(intEdges = tail)))
-      case Nil => nextInt
-    }
-  }
-  def nextLongWithEdges: (Long, Randomizer) = {
-    edges.longEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(longEdges = tail)))
-      case Nil => nextLong
-    }
   }
   def nextFloatBetween0And1: (Float, Randomizer) = {
     val (i, r) = thisRandomizer.next(24)
@@ -96,12 +66,6 @@ private[prop] class Randomizer(seed: Long, edges: Edges) { thisRandomizer =>
     val (e, re) = chooseInt(0, 0xfe)
     val (m, rm) = chooseInt(0, 0x7fffff)
     (java.lang.Float.intBitsToFloat((s << 31) | (e << 23) | m), rm)
-  }
-  def nextFloatWithEdges: (Float, Randomizer) = {
-    edges.floatEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(floatEdges = tail)))
-      case Nil => nextFloat
-    }
   }
   def nextDoubleBetween0And1: (Double, Randomizer) = {
     val (ia, ra) = thisRandomizer.next(26)
@@ -114,237 +78,1222 @@ private[prop] class Randomizer(seed: Long, edges: Edges) { thisRandomizer =>
     val (m, rm) = re.chooseLong(0L, 0xfffffffffffffL)
     (java.lang.Double.longBitsToDouble((s << 63) | (e << 52) | m), rm)
   }
-  def nextDoubleWithEdges: (Double, Randomizer) = {
-    edges.doubleEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(doubleEdges = tail)))
-      case Nil => nextDouble
-    }
-  }
   def nextPosInt: (PosInt, Randomizer) = {
     val (i, r) = next(31) // 31 ensures sign bit is 0
     val pos = if (i == 0) 1 else i
-    (PosInt.from(pos).get, r)
-  }
-  def nextPosIntWithEdges: (PosInt, Randomizer) = {
-    edges.posIntEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posIntEdges = tail)))
-      case Nil => nextPosInt
-    }
+    (PosInt.ensuringValid(pos), r)
   }
   def nextPosZInt: (PosZInt, Randomizer) = {
     val (i, r) = next(31) // 31 ensures sign bit is 0
-    (PosZInt.from(i).get, r)
-  }
-  def nextPosZIntWithEdges: (PosZInt, Randomizer) = {
-    edges.posZIntEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posZIntEdges = tail)))
-      case Nil => nextPosZInt
-    }
+    (PosZInt.ensuringValid(i), r)
   }
   def nextPosLong: (PosLong, Randomizer) = {
     val (ia, ra) = thisRandomizer.next(31) // 31 ensures sign bit is 0
     val (ib, rb) = ra.next(32)
     val candidate = (ia.toLong << 32) + ib
     val pos = if (candidate == 0L) 1L else candidate
-    (PosLong.from(pos).get, rb)
-  }
-  def nextPosLongWithEdges: (PosLong, Randomizer) = {
-    edges.posLongEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posLongEdges = tail)))
-      case Nil => nextPosLong
-    }
+    (PosLong.ensuringValid(pos), rb)
   }
   def nextPosZLong: (PosZLong, Randomizer) = {
     val (ia, ra) = thisRandomizer.next(31) // 31 ensures sign bit is 0
     val (ib, rb) = ra.next(32)
     val pos = (ia.toLong << 32) + ib
-    (PosLong.from(pos).get, rb)
-  }
-  def nextPosZLongWithEdges: (PosZLong, Randomizer) = {
-    edges.posZLongEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posZLongEdges = tail)))
-      case Nil => nextPosZLong
-    }
+    (PosLong.ensuringValid(pos), rb)
   }
   def nextPosFloat: (PosFloat, Randomizer) = {
     val (f, r) = nextFloat
     val candidate = f.abs // 0.0f or greater
     val pos = if (candidate <= 1.0f) candidate else candidate + 1.0f
-    (PosFloat.from(pos).get, r)
+    (PosFloat.ensuringValid(pos), r)
   }
-  def nextPosFloatWithEdges: (PosFloat, Randomizer) = {
-    edges.posFloatEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posFloatEdges = tail)))
-      case Nil => nextPosFloat
-    }
+  def nextPosFiniteFloat: (PosFiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val posFinite =
+      n match {
+        case 0.0F => Float.MinPositiveValue
+        case -0.0F => -Float.MinPositiveValue
+        case Float.PositiveInfinity => Float.MaxValue
+        case Float.NegativeInfinity => Float.MaxValue
+        case v if v < 0.0F => -v
+        case _ => n
+      }
+    (PosFiniteFloat.ensuringValid(posFinite), r)
   }
   def nextPosZFloat: (PosZFloat, Randomizer) = {
     val (f, r) = nextFloat
     val pos = f.abs // 0.0f or greater
-    (PosZFloat.from(pos).get, r)
+    (PosZFloat.ensuringValid(pos), r)
   }
-  def nextPosZFloatWithEdges: (PosZFloat, Randomizer) = {
-    edges.posZFloatEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posZFloatEdges = tail)))
-      case Nil => nextPosZFloat
-    }
+  def nextFiniteFloat: (FiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val finite =
+      n match {
+        case Float.PositiveInfinity => Float.MaxValue
+        case Float.NegativeInfinity => Float.MaxValue
+        case _ => n
+      }
+    (FiniteFloat.ensuringValid(finite), r)
+  }
+  def nextFiniteDouble: (FiniteDouble, Randomizer) = {
+    val (n, r) = nextDouble // TODO: Study nextFloat and nextDouble to see if it produces NaNs or Infinities.
+    val finite =            // See if it produces non-normal (less than max precision) values
+      n match {
+        case Double.PositiveInfinity => Double.MaxValue
+        case Double.NegativeInfinity => Double.MaxValue
+        case _ => n
+      }
+    (FiniteDouble.ensuringValid(finite), r)
+  }
+  def nextPosZFiniteFloat: (PosZFiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val posZFinite =
+      n match {
+        case Float.PositiveInfinity => Float.MaxValue
+        case Float.NegativeInfinity => Float.MaxValue
+        case v if v < 0.0F => -v
+        case _ => n
+      }
+    (PosZFiniteFloat.ensuringValid(posZFinite), r)
   }
   def nextPosDouble: (PosDouble, Randomizer) = {
     val (d, r) = nextDouble
     val candidate = d.abs // 0.0 or greater
-    val pos = if (candidate <= 1.0) candidate else candidate + 1.0
-    (PosDouble.from(pos).get, r)
+    val pos = if (candidate <= 1.0) candidate else candidate + 1.0 // TODO: Is this correct? If so, document why, because it looks wrong to me.
+    (PosDouble.ensuringValid(pos), r)
   }
-  def nextPosDoubleWithEdges: (PosDouble, Randomizer) = {
-    edges.posDoubleEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posDoubleEdges = tail)))
-      case Nil => nextPosDouble
-    }
+  def nextPosFiniteDouble: (PosFiniteDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val posFinite =
+      d match {
+        case 0.0 => Double.MinPositiveValue
+        case -0.0 => Double.MinPositiveValue
+        case Double.PositiveInfinity => Double.MaxValue
+        case Double.NegativeInfinity => Double.MaxValue
+        case v if v < 0.0 => -v
+        case _ => d
+      }
+    (PosFiniteDouble.ensuringValid(posFinite), r)
+  }
+  def nextNonZeroDouble: (NonZeroDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val nonZero = if (d == 0.0 || d == -0.0) Double.MinPositiveValue else d
+    (NonZeroDouble.ensuringValid(nonZero), r)
+  }
+  def nextNonZeroFiniteDouble: (NonZeroFiniteDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val nonZeroFinite =
+      d match {
+        case 0.0 => Double.MinPositiveValue
+        case -0.0 => -Double.MinPositiveValue
+        case Double.PositiveInfinity => Double.MaxValue
+        case Double.NegativeInfinity => Double.MinValue
+        case v if v > 0.0 => -v
+        case _ => d
+      }
+    (NonZeroFiniteDouble.ensuringValid(nonZeroFinite), r)
+  }
+  def nextNonZeroFloat: (NonZeroFloat, Randomizer) = {
+    val (f, r) = nextFloat
+    val nonZero = if (f == 0.0F || f == -0.0F) Float.MinPositiveValue else f
+    (NonZeroFloat.ensuringValid(nonZero), r)
+  }
+  def nextNonZeroFiniteFloat: (NonZeroFiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val nonZeroFinite =
+      n match {
+        case 0.0F => Float.MinPositiveValue
+        case -0.0F => -Float.MinPositiveValue
+        case Float.PositiveInfinity => Float.MaxValue
+        case Float.NegativeInfinity => Float.MinValue
+        case v if v > 0.0F => -v
+        case _ => n
+      }
+    (NonZeroFiniteFloat.ensuringValid(nonZeroFinite), r)
+  }
+  def nextNonZeroInt: (NonZeroInt, Randomizer) = {
+    val (i, r) = nextInt
+    val nonZero = if (i == 0) 1 else i
+    (NonZeroInt.ensuringValid(nonZero), r)
+  }
+  def nextNonZeroLong: (NonZeroLong, Randomizer) = {
+    val (i, r) = nextLong
+    val nonZero = if (i == 0) 1 else i
+    (NonZeroLong.ensuringValid(nonZero), r)
+  }
+  def nextNegDouble: (NegDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val neg =
+      d match {
+        case 0.0 => -Double.MinPositiveValue
+        case -0.0 => -Double.MinPositiveValue
+        case v if v > 0.0 => -v
+        case _ => d
+      }
+    (NegDouble.ensuringValid(neg), r)
+  }
+  def nextNegFiniteDouble: (NegFiniteDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val negFinite =
+      d match {
+        case 0.0 => -Double.MinPositiveValue
+        case -0.0 => -Double.MinPositiveValue
+        case Double.PositiveInfinity => Double.MinValue
+        case Double.NegativeInfinity => Double.MinValue
+        case v if v > 0.0 => -v
+        case _ => d
+      }
+    (NegFiniteDouble.ensuringValid(negFinite), r)
+  }
+  def nextNegFloat: (NegFloat, Randomizer) = {
+    val (f, r) = nextFloat
+    val neg =
+      f match {
+        case 0.0F => -Float.MinPositiveValue
+        case -0.0F => -Float.MinPositiveValue
+        case v if v > 0.0F => -v
+        case _ => f
+      }
+    (NegFloat.ensuringValid(neg), r)
+  }
+  def nextNegFiniteFloat: (NegFiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val negFinite =
+      n match {
+        case 0.0 => -Float.MinPositiveValue
+        case -0.0 => -Float.MinPositiveValue
+        case Float.PositiveInfinity => Float.MinValue
+        case Float.NegativeInfinity => Float.MinValue
+        case v if v > 0.0 => -v
+        case _ => n
+      }
+    (NegFiniteFloat.ensuringValid(negFinite), r)
+  }
+  def nextNegInt: (NegInt, Randomizer) = {
+    val (n, r) = nextInt
+    val neg =
+      n match {
+        case 0 => -1
+        case v if v > 0 => -v
+        case _ => n
+      }
+    (NegInt.ensuringValid(neg), r)
+  }
+  def nextNegLong: (NegLong, Randomizer) = {
+    val (n, r) = nextLong
+    val neg =
+      n match {
+        case 0L => -1L
+        case v if v > 0L => -v
+        case _ => n
+      }
+    (NegLong.ensuringValid(neg), r)
+  }
+  def nextNegZDouble: (NegZDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val negZ = if (d > 0.0) -d else d
+    (NegZDouble.ensuringValid(negZ), r)
+  }
+  def nextNegZFiniteDouble: (NegZFiniteDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val negFinite =
+      d match {
+        case Double.PositiveInfinity => Double.MinValue
+        case Double.NegativeInfinity => Double.MinValue
+        case v if v > 0.0 => -v
+        case _ => d
+      }
+    (NegZFiniteDouble.ensuringValid(negFinite), r)
+  }
+  def nextNegZFloat: (NegZFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val negZ = if (n > 0.0F) -n else n
+    (NegZFloat.ensuringValid(negZ), r)
+  }
+  def nextNegZFiniteFloat: (NegZFiniteFloat, Randomizer) = {
+    val (n, r) = nextFloat
+    val negZFinite =
+      n match {
+        case Float.PositiveInfinity => Float.MinValue
+        case Float.NegativeInfinity => Float.MinValue
+        case v if v > 0.0 => -v
+        case _ => n
+      }
+    (NegZFiniteFloat.ensuringValid(negZFinite), r)
+  }
+  def nextNegZInt: (NegZInt, Randomizer) = {
+    val (n, r) = nextInt
+    val negZ = if (n > 0) -n else n
+    (NegZInt.ensuringValid(negZ), r)
+  }
+  def nextNegZLong: (NegZLong, Randomizer) = {
+    val (n, r) = nextLong
+    val negZ = if (n > 0L) -n else n
+    (NegZLong.ensuringValid(negZ), r)
   }
   def nextPosZDouble: (PosZDouble, Randomizer) = {
     val (d, r) = nextDouble
     val pos = d.abs // 0.0 or greater
-    (PosZDouble.from(pos).get, r)
+    (PosZDouble.ensuringValid(pos), r)
   }
-  def nextPosZDoubleWithEdges: (PosZDouble, Randomizer) = {
-    edges.posZDoubleEdges match {
-      case head :: tail => (head, new Randomizer(seed, edges.copy(posZDoubleEdges = tail)))
-      case Nil => nextPosZDouble
-    }
+  def nextPosZFiniteDouble: (PosZFiniteDouble, Randomizer) = {
+    val (d, r) = nextDouble
+    val posZFinite =
+      d match {
+        case Double.PositiveInfinity => Double.MaxValue
+        case Double.NegativeInfinity => Double.MaxValue
+        case v if v < 0.0 => -v
+        case _ => d
+      }
+    (PosZFiniteDouble.ensuringValid(posZFinite), r)
   }
   // Maybe add in some > 16 bit UTF-16 encodings
   def nextString(length: Int): (String, Randomizer) = {
     require(length >= 0, "; the length passed to nextString must be >= 0")
     @tailrec
-    def loop(acc: List[Char], count: Int, nextRandomizer: Randomizer): (String, Randomizer) = {
-      if (count == length) (acc.mkString, nextRandomizer)
+    def loop(acc: List[Char], count: Int, nextRnd: Randomizer): (String, Randomizer) = {
+      if (count == length) (acc.mkString, nextRnd)
       else {
-        val (c, r) = nextRandomizer.nextChar
+        val (c, r) = nextRnd.nextChar
         loop(c :: acc, count + 1, r)
       }
     }
     loop(List.empty, 0, thisRandomizer)
   }
+  // TODO: Not sure if we should have a nextList here because it ties Randomizer to Generator.
+  // And length should be a PosZInt, which will then simplify the line of code 7 down from here, the genOfT.next one.
   def nextList[T](length: Int)(implicit genOfT: Generator[T]): (List[T], Randomizer) = {
     require(length >= 0, "; the length passed to nextString must be >= 0")
     @tailrec
-    def loop(acc: List[T], count: Int, nextRandomizer: Randomizer): (List[T], Randomizer) = {
-      if (count == length) (acc, nextRandomizer)
+    def loop(acc: List[T], count: Int, nextRnd: Randomizer): (List[T], Randomizer) = {
+      if (count == length) (acc, nextRnd)
       else {
-        val (o, r) = genOfT.next(length, nextRandomizer)
+        val (o, _, r) = genOfT.next(SizeParam(PosZInt(0), PosZInt.ensuringValid(length), PosZInt.ensuringValid(length)), Nil, nextRnd) // Because starts at 0 and goes to a max value of type Int
         loop(o :: acc, count + 1, r)
       }
     }
     loop(List.empty, 0, thisRandomizer)
   }
-  def chooseInt(from: Int, to: Int): (Int, Randomizer) = {
-    if(from == to) {
-      (from, this.nextInt._2)
-    } else {
+
+  def chooseChar(from: Char, to: Char): (Char, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
       val min = math.min(from, to)
       val max = math.max(from, to)
-      @annotation.tailrec
-      def loop(state: Randomizer): (Int, Randomizer) = {
-        val next = state.nextInt
-        if (min <= next._1 && next._1 <= max) {
-          next
-        } else if(0 < (max - min)){
-          val x = (next._1 % (max - min + 1)) + min
-          if (min <= x && x <= max) {
-            x -> next._2
-          } else {
-            loop(next._2)
-          }
-        } else {
-          loop(next._2)
-        }
+
+      val nextPair = nextChar
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val nextBetween = min + (nextValue % (max - min + 1)).abs
+        (nextBetween.toChar, nextRnd)
       }
-      loop(this)
     }
   }
-  def chooseLong(from: Long, to: Long): (Long, Randomizer) = {
-    if(from == to) {
-      (from, this.nextLong._2)
-    } else {
+
+  def chooseByte(from: Byte, to: Byte): (Byte, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
       val min = math.min(from, to)
       val max = math.max(from, to)
-      @annotation.tailrec
-      def loop(state: Randomizer): (Long, Randomizer) = {
-        val next = state.nextLong
-        if (min <= next._1 && next._1 <= max) {
-          next
-        } else if(0 < (max - min)){
-          val x = (next._1 % (max - min + 1)) + min
-          if (min <= x && x <= max) {
-            x -> next._2
-          } else {
-            loop(next._2)
-          }
-        } else {
-          loop(next._2)
-        }
+
+      val nextPair = nextByte
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val nextBetween = min + (nextValue % (max - min + 1)).abs
+        (nextBetween.toByte, nextRnd)
       }
-      loop(this)
+    }
+  }
+
+  def chooseShort(from: Short, to: Short): (Short, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextShort
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val nextBetween = min + (nextValue % (max - min + 1)).abs
+        (nextBetween.toShort, nextRnd)
+      }
+    }
+  }
+
+  def chooseInt(from: Int, to: Int): (Int, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // generate a positive Int
+      val nextPair = next(31) // 31 ensures sign bit is 0
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (nextBetween, nextRnd)
+      }
+    }
+  }
+
+  def chooseFloat(from: Float, to: Float): (Float, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (nextBetween, nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosFloat(from: PosFloat, to: PosFloat): (PosFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosFloat.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosFiniteFloat(from: PosFiniteFloat, to: PosFiniteFloat): (PosFiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        (PosFiniteFloat.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosZFloat(from: PosZFloat, to: PosZFloat): (PosZFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosZFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosZFloat.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosZFiniteFloat(from: PosZFiniteFloat, to: PosZFiniteFloat): (PosZFiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosZFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        //val nextBetween = min + (nextValue % (max - min)).abs
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        (PosZFiniteFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseDouble(from: Double, to: Double): (Double, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (nextBetween, nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosInt(from: PosInt, to: PosInt): (PosInt, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // generate a positive Int
+      val (nextValue, nextRnd) = next(31) // 31 ensures sign bit is 0
+
+      if (nextValue >= min && nextValue <= max)
+        (PosInt.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (PosInt.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def choosePosZInt(from: PosZInt, to: PosZInt): (PosZInt, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // generate a positive Int
+      val (nextValue, nextRnd) = next(31) // 31 ensures sign bit is 0
+
+      if (nextValue >= min && nextValue <= max)
+        (PosZInt.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (PosZInt.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseLong(from: Long, to: Long): (Long, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // Generate a positive Long
+      val (ia, nextRnd) = thisRandomizer.next(31) // 31 ensures sign bit is 0
+      val (ib, nextNextRnd) = nextRnd.next(32)
+      val nextValue = (ia.toLong << 32) + ib
+
+      if (nextValue >= min && nextValue <= max)
+        (nextValue, nextNextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (nextBetween, nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosLong(from: PosLong, to: PosLong): (PosLong, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // Generate a positive Long
+      val (ia, nextRnd) = thisRandomizer.next(31) // 31 ensures sign bit is 0
+      val (ib, nextNextRnd) = nextRnd.next(32)
+      val nextValue = (ia.toLong << 32) + ib
+
+      if (nextValue >= min && nextValue <= max)
+        (PosLong.ensuringValid(nextValue), nextNextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (PosLong.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosZLong(from: PosZLong, to: PosZLong): (PosZLong, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      // Generate a positive Long
+      val (ia, nextRnd) = thisRandomizer.next(31) // 31 ensures sign bit is 0
+      val (ib, nextNextRnd) = nextRnd.next(32)
+      val nextValue = (ia.toLong << 32) + ib
+
+      if (nextValue >= min && nextValue <= max)
+        (PosZLong.ensuringValid(nextValue), nextNextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)) + min
+        (PosZLong.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def choosePosDouble(from: PosDouble, to: PosDouble): (PosDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def choosePosFiniteDouble(from: PosFiniteDouble, to: PosFiniteDouble): (PosFiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosFiniteDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def choosePosZDouble(from: PosZDouble, to: PosZDouble): (PosZDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosZDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosZDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def choosePosZFiniteDouble(from: PosZFiniteDouble, to: PosZFiniteDouble): (PosZFiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer) // TODO: Shouldn't this be thisRandomizer because I didn't use it? I am trying this in choosePosInt.
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextPosZFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (PosZFiniteDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegInt(from: NegInt, to: NegInt): (NegInt, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNegInt
+
+      if (nextValue >= min && nextValue <= max)
+        (NegInt.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)).abs + min
+        (NegInt.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegLong(from: NegLong, to: NegLong): (NegLong, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNegLong
+
+      if (nextValue >= min && nextValue <= max)
+        (NegLong.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)).abs + min
+        (NegLong.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegFloat(from: NegFloat, to: NegFloat): (NegFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegFiniteFloat(from: NegFiniteFloat, to: NegFiniteFloat): (NegFiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        (NegFiniteFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegDouble(from: NegDouble, to: NegDouble): (NegDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegFiniteDouble(from: NegFiniteDouble, to: NegFiniteDouble): (NegFiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegFiniteDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZInt(from: NegZInt, to: NegZInt): (NegZInt, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNegZInt
+
+      if (nextValue >= min && nextValue <= max)
+        (NegZInt.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)).abs + min
+        (NegZInt.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZLong(from: NegZLong, to: NegZLong): (NegZLong, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNegZLong
+
+      if (nextValue >= min && nextValue <= max)
+        (NegZLong.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)).abs + min
+        (NegZLong.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZFloat(from: NegZFloat, to: NegZFloat): (NegZFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegZFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegZFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZFiniteFloat(from: NegZFiniteFloat, to: NegZFiniteFloat): (NegZFiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegZFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        (NegZFiniteFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZDouble(from: NegZDouble, to: NegZDouble): (NegZDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegZDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegZDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNegZFiniteDouble(from: NegZFiniteDouble, to: NegZFiniteDouble): (NegZFiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNegZFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (NegZFiniteDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNonZeroInt(from: NonZeroInt, to: NonZeroInt): (NonZeroInt, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNonZeroInt
+
+      if (nextValue >= min && nextValue <= max)
+        (NonZeroInt.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween = (nextValue % (max - min + 1)).abs + min
+        if (nextBetween == 0)
+          (NonZeroInt(1), nextRnd)
+        else
+          (NonZeroInt.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNonZeroLong(from: NonZeroLong, to: NonZeroLong): (NonZeroLong, Randomizer) = {
+
+    if (from == to) {
+      (from, thisRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val (nextValue, nextRnd) = nextNonZeroLong
+
+      if (nextValue >= min && nextValue <= max)
+        (NonZeroLong.ensuringValid(nextValue), nextRnd)
+      else {
+        val nextBetween: Long = (nextValue % (max - min + 1)).abs + min
+        if (nextBetween == 0L)
+          (NonZeroLong(1L), nextRnd)
+        else
+          (NonZeroLong.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNonZeroFloat(from: NonZeroFloat, to: NonZeroFloat): (NonZeroFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNonZeroFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        if (nextBetween == 0.0f)
+          (NonZeroFloat(1.0f), nextRnd)
+        else
+          (NonZeroFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def finiteFloatBetweenAlgorithm(between0And1: Float, min: Float, max: Float): Float = {
+    if (min < 0.0f && max > 0.0f) {
+      val maxMinusMin = max - min
+      if (maxMinusMin.isInfinity) {
+        val neg = between0And1 * min
+        val pos = between0And1 * max
+        min + neg + pos
+      }
+      else
+        min + (between0And1 * maxMinusMin).abs
+    }
+    else
+      min + (between0And1 * (max - min)).abs
+  }
+
+  def chooseNonZeroFiniteFloat(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat): (NonZeroFiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNonZeroFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        if (nextBetween == 0.0f)
+          (NonZeroFiniteFloat(1.0f), nextRnd)
+        else
+          (NonZeroFiniteFloat.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNonZeroDouble(from: NonZeroDouble, to: NonZeroDouble): (NonZeroDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNonZeroDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        if (nextBetween == 0.0)
+          (NonZeroDouble(1.0), nextRnd)
+        else
+          (NonZeroDouble.ensuringValid(nextBetween), nextRnd)
+      }
+    }
+  }
+
+  def chooseNonZeroFiniteDouble(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble): (NonZeroFiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextNonZeroFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        if (nextBetween == 0.0)
+          (NonZeroFiniteDouble(1.0), nextNextRnd)
+        else
+          (NonZeroFiniteDouble.ensuringValid(nextBetween), nextNextRnd)
+
+      }
+    }
+  }
+
+  def chooseFiniteFloat(from: FiniteFloat, to: FiniteFloat): (FiniteFloat, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextFiniteFloat
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextFloatBetween0And1
+        val nextBetween = finiteFloatBetweenAlgorithm(between0And1, min, max)
+        (FiniteFloat.ensuringValid(nextBetween), nextNextRnd)
+      }
+    }
+  }
+
+  def chooseFiniteDouble(from: FiniteDouble, to: FiniteDouble): (FiniteDouble, Randomizer) = {
+
+    if (from == to) {
+      (from, nextRandomizer)
+    }
+    else {
+      val min = math.min(from, to)
+      val max = math.max(from, to)
+
+      val nextPair = nextFiniteDouble
+      val (nextValue, nextRnd) = nextPair
+
+      if (nextValue >= min && nextValue <= max)
+        nextPair
+      else {
+        val (between0And1, nextNextRnd) = nextRnd.nextDoubleBetween0And1
+        val nextBetween = min + (between0And1 * (max - min)).abs
+        (FiniteDouble.ensuringValid(nextBetween), nextNextRnd)
+      }
     }
   }
 }
 
-private[prop] object Randomizer {
-  private val byteEdges = List(Byte.MinValue, -1.toByte, 0.toByte, 1.toByte, Byte.MaxValue)
-  private val shortEdges = List(Short.MinValue, -1.toShort, 0.toShort, 1.toShort, Short.MaxValue)
-  private val charEdges = List(Char.MinValue, Char.MaxValue)
-  private val intEdges = List(Int.MinValue, -1, 0, 1, Int.MaxValue)
-  private val posIntEdges = List(PosInt(1), PosInt.MaxValue)
-  private val posZIntEdges = List(PosZInt(0), PosZInt(1), PosZInt.MaxValue)
-  private val posLongEdges = List(PosLong(1L), PosLong.MaxValue)
-  private val posZLongEdges = List(PosZLong(0L), PosZLong(1L), PosZLong.MaxValue)
-  private val posFloatEdges = List(PosFloat(1.0f), PosFloat.MaxValue)
-  private val posZFloatEdges = List(PosZFloat(0.0f), PosZFloat(1.0f), PosZFloat.MaxValue)
-  private val posDoubleEdges = List(PosDouble(1.0), PosDouble.MaxValue)
-  private val posZDoubleEdges = List(PosZDouble(0.0), PosZDouble(1.0), PosZDouble.MaxValue)
-  private val longEdges = List(Long.MinValue, -1, 0, 1, Long.MaxValue)
-  private val standardEdges = 
-    Edges(
-      byteEdges,
-      shortEdges,
-      charEdges,
-      intEdges,
-      longEdges,
-      List(0.0f),
-      List(0.0),
-      posIntEdges,
-      posZIntEdges,
-      posLongEdges,
-      posZLongEdges,
-      posFloatEdges,
-      posZFloatEdges,
-      posDoubleEdges,
-      posZDoubleEdges
-    )
+object Randomizer {
+
+  import java.util.concurrent.atomic.AtomicReference
+
+  private[scalatest] val defaultSeed: AtomicReference[Option[Long]] = new AtomicReference(None)
+
   def default(): Randomizer =
-    new Randomizer(
-      (System.currentTimeMillis() ^ 0x5DEECE66DL) & ((1L << 48) - 1),
-      Edges(
-        scala.util.Random.shuffle(byteEdges),
-        scala.util.Random.shuffle(shortEdges),
-        scala.util.Random.shuffle(charEdges),
-        scala.util.Random.shuffle(intEdges),
-        scala.util.Random.shuffle(longEdges),
-        List(0.0f),
-        List(0.0),
-        scala.util.Random.shuffle(posIntEdges),
-        scala.util.Random.shuffle(posZIntEdges),
-        scala.util.Random.shuffle(posLongEdges),
-        scala.util.Random.shuffle(posZLongEdges),
-        scala.util.Random.shuffle(posFloatEdges),
-        scala.util.Random.shuffle(posZFloatEdges),
-        scala.util.Random.shuffle(posDoubleEdges),
-        scala.util.Random.shuffle(posZDoubleEdges)
-      )
+    apply(
+      defaultSeed.get() match {
+        case Some(seed) => seed
+        case None => System.currentTimeMillis()
+      }
     )
-  // Note, this method where you pass the seed in will produce edges in always the same order, so it 
-  // is completely predictable. Maybe I should offer a way to let people customize edges too I suppose.
-  def apply(seed: Long): Randomizer = new Randomizer((seed ^ 0x5DEECE66DL) & ((1L << 48) - 1), standardEdges)
+
+  def apply(seed: Long): Randomizer = new Randomizer((seed ^ 0x5DEECE66DL) & ((1L << 48) - 1))
+
+  def shuffle[T](xs: List[T], rnd: Randomizer): (List[T], Randomizer) = {
+
+    import scala.collection.mutable.ArrayBuffer
+
+    val buf = ArrayBuffer.empty[T]
+    buf ++= xs
+
+    def swap(i: Int, j: Int) {
+      val tmp = buf(i)
+      buf(i) = buf(j)
+      buf(j) = tmp
+    }
+
+    var nextRnd = rnd
+
+    for (n <- buf.length to 2 by -1) {
+      val (ni, nr) = rnd.nextInt
+      nextRnd = nr
+      val k = ni.abs % n
+      swap(n - 1, k)
+    }
+
+    (buf.toList, nextRnd)
+  }
 }
 
 

--- a/scalatest/src/main/scala/org/scalatest/prop/ScalaCheckPropertyChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/ScalaCheckPropertyChecks.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+package prop
+
+/**
+  * Trait that facilitates property checks on data supplied by tables and ScalaCheck generators.
+  *
+  * <p>
+  * This trait extends both <a href="TableDrivenPropertyChecks.html"><code>TableDrivenPropertyChecks</code></a> and
+  * <a href="ScalaCheckDrivenPropertyChecks.html"><code>ScalaCheckDrivenPropertyChecks</code></a>. Thus by mixing in
+  * this trait you can perform property checks on data supplied either by tables or generators. For the details of
+  * table- and generator-driven property checks, see the documentation for each by following the links above.
+  * </p>
+  *
+  * <p>
+  * For a quick example of using both table and generator-driven property checks in the same suite of tests, however,
+  * imagine you want to test this <code>Fraction</code> class:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * class Fraction(n: Int, d: Int) {
+  *
+  *   require(d != 0)
+  *   require(d != Integer.MIN_VALUE)
+  *   require(n != Integer.MIN_VALUE)
+  *
+  *   val numer = if (d &lt; 0) -1 * n else n
+  *   val denom = d.abs
+  *
+  *   override def toString = numer + " / " + denom
+  * }
+  * </pre>
+  *
+  * <p>
+  * If you mix in <code>PropertyChecks</code>, you could use a generator-driven property check to test that the passed values for numerator and
+  * denominator are properly normalized, like this:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * forAll { (n: Int, d: Int) =&gt;
+  *
+  *   whenever (d != 0 && d != Integer.MIN_VALUE
+  *       && n != Integer.MIN_VALUE) {
+  *
+  *     val f = new Fraction(n, d)
+  *
+  *     if (n &lt; 0 && d &lt; 0 || n &gt; 0 && d &gt; 0)
+  *       f.numer should be &gt; 0
+  *     else if (n != 0)
+  *       f.numer should be &lt; 0
+  *     else
+  *       f.numer shouldEqual 0
+  *
+  *     f.denom should be &gt; 0
+  *   }
+  * }
+  * </pre>
+  *
+  * <p>
+  * And you could use a table-driven property check to test that all combinations of invalid values passed to the <code>Fraction</code> constructor
+  * produce the expected <code>IllegalArgumentException</code>, like this:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * val invalidCombos =
+  *   Table(
+  *     ("n",               "d"),
+  *     (Integer.MIN_VALUE, Integer.MIN_VALUE),
+  *     (1,                 Integer.MIN_VALUE),
+  *     (Integer.MIN_VALUE, 1),
+  *     (Integer.MIN_VALUE, 0),
+  *     (1,                 0)
+  *   )
+  *
+  * forAll (invalidCombos) { (n: Int, d: Int) =&gt;
+  *   an [IllegalArgumentException] should be thrownBy {
+  *     new Fraction(n, d)
+  *   }
+  * }
+  * </pre>
+  *
+  * @author Bill Venners
+  */
+trait ScalaCheckPropertyChecks extends TableDrivenPropertyChecks with ScalaCheckDrivenPropertyChecks
+
+/**
+  * Companion object that facilitates the importing of <code>PropertyChecks</code> members as
+  * an alternative to mixing it in. One use case is to import <code>PropertyChecks</code> members so you can use
+  * them in the Scala interpreter.
+  *
+  * @author Bill Venners
+  */
+object ScalaCheckPropertyChecks extends ScalaCheckPropertyChecks

--- a/scalatest/src/main/scala/org/scalatest/prop/Shrinker.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Shrinker.scala
@@ -23,11 +23,11 @@ import Stream.empty
 // Maybe this should be a trait, so that people can, hmm. Could 
 // make subclasses with extra methods, like nextSmallInt or something,
 // and in a pattern match narrow the type and call that method.
-private[prop] trait Shrinker[T] {
+trait Shrinker[T] {
   def apply(init: T): Stream[T]
 }
 
-private[prop] object Shrinker {
+object Shrinker {
   def intShrinker: Shrinker[Int] =
     new Shrinker[Int] {
       def apply(init: Int): Stream[Int] = 0 #:: 1 #:: -1 #:: empty

--- a/scalatest/src/main/scala/org/scalatest/prop/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/package.scala
@@ -19,6 +19,7 @@ import org.scalactic.anyvals._
 import scala.annotation.tailrec
 import scala.reflect.runtime.universe.TypeTag
 
+// TODO: Get rid of the PosZInt.ensuringValid calls by chosing a PosZInt between 1 and 20 instead of an Int
 package object prop {
 
   /**
@@ -34,6 +35,707 @@ package object prop {
    */
   @deprecated("Please use org.scalatest.check.Checkers instead.", "ScalaTest 3.1.0")
   val Checkers: org.scalatest.check.Checkers.type = org.scalatest.check.Checkers 
+
+  // The valueOf methods are called by the function generators.
+  def valueOf[B](a: Any, multiplier: Int)(implicit genOfB: Generator[B]): B = {
+    val seed = a.hashCode.toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfB.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[C](a: Any, b: Any, multiplier: Int)(implicit genOfC: Generator[C]): C = {
+    def combinedHashCode(a: Any, b: Any): Int = 
+      37 * (
+        37 + a.hashCode
+      ) + b.hashCode
+    val seed = combinedHashCode(a, b).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfC.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[D](a: Any, b: Any, c: Any, multiplier: Int)(implicit genOfD: Generator[D]): D = {
+    def combinedHashCode(a: Any, b: Any, c: Any): Int = 
+      37 * (
+        37 * (
+          37 + a.hashCode
+        ) + b.hashCode
+      ) + c.hashCode
+    val seed = combinedHashCode(a, b, c).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfD.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[E](a: Any, b: Any, c: Any, d: Any, multiplier: Int)(implicit genOfE: Generator[E]): E = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 + a.hashCode
+          ) + b.hashCode
+        ) + c.hashCode
+      ) + d.hashCode
+    val seed = combinedHashCode(a, b, c, d).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfE.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[F](a: Any, b: Any, c: Any, d: Any, e: Any, multiplier: Int)(implicit genOfF: Generator[F]): F = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 + a.hashCode
+            ) + b.hashCode
+          ) + c.hashCode
+        ) + d.hashCode
+      ) + e.hashCode
+    val seed = combinedHashCode(a, b, c, d, e).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfF.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[G](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, multiplier: Int)(implicit genOfG: Generator[G]): G = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 + a.hashCode
+              ) + b.hashCode
+            ) + c.hashCode
+          ) + d.hashCode
+        ) + e.hashCode
+      ) + f.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfG.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[H](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, multiplier: Int)(implicit genOfH: Generator[H]): H = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 + a.hashCode
+                ) + b.hashCode
+              ) + c.hashCode
+            ) + d.hashCode
+          ) + e.hashCode
+        ) + f.hashCode
+      ) + g.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfH.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[I](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, multiplier: Int)(implicit genOfI: Generator[I]): I = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 + a.hashCode
+                  ) + b.hashCode
+                ) + c.hashCode
+              ) + d.hashCode
+            ) + e.hashCode
+          ) + f.hashCode
+        ) + g.hashCode
+      ) + h.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfI.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[J](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, multiplier: Int)(implicit genOfJ: Generator[J]): J = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 + a.hashCode
+                    ) + b.hashCode
+                  ) + c.hashCode
+                ) + d.hashCode
+              ) + e.hashCode
+            ) + f.hashCode
+          ) + g.hashCode
+        ) + h.hashCode
+      ) + i.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfJ.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[K](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, multiplier: Int)(implicit genOfK: Generator[K]): K = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 + a.hashCode
+                      ) + b.hashCode
+                    ) + c.hashCode
+                  ) + d.hashCode
+                ) + e.hashCode
+              ) + f.hashCode
+            ) + g.hashCode
+          ) + h.hashCode
+        ) + i.hashCode
+      ) + j.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfK.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[L](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, multiplier: Int)(implicit genOfL: Generator[L]): L = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 + a.hashCode
+                        ) + b.hashCode
+                      ) + c.hashCode
+                    ) + d.hashCode
+                  ) + e.hashCode
+                ) + f.hashCode
+              ) + g.hashCode
+            ) + h.hashCode
+          ) + i.hashCode
+        ) + j.hashCode
+      ) + k.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfL.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[M](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, multiplier: Int)(implicit genOfM: Generator[M]): M = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 + a.hashCode
+                          ) + b.hashCode
+                        ) + c.hashCode
+                      ) + d.hashCode
+                    ) + e.hashCode
+                  ) + f.hashCode
+                ) + g.hashCode
+              ) + h.hashCode
+            ) + i.hashCode
+          ) + j.hashCode
+        ) + k.hashCode
+      ) + l.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfM.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[N](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, multiplier: Int)(implicit genOfN: Generator[N]): N = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 + a.hashCode
+                            ) + b.hashCode
+                          ) + c.hashCode
+                        ) + d.hashCode
+                      ) + e.hashCode
+                    ) + f.hashCode
+                  ) + g.hashCode
+                ) + h.hashCode
+              ) + i.hashCode
+            ) + j.hashCode
+          ) + k.hashCode
+        ) + l.hashCode
+      ) + m.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfN.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[O](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, multiplier: Int)(implicit genOfO: Generator[O]): O = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 + a.hashCode
+                              ) + b.hashCode
+                            ) + c.hashCode
+                          ) + d.hashCode
+                        ) + e.hashCode
+                      ) + f.hashCode
+                    ) + g.hashCode
+                  ) + h.hashCode
+                ) + i.hashCode
+              ) + j.hashCode
+            ) + k.hashCode
+          ) + l.hashCode
+        ) + m.hashCode
+      ) + n.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfO.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[P](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, multiplier: Int)(implicit genOfP: Generator[P]): P = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 + a.hashCode
+                                ) + b.hashCode
+                              ) + c.hashCode
+                            ) + d.hashCode
+                          ) + e.hashCode
+                        ) + f.hashCode
+                      ) + g.hashCode
+                    ) + h.hashCode
+                  ) + i.hashCode
+                ) + j.hashCode
+              ) + k.hashCode
+            ) + l.hashCode
+          ) + m.hashCode
+        ) + n.hashCode
+      ) + o.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfP.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[Q](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, multiplier: Int)(implicit genOfQ: Generator[Q]): Q = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 + a.hashCode
+                                  ) + b.hashCode
+                                ) + c.hashCode
+                              ) + d.hashCode
+                            ) + e.hashCode
+                          ) + f.hashCode
+                        ) + g.hashCode
+                      ) + h.hashCode
+                    ) + i.hashCode
+                  ) + j.hashCode
+                ) + k.hashCode
+              ) + l.hashCode
+            ) + m.hashCode
+          ) + n.hashCode
+        ) + o.hashCode
+      ) + p.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfQ.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[R](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, multiplier: Int)(implicit genOfR: Generator[R]): R = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 + a.hashCode
+                                    ) + b.hashCode
+                                  ) + c.hashCode
+                                ) + d.hashCode
+                              ) + e.hashCode
+                            ) + f.hashCode
+                          ) + g.hashCode
+                        ) + h.hashCode
+                      ) + i.hashCode
+                    ) + j.hashCode
+                  ) + k.hashCode
+                ) + l.hashCode
+              ) + m.hashCode
+            ) + n.hashCode
+          ) + o.hashCode
+        ) + p.hashCode
+      ) + q.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfR.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[S](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, multiplier: Int)(implicit genOfS: Generator[S]): S = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 * (
+                                        37 + a.hashCode
+                                      ) + b.hashCode
+                                    ) + c.hashCode
+                                  ) + d.hashCode
+                                ) + e.hashCode
+                              ) + f.hashCode
+                            ) + g.hashCode
+                          ) + h.hashCode
+                        ) + i.hashCode
+                      ) + j.hashCode
+                    ) + k.hashCode
+                  ) + l.hashCode
+                ) + m.hashCode
+              ) + n.hashCode
+            ) + o.hashCode
+          ) + p.hashCode
+        ) + q.hashCode
+      ) + r.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfS.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[T](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, multiplier: Int)(implicit genOfT: Generator[T]): T = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 * (
+                                        37 * (
+                                          37 + a.hashCode
+                                        ) + b.hashCode
+                                      ) + c.hashCode
+                                    ) + d.hashCode
+                                  ) + e.hashCode
+                                ) + f.hashCode
+                              ) + g.hashCode
+                            ) + h.hashCode
+                          ) + i.hashCode
+                        ) + j.hashCode
+                      ) + k.hashCode
+                    ) + l.hashCode
+                  ) + m.hashCode
+                ) + n.hashCode
+              ) + o.hashCode
+            ) + p.hashCode
+          ) + q.hashCode
+        ) + r.hashCode
+      ) + s.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfT.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[U](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any, multiplier: Int)(implicit genOfU: Generator[U]): U = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 * (
+                                        37 * (
+                                          37 * (
+                                            37 + a.hashCode
+                                          ) + b.hashCode
+                                        ) + c.hashCode
+                                      ) + d.hashCode
+                                    ) + e.hashCode
+                                  ) + f.hashCode
+                                ) + g.hashCode
+                              ) + h.hashCode
+                            ) + i.hashCode
+                          ) + j.hashCode
+                        ) + k.hashCode
+                      ) + l.hashCode
+                    ) + m.hashCode
+                  ) + n.hashCode
+                ) + o.hashCode
+              ) + p.hashCode
+            ) + q.hashCode
+          ) + r.hashCode
+        ) + s.hashCode
+      ) + t.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfU.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[V](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any, u: Any, multiplier: Int)(implicit genOfV: Generator[V]): V = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any, u: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 * (
+                                        37 * (
+                                          37 * (
+                                            37 * (
+                                              37 + a.hashCode
+                                            ) + b.hashCode
+                                          ) + c.hashCode
+                                        ) + d.hashCode
+                                      ) + e.hashCode
+                                    ) + f.hashCode
+                                  ) + g.hashCode
+                                ) + h.hashCode
+                              ) + i.hashCode
+                            ) + j.hashCode
+                          ) + k.hashCode
+                        ) + l.hashCode
+                      ) + m.hashCode
+                    ) + n.hashCode
+                  ) + o.hashCode
+                ) + p.hashCode
+              ) + q.hashCode
+            ) + r.hashCode
+          ) + s.hashCode
+        ) + t.hashCode
+      ) + u.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfV.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
+
+  def valueOf[W](a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any, u: Any, v: Any, multiplier: Int)(implicit genOfW: Generator[W]): W = {
+    def combinedHashCode(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, i: Any, j: Any, k: Any, l: Any, m: Any, n: Any, o: Any, p: Any, q: Any, r: Any, s: Any, t: Any, u: Any, v: Any): Int = 
+      37 * (
+        37 * (
+          37 * (
+            37 * (
+              37 * (
+                37 * (
+                  37 * (
+                    37 * (
+                      37 * (
+                        37 * (
+                          37 * (
+                            37 * (
+                              37 * (
+                                37 * (
+                                  37 * (
+                                    37 * (
+                                      37 * (
+                                        37 * (
+                                          37 * (
+                                            37 * (
+                                              37 * (
+                                                37 + a.hashCode
+                                              ) + b.hashCode
+                                            ) + c.hashCode
+                                          ) + d.hashCode
+                                        ) + e.hashCode
+                                      ) + f.hashCode
+                                    ) + g.hashCode
+                                  ) + h.hashCode
+                                ) + i.hashCode
+                              ) + j.hashCode
+                            ) + k.hashCode
+                          ) + l.hashCode
+                        ) + m.hashCode
+                      ) + n.hashCode
+                    ) + o.hashCode
+                  ) + p.hashCode
+                ) + q.hashCode
+              ) + r.hashCode
+            ) + s.hashCode
+          ) + t.hashCode
+        ) + u.hashCode
+      ) + v.hashCode
+    val seed = combinedHashCode(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v).toLong * multiplier
+    val rnd = Randomizer(seed)
+    val maxSize = PosZInt(20)
+    val (size, nextRnd) = rnd.choosePosZInt(1, maxSize) // size will be positive because between 1 and 20, inclusive
+    val (result, _, _) = genOfW.next(SizeParam(PosZInt(0), maxSize, size), Nil, nextRnd)
+    result
+  }
 }
-
-


### PR DESCRIPTION
Back-ported in-house Generator from 3.2.x into 3.1.x.

This paths the way to separate ScalaCheck integration code out into its own module.