### PR TITLE
ScalaCheck Package Change

### DIFF
--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -170,7 +170,7 @@ val copyrightTemplate = """/*
  * limitations under the License.
  */
 package org.scalatest
-package prop
+package check
 """
 
 val propertyCheckPreamble = """
@@ -182,6 +182,7 @@ import org.scalacheck.Prop._
 import org.scalatest.exceptions.DiscardedEvaluationException
 import org.scalatest.enablers.CheckerAsserting
 import org.scalactic._
+import org.scalatest.prop.Whenever
 
 /**
  * Trait containing methods that faciliate property checks against generated data using ScalaCheck.
@@ -194,7 +195,7 @@ import org.scalactic._
  * </p>
  *
  * <p>
- * For an example of trait <code>GeneratorDrivenPropertyChecks</code> in action, imagine you want to test this <code>Fraction</code> class:
+ * For an example of trait <code>ScalaCheckDrivenPropertyChecks</code> in action, imagine you want to test this <code>Fraction</code> class:
  * </p>
  *  
  * <pre class="stHighlight">
@@ -212,7 +213,7 @@ import org.scalactic._
  * </pre>
  *
  * <p>
- * To test the behavior of <code>Fraction</code>, you could mix in or import the members of <code>GeneratorDrivenPropertyChecks</code>
+ * To test the behavior of <code>Fraction</code>, you could mix in or import the members of <code>ScalaCheckDrivenPropertyChecks</code>
  * (and <code>Matchers</code>) and check a property using a <code>forAll</code> method, like this:
  * </p>
  *
@@ -237,7 +238,7 @@ import org.scalactic._
  * </pre>
  *
  * <p>
- * Trait <code>GeneratorDrivenPropertyChecks</code> provides overloaded <code>forAll</code> methods
+ * Trait <code>ScalaCheckDrivenPropertyChecks</code> provides overloaded <code>forAll</code> methods
  * that allow you to check properties using the data provided by a ScalaCheck generator. The simplest form
  * of <code>forAll</code> method takes two parameter lists, the second of which is implicit. The first parameter list
  * is a "property" function with one to six parameters. An implicit <code>Arbitrary</code> generator and <code>Shrink</code> object needs to be supplied for
@@ -509,11 +510,11 @@ import org.scalactic._
  * </table>
  *
  * <p>
- * The <code>forAll</code> methods of trait <code>GeneratorDrivenPropertyChecks</code> each take a <code>PropertyCheckConfiguration</code>
+ * The <code>forAll</code> methods of trait <code>ScalaCheckDrivenPropertyChecks</code> each take a <code>PropertyCheckConfiguration</code>
  * object as an implicit parameter. This object provides values for each of the five configuration parameters. Trait <code>Configuration</code>
  * provides an implicit <code>val</code> named <code>generatorDrivenConfig</code> with each configuration parameter set to its default value. 
  * If you want to set one or more configuration parameters to a different value for all property checks in a suite you can override this
- * val (or hide it, for example, if you are importing the members of the <code>GeneratorDrivenPropertyChecks</code> companion object rather
+ * val (or hide it, for example, if you are importing the members of the <code>ScalaCheckDrivenPropertyChecks</code> companion object rather
  * than mixing in the trait.) For example, if
  * you want all parameters at their defaults except for <code>minSize</code> and <code>maxSize</code>, you can override
  * <code>generatorDrivenConfig</code>, like this:
@@ -534,7 +535,7 @@ import org.scalactic._
  *
  * <p>
  * In addition to taking a <code>PropertyCheckConfiguration</code> object as an implicit parameter, the <code>forAll</code> methods of trait
- * <code>GeneratorDrivenPropertyChecks</code> also take a variable length argument list of <code>PropertyCheckConfigParam</code>
+ * <code>ScalaCheckDrivenPropertyChecks</code> also take a variable length argument list of <code>PropertyCheckConfigParam</code>
  * objects that you can use to override the values provided by the implicit <code>PropertyCheckConfiguration</code> for a single <code>forAll</code>
  * invocation. For example, if you want to set <code>minSuccessful</code> to 500 for just one particular <code>forAll</code> invocation,
  * you can do so like this:
@@ -579,7 +580,7 @@ import org.scalactic._
  * 
  * @author Bill Venners
  */
-trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
+trait ScalaCheckDrivenPropertyChecks extends Whenever with ScalaCheckConfiguration {
 
   /**
    * Performs a property check by applying the specified property check function to arguments
@@ -630,7 +631,7 @@ trait GeneratorDrivenPropertyChecks extends Whenever with Configuration {
    * <code>PropertyGenConfig</code> object passed implicitly to its <code>apply</code> methods with parameter values passed to its constructor.
    *
    * <p>
-   * Instances of this class are returned by trait <code>GeneratorDrivenPropertyChecks</code> <code>forAll</code> method that accepts a variable length
+   * Instances of this class are returned by trait <code>ScalaCheckDrivenPropertyChecks</code> <code>forAll</code> method that accepts a variable length
    * argument list of <code>PropertyCheckConfigParam</code> objects. Thus it is used with functions of all six arities.
    * Here are some examples:
    * </p>
@@ -1160,7 +1161,7 @@ $tupleBusters$
 
 val generatorDrivenPropertyChecksCompanionObjectVerbatimString = """
 
-object GeneratorDrivenPropertyChecks extends GeneratorDrivenPropertyChecks
+object ScalaCheckDrivenPropertyChecks extends ScalaCheckDrivenPropertyChecks
 """
 
 val generatorSuitePreamble = """
@@ -2529,7 +2530,7 @@ $okayExpressions$
 
   def genPropertyChecks(targetDir: File): Seq[File] = {
     targetDir.mkdirs()
-    val targetFile = new File(targetDir, "GeneratorDrivenPropertyChecks.scala")
+    val targetFile = new File(targetDir, "ScalaCheckDrivenPropertyChecks.scala")
 
     if (!targetFile.exists || generatorSource.lastModified > targetFile.lastModified) {
       val bw = new BufferedWriter(new FileWriter(targetFile))
@@ -2607,7 +2608,7 @@ $okayExpressions$
       if (doItForCheckers)
         "Checkers"
       else {
-        if (withTables) "PropertyChecks" else "GeneratorDrivenPropertyChecks"
+        if (withTables) "ScalaCheckPropertyChecks" else "ScalaCheckDrivenPropertyChecks"
       }
     val suiteClassName = traitOrObjectName + (if (mixinInvitationStyle) "Mixin" else "Import") + "Suite" 
     val fileName = suiteClassName + ".scala" 
@@ -2626,7 +2627,7 @@ $okayExpressions$
           bw.write("import org.scalacheck.Prop.{Exception => _, _}\n")
         }
         if (!mixinInvitationStyle)
-          bw.write("import " + traitOrObjectName + "._\n")
+          bw.write("import org.scalatest.check." + traitOrObjectName + "._\n")
         bw.write("\n")
         bw.write(
           "class " + suiteClassName + " extends FunSpec " +

--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -139,6 +139,7 @@ object GenScalaTestJS {
         "run.scala"
       )
     ) ++
+    copyDir("scalatest/src/main/scala/org/scalatest/check", "org/scalatest/check", targetDir, List.empty) ++
     copyDir("scalatest/src/main/scala/org/scalatest/fixture", "org/scalatest/fixture", targetDir,
       List(
         "Spec.scala",
@@ -301,6 +302,7 @@ object GenScalaTestJS {
         "DeprecatedTimeLimitedTestsSpec.scala",   // skipped because DeprecatedTimeLimitedTests not supported.
         "TimeoutsSpec.scala"            // skipped because Timeouts not supported.
       )) ++
+    copyDir("scalatest-test/src/test/scala/org/scalatest/check", "org/scalatest/check", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/enablers", "org/scalatest/enablers", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/events/examples", "org/scalatest/events/examples", targetDir, List.empty) ++
     copyDir("scalatest-test/src/test/scala/org/scalatest/events", "org/scalatest/events", targetDir,

--- a/scalatest-test/src/test/scala/org/scalatest/check/PropertyCheckConfigHelperSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/check/PropertyCheckConfigHelperSuite.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 package org.scalatest
-package prop
+package check
 
 import org.scalactic.anyvals._
 
 @deprecated("Remove when removing PropertyCheckConfig")
 class PropertyCheckConfigHelperSuite extends FunSuite with Matchers {
 
-  import Configuration._
+  import ScalaCheckConfiguration._
 
   val DefaultMinSuccessful: PosInt = 9
   val PassedMinSuccessful: PosInt = 3

--- a/scalatest-test/src/test/scala/org/scalatest/check/PropertyCheckConfigurationHelperSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/check/PropertyCheckConfigurationHelperSuite.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 package org.scalatest
-package prop
+package check
 
 import org.scalactic.anyvals._
 
 class PropertyCheckConfigurationHelperSuite extends FunSuite with Matchers {
 
-  import org.scalatest.prop.Configuration._
+  import org.scalatest.check.ScalaCheckConfiguration._
 
   val DefaultMinSuccessful: PosInt = 9
   val PassedMinSuccessful: PosInt = 3

--- a/scalatest/src/main/scala/org/scalatest/check/Checkers.scala
+++ b/scalatest/src/main/scala/org/scalatest/check/Checkers.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.prop
+package org.scalatest.check
 
 import org.scalatest.enablers.CheckerAsserting
 import org.scalacheck.Arbitrary
@@ -221,7 +221,7 @@ repeatedly pass generated data to the function. In this case, the test data is c
  *
  * @author Bill Venners
  */
-trait Checkers extends Configuration {
+trait Checkers extends ScalaCheckConfiguration {
 
   /**
    * Convert the passed 1-arg function into a property, and check it.

--- a/scalatest/src/main/scala/org/scalatest/check/ScalaCheckConfiguration.scala
+++ b/scalatest/src/main/scala/org/scalatest/check/ScalaCheckConfiguration.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.check
+
+import org.scalacheck.Test.Parameters
+import org.scalactic.anyvals.{PosZInt, PosZDouble, PosInt}
+import org.scalacheck.Test.TestCallback
+import org.scalatest.prop.Configuration
+
+/**
+ * Trait providing methods and classes used to configure property checks provided by the
+ * the <code>forAll</code> methods of trait <code>GeneratorDrivenPropertyChecks</code> (for ScalaTest-style
+ * property checks) and the <code>check</code> methods of trait <code>Checkers</code> (for ScalaCheck-style property checks).
+ *
+ * @author Bill Venners
+ */
+private[scalatest] trait ScalaCheckConfiguration extends Configuration {
+
+  private[scalatest] def getParams(
+                               configParams: Seq[Configuration#PropertyCheckConfigParam],
+                               c: PropertyCheckConfigurable
+                               ): Parameters = {
+
+    val config: PropertyCheckConfiguration = c.asPropertyCheckConfiguration
+    var minSuccessful: Option[Int] = None
+    var maxDiscarded: Option[Int] = None
+    var maxDiscardedFactor: Option[Double] = None
+    var pminSize: Option[Int] = None
+    var psizeRange: Option[Int] = None
+    var pmaxSize: Option[Int] = None
+    var pworkers: Option[Int] = None
+
+    var minSuccessfulTotalFound = 0
+    var maxDiscardedTotalFound = 0
+    var maxDiscardedFactorTotalFound = 0
+    var minSizeTotalFound = 0
+    var sizeRangeTotalFound = 0
+    var maxSizeTotalFound = 0
+    var workersTotalFound = 0
+
+    for (configParam <- configParams) {
+      configParam match {
+        case param: MinSuccessful =>
+          minSuccessful = Some(param.value)
+          minSuccessfulTotalFound += 1
+        case param: MaxDiscarded =>
+          maxDiscarded = Some(param.value)
+          maxDiscardedTotalFound += 1
+        case param: MaxDiscardedFactor =>
+          maxDiscardedFactor = Some(param.value)
+          maxDiscardedFactorTotalFound += 1
+        case param: MinSize =>
+          pminSize = Some(param.value)
+          minSizeTotalFound += 1
+        case param: SizeRange =>
+          psizeRange = Some(param.value)
+          sizeRangeTotalFound += 1
+        case param: MaxSize =>
+          pmaxSize = Some(param.value)
+          maxSizeTotalFound += 1
+        case param: Workers =>
+          pworkers = Some(param.value)
+          workersTotalFound += 1
+      }
+    }
+
+    if (minSuccessfulTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MinSuccessful config parameters, but " + minSuccessfulTotalFound + " were passed")
+    val maxDiscardedAndFactorTotalFound = maxDiscardedTotalFound + maxDiscardedFactorTotalFound
+    if (maxDiscardedAndFactorTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MaxDiscarded or MaxDiscardedFactor config parameters, but " + maxDiscardedAndFactorTotalFound + " were passed")
+    if (minSizeTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one MinSize config parameters, but " + minSizeTotalFound + " were passed")
+    val maxSizeAndSizeRangeTotalFound = maxSizeTotalFound + sizeRangeTotalFound
+    if (maxSizeAndSizeRangeTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one SizeRange or MaxSize config parameters, but " + maxSizeAndSizeRangeTotalFound + " were passed")
+    if (workersTotalFound > 1)
+      throw new IllegalArgumentException("can pass at most one Workers config parameters, but " + workersTotalFound + " were passed")
+
+    val minSuccessfulTests: Int = minSuccessful.getOrElse(config.minSuccessful)
+
+    val minSize: Int = pminSize.getOrElse(config.minSize)
+
+    val maxSize = {
+      (psizeRange, pmaxSize, config.legacyMaxSize) match {
+        case (None, None, Some(legacyMaxSize)) =>
+          legacyMaxSize
+        case (None, Some(maxSize), _) =>
+          maxSize
+        case _ =>
+          psizeRange.getOrElse(config.sizeRange.value) + minSize
+      }
+    }
+
+    val maxDiscardRatio: Float = {
+      (maxDiscardedFactor, maxDiscarded, config.legacyMaxDiscarded, minSuccessful) match {
+        case (None, None, Some(legacyMaxDiscarded), Some(specifiedMinSuccessful)) =>
+          PropertyCheckConfiguration.calculateMaxDiscardedFactor(specifiedMinSuccessful, legacyMaxDiscarded).toFloat
+        case (None, Some(md), _, _) =>
+          if (md < 0) Parameters.default.maxDiscardRatio
+          else PropertyCheckConfiguration.calculateMaxDiscardedFactor(minSuccessfulTests, md).toFloat
+        case _ =>
+          maxDiscardedFactor.getOrElse(config.maxDiscardedFactor.value).toFloat
+      }
+    }
+
+    Parameters.default
+      .withMinSuccessfulTests(minSuccessfulTests)
+      .withMinSize(minSize)
+      .withMaxSize(maxSize)
+      .withWorkers(pworkers.getOrElse(config.workers))
+      .withTestCallback(new TestCallback {})
+      .withMaxDiscardRatio(maxDiscardRatio)
+      .withCustomClassLoader(None)
+  }
+}
+
+/**
+ * Companion object that facilitates the importing of <code>Configuration</code> members as
+ * an alternative to mixing it in. One use case is to import <code>Configuration</code> members so you can use
+ * them in the Scala interpreter.
+ */
+private[scalatest] object ScalaCheckConfiguration extends ScalaCheckConfiguration

--- a/scalatest/src/main/scala/org/scalatest/check/ScalaCheckPropertyChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/check/ScalaCheckPropertyChecks.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 package org.scalatest
-package prop
+package check
+
+import org.scalatest.prop.TableDrivenPropertyChecks
 
 /**
  * Trait that facilitates property checks on data supplied by tables and generators.
@@ -95,7 +97,7 @@ package prop
  *
  * @author Bill Venners
  */
-trait PropertyChecks extends TableDrivenPropertyChecks with GeneratorDrivenPropertyChecks
+trait ScalaCheckPropertyChecks extends TableDrivenPropertyChecks with ScalaCheckDrivenPropertyChecks
 
 /**
  * Companion object that facilitates the importing of <code>PropertyChecks</code> members as 
@@ -104,5 +106,5 @@ trait PropertyChecks extends TableDrivenPropertyChecks with GeneratorDrivenPrope
  *
  * @author Bill Venners
  */
-object PropertyChecks extends PropertyChecks
+object ScalaCheckPropertyChecks extends ScalaCheckPropertyChecks
 

--- a/scalatest/src/main/scala/org/scalatest/prop/Configuration.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Configuration.scala
@@ -31,7 +31,7 @@ trait Configuration {
 
   @deprecated("Use PropertyCheckConfiguration directly instead.")
   trait PropertyCheckConfigurable {
-    private [prop] def asPropertyCheckConfiguration: PropertyCheckConfiguration
+    private [scalatest] def asPropertyCheckConfiguration: PropertyCheckConfiguration
    }
 
   object PropertyCheckConfiguration {
@@ -50,7 +50,7 @@ trait Configuration {
     private [scalatest] val legacyMaxDiscarded: Option[Int] = None
     @deprecated("Transitional value to ensure upgrade compatibility when mixing PropertyCheckConfig and minSize parameters.  Remove with PropertyCheckConfig class")
     private [scalatest] val legacyMaxSize: Option[Int] = None
-    private [prop] def asPropertyCheckConfiguration = this
+    private [scalatest] def asPropertyCheckConfiguration = this
   }
 
   /**
@@ -131,7 +131,7 @@ trait Configuration {
     require(maxSize >= 0, "maxSize had value " + maxSize + ", but must be greater than or equal to zero")
     require(minSize <= maxSize, "minSize had value " + minSize + ", which must be less than or equal to maxSize, which had value " + maxSize)
     require(workers > 0, "workers had value " + workers + ", but must be greater than zero")
-    private [prop] def asPropertyCheckConfiguration = this
+    private [scalatest] def asPropertyCheckConfiguration = this
   }
 
   import scala.language.implicitConversions
@@ -351,104 +351,6 @@ trait Configuration {
    *
    */
   def workers(value: PosInt): Workers = new Workers(value)
-
-  private[prop] def getParams(
-                               configParams: Seq[Configuration#PropertyCheckConfigParam],
-                               c: PropertyCheckConfigurable
-                               ): Parameters = {
-
-    val config: PropertyCheckConfiguration = c.asPropertyCheckConfiguration
-    var minSuccessful: Option[Int] = None
-    var maxDiscarded: Option[Int] = None
-    var maxDiscardedFactor: Option[Double] = None
-    var pminSize: Option[Int] = None
-    var psizeRange: Option[Int] = None
-    var pmaxSize: Option[Int] = None
-    var pworkers: Option[Int] = None
-
-    var minSuccessfulTotalFound = 0
-    var maxDiscardedTotalFound = 0
-    var maxDiscardedFactorTotalFound = 0
-    var minSizeTotalFound = 0
-    var sizeRangeTotalFound = 0
-    var maxSizeTotalFound = 0
-    var workersTotalFound = 0
-
-    for (configParam <- configParams) {
-      configParam match {
-        case param: MinSuccessful =>
-          minSuccessful = Some(param.value)
-          minSuccessfulTotalFound += 1
-        case param: MaxDiscarded =>
-          maxDiscarded = Some(param.value)
-          maxDiscardedTotalFound += 1
-        case param: MaxDiscardedFactor =>
-          maxDiscardedFactor = Some(param.value)
-          maxDiscardedFactorTotalFound += 1
-        case param: MinSize =>
-          pminSize = Some(param.value)
-          minSizeTotalFound += 1
-        case param: SizeRange =>
-          psizeRange = Some(param.value)
-          sizeRangeTotalFound += 1
-        case param: MaxSize =>
-          pmaxSize = Some(param.value)
-          maxSizeTotalFound += 1
-        case param: Workers =>
-          pworkers = Some(param.value)
-          workersTotalFound += 1
-      }
-    }
-
-    if (minSuccessfulTotalFound > 1)
-      throw new IllegalArgumentException("can pass at most one MinSuccessful config parameters, but " + minSuccessfulTotalFound + " were passed")
-    val maxDiscardedAndFactorTotalFound = maxDiscardedTotalFound + maxDiscardedFactorTotalFound
-    if (maxDiscardedAndFactorTotalFound > 1)
-      throw new IllegalArgumentException("can pass at most one MaxDiscarded or MaxDiscardedFactor config parameters, but " + maxDiscardedAndFactorTotalFound + " were passed")
-    if (minSizeTotalFound > 1)
-      throw new IllegalArgumentException("can pass at most one MinSize config parameters, but " + minSizeTotalFound + " were passed")
-    val maxSizeAndSizeRangeTotalFound = maxSizeTotalFound + sizeRangeTotalFound
-    if (maxSizeAndSizeRangeTotalFound > 1)
-      throw new IllegalArgumentException("can pass at most one SizeRange or MaxSize config parameters, but " + maxSizeAndSizeRangeTotalFound + " were passed")
-    if (workersTotalFound > 1)
-      throw new IllegalArgumentException("can pass at most one Workers config parameters, but " + workersTotalFound + " were passed")
-
-    val minSuccessfulTests: Int = minSuccessful.getOrElse(config.minSuccessful)
-
-    val minSize: Int = pminSize.getOrElse(config.minSize)
-
-    val maxSize = {
-      (psizeRange, pmaxSize, config.legacyMaxSize) match {
-        case (None, None, Some(legacyMaxSize)) =>
-          legacyMaxSize
-        case (None, Some(maxSize), _) =>
-          maxSize
-        case _ =>
-          psizeRange.getOrElse(config.sizeRange.value) + minSize
-      }
-    }
-
-    val maxDiscardRatio: Float = {
-      (maxDiscardedFactor, maxDiscarded, config.legacyMaxDiscarded, minSuccessful) match {
-        case (None, None, Some(legacyMaxDiscarded), Some(specifiedMinSuccessful)) =>
-          PropertyCheckConfiguration.calculateMaxDiscardedFactor(specifiedMinSuccessful, legacyMaxDiscarded).toFloat
-        case (None, Some(md), _, _) =>
-          if (md < 0) Parameters.default.maxDiscardRatio
-          else PropertyCheckConfiguration.calculateMaxDiscardedFactor(minSuccessfulTests, md).toFloat
-        case _ =>
-          maxDiscardedFactor.getOrElse(config.maxDiscardedFactor.value).toFloat
-      }
-    }
-
-    Parameters.default
-      .withMinSuccessfulTests(minSuccessfulTests)
-      .withMinSize(minSize)
-      .withMaxSize(maxSize)
-      .withWorkers(pworkers.getOrElse(config.workers))
-      .withTestCallback(new TestCallback {})
-      .withMaxDiscardRatio(maxDiscardRatio)
-      .withCustomClassLoader(None)
-  }
 
   /**
    * Implicit <code>PropertyCheckConfig</code> value providing default configuration values.

--- a/scalatest/src/main/scala/org/scalatest/prop/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/package.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+/**
+ * ScalaTest's main traits, classes, and other members, including members supporting ScalaTest's DSL for the Scala interpreter.
+ */
+package object prop {
+
+  @deprecated("Please use org.scalatest.check.Checkers instead.")
+  type Checkers = org.scalatest.check.Checkers
+
+  @deprecated("Please use org.scalatest.check.Checkers instead.")
+  lazy val Checkers = org.scalatest.check.Checkers
+
+  @deprecated("Please use org.scalatest.check.ScalaCheckDrivenPropertyChecks instead.")
+  type GeneratorDrivenPropertyChecks = org.scalatest.check.ScalaCheckDrivenPropertyChecks
+
+  @deprecated("Please use org.scalatest.check.ScalaCheckDrivenPropertyChecks instead.")
+  lazy val GeneratorDrivenPropertyChecks = org.scalatest.check.ScalaCheckDrivenPropertyChecks
+
+  @deprecated("Please use org.scalatest.check.ScalaCheckPropertyChecks instead.")
+  type PropertyChecks = org.scalatest.check.ScalaCheckPropertyChecks
+
+  @deprecated("Please use org.scalatest.check.ScalaCheckPropertyChecks instead.")
+  lazy val PropertyChecks = org.scalatest.check.ScalaCheckPropertyChecks
+
+}


### PR DESCRIPTION
Moved scalacheck integration code to org.scalatest.check package, and deprecated them in prop package.