### PR TITLE
Move `PatienceConfig` out of `AbstractPatienceConfiguration`

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/concurrent/AbstractPatienceConfiguration.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/AbstractPatienceConfiguration.scala
@@ -53,42 +53,8 @@ import org.scalatest.time.{Span, Millis}
  */
 trait AbstractPatienceConfiguration extends ScaledTimeSpans {
 
-  /**
-   * Configuration object for asynchronous constructs, such as those provided by traits <a href="Eventually.html"><code>Eventually</code></a> and
-   * <a href="AsyncAssertions.html"><code>AsyncAssertions</code></a>.
-   *
-   * <p>
-   * The default values for the parameters are:
-   * </p>
-   *
-   * <table style="border-collapse: collapse; border: 1px solid black">
- * <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><strong>Configuration Parameter</strong></th><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><strong>Default Value</strong></th></tr>
-   * <tr>
-   * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-   * <code>timeout</code>
-   * </td>
-   * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-   * <code>scaled(150 milliseconds)</code>
-   * </td>
-   * </tr>
-   * <tr>
-   * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-   * <code>interval</code>
-   * </td>
-   * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-   * <code>scaled(15 milliseconds)</code>
-   * </td>
-   * </tr>
-   * </table>
-   *
-   * @param timeout the maximum amount of time to wait for an asynchronous operation to complete before giving up and throwing
-   *   <code>TestFailedException</code>.
-   * @param interval the amount of time to sleep between each check of the status of an asynchronous operation when polling
-   *
-   * @author Bill Venners
-   * @author Chua Chee Seng
-   */
-  final case class PatienceConfig(timeout: Span = scaled(Span(150, Millis)), interval: Span = scaled(Span(15, Millis)))
+  protected def defaultPatienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(150, Millis)), interval = scaled(Span(15, Millis)))
 
   /**
    * Returns a <code>PatienceConfig</code> value providing default configuration values if implemented and made implicit in subtraits.

--- a/scalatest/src/main/scala/org/scalatest/concurrent/IntegrationPatience.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/IntegrationPatience.scala
@@ -68,7 +68,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
  */
 trait IntegrationPatience extends AbstractPatienceConfiguration { this: PatienceConfiguration =>
 
-  private val defaultPatienceConfig: PatienceConfig =
+  override protected val defaultPatienceConfig: PatienceConfig =
     PatienceConfig(
       timeout = scaled(Span(15, Seconds)),
       interval = scaled(Span(150, Millis))

--- a/scalatest/src/main/scala/org/scalatest/concurrent/PatienceConfig.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/PatienceConfig.scala
@@ -1,0 +1,40 @@
+package org.scalatest.concurrent
+
+import org.scalatest.time.{Millis, Span}
+
+/**
+  * Configuration object for asynchronous constructs, such as those provided by traits <a href="Eventually.html"><code>Eventually</code></a> and
+  * <a href="AsyncAssertions.html"><code>AsyncAssertions</code></a>.
+  *
+  * <p>
+  * The default values for the parameters are:
+  * </p>
+  *
+  * <table style="border-collapse: collapse; border: 1px solid black">
+  * <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><strong>Configuration Parameter</strong></th><th style="background-color: #CCCCCC; border-width: 1px; padding: 3px; text-align: center; border: 1px solid black"><strong>Default Value</strong></th></tr>
+  * <tr>
+  * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
+  * <code>timeout</code>
+  * </td>
+  * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
+  * <code>150 milliseconds</code>
+  * </td>
+  * </tr>
+  * <tr>
+  * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
+  * <code>interval</code>
+  * </td>
+  * <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
+  * <code>15 milliseconds</code>
+  * </td>
+  * </tr>
+  * </table>
+  *
+  * @param timeout the maximum amount of time to wait for an asynchronous operation to complete before giving up and throwing
+  *   <code>TestFailedException</code>.
+  * @param interval the amount of time to sleep between each check of the status of an asynchronous operation when polling
+  *
+  * @author Bill Venners
+  * @author Chua Chee Seng
+  */
+final case class PatienceConfig(timeout: Span = Span(150, Millis), interval: Span = Span(15, Millis))

--- a/scalatest/src/main/scala/org/scalatest/concurrent/PatienceConfiguration.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/PatienceConfiguration.scala
@@ -81,8 +81,6 @@ import PatienceConfiguration._
  */
 trait PatienceConfiguration extends AbstractPatienceConfiguration {
 
-  private val defaultPatienceConfig = PatienceConfig()
-
   /**
    * Implicit <code>PatienceConfig</code> value providing default configuration values.
    *


### PR DESCRIPTION
Change `PatienceConfig` to no longer be a path-dependant type to avoid
 confusion with multiple instances.
Add a protected `defaultPatienceConfig` to
 `AbstractPatienceConfiguration` to allow scaling and overriding by
 derived traits
Resolve: #1487