### PR TITLE
-S Init Seed Fix

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -2204,12 +2204,10 @@ object Randomizer {
     * @return A Randomizer, ready to begin producing random values.
     */
   def default(): Randomizer =
-    apply(
-      defaultSeed.get() match {
-        case Some(seed) => seed
-        case None => System.currentTimeMillis()
-      }
-    )
+    defaultSeed.get() match {
+      case Some(seed) => new Randomizer(seed)
+      case None => apply(System.currentTimeMillis())
+    }
 
   /**
     * A Randomizer, initialized with the specified seed value.


### PR DESCRIPTION
Fixed seed passed in from -S not being used as init seed problem.

@bvenners mentioned to me this morning that @jducoeur encountered some problem when trying to use the backported -S feature, I can reproduce a problem that the init seed passed in from -S is not being used as init seed correctly, and this PR is the fix for it.

When I ran the tests, a generator related flicker happened and I captured the init seed, after this PR is merged, you can try to reproduce the flicker by running: 

```
> sbt "scalactic-test/testOnly org.scalactic.anyvals.NegDoubleGeneratedSpec -- -S 1568769615146"
```

@jducoeur : Sorry for any inconvenient caused previously.