### PR TITLE
Finished the documentation for CommonGenerators

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -1911,6 +1911,7 @@ object ScalatestBuild {
     scalacOptions in (Compile, doc) ++=
       Seq[String](
         "-Ymacro-no-expand", // avoids need to separate out macros in docsrc dir
+        "-groups", // enables the @group tags in Scaladocs
         "-sourcepath", docsrcDir.value.getAbsolutePath,
         "-doc-title", projectTitle.value +" "+ releaseVersion,
         "-doc-source-url", scalatestDocSourceUrl)
@@ -1919,6 +1920,7 @@ object ScalatestBuild {
     scalacOptions in (Compile, doc) ++=
       Seq[String](
         "-Ymacro-no-expand", // avoids need to separate out macros in docsrc dir
+        "-groups", // enables the @group tags in Scaladocs
         "-sourcepath", docsrcDir.value.getAbsolutePath,
         "-doc-title", projectTitle.value +" "+ releaseVersion,
         "-doc-source-url", scalacticDocSourceUrl)

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -16,9 +16,12 @@
 package org.scalatest.prop
 
 import org.scalactic.anyvals._
+
 import scala.annotation.tailrec
 import org.scalactic.source.TypeInfo
 import org.scalactic.Requirements._
+import org.scalatest.prop.Generator.function1Generator
+
 import scala.collection.immutable.SortedSet
 import scala.collection.immutable.SortedMap
 
@@ -26,12 +29,69 @@ import scala.collection.immutable.SortedMap
   * Provides various specialized [[Generator]]s that are often useful.
   *
   * This exists as both a trait that you can mix into your classes, and an object
-  * that you can import -- choose whichever better suits your tests.
+  * that you can import -- choose whichever better suits your tests. However, you
+  * usually should not need to pull this in directly, since it is already mixed into
+  * both [[GeneratorDrivenPropertyChecks]] and [[TableDrivenPropertyChecks]].
   *
   * This incorporates the standard [[Generator]]s defined in the [[Generator]] object,
   * so you generally shouldn't need both.
+  *
+  * @groupprio Specific 10
+  * @groupname Specific Creating Generators from Specific Values
+  * @groupdesc Specific These functions let you create [[Generator]]s that only return specific
+  *            values
+  *
+  * @groupprio Higher 20
+  * @groupname Higher Creating Higher-Order Generators from other Generators
+  * @groupdesc Higher These functions let you create [[Generator]]s that are built from more
+  *            than one existing [[Generator]].
+  *
+  * @groupprio Common 30
+  * @groupname Common Generators for Many Common Types
+  * @groupdesc Common These cover types from both the Scala Standard Library and Scalactic
+  *
+  * @groupprio Values 40
+  * @groupname Values Generators that produce the values from Scalactic Types
+  * @groupdesc Values Scalactic has many highly-precise numeric types such as [[NonZeroLong]],
+  *            [[PosZFloat]] or [[FiniteDouble]]. These help you make sure your code is using
+  *            exactly the numbers you intend, and they are very convenient for using with
+  *            [[Generator]]s. But if the code under test is ''not'' using Scalactic, you
+  *            sometimes find that you need to type `.value` a lot. These Generators do that
+  *            for so: you can choose a precise numeric Generator, but get the conventional
+  *            numeric type from it.
+  *
+  * @groupprio Collections 50
+  * @groupname Collections Generators for standard Collections
+  * @groupdesc Collections These functions take one or more types `T`, and create [[Generator]]s that
+  *            produce collections of `T`.
+  *
+  * @groupprio Betweeners 60
+  * @groupname Betweeners Range-based Generator Creation
+  * @groupdesc Betweeners Functions that create [[Generator]]s for values in a specific range
+  *            of a specific type.
+  *
+  * @groupprio Functions 70
+  * @groupname Functions Generators that Produce Functions
+  * @groupdesc Functions These functions create [[Generator]]s that produce random functions with
+  *            specified parameter and return types.
+  *
+  * @groupprio InstancesOf 80
+  * @groupname InstancesOf Generators for instances of case classes
+  * @groupdesc InstancesOf These functions are one way to create [[Generator]]s for case
+  *            class instances.
+  *
+  * @groupprio Tools 90
+  * @groupname Tools Tools for Developing Generators
+  *
+  * @group Others
   */
 trait CommonGenerators {
+
+  /////////////////////////////////////////////////
+  //
+  // Between-related functions
+  //
+
 
   /**
     * Create a [[Generator]] that returns values in the specified range.
@@ -73,6 +133,8 @@ trait CommonGenerators {
     * @param gen an instance of `Generator[T]`, which should usually be in implicit scope
     * @tparam T the type to choose a value from
     * @return a new [[Generator]], that produces values in the specified range
+    *
+    * @group Betweeners
     */
   def between[T](from: T, to: T)(implicit ord: Ordering[T], chooser: Chooser[T], gen: Generator[T]): Generator[T] = {
     import ord.mkOrderingOps
@@ -111,6 +173,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def bytesBetween(from: Byte, to: Byte): Generator[Byte] = between(from, to)
 
@@ -126,6 +190,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def shortsBetween(from: Short, to: Short): Generator[Short] = between(from, to)
 
@@ -141,6 +207,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def intsBetween(from: Int, to: Int): Generator[Int] = between(from, to)
 
@@ -156,6 +224,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def longsBetween(from: Long, to: Long): Generator[Long] = between(from, to)
 
@@ -171,6 +241,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def charsBetween(from: Char, to: Char): Generator[Char] = between(from, to)
 
@@ -186,6 +258,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def floatsBetween(from: Float, to: Float): Generator[Float] = between(from, to)
 
@@ -201,6 +275,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def doublesBetween(from: Double, to: Double): Generator[Double] = between(from, to)
 
@@ -216,6 +292,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posIntsBetween(from: PosInt, to: PosInt): Generator[PosInt] = between(from, to)
 
@@ -231,6 +309,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posLongsBetween(from: PosLong, to: PosLong): Generator[PosLong] = between(from, to)
 
@@ -246,6 +326,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posFloatsBetween(from: PosFloat, to: PosFloat): Generator[PosFloat] = between(from, to)
 
@@ -261,6 +343,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posFiniteFloatsBetween(from: PosFiniteFloat, to: PosFiniteFloat): Generator[PosFiniteFloat] = between(from, to)
 
@@ -276,6 +360,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posDoublesBetween(from: PosDouble, to: PosDouble): Generator[PosDouble] = between(from, to)
 
@@ -291,6 +377,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posFiniteDoublesBetween(from: PosFiniteDouble, to: PosFiniteDouble): Generator[PosFiniteDouble] = between(from, to)
 
@@ -306,6 +394,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZIntsBetween(from: PosZInt, to: PosZInt): Generator[PosZInt] = between(from, to)
 
@@ -321,6 +411,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZLongsBetween(from: PosZLong, to: PosZLong): Generator[PosZLong] = between(from, to)
 
@@ -336,6 +428,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZFloatsBetween(from: PosZFloat, to: PosZFloat): Generator[PosZFloat] = between(from, to)
 
@@ -351,6 +445,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZFiniteFloatsBetween(from: PosZFiniteFloat, to: PosZFiniteFloat): Generator[PosZFiniteFloat] = between(from, to)
 
@@ -366,6 +462,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZDoublesBetween(from: PosZDouble, to: PosZDouble): Generator[PosZDouble] = between(from, to)
 
@@ -381,6 +479,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def posZFiniteDoublesBetween(from: PosZFiniteDouble, to: PosZFiniteDouble): Generator[PosZFiniteDouble] = between(from, to)
 
@@ -396,6 +496,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negIntsBetween(from: NegInt, to: NegInt): Generator[NegInt] = between(from, to)
 
@@ -411,6 +513,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negLongsBetween(from: NegLong, to: NegLong): Generator[NegLong] = between(from, to)
 
@@ -426,6 +530,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negFloatsBetween(from: NegFloat, to: NegFloat): Generator[NegFloat] = between(from, to)
 
@@ -441,6 +547,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negFiniteFloatsBetween(from: NegFiniteFloat, to: NegFiniteFloat): Generator[NegFiniteFloat] = between(from, to)
 
@@ -456,6 +564,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negDoublesBetween(from: NegDouble, to: NegDouble): Generator[NegDouble] = between(from, to)
 
@@ -471,6 +581,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negFiniteDoublesBetween(from: NegFiniteDouble, to: NegFiniteDouble): Generator[NegFiniteDouble] = between(from, to)
 
@@ -486,6 +598,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZIntsBetween(from: NegZInt, to: NegZInt): Generator[NegZInt] = between(from, to)
 
@@ -501,6 +615,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZLongsBetween(from: NegZLong, to: NegZLong): Generator[NegZLong] = between(from, to)
 
@@ -516,6 +632,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZFloatsBetween(from: NegZFloat, to: NegZFloat): Generator[NegZFloat] = between(from, to)
 
@@ -531,6 +649,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZFiniteFloatsBetween(from: NegZFiniteFloat, to: NegZFiniteFloat): Generator[NegZFiniteFloat] = between(from, to)
 
@@ -546,6 +666,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZDoublesBetween(from: NegZDouble, to: NegZDouble): Generator[NegZDouble] = between(from, to)
 
@@ -561,6 +683,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def negZFiniteDoublesBetween(from: NegZFiniteDouble, to: NegZFiniteDouble): Generator[NegZFiniteDouble] = between(from, to)
 
@@ -576,6 +700,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroIntsBetween(from: NonZeroInt, to: NonZeroInt): Generator[NonZeroInt] = between(from, to)
 
@@ -591,6 +717,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroLongsBetween(from: NonZeroLong, to: NonZeroLong): Generator[NonZeroLong] = between(from, to)
 
@@ -606,6 +734,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroFloatsBetween(from: NonZeroFloat, to: NonZeroFloat): Generator[NonZeroFloat] = between(from, to)
 
@@ -621,6 +751,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroFiniteFloatsBetween(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat): Generator[NonZeroFiniteFloat] = between(from, to)
 
@@ -636,6 +768,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroDoublesBetween(from: NonZeroDouble, to: NonZeroDouble): Generator[NonZeroDouble] = between(from, to)
 
@@ -651,6 +785,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def nonZeroFiniteDoublesBetween(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble): Generator[NonZeroFiniteDouble] = between(from, to)
 
@@ -666,6 +802,8 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def finiteFloatsBetween(from: FiniteFloat, to: FiniteFloat): Generator[FiniteFloat] = between(from, to)
 
@@ -681,8 +819,17 @@ trait CommonGenerators {
     * @param from one end of the desired range
     * @param to the other end of the desired range
     * @return a value within that range, inclusive of the bounds
+    *
+    * @group Betweeners
     */
   def finiteDoublesBetween(from: FiniteDouble, to: FiniteDouble): Generator[FiniteDouble] = between(from, to)
+
+
+
+  /////////////////////////////////////////////////
+  //
+  // Other interesting Generator-creating functions
+  //
 
   /**
     * Given a list of values of type [[T]], this creates a [[Generator]] that will only
@@ -696,6 +843,8 @@ trait CommonGenerators {
     * @param rest more values of type [[T]], as many as you wish
     * @tparam T the type that will be produced by the resulting [[Generator]]
     * @return a [[Generator]] that produces exactly the specified values
+    *
+    * @group Specific
     */
   def specificValues[T](first: T, second: T, rest: T*): Generator[T] =
     new Generator[T] {
@@ -722,6 +871,8 @@ trait CommonGenerators {
     * @param theValue the value to produce
     * @tparam T the type of that value
     * @return a [[Generator]] that will always produce that value
+    *
+    * @group Specific
     */
   def specificValue[T](theValue: T): Generator[T] =
     new Generator[T] {
@@ -774,6 +925,8 @@ trait CommonGenerators {
     * @param rest as many more [[Generator]] and weight pairs as you like
     * @tparam T the type being produced by all of these [[Generator]]s
     * @return a single [[Generator]], that invokes its constituents according to their weights
+    *
+    * @group Higher
     */
   def frequency[T](first: (Int, Generator[T]), second: (Int, Generator[T]), rest: (Int, Generator[T])*): Generator[T] = {
     val distribution: Vector[(Int, Generator[T])] = (first +: second +: rest).toVector
@@ -858,6 +1011,8 @@ trait CommonGenerators {
     * @param rest any number of additional [[Generator]]s to choose from
     * @tparam T the type to be produced
     * @return a single [[Generator]] that invokes each of its constituents roughly the same number of times
+    *
+    * @group Higher
     */
   def evenly[T](first: Generator[T], second: Generator[T], rest: Generator[T]*): Generator[T] = {
     val distributees: Vector[Generator[T]] = (first +: second +: rest).toVector
@@ -876,259 +1031,1288 @@ trait CommonGenerators {
     }
   }
 
+
+
+  /////////////////////////////////////////////////
+  //
+  // Functions that are just shells around those in Generator
+  //
+
+  /**
+    * A [[Generator]] that produces [[Byte]] values.
+    *
+    * @group Common
+    */
   val bytes: Generator[Byte] = Generator.byteGenerator
+
+  /**
+    * A [[Generator]] that produces [[Short]] values.
+    *
+    * @group Common
+    */
   val shorts: Generator[Short] = Generator.shortGenerator
+
+  /**
+    * A [[Generator]] that produces [[Int]] values.
+    *
+    * @group Common
+    */
   val ints: Generator[Int] = Generator.intGenerator
+
+  /**
+    * A [[Generator]] that produces [[Long]] values.
+    *
+    * @group Common
+    */
   val longs: Generator[Long] = Generator.longGenerator
+
+  /**
+    * A [[Generator]] that produces [[Char]] values.
+    *
+    * @group Common
+    */
   val chars: Generator[Char] = Generator.charGenerator
+
+  /**
+    * A [[Generator]] that produces [[Float]] values.
+    *
+    * @group Common
+    */
   val floats: Generator[Float] = Generator.floatGenerator
+
+  /**
+    * A [[Generator]] that produces [[Double]] values.
+    *
+    * @group Common
+    */
   val doubles: Generator[Double] = Generator.doubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[String]] values.
+    *
+    * @group Common
+    */
   val strings: Generator[String] = Generator.stringGenerator
-  def lists[T](implicit genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] = Generator.listGenerator[T]
+
+  /**
+    * A [[Generator]] that produces [[PosInt]] values.
+    *
+    * @group Common
+    */
+  val posInts: Generator[PosInt] = Generator.posIntGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZInt]] values.
+    *
+    * @group Common
+    */
+  val posZInts: Generator[PosZInt] = Generator.posZIntGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosLong]] values.
+    *
+    * @group Common
+    */
+  val posLongs: Generator[PosLong] = Generator.posLongGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZLong]] values.
+    *
+    * @group Common
+    */
+  val posZLongs: Generator[PosZLong] = Generator.posZLongGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosFloat]] values.
+    *
+    * @group Common
+    */
+  val posFloats: Generator[PosFloat] = Generator.posFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosFiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val posFiniteFloats: Generator[PosFiniteFloat] = Generator.posFiniteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZFloat]] values.
+    *
+    * @group Common
+    */
+  val posZFloats: Generator[PosZFloat] = Generator.posZFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZFiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val posZFiniteFloats: Generator[PosZFiniteFloat] = Generator.posZFiniteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosDouble]] values.
+    *
+    * @group Common
+    */
+  val posDoubles: Generator[PosDouble] = Generator.posDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosFiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val posFiniteDoubles: Generator[PosFiniteDouble] = Generator.posFiniteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZDouble]] values.
+    *
+    * @group Common
+    */
+  val posZDoubles: Generator[PosZDouble] = Generator.posZDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[PosZFiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val posZFiniteDoubles: Generator[PosZFiniteDouble] = Generator.posZFiniteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegInt]] values.
+    *
+    * @group Common
+    */
+  val negInts: Generator[NegInt] = Generator.negIntGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZInt]] values.
+    *
+    * @group Common
+    */
+  val negZInts: Generator[NegZInt] = Generator.negZIntGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegLong]] values.
+    *
+    * @group Common
+    */
+  val negLongs: Generator[NegLong] = Generator.negLongGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZLong]] values.
+    *
+    * @group Common
+    */
+  val negZLongs: Generator[NegZLong] = Generator.negZLongGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegFloat]] values.
+    *
+    * @group Common
+    */
+  val negFloats: Generator[NegFloat] = Generator.negFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegFiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val negFiniteFloats: Generator[NegFiniteFloat] = Generator.negFiniteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZFloat]] values.
+    *
+    * @group Common
+    */
+  val negZFloats: Generator[NegZFloat] = Generator.negZFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZFiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val negZFiniteFloats: Generator[NegZFiniteFloat] = Generator.negZFiniteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegDouble]] values.
+    *
+    * @group Common
+    */
+  val negDoubles: Generator[NegDouble] = Generator.negDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegFiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val negFiniteDoubles: Generator[NegFiniteDouble] = Generator.negFiniteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZDouble]] values.
+    *
+    * @group Common
+    */
+  val negZDoubles: Generator[NegZDouble] = Generator.negZDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NegZFiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val negZFiniteDoubles: Generator[NegZFiniteDouble] = Generator.negZFiniteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroInt]] values.
+    *
+    * @group Common
+    */
+  val nonZeroInts: Generator[NonZeroInt] = Generator.nonZeroIntGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroLong]] values.
+    *
+    * @group Common
+    */
+  val nonZeroLongs: Generator[NonZeroLong] = Generator.nonZeroLongGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroFloat]] values.
+    *
+    * @group Common
+    */
+  val nonZeroFloats: Generator[NonZeroFloat] = Generator.nonZeroFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroFiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val nonZeroFiniteFloats: Generator[NonZeroFiniteFloat] = Generator.nonZeroFiniteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroDouble]] values.
+    *
+    * @group Common
+    */
+  val nonZeroDoubles: Generator[NonZeroDouble] = Generator.nonZeroDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NonZeroFiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val nonZeroFiniteDoubles: Generator[NonZeroFiniteDouble] = Generator.nonZeroFiniteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[FiniteFloat]] values.
+    *
+    * @group Common
+    */
+  val finiteFloats: Generator[FiniteFloat] = Generator.finiteFloatGenerator
+
+  /**
+    * A [[Generator]] that produces [[FiniteDouble]] values.
+    *
+    * @group Common
+    */
+  val finiteDoubles: Generator[FiniteDouble] = Generator.finiteDoubleGenerator
+
+  /**
+    * A [[Generator]] that produces [[NumericChar]] values.
+    *
+    * @group Common
+    */
+  val numericChars: Generator[NumericChar] = Generator.numericCharGenerator
+
+  /**
+    * A [[Generator]] that produces positive [[Int]] values, not including zero.
+    *
+    * @group Values
+    */
+  val posIntValues: Generator[Int] = Generator.posIntGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Int]] values, including zero.
+    *
+    * @group Values
+    */
+  val posZIntValues: Generator[Int] = Generator.posZIntGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Long]] values, not including zero.
+    *
+    * @group Values
+    */
+  val posLongValues: Generator[Long] = Generator.posLongGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Long]] values, including zero.
+    *
+    * @group Values
+    */
+  val posZLongValues: Generator[Long] = Generator.posZLongGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Float]] values, not including zero
+    * but including infinites and `NaN`.
+    *
+    * @group Values
+    */
+  val posFloatValues: Generator[Float] = Generator.posFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Float]] values, not including zero,
+    * infinity or `NaN`.
+    *
+    * @group Values
+    */
+  val posFiniteFloatValues: Generator[Float] = Generator.posFiniteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Float]] values, including zero, infinity
+    * and `NaN`.
+    *
+    * @group Values
+    */
+  val posZFloatValues: Generator[Float] = Generator.posZFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Float]] values, including zero but not
+    * including infinity or `NaN`.
+    *
+    * @group Values
+    */
+  val posZFiniteFloatValues: Generator[Float] = Generator.posZFiniteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Double]] values, not including zero but
+    * including infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val posDoubleValues: Generator[Double] = Generator.posDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Double]] values, not including zero,
+    * infinity or `NaN`.
+    *
+    * @group Values
+    */
+  val posFiniteDoubleValues: Generator[Double] = Generator.posFiniteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Double]] values, including zero, infinity
+    * and `NaN`.
+    *
+    * @group Values
+    */
+  val posZDoubleValues: Generator[Double] = Generator.posZDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces positive [[Int]] values.
+    *
+    * @group Values
+    */
+  val posZFiniteDoubleValues: Generator[Double] = Generator.posZFiniteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Int]] values, not including zero.
+    *
+    * @group Values
+    */
+  val negIntValues: Generator[Int] = Generator.negIntGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Int]] values, including zero.
+    *
+    * @group Values
+    */
+  val negZIntValues: Generator[Int] = Generator.negZIntGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Long]] values, not including zero.
+    *
+    * @group Values
+    */
+  val negLongValues: Generator[Long] = Generator.negLongGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Long]] values, including zero.
+    *
+    * @group Values
+    */
+  val negZLongValues: Generator[Long] = Generator.negZLongGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Float]] values, not including zero but including
+    * infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val negFloatValues: Generator[Float] = Generator.negFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Float]] values, not including zero, infinity
+    * or `NaN`.
+    *
+    * @group Values
+    */
+  val negFiniteFloatValues: Generator[Float] = Generator.negFiniteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Float]] values, including zero, infinity
+    * and `NaN`.
+    *
+    * @group Values
+    */
+  val negZFloatValues: Generator[Float] = Generator.negZFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Float]] values, including zero but not
+    * including infinity or `NaN`.
+    *
+    * @group Values
+    */
+  val negZFiniteFloatValues: Generator[Float] = Generator.negZFiniteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Double]] values, not including zero but including
+    * infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val negDoubleValues: Generator[Double] = Generator.negDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Double]] values, not including zero, infinity or
+    * `NaN`.
+    *
+    * @group Values
+    */
+  val negFiniteDoubleValues: Generator[Double] = Generator.negFiniteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Double]] values, including zero, infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val negZDoubleValues: Generator[Double] = Generator.negZDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces negative [[Double]] values, including zero but not including
+    * infinity or `NaN`.
+    *
+    * @group Values
+    */
+  val negZFiniteDoubleValues: Generator[Double] = Generator.negZFiniteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Int]] values.
+    *
+    * @group Values
+    */
+  val nonZeroIntValues: Generator[Int] = Generator.nonZeroIntGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Long]] values.
+    *
+    * @group Values
+    */
+  val nonZeroLongValues: Generator[Long] = Generator.nonZeroLongGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Float]] values, including infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val nonZeroFloatValues: Generator[Float] = Generator.nonZeroFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Float]] values, not including infinity
+    * or `NaN`.
+    *
+    * @group Values
+    */
+  val nonZeroFiniteFloatValues: Generator[Float] = Generator.nonZeroFiniteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Double]] values, including infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val nonZeroDoubleValues: Generator[Double] = Generator.nonZeroDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces non-zero [[Double]] values, not including infinity and `NaN`.
+    *
+    * @group Values
+    */
+  val nonZeroFiniteDoubleValues: Generator[Double] = Generator.nonZeroFiniteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces [[Float]] values, including zero but not including infinities or `NaN`.
+    *
+    * @group Values
+    */
+  val finiteFloatValues: Generator[Float] = Generator.finiteFloatGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces [[Double]] values, including zero but not including infinities or `NaN`.
+    *
+    * @group Values
+    */
+  val finiteDoubleValues: Generator[Double] = Generator.finiteDoubleGenerator.map(_.value)
+
+  /**
+    * A [[Generator]] that produces digit [[Char]]s.
+  *
+    * @group Values
+    */
+  val numericCharValues: Generator[Char] = Generator.numericCharGenerator.map(_.value)
+
+
+  /**
+    * Given [[Generator]]s for types [[A]] and [[B]], get one that produces Tuples of those types.
+    *
+    * [[tuple2s]] (and its variants, up through [[tuple22s]]) will create [[Generator]]s on
+    * demand for essentially arbitrary Tuples, so long as you have [[Generator]]s in implicit scope for all
+    * of the component types.
+    *
+    * @param genOfA a [[Generator]] for type [[A]]
+    * @param genOfB a [[Generator]] for type [[B]]
+    * @tparam A the first type in the Tuple
+    * @tparam B the second type in the Tuple
+    * @return a [[Generator]] that produces the desired types, Tupled together.
+    *
+    * @group Collections
+    */
   def tuple2s[A, B](implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[(A, B)] = Generator.tuple2Generator[A, B]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple3s[A, B, C](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[(A, B, C)] = Generator.tuple3Generator[A, B, C]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple4s[A, B, C, D](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[(A, B, C, D)] = Generator.tuple4Generator[A, B, C, D]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple5s[A, B, C, D, E](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[(A, B, C, D, E)] = Generator.tuple5Generator[A, B, C, D, E]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple6s[A, B, C, D, E, F](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[(A, B, C, D, E, F)] = Generator.tuple6Generator[A, B, C, D, E, F]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple7s[A, B, C, D, E, F, G](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G]): Generator[(A, B, C, D, E, F, G)] = Generator.tuple7Generator[A, B, C, D, E, F, G]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple8s[A, B, C, D, E, F, G, H](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H]): Generator[(A, B, C, D, E, F, G, H)] = Generator.tuple8Generator[A, B, C, D, E, F, G, H]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple9s[A, B, C, D, E, F, G, H, I](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[(A, B, C, D, E, F, G, H, I)] = Generator.tuple9Generator[A, B, C, D, E, F, G, H, I]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple10s[A, B, C, D, E, F, G, H, I, J](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                              genOfJ: Generator[J]): Generator[(A, B, C, D, E, F, G, H, I, J)] = Generator.tuple10Generator[A, B, C, D, E, F, G, H, I, J]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple11s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                             genOfJ: Generator[J], genOfK: Generator[K]): Generator[(A, B, C, D, E, F, G, H, I, J, K)] = Generator.tuple11Generator[A, B, C, D, E, F, G, H, I, J, K]
+                                                genOfJ: Generator[J], genOfK: Generator[K]): Generator[(A, B, C, D, E, F, G, H, I, J, K)] = Generator.tuple11Generator[A, B, C, D, E, F, G, H, I, J, K]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple12s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L)] = Generator.tuple12Generator[A, B, C, D, E, F, G, H, I, J, K, L]
+                                                   genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L)] = Generator.tuple12Generator[A, B, C, D, E, F, G, H, I, J, K, L]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple13s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                   genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = Generator.tuple13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
+                                                      genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = Generator.tuple13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                      genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = Generator.tuple14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+                                                         genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = Generator.tuple14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                         genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = Generator.tuple15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+                                                            genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = Generator.tuple15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                            genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = Generator.tuple16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+                                                               genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = Generator.tuple16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                               genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = Generator.tuple17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+                                                                  genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = Generator.tuple17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                                  genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = Generator.tuple18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+                                                                     genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = Generator.tuple18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                                     genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = Generator.tuple19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+                                                                        genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = Generator.tuple19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                            genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
                                                                            genOfT: Generator[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = Generator.tuple20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
   def tuple21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
-                                                                           genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
-                                                                           genOfT: Generator[T], genOfU: Generator[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = Generator.tuple21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
-  def tuple22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                               genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
-                                                                              genOfT: Generator[T], genOfU: Generator[U], genOfV: Generator[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = Generator.tuple22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+                                                                              genOfT: Generator[T], genOfU: Generator[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = Generator.tuple21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+
+  /**
+    * See [[tuple2s]].
+    *
+    * @group Collections
+    */
+  def tuple22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+                                                                                 genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
+                                                                                 genOfT: Generator[T], genOfU: Generator[U], genOfV: Generator[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = Generator.tuple22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+
+  /**
+    * Given a [[Generator]] for type [[T]], this creates one for a [[Vector]] of [[T]].
+    *
+    * Note that the [[Vector]] type is considered to have a "size", so you can use the configuration parameters
+    * [[Configuration.minSize]] and [[Configuration.sizeRange]] to constrain the sizes of the resulting `Vector`s
+    * when you use this [[Generator]].
+    *
+    * The resulting [[Generator]] also has the [[HavingLength]] trait, so you can use it to generate [[Vector]]s
+    * with specific lengths.
+    *
+    * @param genOfT a [[Generator]] that produces values of type [[T]]
+    * @tparam T the type to produce
+    * @return a [[Generator]] that produces values of type `Vector[T]`
+    *
+    * @group Collections
+    */
+  def vectors[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
+
+  /**
+    * Given an existing `Generator[T]`, this creates a `Generator[List[T]]`.
+    *
+    * @param genOfT a [[Generator]] that produces values of type [[T]]
+    * @tparam T the type that we are producing a List of
+    * @return a List of values of type [[T]]
+    *
+    * @group Collections
+    */
+  def lists[T](implicit genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] = Generator.listGenerator[T]
+
+  /**
+    * Given a [[Generator]] that produces values of type [[T]], this creates one for a [[Set]] of [[T]].
+    *
+    * Note that the [[Set]] type is considered to have a "size", so you can use the configuration parameters
+    * [[Configuration.minSize]] and [[Configuration.sizeRange]] to constrain the sizes of the resulting `Set`s
+    * when you use this [[Generator]].
+    *
+    * The resulting [[Generator]] also has the [[HavingSize]] trait, so you can use it to generate [[Set]]s
+    * with specific sizes.
+    *
+    * @param genOfT a [[Generator]] that produces values of type [[T]]
+    * @tparam T the type to produce
+    * @return a [[Generator]] that produces `Set[T]`.
+    *
+    * @group Collections
+    */
+  def sets[T](implicit genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] = Generator.setGenerator
+
+  /**
+    * Given a [[Generator]] that produces values of type [[T]], this creates one for a [[SortedSet]] of [[T]].
+    *
+    * Note that the [[SortedSet]] type is considered to have a "size", so you can use the configuration parameters
+    * [[Configuration.minSize]] and [[Configuration.sizeRange]] to constrain the sizes of the resulting `SortedSet`s
+    * when you use this [[Generator]].
+    *
+    * The resulting [[Generator]] also has the [[HavingSize]] trait, so you can use it to generate [[SortedSet]]s
+    * with specific sizes.
+    *
+    * @param genOfT a [[Generator]] that produces values of type [[T]]
+    * @tparam T the type to produce
+    * @return a [[Generator]] that produces `SortedSet[T]`.
+    *
+    * @group Collections
+    */
+  def sortedSets[T](implicit genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] = Generator.sortedSetGenerator
+
+  /**
+    * Given a [[Generator]] that produces Tuples of key/value pairs, this gives you one that produces [[Map]]s
+    * with those pairs.
+    *
+    * If you are simply looking for random pairing of the key and value types, this is pretty easy to use:
+    * if both the key and value types have [[Generator]]s, then the Tuple and Map ones will be automatically
+    * and implicitly created when you need them.
+    *
+    * The resulting [[Generator]] also has the [[HavingSize]] trait, so you can use it to generate [[Map]]s
+    * with specific sizes.
+    *
+    * @param genOfTuple2KV a [[Generator]] that produces Tuples of [[K]] and [[V]]
+    * @tparam K the type of the keys for the [[Map]]
+    * @tparam V the type of the values for the [[Map]]
+    * @return a [[Generator]] of [[Map]]s from [[K]] to [[V]]
+    *
+    * @group Collections
+    */
+  def maps[K, V](implicit genOfTupleKV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] = Generator.mapGenerator
+
+  /**
+    * Given a [[Generator]] that produces Tuples of key/value pairs, this gives you one that produces [[SortedMap]]s
+    * with those pairs.
+    *
+    * If you are simply looking for random pairing of the key and value types, this is pretty easy to use:
+    * if both the key and value types have [[Generator]]s, then the Tuple and SortedMap ones will be automatically
+    * and implicitly created when you need them.
+    *
+    * The resulting [[Generator]] also has the [[HavingSize]] trait, so you can use it to generate [[SortedMap]]s
+    * with specific sizes.
+    *
+    * @param genOfTuple2KV a [[Generator]] that produces Tuples of [[K]] and [[V]]
+    * @tparam K the type of the keys for the [[SortedMap]]
+    * @tparam V the type of the values for the [[SortedMap]]
+    * @return a [[Generator]] of [[SortedMap]]s from [[K]] to [[V]]
+    *
+    * @group Collections
+    */
+  def sortedMaps[K, V](implicit genOfTupleKV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] = Generator.sortedMapGenerator
+
+
+  /**
+    * Given a [[Generator]] that produces values of type [[A]], this returns one that produces ''functions'' that return
+    * a T.
+    *
+    * The functions produced here are nullary -- they take no parameters, they just spew out values of type [[A]].
+    *
+    * @param genOfT a [[Generator]] that produces functions that return [[A]]
+    * @tparam A the type to return from the generated functions
+    * @return a [[Generator]] that produces functions that return values of type [[A]]
+    *
+    * @group Functions
+    */
   def function0s[A](implicit genOfA: Generator[A]): Generator[() => A] = Generator.function0Generator[A]
+
+  /**
+    * Create a [[Generator]] of functions from type [[A]] to type [[B]].
+    *
+    * Note that the generated functions are, necessarily, pretty random. In practice, the function you get from a
+    * [[function1s]] call (and its variations, up through [[function22s]]) takes the hashes of its input
+    * values, combines those with a randomly-chosen number, and combines them in order to choose the generated value
+    * [[B]].
+    *
+    * That said, each of the generated functions ''is'' deterministic: given the same input parameters and the same
+    * randomly-chosen number, you will always get the same [[B]] result. And the `toString` function on the generated
+    * function will show the formula you need to use in order to recreate that, which will look something like:
+    *
+    * {{{
+    *   (a: Int, b: String, c: Float) =>
+    *     org.scalatest.prop.valueOf[String](a, b, c)(131)
+    * }}}
+    *
+    * The number and type of the `a`, `b`, `c`, etc, parameters, as well as the type parameter of [[valueOf]], will depend
+    * on the function type you are generating, but they will always follow this pattern. [[valueOf]] is the underlying
+    * function that takes these parameters and the randomly-chosen number, and returns a value of the specified type.
+    *
+    * So if a property evaluation fails, the display of the generated function will tell you how to call [[valueOf]]
+    * to recreate the failure.
+    *
+    * The `typeInfo` parameters are automatically created via macros; you should generally not try to pass them manually.
+    *
+    * @param genOfB a [[Generator]] for the desired result type [[B]]
+    * @param typeInfoA automatically-created type information for type [[A]]
+    * @param typeInfoB automatically-created type information for type [[B]]
+    * @tparam A the input type for the generated functions
+    * @tparam B the result type for the generated functions
+    * @return a [[Generator]] that produces functions that take values of [[A]] and returns values of [[B]]
+    *
+    * @group Functions
+    */
   def function1s[A, B](implicit genOfB: Generator[B], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B]): Generator[A => B] =
     Generator.function1Generator[A, B]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function2s[A, B, C](implicit genOfC: Generator[C], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C]): Generator[(A, B) => C] =
     Generator.function2Generator[A, B, C]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function3s[A, B, C, D](implicit genOfD: Generator[D], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D]): Generator[(A, B, C) => D] =
     Generator.function3Generator[A, B, C, D]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function4s[A, B, C, D, E](implicit genOfE: Generator[E], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E]): Generator[(A, B, C, D) => E] =
     Generator.function4Generator[A, B, C, D, E]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function5s[A, B, C, D, E, F](implicit genOfF: Generator[F], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F]): Generator[(A, B, C, D, E) => F] =
     Generator.function5Generator[A, B, C, D, E, F]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function6s[A, B, C, D, E, F, G](implicit genOfG: Generator[G], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G]): Generator[(A, B, C, D, E, F) => G] =
     Generator.function6Generator[A, B, C, D, E, F, G]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function7s[A, B, C, D, E, F, G, H](implicit genOfH: Generator[H], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H]): Generator[(A, B, C, D, E, F, G) => H] =
     Generator.function7Generator[A, B, C, D, E, F, G, H]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function8s[A, B, C, D, E, F, G, H, I](implicit genOfI: Generator[I], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I]): Generator[(A, B, C, D, E, F, G, H) => I] =
     Generator.function8Generator[A, B, C, D, E, F, G, H, I]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function9s[A, B, C, D, E, F, G, H, I, J](implicit genOfJ: Generator[J], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J]): Generator[(A, B, C, D, E, F, G, H, I) => J] =
     Generator.function9Generator[A, B, C, D, E, F, G, H, I, J]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function10s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfK: Generator[K], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K]): Generator[(A, B, C, D, E, F, G, H, I, J) => K] =
     Generator.function10Generator[A, B, C, D, E, F, G, H, I, J, K]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function11s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfL: Generator[L], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] =
     Generator.function11Generator[A, B, C, D, E, F, G, H, I, J, K, L]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function12s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfM: Generator[M], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] =
     Generator.function12Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function13s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfN: Generator[N], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] =
     Generator.function13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfO: Generator[O], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] =
     Generator.function14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfP: Generator[P], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] =
     Generator.function15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfQ: Generator[Q], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] =
     Generator.function16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfR: Generator[R], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] =
     Generator.function17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfS: Generator[S], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] =
     Generator.function18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfT: Generator[T], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] =
     Generator.function19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfU: Generator[U], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] =
     Generator.function20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfV: Generator[V], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] =
     Generator.function21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+
+  /**
+    * See [[function1s]].
+    *
+    * @group Functions
+    */
   def function22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](implicit genOfW: Generator[W], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V], typeInfoW: TypeInfo[W]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] =
     Generator.function22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
 
-  val posInts: Generator[PosInt] = Generator.posIntGenerator
-  val posZInts: Generator[PosZInt] = Generator.posZIntGenerator
-  val posLongs: Generator[PosLong] = Generator.posLongGenerator
-  val posZLongs: Generator[PosZLong] = Generator.posZLongGenerator
-  val posFloats: Generator[PosFloat] = Generator.posFloatGenerator
-  val posFiniteFloats: Generator[PosFiniteFloat] = Generator.posFiniteFloatGenerator
-  val posZFloats: Generator[PosZFloat] = Generator.posZFloatGenerator
-  val posZFiniteFloats: Generator[PosZFiniteFloat] = Generator.posZFiniteFloatGenerator
-  val posDoubles: Generator[PosDouble] = Generator.posDoubleGenerator
-  val posFiniteDoubles: Generator[PosFiniteDouble] = Generator.posFiniteDoubleGenerator
-  val posZDoubles: Generator[PosZDouble] = Generator.posZDoubleGenerator
-  val posZFiniteDoubles: Generator[PosZFiniteDouble] = Generator.posZFiniteDoubleGenerator
-  val negInts: Generator[NegInt] = Generator.negIntGenerator
-  val negZInts: Generator[NegZInt] = Generator.negZIntGenerator
-  val negLongs: Generator[NegLong] = Generator.negLongGenerator
-  val negZLongs: Generator[NegZLong] = Generator.negZLongGenerator
-  val negFloats: Generator[NegFloat] = Generator.negFloatGenerator
-  val negFiniteFloats: Generator[NegFiniteFloat] = Generator.negFiniteFloatGenerator
-  val negZFloats: Generator[NegZFloat] = Generator.negZFloatGenerator
-  val negZFiniteFloats: Generator[NegZFiniteFloat] = Generator.negZFiniteFloatGenerator
-  val negDoubles: Generator[NegDouble] = Generator.negDoubleGenerator
-  val negFiniteDoubles: Generator[NegFiniteDouble] = Generator.negFiniteDoubleGenerator
-  val negZDoubles: Generator[NegZDouble] = Generator.negZDoubleGenerator
-  val negZFiniteDoubles: Generator[NegZFiniteDouble] = Generator.negZFiniteDoubleGenerator
-  val nonZeroInts: Generator[NonZeroInt] = Generator.nonZeroIntGenerator
-  val nonZeroLongs: Generator[NonZeroLong] = Generator.nonZeroLongGenerator
-  val nonZeroFloats: Generator[NonZeroFloat] = Generator.nonZeroFloatGenerator
-  val nonZeroFiniteFloats: Generator[NonZeroFiniteFloat] = Generator.nonZeroFiniteFloatGenerator
-  val nonZeroDoubles: Generator[NonZeroDouble] = Generator.nonZeroDoubleGenerator
-  val nonZeroFiniteDoubles: Generator[NonZeroFiniteDouble] = Generator.nonZeroFiniteDoubleGenerator
-  val finiteFloats: Generator[FiniteFloat] = Generator.finiteFloatGenerator
-  val finiteDoubles: Generator[FiniteDouble] = Generator.finiteDoubleGenerator
-  val numericChars: Generator[NumericChar] = Generator.numericCharGenerator
 
-  val posIntValues: Generator[Int] = Generator.posIntGenerator.map(_.value)
-  val posZIntValues: Generator[Int] = Generator.posZIntGenerator.map(_.value)
-  val posLongValues: Generator[Long] = Generator.posLongGenerator.map(_.value)
-  val posZLongValues: Generator[Long] = Generator.posZLongGenerator.map(_.value)
-  val posFloatValues: Generator[Float] = Generator.posFloatGenerator.map(_.value)
-  val posFiniteFloatValues: Generator[Float] = Generator.posFiniteFloatGenerator.map(_.value)
-  val posZFloatValues: Generator[Float] = Generator.posZFloatGenerator.map(_.value)
-  val posZFiniteFloatValues: Generator[Float] = Generator.posZFiniteFloatGenerator.map(_.value)
-  val posDoubleValues: Generator[Double] = Generator.posDoubleGenerator.map(_.value)
-  val posFiniteDoubleValues: Generator[Double] = Generator.posFiniteDoubleGenerator.map(_.value)
-  val posZDoubleValues: Generator[Double] = Generator.posZDoubleGenerator.map(_.value)
-  val posZFiniteDoubleValues: Generator[Double] = Generator.posZFiniteDoubleGenerator.map(_.value)
-  val negIntValues: Generator[Int] = Generator.negIntGenerator.map(_.value)
-  val negZIntValues: Generator[Int] = Generator.negZIntGenerator.map(_.value)
-  val negLongValues: Generator[Long] = Generator.negLongGenerator.map(_.value)
-  val negZLongValues: Generator[Long] = Generator.negZLongGenerator.map(_.value)
-  val negFloatValues: Generator[Float] = Generator.negFloatGenerator.map(_.value)
-  val negFiniteFloatValues: Generator[Float] = Generator.negFiniteFloatGenerator.map(_.value)
-  val negZFloatValues: Generator[Float] = Generator.negZFloatGenerator.map(_.value)
-  val negZFiniteFloatValues: Generator[Float] = Generator.negZFiniteFloatGenerator.map(_.value)
-  val negDoubleValues: Generator[Double] = Generator.negDoubleGenerator.map(_.value)
-  val negFiniteDoubleValues: Generator[Double] = Generator.negFiniteDoubleGenerator.map(_.value)
-  val negZDoubleValues: Generator[Double] = Generator.negZDoubleGenerator.map(_.value)
-  val negZFiniteDoubleValues: Generator[Double] = Generator.negZFiniteDoubleGenerator.map(_.value)
-  val nonZeroIntValues: Generator[Int] = Generator.nonZeroIntGenerator.map(_.value)
-  val nonZeroLongValues: Generator[Long] = Generator.nonZeroLongGenerator.map(_.value)
-  val nonZeroFloatValues: Generator[Float] = Generator.nonZeroFloatGenerator.map(_.value)
-  val nonZeroFiniteFloatValues: Generator[Float] = Generator.nonZeroFiniteFloatGenerator.map(_.value)
-  val nonZeroDoubleValues: Generator[Double] = Generator.nonZeroDoubleGenerator.map(_.value)
-  val nonZeroFiniteDoubleValues: Generator[Double] = Generator.nonZeroFiniteDoubleGenerator.map(_.value)
-  val finiteFloatValues: Generator[Float] = Generator.finiteFloatGenerator.map(_.value)
-  val finiteDoubleValues: Generator[Double] = Generator.finiteDoubleGenerator.map(_.value)
-  val numericCharValues: Generator[Char] = Generator.numericCharGenerator.map(_.value)
-
-  def vectors[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
-  def sets[T](implicit genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] = Generator.setGenerator
-  def sortedSets[T](implicit genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] = Generator.sortedSetGenerator
-  def maps[K, V](implicit genOfTupleKV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] = Generator.mapGenerator
-  def sortedMaps[K, V](implicit genOfTupleKV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] = Generator.sortedMapGenerator
-
+  /**
+    * The `instancesOf` function (which has overloads depending on how many parameters you need)
+    * is one way to create a [[Generator]] for case classes and other situations where you
+    * want to build a type out of other types.
+    *
+    * To understand how it works, look at this example:
+    * {{{
+    *   case class Person(name: String, age: Int)
+    *   implicit val persons: Generator[Person] =
+    *     instancesOf(Person) { p =>
+    *       (p.name, p.age)
+    *     } (strings, posZIntValues)
+    * }}}
+    * What's going on here? `instancesOf` is taking two types ([[String]] and [[Int]]),
+    * a function (a case class constructor) that turns those types into a third type (`Person`),
+    * and a second function that takes a `Person` and deconstructs it back to its component
+    * pieces. From those, it creates a [[Generator]].
+    *
+    * The last parameters -- the `(strings, posZIntValues)` -- are the [[Generator]]s for
+    * the component types. If you are good with using the default Generators for those types,
+    * you can just let those parameters be resolved implicitly. (But in this case, that
+    * could result in negative ages, which doesn't make any sense.)
+    *
+    * After creating a [[Generator]] this way, you can use it like any other Generator in
+    * your property checks.
+    *
+    * Alternatively, you can construct Generators for case classes using for
+    * comprehensions, like this:
+    * {{{
+    *   implicit val persons: Generator[Person] = for {
+    *     name <- strings
+    *     age <- posZIntValues
+    *   }
+    *     yield Person(name, age)
+    * }}}
+    * Which approach you use is mainly up to personal taste and the coding standards
+    * of your project.
+    *
+    * @param construct a constructor that builds the target type from its constituents;
+    *                  most often, a case class constructor
+    * @param deconstruct a deconstructor function that takes the target type and breaks
+    *                    is down into its constituents
+    * @param genOfA a [[Generator]] for the input type
+    * @tparam A the input type
+    * @tparam B the target type to be generated
+    * @return a [[Generator]] for the target type
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B](construct: A => B)(deconstruct: B => A)(implicit genOfA: Generator[A]): Generator[B] =
     new GeneratorFor1[A, B](construct, deconstruct)(genOfA)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C](construct: (A, B) => C)(deconstruct: C => (A, B))(implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[C] =
     new GeneratorFor2[A, B, C](construct, deconstruct)(genOfA, genOfB)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D](construct: (A, B, C) => D)(deconstruct: D => (A, B, C))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[D] =
     new GeneratorFor3[A, B, C, D](construct, deconstruct)(genOfA, genOfB, genOfC)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E](construct: (A, B, C, D) => E)(deconstruct: E => (A, B, C, D))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[E] =
     new GeneratorFor4[A, B, C, D, E](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F](construct: (A, B, C, D, E) => F)(deconstruct: F => (A, B, C, D, E))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[F] =
     new GeneratorFor5[A, B, C, D, E, F](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G](construct: (A, B, C, D, E, F) => G)(deconstruct: G => (A, B, C, D, E, F))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[G] =
     new GeneratorFor6[A, B, C, D, E, F, G](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H](construct: (A, B, C, D, E, F, G) => H)(deconstruct: H => (A, B, C, D, E, F, G))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                   genOfG: Generator[G]): Generator[H] =
     new GeneratorFor7[A, B, C, D, E, F, G, H](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I](construct: (A, B, C, D, E, F, G, H) => I)(deconstruct: I => (A, B, C, D, E, F, G, H))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                   genOfG: Generator[G], genOfH: Generator[H]): Generator[I] =
     new GeneratorFor8[A, B, C, D, E, F, G, H, I](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J](construct: (A, B, C, D, E, F, G, H, I) => J)(deconstruct: J => (A, B, C, D, E, F, G, H, I))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                            genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[J] =
     new GeneratorFor9[A, B, C, D, E, F, G, H, I, J](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K](construct: (A, B, C, D, E, F, G, H, I, J) => K)(deconstruct: K => (A, B, C, D, E, F, G, H, I, J))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                     genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J]): Generator[K] =
     new GeneratorFor10[A, B, C, D, E, F, G, H, I, J, K](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L](construct: (A, B, C, D, E, F, G, H, I, J, K) => L)(deconstruct: L => (A, B, C, D, E, F, G, H, I, J, K))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                              genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K]): Generator[L] =
     new GeneratorFor11[A, B, C, D, E, F, G, H, I, J, K, L](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M](construct: (A, B, C, D, E, F, G, H, I, J, K, L) => M)(deconstruct: M => (A, B, C, D, E, F, G, H, I, J, K, L))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                       genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[M] =
     new GeneratorFor12[A, B, C, D, E, F, G, H, I, J, K, L, M](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => N)(deconstruct: N => (A, B, C, D, E, F, G, H, I, J, K, L, M))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[N] =
     new GeneratorFor13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O)(deconstruct: O => (A, B, C, D, E, F, G, H, I, J, K, L, M, N))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                  genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                  genOfN: Generator[N]): Generator[O] =
     new GeneratorFor14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P)(deconstruct: P => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                  genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                  genOfN: Generator[N], genOfO: Generator[O]): Generator[P] =
     new GeneratorFor15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q)(deconstruct: Q => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                           genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                           genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[Q] =
     new GeneratorFor16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R)(deconstruct: R => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                    genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                    genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[R] =
     new GeneratorFor17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S)(deconstruct: S => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                             genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                             genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[S] =
     new GeneratorFor18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T)(deconstruct: T => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                      genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                      genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[T] =
     new GeneratorFor19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U)(deconstruct: U => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                               genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                               genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T]): Generator[U] =
     new GeneratorFor20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V)(deconstruct: V => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                        genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                        genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
                                                                                                                                                                                                                                        genOfU: Generator[U]): Generator[V] =
     new GeneratorFor21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT, genOfU)
 
+  /**
+    * See the simple `[A, B]` version of `instancesOf()` for details.
+    *
+    * @group InstancesOf
+    */
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W)(deconstruct: W => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                                 genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                                 genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
@@ -1169,6 +2353,8 @@ trait CommonGenerators {
     * @param pf a [[PartialFunction]] that takes the generated values, and sorts them into "buckets" by String names
     * @tparam A the type to be generated
     * @return statistics on how many values wound up in each bucket
+    *
+    * @group Tools
     */
   // classify will need to use the same sizing algo as forAll, and same edges approach
   def classify[A](count: PosInt, genOfA: Generator[A])(pf: PartialFunction[A, String]): Classification = {
@@ -1194,10 +2380,8 @@ trait CommonGenerators {
     Classification(count, theMap)
   }
 
-  // TODO: is there any good reason for this to be a def? It seems a good candidate to be a
-  // val instead.
   /**
-    * Create a [[Generator]] of prime numbers.
+    * A [[Generator]] of prime numbers.
     *
     * As the name implies, this doesn't try to generate entirely arbitrary prime numbers. Instead,
     * it takes the simpler and more efficient approach of choosing randomly from a hard-coded
@@ -1205,8 +2389,10 @@ trait CommonGenerators {
     * this is 7919.
     *
     * @return a [[Generator]] that will produce smallish prime numbers
+    *
+    * @group Tools
     */
-  def first1000Primes: Generator[Int] =
+  lazy val first1000Primes: Generator[Int] =
     new Generator[Int] { thisIntGenerator =>
       def next(szp: SizeParam, edges: List[Int], rnd: Randomizer): (Int, List[Int], Randomizer) = {
         edges match {
@@ -1220,6 +2406,12 @@ trait CommonGenerators {
     }
 }
 
+/**
+  * An import-able version of [[CommonGenerators]].
+  *
+  * You should not usually need to import this directly, since it is mixed into
+  * [[GeneratorDrivenPropertyChecks]] and [[TableDrivenPropertyChecks]].
+  */
 object CommonGenerators extends CommonGenerators {
   private val primeNumbers =
     Vector(


### PR DESCRIPTION
Much of this is simply about filling in the boilerplate for the Generators that are just external references.

But I also decided that this list is long enough to warrant using Scaladoc's @group mechanism. (Note the tweaked to the build file to turn that on.) The order of the sections is arbitrary, and be be easily rearranged by changing the values on the @groupprio entries in the top-level Scaladoc.