### PR TITLE
#1519: add/complete Generators for Option, Or and Either

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -3389,6 +3389,22 @@ If it doesn't show up for a while, please delete this comment.
       }
     }
 
+    "offer an ors method" that {
+      "returns the default implicit generator that produces arbitrary Ors" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalactic._
+        val implicitGen = implicitly[Generator[Int Or String]]
+        val namedGen = ors[Int, String]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+
     "offer a lists method" that {
       "returns the default implicit generator that produces arbitrary Lists" in {
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -3234,7 +3234,7 @@ If it doesn't show up for a while, please delete this comment.
           samplesLoop(count + 1, nextNextRnd, value :: acc)
         } 
       }
-      samplesLoop(100, originalRnd, Nil)
+      samplesLoop(0, originalRnd, Nil)
     }
 
     "offer a booleans method" that {
@@ -3374,34 +3374,38 @@ If it doesn't show up for a while, please delete this comment.
       }
     }
 
+    /**
+      * A common function to reduce the massive amounts of boilerplate in all of these
+      * tests.
+      *
+      * This takes two Generators, an explicit one from CommonGenerators and an
+      * implicit one of the same type, and confirms that they actually are the same.
+      * (Or more precisely, that they produce the same results.)
+      *
+      * @param namedGen the named Generator, from CommonGenerators
+      * @param implicitGen the implicit Generator of the same type, from Generators
+      * @tparam T the type being generated
+      */
+    def compareGens[T](namedGen: Generator[T])(implicit implicitGen: Generator[T]): Unit = {
+      val rnd = Randomizer.default
+      val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+      val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+      implicitGenEdges shouldEqual namedGenEdges
+      val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+      val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+      implicitGenSamples shouldEqual namedGenSamples
+    }
+
     "offer an options method" that {
       "returns the default implicit generator that produces arbitrary Options" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
-        val implicitGen = implicitly[Generator[Option[Int]]]
-        val namedGen = options[Int]
-        val rnd = Randomizer.default
-        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
-        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
-        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
-        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
-        implicitGenSamples shouldEqual namedGenSamples
+        compareGens(CommonGenerators.options[Int])
       }
     }
 
     "offer an ors method" that {
       "returns the default implicit generator that produces arbitrary Ors" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         import org.scalactic._
-        val implicitGen = implicitly[Generator[Int Or String]]
-        val namedGen = ors[Int, String]
-        val rnd = Randomizer.default
-        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
-        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
-        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
-        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
-        implicitGenSamples shouldEqual namedGenSamples
+        compareGens(CommonGenerators.ors[Int, String])
       }
     }
 
@@ -4736,6 +4740,7 @@ If it doesn't show up for a while, please delete this comment.
         implicitGenSamples shouldEqual namedGenSamples
       }
     }
+
     "offer a function1s method" that {
       "should use the implicit provider that uses hashCode to tweak a seed and has a pretty toString" in {
         val implicitGen = implicitly[Generator[Long => Int]]
@@ -4744,11 +4749,18 @@ If it doesn't show up for a while, please delete this comment.
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
         implicitGenEdges shouldEqual namedGenEdges
-        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
-        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
-        implicitGenSamples shouldEqual namedGenSamples
+        val implicitGenSamples = samplesForGen(implicitGen, 1, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 1, rnd)
+        // We can't actually compare the functions themselves, which don't have
+        // equality operations. So instead, we spot-check that they are producing
+        // the same results:
+        val (param, _) = rnd.nextLong
+        val implicitGenResults = implicitGenSamples.map(_(param))
+        val namedGenResults = namedGenSamples.map(_(param))
+        implicitGenResults shouldEqual namedGenResults
       }
     }
+
     "offer a function2s method" that {
       "should use the implicit provider that uses hashCode to tweak a seed and has a pretty toString" in {
         val implicitGen = implicitly[Generator[(Long, String) => Int]]
@@ -4759,7 +4771,14 @@ If it doesn't show up for a while, please delete this comment.
         implicitGenEdges shouldEqual namedGenEdges
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
-        implicitGenSamples shouldEqual namedGenSamples
+        // We can't actually compare the functions themselves, which don't have
+        // equality operations. So instead, we spot-check that they are producing
+        // the same results:
+        val (param1, nextRnd) = rnd.nextLong
+        val (param2, _) = nextRnd.nextString(100)
+        val implicitGenResults = implicitGenSamples.map(_(param1, param2))
+        val namedGenResults = namedGenSamples.map(_(param1, param2))
+        implicitGenResults shouldEqual namedGenResults
       }
     }
     "offer a vectors method" that {

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -3373,6 +3373,22 @@ If it doesn't show up for a while, please delete this comment.
         implicitGenSamples shouldEqual namedGenSamples
       }
     }
+
+    "offer an options method" that {
+      "returns the default implicit generator that produces arbitrary Options" in {
+        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        val implicitGen = implicitly[Generator[Option[Int]]]
+        val namedGen = options[Int]
+        val rnd = Randomizer.default
+        val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
+        val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
+        implicitGenEdges shouldEqual namedGenEdges
+        val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
+        val namedGenSamples = samplesForGen(namedGen, 100, rnd)
+        implicitGenSamples shouldEqual namedGenSamples
+      }
+    }
+
     "offer a lists method" that {
       "returns the default implicit generator that produces arbitrary Lists" in {
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -3409,6 +3409,12 @@ If it doesn't show up for a while, please delete this comment.
       }
     }
 
+    "offer an eithers method" that {
+      "returns the default implicit generator that produces arbitrary Eithers" in {
+        compareGens(CommonGenerators.eithers[String, Int])
+      }
+    }
+
     "offer a lists method" that {
       "returns the default implicit generator that produces arbitrary Lists" in {
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._

--- a/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2192,6 +2192,69 @@ class GeneratorSpec extends FunSpec with Matchers {
       }
     }
 
+    describe("for Ors") {
+      it("should use the base types for edges") {
+        import Generator._
+        import org.scalactic._
+        val gGen = intGenerator
+        val bGen = stringGenerator
+        val gen = orGenerator[Int, String]
+
+        val rnd = Randomizer.default
+        val (gEdges, _) = gGen.initEdges(100, rnd)
+        val (bEdges, _) = bGen.initEdges(100, rnd)
+        val (orEdges, _) = gen.initEdges(100, rnd)
+
+        orEdges should contain theSameElementsAs(gEdges.map(Good(_)) ++ bEdges.map(Bad(_)))
+      }
+
+      it("should use the base types for canonicals") {
+        import Generator._
+        import org.scalactic._
+        val gGen = intGenerator
+        val bGen = stringGenerator
+        val gen = orGenerator[Int, String]
+
+        val rnd = Randomizer.default
+        val (gCanon, _) = gGen.canonicals(rnd)
+        val (bCanon, _) = bGen.canonicals(rnd)
+        val (orCanon, _) = gen.canonicals(rnd)
+
+        orCanon.toList should contain theSameElementsAs((gCanon.map(Good(_)) ++ bCanon.map(Bad(_))).toList)
+      }
+
+      it("should produce an appropriate mix of Good and Bad") {
+        import Generator._
+        import org.scalactic._
+        val gen = orGenerator[Int, String]
+
+        val classification = CommonGenerators.classify(1000, gen) {
+          case Good(_) => "Good"
+          case Bad(_) => "Bad"
+        }
+
+        // It's arbitrary, but we know that it produces Bad about a quarter of the time:
+        classification.portions("Bad") should be (.25 +- .02)
+      }
+
+      it("should use the base types to shrink") {
+        import Generator._
+        import org.scalactic._
+        val gGen = intGenerator
+        val bGen = stringGenerator
+        val gen = orGenerator[Int, String]
+
+        val rnd = Randomizer.default
+        val (gShrink, _) = gGen.shrink(1000, rnd)
+        val (bShrink, _) = bGen.shrink("hello world!", rnd)
+        val (orGoodShrink, _) = gen.shrink(Good(1000), rnd)
+        val (orBadShrink, _) = gen.shrink(Bad("hello world!"), rnd)
+
+        orGoodShrink.toList should contain theSameElementsAs(gShrink.map(Good(_)).toList)
+        orBadShrink.toList should contain theSameElementsAs(bShrink.map(Bad(_)).toList)
+      }
+    }
+
     describe("for Lists") {
       it("should offer a List[T] generator that returns a List[T] whose length equals the passed size") {
   

--- a/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -589,27 +589,13 @@ abstract class UnitPropCheckerAsserting {
             pos
           )
 
-        case PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
+        case failure @ PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
           indicateFailure(
-            sde => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + EOL +
-              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + EOL +
-              "  " + FailureMessages.propertyFailed(prettifier, succeeded) + EOL +
-              (
-                sde match {
-                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
-                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + EOL
-                  case _ => ""
-                }
-                ) +
-              "  " + FailureMessages.occurredOnValues + EOL +
-              prettyArgs(getArgsWithSpecifiedNames(argNames, argsPassed), prettifier) + EOL +
-              "  )" +
-              getLabelDisplay(labels.toSet) + EOL +
-              "  " + FailureMessages.initSeed(prettifier, initSeed),
+            sde => failureStr(failure, sde, prettifier, argNames, labels),
             FailureMessages.propertyFailed(prettifier, succeeded),
             argsPassed,
             labels,
-            None,
+            ex,
             pos
           )
 
@@ -1353,23 +1339,9 @@ trait FuturePropCheckerAsserting {
             pos
           )
 
-        case PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
+        case failure @ PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) =>
           indicateFutureFailure(
-            sde => FailureMessages.propertyException(prettifier, UnquotedString(sde.getClass.getSimpleName)) + EOL +
-              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + EOL +
-              "  " + FailureMessages.propertyFailed(prettifier, succeeded) + EOL +
-              (
-                sde match {
-                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
-                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + EOL
-                  case _ => ""
-                }
-                ) +
-              "  " + FailureMessages.occurredOnValues + EOL +
-              prettyArgs(getArgsWithSpecifiedNames(argNames, argsPassed), prettifier) + EOL +
-              "  )" +
-              getLabelDisplay(labels.toSet) + EOL +
-              "  " + FailureMessages.initSeed(prettifier, initSeed),
+            sde => failureStr(failure, sde, prettifier, argNames, labels),
             FailureMessages.propertyFailed(prettifier, succeeded),
             argsPassed,
             labels,
@@ -1593,6 +1565,51 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting with FutureP
       "\n  " + (if (labels.size == 1) Resources.propCheckLabel else Resources.propCheckLabels) + "\n" + labels.map("    " + _).mkString("\n")
     else
       ""
+
+  /**
+    * This computes the string to display when a property check fails. It's showing quite a bit, so there's a lot
+    * to it.
+    *
+    * @param failure the actual property check failure, which contains lots of stuff we need to show
+    * @param outerEx the outer exception, generally pointing to the forAll itself
+    * @param prettifier the Prettifier that we will use to improve the error displays
+    * @param argNames the names on the property check arguments, if any
+    * @param labels
+    * @return the detailed error message to show to the user
+    */
+  private[enablers] def failureStr(failure: PropertyCheckResult.Failure, outerEx: StackDepthException, prettifier: Prettifier, argNames: Option[List[String]], labels: List[String]): String = {
+    // ex is the *inner* Exception, where we actually threw. If defined, this is typically the line
+    // that the user really cares about:
+    val PropertyCheckResult.Failure(succeeded, ex, names, argsPassed, initSeed) = failure
+    // If there is an inner Exception, show that message; otherwise, default to something
+    // more generic:
+    val msg = ex match {
+      case Some(ex) => ex.getMessage
+      case None => FailureMessages.propertyException(prettifier, UnquotedString(outerEx.getClass.getSimpleName))
+    }
+    // If there was an inner Exception, that's the line to focus on:
+    val filenameAndLine: Option[String] = ex match {
+      case Some(ex: StackDepthException) => ex.failedCodeFileNameAndLineNumberString
+      case _ => outerEx.failedCodeFileNameAndLineNumberString
+    }
+
+    msg + EOL +
+      ( filenameAndLine match { case Some(s) => " (" + s + ")"; case None => "" }) + EOL +
+      "  " + FailureMessages.propertyFailed(prettifier, succeeded) + EOL +
+      (
+        // This is where we display the location of the *outer* Exception, typically the forAll:
+        outerEx match {
+          case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+            "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + EOL
+          case _ => ""
+        }
+      ) +
+      "  " + FailureMessages.occurredOnValues + EOL +
+      prettyArgs(getArgsWithSpecifiedNames(argNames, argsPassed), prettifier) + EOL +
+      "  )" +
+      getLabelDisplay(labels.toSet) + EOL +
+      "  " + FailureMessages.initSeed(prettifier, initSeed)
+  }
 
   def calcSizes(minSize: PosZInt, maxSize: PosZInt, initRndm: Randomizer): (List[PosZInt], Randomizer) = {
     @tailrec

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -15,6 +15,7 @@
  */
 package org.scalatest.prop
 
+import org.scalactic._
 import org.scalactic.anyvals._
 
 import scala.annotation.tailrec
@@ -1780,6 +1781,17 @@ trait CommonGenerators {
     * @group Collections
     */
   def options[T](implicit genOfT: Generator[T]): Generator[Option[T]] = Generator.optionGenerator
+
+  /**
+    * Given [[Generator]]s for two types, [[G]] and [[B]], this provides one for `G Or B`.
+    *
+    * @param genOfG a [[Generator]] that produces type [[G]]
+    * @param genOfB a [[Generator]] that produces type [[B]]
+    * @tparam G the "good" type for an [[Or]]
+    * @tparam B the "bad" type for an [[Or]]
+    * @return a [[Generator]] that produces `G Or B`
+    */
+  def ors[G, B](implicit genOfG: Generator[G], genOfB: Generator[B]): Generator[G Or B] = Generator.orGenerator
 
   /**
     * Given an existing `Generator[T]`, this creates a `Generator[List[T]]`.

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -1794,6 +1794,17 @@ trait CommonGenerators {
   def ors[G, B](implicit genOfG: Generator[G], genOfB: Generator[B]): Generator[G Or B] = Generator.orGenerator
 
   /**
+    * Given [[Generator]]s for two types, [[L]] and [[R]], this provides one for `Either[L, R]`.
+    *
+    * @param genOfL a [[Generator]] that produces type [[L]]
+    * @param genOfR a [[Generator]] that produces type [[R]]
+    * @tparam L the Left type for an [[Either]]
+    * @tparam R the Right type for an [[Either]]
+    * @return a [[Generator]] that produces `Either[L, R]`
+    */
+  def eithers[L, R](implicit genOfL: Generator[L], genOfR: Generator[R]): Generator[Either[L, R]] = Generator.eitherGenerator
+
+  /**
     * Given an existing `Generator[T]`, this creates a `Generator[List[T]]`.
     *
     * @param genOfT a [[Generator]] that produces values of type [[T]]

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -1771,6 +1771,17 @@ trait CommonGenerators {
   def vectors[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
 
   /**
+    * Given an existing `Generator[T]`, this creates a `Generator[Option[T]]`.
+    *
+    * @param genOfT a [[Generator]] that produces values of type [[T]]
+    * @tparam T the type that we are producing an Option of
+    * @return a Generator that produces `Option[T]`
+    *
+    * @group Collections
+    */
+  def options[T](implicit genOfT: Generator[T]): Generator[Option[T]] = Generator.optionGenerator
+
+  /**
     * Given an existing `Generator[T]`, this creates a `Generator[List[T]]`.
     *
     * @param genOfT a [[Generator]] that produces values of type [[T]]

--- a/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2744,6 +2744,13 @@ object Generator {
         val edges = None :: edgesOfT.map(t => Some(t))
         (edges, nextRnd)
       }
+
+      override def canonicals(rnd: Randomizer): (Iterator[Option[T]], Randomizer) = {
+        // The canonicals of Option[T] are the canonicals of T, plus None
+        val (tCanonicals, nextRnd) = genOfT.canonicals(rnd)
+        (Iterator(None) ++ tCanonicals.map(Some(_)), nextRnd)
+      }
+
       def next(szp: SizeParam, edges: List[Option[T]], rnd: Randomizer): (Option[T], List[Option[T]], Randomizer) = {
         edges match {
           case head :: tail =>
@@ -2758,6 +2765,21 @@ object Generator {
             }
         }
       }
+
+      override def shrink(value: Option[T], rnd: Randomizer): (Iterator[Option[T]], Randomizer) = {
+        value match {
+          // If there is a real value, shrink that value, and return that and None.
+          case Some(t) => {
+            val (tShrinks, nextRnd) = genOfT.shrink(t, rnd)
+            (Iterator(None) ++ tShrinks.map(Some(_)), nextRnd)
+          }
+
+          // There's no way to simplify None:
+          case None => (Iterator.empty, rnd)
+        }
+      }
+
+      override def toString = "Generator[Option[T]]"
     }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2811,6 +2811,14 @@ object Generator {
         }
         (loop(maxLength, edgesOfG, edgesOfB, Nil), nextNextRnd)
       }
+
+      override def canonicals(rnd: Randomizer): (Iterator[Or[G, B]], Randomizer) = {
+        val (goodCanon, nextRnd) = genOfG.canonicals(rnd)
+        val (badCanon, nextNextRnd) = genOfB.canonicals(nextRnd)
+
+        (goodCanon.map(Good(_)) ++ badCanon.map(Bad(_)), nextNextRnd)
+      }
+
       def next(szp: SizeParam, edges: List[G Or B], rnd: Randomizer): (G Or B, List[G Or B], Randomizer) = {
         edges match {
           case head :: tail => 
@@ -2825,6 +2833,19 @@ object Generator {
               val (nextG, _, nextRnd) = genOfG.next(szp, Nil, rnd)
               (Good(nextG), Nil, nextRnd)
             }
+        }
+      }
+
+      override def shrink(value: Or[G, B], rnd: Randomizer): (Iterator[Or[G, B]], Randomizer) = {
+        value match {
+          case Good(g) => {
+            val (gShrink, nextRnd) = genOfG.shrink(g, rnd)
+            (gShrink.map(Good(_)), nextRnd)
+          }
+          case Bad(b) => {
+            val (bShrink, nextRnd) = genOfB.shrink(b, rnd)
+            (bShrink.map(Bad(_)), nextRnd)
+          }
         }
       }
     }


### PR DESCRIPTION
There were partial Generators already for Option and Or, but they were only half-finished, and had no tests.

Did a little refactoring in CommonGeneratorsSpec, to reduce unnecessary boilerplate.  We might want to go through and apply that more broadly -- it would make the file *much* more tractable.

Discovered along the way that CommonGeneratorsSpec had a serious bug, such that most of the tests were doing much less than they appeared.  Fixed that.

That revealed that the function1/2s tests were fundamentally broken -- they were trying an impossible test, since equality isn't defined on functions.  So rewrote those tests to test results instead of identity.