### PR TITLE
Added third-party Future support for asynchronous testing

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/AsyncEngineSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncEngineSpec.scala
@@ -125,7 +125,7 @@ class AsyncEngineSpec extends FlatSpec with Matchers {
   // SKIP-SCALATESTJS,NATIVE-START
   "AsyncEngine" should "abort a suite if an exception that should cause an abort is thrown in a test" in {
     val ex = new OutOfMemoryError("I meant to do that!")
-    class MySpec extends AsyncFunSuite {
+    class MySpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
       test("should abort the suite") {
         Future.failed(ex)
       }
@@ -142,7 +142,7 @@ class AsyncEngineSpec extends FlatSpec with Matchers {
     // way back up. Suite aborts were caused by before or after code that died. Now we have a new problem
     // in async of what do we do when a test dies with OutOfMemoryError. Can't just propagate it back.
     // Unless there's someplace we can throw it, maybe have to report SuiteAborted. 
-    class SuiteThatAborts extends AsyncFunSuite {
+    class SuiteThatAborts extends AsyncFunSuite with DefaultFutureAssertionConverter {
       // SKIP-SCALATESTJS,NATIVE-START
       implicit def executionContext = scala.concurrent.ExecutionContext.Implicits.global
       // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec.scala
@@ -32,7 +32,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -148,7 +148,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -195,7 +195,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -240,7 +240,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -280,7 +280,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           val promise = Promise[Assertion]
@@ -343,7 +343,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
       // job to be enqueued via SerialExecutionContext.execute, and that
       // will do the final notify. After running that job, the Future passed
       // to runNow will be complete, and runNow will return.
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           val promise = Promise[Assertion]
@@ -369,7 +369,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -397,7 +397,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -443,7 +443,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -482,7 +482,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -501,7 +501,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           info(
@@ -525,7 +525,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -557,7 +557,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -591,7 +591,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -610,7 +610,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpecLike {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -641,7 +641,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should report as failed test when non-fatal exception is thrown from scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -676,7 +676,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -701,7 +701,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -728,7 +728,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -747,7 +747,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -776,7 +776,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should report as failed test when non-fatal exception is thrown from Future returned by scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -813,7 +813,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -838,7 +838,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -865,7 +865,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -884,7 +884,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -911,7 +911,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -943,7 +943,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -981,7 +981,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     // SKIP-SCALATESTJS,NATIVE-START
     it("should propagate fatal exception when thrown from scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -1009,7 +1009,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should propagate fatal exception when thrown from Future returned by scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -1039,7 +1039,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     // SKIP-SCALATESTJS,NATIVE-END
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         Feature("a feature") {
           Scenario("test 1") { succeed }
           Scenario("test 1") { succeed }
@@ -1060,7 +1060,7 @@ class AsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -88,7 +88,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -141,7 +141,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -185,7 +185,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           SleepHelper.sleep(30)
@@ -227,7 +227,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -270,7 +270,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           val promise = Promise[Assertion]
@@ -329,7 +329,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -361,7 +361,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -408,7 +408,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -448,7 +448,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -468,7 +468,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           info(
@@ -493,7 +493,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -523,7 +523,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -555,7 +555,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -575,7 +575,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           note(
@@ -600,7 +600,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -623,7 +623,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -648,7 +648,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -668,7 +668,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           alert(
@@ -693,7 +693,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -716,7 +716,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -741,7 +741,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -761,7 +761,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           markup(
@@ -786,7 +786,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -816,7 +816,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -848,7 +848,7 @@ class AsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec.scala
@@ -32,7 +32,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -148,7 +148,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -195,7 +195,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -240,7 +240,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -279,7 +279,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           val promise = Promise[Assertion]
@@ -334,7 +334,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -362,7 +362,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -407,7 +407,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -445,7 +445,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -464,7 +464,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -491,7 +491,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -523,7 +523,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -557,7 +557,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -576,7 +576,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -603,7 +603,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -628,7 +628,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -655,7 +655,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -674,7 +674,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -701,7 +701,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -753,7 +753,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -772,7 +772,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -799,7 +799,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -831,7 +831,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -865,7 +865,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         Feature("a feature") {
           Scenario("test 1") { succeed }
           Scenario("test 1") { succeed }
@@ -886,7 +886,7 @@ class AsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFeatureSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
+class AsyncFeatureSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -182,7 +182,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           SleepHelper.sleep(3000)
@@ -224,7 +224,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -267,7 +267,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           val promise = Promise[Assertion]
@@ -326,7 +326,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           Future {
@@ -405,7 +405,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -445,7 +445,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -465,7 +465,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           info(
@@ -490,7 +490,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -520,7 +520,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -552,7 +552,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -572,7 +572,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           note(
@@ -597,7 +597,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -620,7 +620,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -645,7 +645,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -665,7 +665,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           alert(
@@ -690,7 +690,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -713,7 +713,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -738,7 +738,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -758,7 +758,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           markup(
@@ -783,7 +783,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -813,7 +813,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -845,7 +845,7 @@ class AsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec.scala
@@ -28,7 +28,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -90,7 +90,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -144,7 +144,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -191,7 +191,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -236,7 +236,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -276,7 +276,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           val promise = Promise[Assertion]
@@ -332,7 +332,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -360,7 +360,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -406,7 +406,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -445,7 +445,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -464,7 +464,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -494,7 +494,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -526,7 +526,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -545,7 +545,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -568,7 +568,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -593,7 +593,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -612,7 +612,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -635,7 +635,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -660,7 +660,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -679,7 +679,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -709,7 +709,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -741,7 +741,7 @@ class AsyncFlatSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFlatSpecLike {
+      class TestSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFlatSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -181,7 +181,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           SleepHelper.sleep(30)
@@ -223,7 +223,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -266,7 +266,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           val promise = Promise[Assertion]
@@ -325,7 +325,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -357,7 +357,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -404,7 +404,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpecLike {
+      class ExampleSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           SleepHelper.sleep(60)
@@ -444,7 +444,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -464,7 +464,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           info("hi there")
@@ -492,7 +492,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -522,7 +522,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -542,7 +542,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           note("hi there")
@@ -563,7 +563,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -586,7 +586,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -606,7 +606,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           alert("hi there")
@@ -627,7 +627,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -650,7 +650,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -670,7 +670,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           markup("hi there")
@@ -698,7 +698,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFlatSpecLike  {
+      class MySuite extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -728,7 +728,7 @@ class AsyncFlatSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFlatSpecLike {
+      class TestSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec.scala
@@ -29,7 +29,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -90,7 +90,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -143,7 +143,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -190,7 +190,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -235,7 +235,7 @@ class AsyncFlatSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -275,7 +275,7 @@ class AsyncFlatSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           val promise = Promise[Assertion]
@@ -331,7 +331,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -359,7 +359,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -405,7 +405,7 @@ class AsyncFlatSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -444,7 +444,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -493,7 +493,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -525,7 +525,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -544,7 +544,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -567,7 +567,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -592,7 +592,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -611,7 +611,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -634,7 +634,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -659,7 +659,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -678,7 +678,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -708,7 +708,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -740,7 +740,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should generate a DuplicateTestNameException is detected") {
-      class TestSpec extends AsyncFlatSpec {
+      class TestSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         behavior of "a feature"
         it should "test 1" in { succeed }
         it should "test 1" in { succeed }
@@ -754,7 +754,7 @@ class AsyncFlatSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFlatSpec {
+      class TestSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFlatSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFlatSpecSpec2 extends AsyncFunSpec {
+class AsyncFlatSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFlatSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -181,7 +181,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           SleepHelper.sleep(30)
@@ -222,7 +222,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -265,7 +265,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           Future {
@@ -403,7 +403,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFlatSpec {
+      class ExampleSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         it should "test 1" in {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           info("hi there")
@@ -491,7 +491,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -521,7 +521,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -541,7 +541,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           note("hi there")
@@ -562,7 +562,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -585,7 +585,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -605,7 +605,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           alert("hi there")
@@ -626,7 +626,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -649,7 +649,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -669,7 +669,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           markup("hi there")
@@ -697,7 +697,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFlatSpec  {
+      class MySuite extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         "test feature" should "test 1" in {
           Future {
@@ -727,7 +727,7 @@ class AsyncFlatSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFlatSpec {
+      class TestSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec.scala
@@ -32,7 +32,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -52,7 +52,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
         }
 
         "test 3" in {
-          Future {
+          Future  {
             pending
           }
         }
@@ -93,7 +93,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -146,7 +146,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -193,7 +193,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -238,7 +238,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -278,7 +278,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -334,7 +334,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -362,7 +362,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -408,7 +408,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -447,7 +447,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -466,7 +466,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -493,7 +493,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -525,7 +525,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -559,7 +559,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -578,7 +578,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -605,7 +605,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -630,7 +630,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -657,7 +657,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -676,7 +676,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -703,7 +703,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -728,7 +728,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -755,7 +755,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -774,7 +774,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -801,7 +801,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -833,7 +833,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
         //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -867,7 +867,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFreeSpecLike {
+      class TestSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         "a feature" - {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -888,7 +888,7 @@ class AsyncFreeSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFreeSpecLike {
+      class TestSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -182,7 +182,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -224,7 +224,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -267,7 +267,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -326,7 +326,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -405,7 +405,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpecLike {
+      class ExampleSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -445,7 +445,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -465,7 +465,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           info(
@@ -489,7 +489,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -519,7 +519,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -551,7 +551,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -571,7 +571,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           note(
@@ -596,7 +596,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -619,7 +619,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -644,7 +644,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -664,7 +664,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           alert(
@@ -689,7 +689,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -712,7 +712,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -737,7 +737,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -757,7 +757,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           markup(
@@ -782,7 +782,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -812,7 +812,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFreeSpecLike  {
+      class MySuite extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -844,7 +844,7 @@ class AsyncFreeSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFreeSpecLike {
+      class TestSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec.scala
@@ -32,7 +32,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -93,7 +93,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -146,7 +146,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -193,7 +193,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -238,7 +238,7 @@ class AsyncFreeSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -278,7 +278,7 @@ class AsyncFreeSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -334,7 +334,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -362,7 +362,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -408,7 +408,7 @@ class AsyncFreeSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -447,7 +447,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -466,7 +466,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -493,7 +493,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -525,7 +525,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -559,7 +559,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -578,7 +578,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -605,7 +605,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -630,7 +630,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -657,7 +657,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -676,7 +676,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -703,7 +703,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -728,7 +728,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -755,7 +755,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -774,7 +774,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -801,7 +801,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -833,7 +833,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -867,7 +867,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFreeSpec {
+      class TestSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         "a feature" - {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -888,7 +888,7 @@ class AsyncFreeSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFreeSpec {
+      class TestSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFreeSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFreeSpecSpec2 extends AsyncFunSpec {
+class AsyncFreeSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -181,7 +181,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -222,7 +222,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -265,7 +265,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -403,7 +403,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFreeSpec {
+      class ExampleSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           info(
@@ -487,7 +487,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -517,7 +517,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -549,7 +549,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -569,7 +569,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           note(
@@ -594,7 +594,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -617,7 +617,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -642,7 +642,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -662,7 +662,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           alert(
@@ -687,7 +687,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -710,7 +710,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -735,7 +735,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -755,7 +755,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           markup(
@@ -780,7 +780,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -810,7 +810,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFreeSpec  {
+      class MySuite extends AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         "test feature" - {
           "test 1" in {
@@ -842,7 +842,7 @@ class AsyncFreeSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFreeSpec {
+      class TestSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec.scala
@@ -28,7 +28,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -89,7 +89,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -142,7 +142,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -189,7 +189,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -234,7 +234,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -274,7 +274,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           val promise = Promise[Assertion]
@@ -330,7 +330,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -404,7 +404,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -443,7 +443,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -462,7 +462,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -489,7 +489,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -521,7 +521,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -555,7 +555,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -574,7 +574,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -601,7 +601,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -626,7 +626,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -653,7 +653,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -672,7 +672,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -699,7 +699,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -724,7 +724,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -751,7 +751,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -770,7 +770,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -797,7 +797,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -829,7 +829,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -863,7 +863,7 @@ class AsyncFunSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSpecLike {
+      class TestSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncFunSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -181,7 +181,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           SleepHelper.sleep(3000)
@@ -222,7 +222,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -265,7 +265,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -403,7 +403,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpecLike {
+      class ExampleSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         it("test 1") {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           info(
@@ -488,7 +488,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -518,7 +518,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -550,7 +550,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -570,7 +570,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           note(
@@ -595,7 +595,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -618,7 +618,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -643,7 +643,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -663,7 +663,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           alert(
@@ -688,7 +688,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -711,7 +711,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -736,7 +736,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -756,7 +756,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           markup(
@@ -781,7 +781,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -811,7 +811,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -843,7 +843,7 @@ class AsyncFunSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSpecLike {
+      class TestSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec.scala
@@ -32,7 +32,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("can be used for tests that return a Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with Expectations */ { // Can resurrect Expectations tests later
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution /* with Expectations */ { // Can resurrect Expectations tests later
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -112,7 +112,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with Expectations */ {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution /* with Expectations */ {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -181,7 +181,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -228,7 +228,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -273,7 +273,7 @@ class AsyncFunSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -313,7 +313,7 @@ class AsyncFunSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           val promise = Promise[Assertion]
@@ -369,7 +369,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -397,7 +397,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -443,7 +443,7 @@ class AsyncFunSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -482,7 +482,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -501,7 +501,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -528,7 +528,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -560,7 +560,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -594,7 +594,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -613,7 +613,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -640,7 +640,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -665,7 +665,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -692,7 +692,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -711,7 +711,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -738,7 +738,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -763,7 +763,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -790,7 +790,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -809,7 +809,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -836,7 +836,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -868,7 +868,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSpec  {
+      class MySuite extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -902,7 +902,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFunSpec {
+      class TestSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
         describe("a feature") {
           it("test 1") { succeed }
           it("test 1") { succeed }
@@ -923,7 +923,7 @@ class AsyncFunSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSpec {
+      class TestSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSpecSpec2 extends AsyncFunSpec {
+class AsyncFunSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return a Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with Expectations */ { // Can resurrect expect later
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution /* with Expectations */ { // Can resurrect expect later
 
         val a = 1
 
@@ -104,7 +104,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with Expectations */ {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution /* with Expectations */ {
 
         val a = 1
 
@@ -171,7 +171,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -214,7 +214,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           SleepHelper.sleep(30)
@@ -255,7 +255,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -298,7 +298,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           val promise = Promise[Assertion]
@@ -357,7 +357,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -389,7 +389,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           Future {
@@ -436,7 +436,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSpec {
+      class ExampleSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
         it("test 1") {
           SleepHelper.sleep(60)
@@ -476,7 +476,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -496,7 +496,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           info(
@@ -521,7 +521,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -551,7 +551,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -583,7 +583,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -603,7 +603,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           note(
@@ -628,7 +628,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -651,7 +651,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -676,7 +676,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -696,7 +696,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           alert(
@@ -721,7 +721,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -744,7 +744,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -769,7 +769,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -789,7 +789,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           markup(
@@ -814,7 +814,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -844,7 +844,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSpecLike  {
+      class MySuite extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         describe("test feature") {
           it("test 1") {
@@ -876,7 +876,7 @@ class AsyncFunSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSpec {
+      class TestSpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
@@ -28,7 +28,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -89,7 +89,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -142,7 +142,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuiteLike {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -189,7 +189,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuiteLike {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -234,7 +234,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -274,7 +274,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           val promise = Promise[Assertion]
@@ -330,7 +330,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -404,7 +404,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -443,7 +443,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -462,7 +462,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -492,7 +492,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -524,7 +524,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -543,7 +543,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -566,7 +566,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -591,7 +591,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -610,7 +610,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -633,7 +633,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -658,7 +658,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -677,7 +677,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -707,7 +707,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -739,7 +739,7 @@ class AsyncFunSuiteLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSuiteLike {
+      class TestSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
+class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuiteLike {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -181,7 +181,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuiteLike {
+      class ExampleSuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           SleepHelper.sleep(30)
@@ -222,7 +222,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -265,7 +265,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -403,7 +403,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuiteLike {
+      class ExampleSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           info("hi there")
@@ -491,7 +491,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -521,7 +521,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -541,7 +541,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           note("hi there")
@@ -562,7 +562,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -585,7 +585,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -605,7 +605,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           alert("hi there")
@@ -626,7 +626,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -649,7 +649,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -668,7 +668,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           markup("hi there")
@@ -696,7 +696,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSuiteLike  {
+      class MySuite extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -726,7 +726,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSuiteLike {
+      class TestSpec extends AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
@@ -29,7 +29,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -91,7 +91,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -144,7 +144,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuite {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -191,7 +191,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuite {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -236,7 +236,7 @@ class AsyncFunSuiteSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -276,7 +276,7 @@ class AsyncFunSuiteSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           val promise = Promise[Assertion]
@@ -332,7 +332,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -360,7 +360,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -406,7 +406,7 @@ class AsyncFunSuiteSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -445,7 +445,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -464,7 +464,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -494,7 +494,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -526,7 +526,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -545,7 +545,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -568,7 +568,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -593,7 +593,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -612,7 +612,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -635,7 +635,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -660,7 +660,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -679,7 +679,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -709,7 +709,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -741,7 +741,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
-      class TestSpec extends AsyncFunSuite {
+      class TestSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
         test("test 1") { succeed }
         test("test 1") { succeed }
       }
@@ -754,7 +754,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected using ignore") {
-      class TestSpec extends AsyncFunSuite {
+      class TestSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
         test("test 1") { succeed }
         ignore("test 1") { succeed }
       }
@@ -767,7 +767,7 @@ class AsyncFunSuiteSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSuite {
+      class TestSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec2.scala
@@ -22,7 +22,7 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
+class AsyncFunSuiteSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
   override def newInstance = new AsyncFunSuiteSpec2
 
@@ -30,7 +30,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -89,7 +89,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -140,7 +140,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuite {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -183,7 +183,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
       @volatile var count = 0
 
-      class ExampleSuite extends AsyncFunSuite {
+      class ExampleSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           SleepHelper.sleep(30)
@@ -224,7 +224,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -267,7 +267,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           val promise = Promise[Assertion]
@@ -326,7 +326,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -405,7 +405,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFunSuite {
+      class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           SleepHelper.sleep(60)
@@ -445,7 +445,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -465,7 +465,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           info("hi there")
@@ -493,7 +493,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -523,7 +523,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -543,7 +543,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           note("hi there")
@@ -564,7 +564,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -587,7 +587,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -607,7 +607,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           alert("hi there")
@@ -628,7 +628,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -651,7 +651,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -670,7 +670,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           markup("hi there")
@@ -698,7 +698,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncFunSuite  {
+      class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
         test("test 1") {
           Future {
@@ -728,7 +728,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFunSuite {
+      class TestSpec extends AsyncFunSuite with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncInspectorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncInspectorsSpec.scala
@@ -30,7 +30,7 @@ import FailureMessages.decorateToStringValue
 import scala.concurrent.Future
 import org.scalatest.exceptions.TestFailedException
 
-class AsyncInspectorsSpec extends AsyncFunSpec with Inspectors with TableDrivenPropertyChecks {
+class AsyncInspectorsSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with Inspectors with TableDrivenPropertyChecks {
 
   describe("Inspectors") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
@@ -27,7 +27,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -88,7 +88,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -141,7 +141,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -188,7 +188,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -233,7 +233,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -273,7 +273,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           val promise = Promise[Assertion]
@@ -329,7 +329,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -357,7 +357,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -403,7 +403,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec2.scala
@@ -21,13 +21,13 @@ import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncPropSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -86,7 +86,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -137,7 +137,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -180,7 +180,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           SleepHelper.sleep(30)
@@ -221,7 +221,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -264,7 +264,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           val promise = Promise[Assertion]
@@ -323,7 +323,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -355,7 +355,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -402,7 +402,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         property("test 1") {
           SleepHelper.sleep(60)

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
@@ -27,7 +27,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -88,7 +88,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -141,7 +141,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -188,7 +188,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -233,7 +233,7 @@ class AsyncPropSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -273,7 +273,7 @@ class AsyncPropSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           val promise = Promise[Assertion]
@@ -329,7 +329,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -357,7 +357,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -403,7 +403,7 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec2.scala
@@ -21,13 +21,13 @@ import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec2 extends AsyncFunSpec {
+class AsyncPropSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncPropSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -86,7 +86,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -137,7 +137,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -180,7 +180,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           SleepHelper.sleep(30)
@@ -221,7 +221,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -264,7 +264,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           val promise = Promise[Assertion]
@@ -323,7 +323,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -355,7 +355,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           Future {
@@ -402,7 +402,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         property("test 1") {
           SleepHelper.sleep(60)

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
@@ -32,7 +32,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -93,7 +93,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -146,7 +146,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -193,7 +193,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -238,7 +238,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -278,7 +278,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -334,7 +334,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -362,7 +362,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -408,7 +408,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -447,7 +447,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -466,7 +466,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -493,7 +493,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -525,7 +525,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -559,7 +559,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -578,7 +578,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -605,7 +605,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -630,7 +630,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -657,7 +657,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -676,7 +676,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -703,7 +703,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -728,7 +728,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -755,7 +755,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -774,7 +774,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -801,7 +801,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -833,7 +833,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -867,7 +867,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" when {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -888,7 +888,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" when {}
         it when {
           "test 1" in { succeed }
@@ -910,7 +910,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" should {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -931,7 +931,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" should {}
         it should {
           "test 1" in { succeed }
@@ -953,7 +953,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" must {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -974,7 +974,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" must {}
         it must {
           "test 1" in { succeed }
@@ -996,7 +996,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" that {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1017,7 +1017,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" which {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1038,7 +1038,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" can {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1059,7 +1059,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         "a feature" can {}
         it can {
           "test 1" in { succeed }
@@ -1081,7 +1081,7 @@ class AsyncWordSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
+class AsyncWordSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -181,7 +181,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -222,7 +222,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -265,7 +265,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -403,7 +403,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           info(
@@ -488,7 +488,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -518,7 +518,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -550,7 +550,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -570,7 +570,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           note(
@@ -595,7 +595,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -618,7 +618,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -643,7 +643,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -663,7 +663,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           alert(
@@ -688,7 +688,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -711,7 +711,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -736,7 +736,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -756,7 +756,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           markup(
@@ -781,7 +781,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -811,7 +811,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -843,7 +843,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
@@ -32,7 +32,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -93,7 +93,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -146,7 +146,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -193,7 +193,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -237,7 +237,7 @@ class AsyncWordSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -277,7 +277,7 @@ class AsyncWordSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -333,7 +333,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -361,7 +361,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -407,7 +407,7 @@ class AsyncWordSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -446,7 +446,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -465,7 +465,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -492,7 +492,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -524,7 +524,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -558,7 +558,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -577,7 +577,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -604,7 +604,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -629,7 +629,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -656,7 +656,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -675,7 +675,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -702,7 +702,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -727,7 +727,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -754,7 +754,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -773,7 +773,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -800,7 +800,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -832,7 +832,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -866,7 +866,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" when {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -887,7 +887,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" when {}
         it when {
           "test 1" in { succeed }
@@ -909,7 +909,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" should {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -930,7 +930,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" should {}
         it should {
           "test 1" in { succeed }
@@ -952,7 +952,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" must {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -973,7 +973,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" must {}
         it must {
           "test 1" in { succeed }
@@ -995,7 +995,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" that {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1016,7 +1016,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" which {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1037,7 +1037,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" can {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1058,7 +1058,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         "a feature" can {}
         it can {
           "test 1" in { succeed }
@@ -1080,7 +1080,7 @@ class AsyncWordSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncWordSpecSpec2 extends AsyncFunSpec {
+class AsyncWordSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -181,7 +181,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(3000)
@@ -222,7 +222,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -265,7 +265,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -324,7 +324,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -356,7 +356,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           Future {
@@ -403,7 +403,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -443,7 +443,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -463,7 +463,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           info(
@@ -488,7 +488,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -518,7 +518,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -550,7 +550,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -570,7 +570,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           note(
@@ -595,7 +595,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -618,7 +618,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -643,7 +643,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -663,7 +663,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           alert(
@@ -688,7 +688,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -711,7 +711,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -736,7 +736,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -756,7 +756,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           markup(
@@ -781,7 +781,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -811,7 +811,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends AsyncWordSpec with DefaultFutureAssertionConverter {
 
         "test feature" should {
           "test 1" in {
@@ -843,7 +843,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends AsyncWordSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAsyncSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAsyncSuite.scala
@@ -23,9 +23,9 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.Promise
 
 // This tests that BeforeAndAfter works correctly when mixed into an AsyncSuite
-class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
+class BeforeAndAfterAsyncSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
-  class TheSuper extends AsyncFunSuite {
+  class TheSuper extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
     @volatile var runTestWasCalled = false
     @volatile var runWasCalled = false
@@ -140,7 +140,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
   test("If super.runTest returns normally, but after code completes abruptly with an " +
     "exception, the status returned by runTest will contain that exception as its unreportedException.") {
        
-    class MySuite extends AsyncFunSuite with BeforeAndAfter {
+    class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       after { throw new NumberFormatException }
       test("test October") { succeed }
@@ -158,7 +158,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
   // SKIP-SCALATESTJS,NATIVE-START
   test("Should propagate and not run after code if super.runTest throw java.lang.annotation.AnnotationFormatError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {
@@ -178,7 +178,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run after code if super.runTest throw java.nio.charset.CoderMalfunctionError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {
@@ -198,7 +198,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run after code if super.runTest throw javax.xml.parsers.FactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {
@@ -218,7 +218,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run after code if super.runTest throw java.lang.LinkageError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {
@@ -238,7 +238,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run after code if super.runTest throw javax.xml.transform.TransformerFactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {
@@ -258,7 +258,7 @@ class BeforeAndAfterAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run after code if super.runTest throw java.lang.VirtualMachineError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfter {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfter {
 
       var afterAllCalled = false
       test("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAsyncSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAsyncSuite.scala
@@ -23,9 +23,9 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.Promise
 
 // This tests that BeforeAndAfterEachTestData works correctly when mixed into an AsyncSuite
-class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
+class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
-  class TheSuper extends AsyncFunSuite {
+  class TheSuper extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
     @volatile var runTestWasCalled = false
     @volatile var runWasCalled = false
@@ -142,7 +142,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
   test("If super.runTest returns normally, but afterEach completes abruptly with an " +
     "exception, the status returned by runTest will contain that exception as its unreportedException.") {
        
-    class MySuite extends AsyncFunSuite with BeforeAndAfterEach {
+    class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       override def afterEach(): Unit = { throw new NumberFormatException }
       test("test October") { succeed }
@@ -160,7 +160,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
   // SKIP-SCALATESTJS,NATIVE-START
   test("Should propagate and not run afterEach if super.runTest throw java.lang.annotation.AnnotationFormatError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {
@@ -180,7 +180,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.nio.charset.CoderMalfunctionError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {
@@ -200,7 +200,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw javax.xml.parsers.FactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {
@@ -220,7 +220,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.lang.LinkageError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {
@@ -240,7 +240,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw javax.xml.transform.TransformerFactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {
@@ -260,7 +260,7 @@ class BeforeAndAfterEachAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.lang.VirtualMachineError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEach {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEach {
 
       var afterAllCalled = false
       test("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
@@ -23,9 +23,9 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.Promise
 
 // This tests that BeforeAndAfterEachTestData works correctly when mixed into an AsyncSuite
-class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
+class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
-  class TheSuper extends AsyncFunSuite {
+  class TheSuper extends AsyncFunSuite with DefaultFutureAssertionConverter {
 
     @volatile var runTestWasCalled = false
     @volatile var runWasCalled = false
@@ -215,7 +215,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
   test("If super.runTest returns normally, but afterEach completes abruptly with an " +
     "exception, the status returned by runTest will contain that exception as its unreportedException.") {
        
-    class MySuite extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       override def afterEach(td: TestData): Unit = { throw new NumberFormatException }
       test("test October") { succeed }
@@ -307,7 +307,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
   // SKIP-SCALATESTJS,NATIVE-START
   test("Should propagate and not run afterEach if super.runTest throw java.lang.annotation.AnnotationFormatError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {
@@ -327,7 +327,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.nio.charset.CoderMalfunctionError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {
@@ -347,7 +347,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw javax.xml.parsers.FactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {
@@ -367,7 +367,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.lang.LinkageError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {
@@ -387,7 +387,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw javax.xml.transform.TransformerFactoryConfigurationError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {
@@ -407,7 +407,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
 
   test("Should propagate and not run afterEach if super.runTest throw java.lang.VirtualMachineError") {
 
-    class ExampleSpec extends AsyncFunSuite with BeforeAndAfterEachTestData {
+    class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with BeforeAndAfterEachTestData {
 
       var afterAllCalled = false
       test("test 1") {

--- a/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
@@ -26,7 +26,7 @@ import scala.util.Success
 // SKIP-SCALATESTJS,NATIVE-END
 import org.scalatest.OutcomeOf.outcomeOf
 
-class CompleteLastlySpec extends AsyncFunSpec {
+class CompleteLastlySpec extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncTestSuite's complete-lastly syntax") {
 /*

--- a/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -32,7 +32,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -148,7 +148,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -195,7 +195,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -240,7 +240,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -280,7 +280,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           val promise = Promise[Assertion]
@@ -343,7 +343,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
       // job to be enqueued via SerialExecutionContext.execute, and that
       // will do the final notify. After running that job, the Future passed
       // to runNow will be complete, and runNow will return.
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           val promise = Promise[Assertion]
@@ -369,7 +369,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -397,7 +397,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -443,7 +443,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -482,7 +482,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -501,7 +501,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           info(
@@ -525,7 +525,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -557,7 +557,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -591,7 +591,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -610,7 +610,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpecLike {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -641,7 +641,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should report as failed test when non-fatal exception is thrown from scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -676,7 +676,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -701,7 +701,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -728,7 +728,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -747,7 +747,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -776,7 +776,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should report as failed test when non-fatal exception is thrown from Future returned by scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -813,7 +813,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -838,7 +838,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -865,7 +865,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -884,7 +884,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -911,7 +911,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -943,7 +943,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -981,7 +981,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     // SKIP-SCALATESTJS,NATIVE-START
     it("should propagate fatal exception when thrown from scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -1009,7 +1009,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
 
     it("should propagate fatal exception when thrown from Future returned by scenario body") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -1039,7 +1039,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     // SKIP-SCALATESTJS,NATIVE-END
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         feature("a feature") {
           scenario("test 1") { succeed }
           scenario("test 1") { succeed }
@@ -1060,7 +1060,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
+class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -88,7 +88,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -141,7 +141,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -185,7 +185,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           SleepHelper.sleep(30)
@@ -227,7 +227,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -270,7 +270,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           val promise = Promise[Assertion]
@@ -329,7 +329,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -361,7 +361,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -408,7 +408,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpecLike {
+      class ExampleSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           SleepHelper.sleep(60)
@@ -448,7 +448,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -468,7 +468,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           info(
@@ -493,7 +493,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -523,7 +523,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -555,7 +555,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -575,7 +575,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           note(
@@ -600,7 +600,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -623,7 +623,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -648,7 +648,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -668,7 +668,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           alert(
@@ -693,7 +693,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -716,7 +716,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -741,7 +741,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -761,7 +761,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           markup(
@@ -786,7 +786,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -816,7 +816,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpecLike  {
+      class MySuite extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -848,7 +848,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
@@ -32,7 +32,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -148,7 +148,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -195,7 +195,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -240,7 +240,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -279,7 +279,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           val promise = Promise[Assertion]
@@ -334,7 +334,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -362,7 +362,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -407,7 +407,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -445,7 +445,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -464,7 +464,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -491,7 +491,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -523,7 +523,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -557,7 +557,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -576,7 +576,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -603,7 +603,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -628,7 +628,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -655,7 +655,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -674,7 +674,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -701,7 +701,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -753,7 +753,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -772,7 +772,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -799,7 +799,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -831,7 +831,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -865,7 +865,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         feature("a feature") {
           scenario("test 1") { succeed }
           scenario("test 1") { succeed }
@@ -886,7 +886,7 @@ class DeprecatedAsyncFeatureSpecSpec extends FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpecLike {
+      class TestSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
+class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -87,7 +87,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         val a = 1
 
@@ -138,7 +138,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -182,7 +182,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           SleepHelper.sleep(3000)
@@ -224,7 +224,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -267,7 +267,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           val promise = Promise[Assertion]
@@ -326,7 +326,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -358,7 +358,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           Future {
@@ -405,7 +405,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncFeatureSpec {
+      class ExampleSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         scenario("test 1") {
           SleepHelper.sleep(60)
@@ -445,7 +445,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         info(
           "hi there"
         )
@@ -465,7 +465,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           info(
@@ -490,7 +490,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -520,7 +520,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -552,7 +552,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         note(
           "hi there"
         )
@@ -572,7 +572,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           note(
@@ -597,7 +597,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -620,7 +620,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -645,7 +645,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         alert(
           "hi there"
         )
@@ -665,7 +665,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           alert(
@@ -690,7 +690,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -713,7 +713,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -738,7 +738,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         markup(
           "hi there"
         )
@@ -758,7 +758,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           markup(
@@ -783,7 +783,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -813,7 +813,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends AsyncFeatureSpec  {
+      class MySuite extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         feature("test feature") {
           scenario("test 1") {
@@ -845,7 +845,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncFeatureSpec {
+      class TestSpec extends AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/FixtureContextSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/FixtureContextSpec.scala
@@ -24,7 +24,7 @@ class FixtureContextSpec extends FunSuite {
   class MyFixtureContext extends FixtureContext
 
   test("Fixture context objects should work in Async styles in Assertion-result tests") {
-    class MyAsyncSpec extends AsyncFlatSpec {
+    class MyAsyncSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
       "A Fixture Context" should "work in an Async style" in new MyFixtureContext {
         assert(1 + 1 == 2)
       }

--- a/scalatest-test/src/test/scala/org/scalatest/FutureOutcomeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/FutureOutcomeSpec.scala
@@ -29,7 +29,7 @@ class SuiteAbortingException(underlying: Throwable) {
 }
 */
 
-class FutureOutcomeSpec extends AsyncFreeSpec with DiagrammedAssertions {
+class FutureOutcomeSpec extends AsyncFreeSpec with DefaultFutureAssertionConverter with DiagrammedAssertions {
   "A FutureOutcome" - {
     "when representing a future outcome that completes with Succeeded" - {
       "should execute appropriate callbacks" in {

--- a/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
@@ -18,11 +18,11 @@ package org.scalatest
 import scala.collection.mutable.ListBuffer
 import org.scalatest.SharedHelpers.SilentReporter
 
-class RandomAsyncTestExecutionSpec extends AsyncFunSuite /* with RandomTestOrder*/ { thisOuterSuite =>
+class RandomAsyncTestExecutionSpec extends AsyncFunSuite with DefaultFutureAssertionConverter /* with RandomTestOrder*/ { thisOuterSuite =>
 
   private val buf = ListBuffer.empty[Int]
 
-  class ExampleSpec extends AsyncFunSuite with RandomTestOrder {
+  class ExampleSpec extends AsyncFunSuite with DefaultFutureAssertionConverter with RandomTestOrder {
 
     test("test one") { thisOuterSuite.synchronized { buf += 1 }; succeed }
     test("test two") { thisOuterSuite.synchronized { buf += 2 }; succeed }

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncCancelAfterFailureSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncCancelAfterFailureSpec.scala
@@ -15,14 +15,15 @@
  */
 package org.scalatest.concurrent
 
+import org.scalatest.DefaultFutureAssertionConverter
 import org.scalatest.SharedHelpers._
 import org.scalatest.{Args, AsyncFlatSpec, AsyncFunSuite}
 import scala.concurrent.{Promise, Future}
 
-class AsyncCancelAfterFailureSpec extends AsyncFlatSpec {
+class AsyncCancelAfterFailureSpec extends AsyncFlatSpec with DefaultFutureAssertionConverter {
 
   "AsyncCancelAfterFailure" should "not interfere if no tests fail" in {
-    class MySuite extends AsyncFunSuite with AsyncCancelAfterFailure {
+    class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter with AsyncCancelAfterFailure {
       test("this test succeeds") {
         Future {
           assert(1 + 1 === 2)
@@ -56,7 +57,7 @@ class AsyncCancelAfterFailureSpec extends AsyncFlatSpec {
   }
 
   it should "cancel remaining tests if a test fails" in {
-    class MySuite extends AsyncFunSuite with AsyncCancelAfterFailure {
+    class MySuite extends AsyncFunSuite with DefaultFutureAssertionConverter with AsyncCancelAfterFailure {
       test("this test succeeds") {
         Future {
           assert(1 + 1 === 2)

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec.scala
@@ -27,7 +27,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
       describe("when it succeeds") {
         it("should succeed without Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(1000L, Millis)
               test("plain old success") { assert(1 + 1 === 2) }
             }
@@ -38,7 +38,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
         }
         it("should succeed with Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old success") { Future { assert(1 + 1 === 2) } }
             }
@@ -51,7 +51,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
       describe("when it fails") {
         it("should fail without Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old failure") { assert(1 + 1 === 3) }
             }
@@ -62,7 +62,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
         }
         it("should fail with Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old failure") { Future { assert(1 + 1 === 3) } }
             }
@@ -76,7 +76,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
     describe("when it times out") {
       it("should fail with a timeout exception with the proper error message test when timeout from main code") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(100L, Millis)
             test("time out failure") { SleepHelper.sleep(500); succeed }
           }
@@ -89,7 +89,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
       }
       it("should fail with a timeout exception with the proper error message test when timeout from future returned") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(100L, Millis)
             test("time out failure") { Future { SleepHelper.sleep(500); succeed } }
           }
@@ -102,7 +102,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
       }
       it("should fail directly with thrown exception, if the test timed out after it completed abruptly from main code") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(10L, Millis)
             test("time out failure") {
               SleepHelper.sleep(50)
@@ -123,7 +123,7 @@ class AsyncTimeLimitedTestsSpec extends FunSpec with Matchers {
       }
       it("should fail with a timeout exception with the proper cause, if the test timed out after it completed abruptly from future returned") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(1000L, Millis)
             test("time out failure") {
               Future {

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.time.{Span, Millis}
 import scala.concurrent.{Promise, Future}
 
 
-class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
+class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with DefaultFutureAssertionConverter with Matchers {
   describe("A time-limited test") {
     describe("when it does not timeout ") {
       describe("when it succeeds") {
         it("should succeed without Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(1000L, Millis)
               test("plain old success") { assert(1 + 1 === 2) }
             }
@@ -43,7 +43,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
         }
         it("should succeed with Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old success") { Future { assert(1 + 1 === 2) } }
             }
@@ -60,7 +60,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
       describe("when it fails") {
         it("should fail without Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old failure") { assert(1 + 1 === 3) }
             }
@@ -75,7 +75,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
         }
         it("should fail with Future") {
           val a =
-            new AsyncFunSuite with AsyncTimeLimitedTests {
+            new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
               val timeLimit = Span(100L, Millis)
               test("plain old failure") { Future { assert(1 + 1 === 3) } }
             }
@@ -93,7 +93,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
     describe("when it times out") {
       it("should fail with a timeout exception with the proper error message test when timeout from main code") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(100L, Millis)
             test("time out failure") { SleepHelper.sleep(500); succeed }
           }
@@ -110,7 +110,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
       }
       it("should fail with a timeout exception with the proper error message test when timeout from future returned") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(100L, Millis)
             test("time out failure") { Future { SleepHelper.sleep(500); succeed } }
           }
@@ -127,7 +127,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
       }
       it("should fail with the thrown exception, if the test timed out after it completed abruptly from main code") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(10L, Millis)
             test("time out failure") {
               SleepHelper.sleep(50)
@@ -153,7 +153,7 @@ class AsyncTimeLimitedTestsSpec2 extends AsyncFunSpec with Matchers {
       }
       it("should fail with a timeout exception with the proper cause, if the test timed out after it completed abruptly from future returned") {
         val a =
-          new AsyncFunSuite with AsyncTimeLimitedTests {
+          new AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTimeLimitedTests {
             val timeLimit = Span(10L, Millis)
             test("time out failure") {
               Future {

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
@@ -26,7 +26,7 @@ import SharedHelpers.serializeRoundtrip
 
 import scala.concurrent.Future
 
-class EventuallySpec extends AsyncFunSpec with Matchers with OptionValues /*with SeveredStackTraces*/ {
+class EventuallySpec extends AsyncFunSpec with DefaultFutureAssertionConverter with Matchers with OptionValues /*with SeveredStackTraces*/ {
 
   describe("The eventually construct when work with T") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitsSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 
 import scala.util.{Try, Success, Failure}
 
-class TimeLimitsSpec extends AsyncFunSpec with Matchers {
+class TimeLimitsSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with Matchers {
 
 /*
   override def withFixture(test: NoArgTest) = {

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncConfigMapFixtureSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncConfigMapFixtureSpec.scala
@@ -22,7 +22,7 @@ class AsyncConfigMapFixtureSpec extends org.scalatest.FunSpec {
   describe("A AsyncConfigMapFixture") {
     it("should pass the config map to each test") {
       val myConfigMap = ConfigMap("hello" -> "world", "salt" -> "pepper")
-      class MySpec extends fixture.AsyncFunSuite with AsyncConfigMapFixture {
+      class MySpec extends fixture.AsyncFunSuite with DefaultFutureAssertionConverter with AsyncConfigMapFixture {
         var configMapPassed = false
         test("test something") { configMap =>
           if (configMap == myConfigMap)

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec.scala
@@ -29,7 +29,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -504,7 +504,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -535,7 +535,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -609,7 +609,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -636,7 +636,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -667,7 +667,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -727,7 +727,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -754,7 +754,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -785,7 +785,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -814,7 +814,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -845,7 +845,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -872,7 +872,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -903,7 +903,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -939,7 +939,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -977,7 +977,7 @@ class AsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpecLike {
+      class TestSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -499,7 +499,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -528,7 +528,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -562,7 +562,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -598,7 +598,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -623,7 +623,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -652,7 +652,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -679,7 +679,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -708,7 +708,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -733,7 +733,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -762,7 +762,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -788,7 +788,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -817,7 +817,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -842,7 +842,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -870,7 +870,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -904,7 +904,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -940,7 +940,7 @@ class AsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpecLike {
+      class TestSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec.scala
@@ -29,7 +29,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -504,7 +504,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -535,7 +535,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -609,7 +609,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -636,7 +636,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -667,7 +667,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -727,7 +727,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -754,7 +754,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -785,7 +785,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -814,7 +814,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -845,7 +845,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -872,7 +872,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -903,7 +903,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -939,7 +939,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -977,7 +977,7 @@ class AsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpec {
+      class TestSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFeatureSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -436,7 +436,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -480,7 +480,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -505,7 +505,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -534,7 +534,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -568,7 +568,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -604,7 +604,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -629,7 +629,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -658,7 +658,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -685,7 +685,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -714,7 +714,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -739,7 +739,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -768,7 +768,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -794,7 +794,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -823,7 +823,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -848,7 +848,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -876,7 +876,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -910,7 +910,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -946,7 +946,7 @@ class AsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpec {
+      class TestSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec.scala
@@ -29,7 +29,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("can be used for tests that return Future under parallel async test execution") {
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike with ParallelTestExecution {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("can be used for tests that did not return Future under parallel async test execution") {
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike with ParallelTestExecution {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
        @volatile var count = 0
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
        @volatile var count = 0
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
        var test2Thread: Option[Thread] = None
        var onCompleteThread: Option[Thread] = None
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
        @volatile var test2Thread: Option[Thread] = None
        var onCompleteThread: Option[Thread] = None
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          // Note we get a StackOverflowError with the following execution
          // context.
@@ -387,7 +387,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should run tests that returns Future and report their result in serial") {
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
 
      it("should run tests that does not return Future and report their result in serial") {
 
-       class ExampleSpec extends fixture.AsyncFlatSpecLike {
+       class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an InfoProvided event for an info in main spec body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -504,7 +504,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an InfoProvided event for an info in test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -538,7 +538,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an InfoProvided event for an info in Future returned by scenario body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -574,7 +574,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a NoteProvided event for a note in main spec body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -600,7 +600,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a NoteProvided event for a note in test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -626,7 +626,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a NoteProvided event for a note in Future returned by test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -654,7 +654,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an AlertProvided event for an alert in main spec body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -680,7 +680,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an AlertProvided event for an alert in test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -706,7 +706,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send an AlertProvided event for an alert in Future returned by test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -734,7 +734,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a MarkupProvided event for a markup in main spec body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -760,7 +760,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a MarkupProvided event for a markup in test body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -793,7 +793,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-       class MySuite extends fixture.AsyncFlatSpecLike  {
+       class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -828,7 +828,7 @@ class AsyncFlatSpecLikeSpec extends org.scalatest.FunSpec {
      }
 
      it("should allow other execution context to be used") {
-       class TestSpec extends fixture.AsyncFlatSpecLike {
+       class TestSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
          // SKIP-SCALATESTJS,NATIVE-START
          override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
          // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFlatSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -436,7 +436,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpecLike {
+      class ExampleSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -480,7 +480,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -505,7 +505,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -537,7 +537,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -571,7 +571,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -594,7 +594,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -617,7 +617,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -642,7 +642,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -688,7 +688,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -713,7 +713,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -736,7 +736,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -766,7 +766,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpecLike  {
+      class MySuite extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -798,7 +798,7 @@ class AsyncFlatSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFlatSpecLike {
+      class TestSpec extends fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec.scala
@@ -30,7 +30,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -95,7 +95,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -152,7 +152,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -203,7 +203,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -252,7 +252,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -296,7 +296,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -356,7 +356,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -388,7 +388,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -438,7 +438,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -481,7 +481,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -508,7 +508,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -542,7 +542,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -578,7 +578,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -604,7 +604,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -630,7 +630,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -658,7 +658,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -684,7 +684,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -710,7 +710,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -738,7 +738,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -764,7 +764,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -797,7 +797,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -832,7 +832,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
-      class TestSpec extends fixture.AsyncFlatSpec {
+      class TestSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         behavior of "a feature"
@@ -848,7 +848,7 @@ class AsyncFlatSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFlatSpec {
+      class TestSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFlatSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFlatSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -436,7 +436,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFlatSpec {
+      class ExampleSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -480,7 +480,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -505,7 +505,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -537,7 +537,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -571,7 +571,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -594,7 +594,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -617,7 +617,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -642,7 +642,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -688,7 +688,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -713,7 +713,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -736,7 +736,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -766,7 +766,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFlatSpec  {
+      class MySuite extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -798,7 +798,7 @@ class AsyncFlatSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFlatSpec {
+      class TestSpec extends fixture.AsyncFlatSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec.scala
@@ -33,7 +33,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -98,7 +98,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -155,7 +155,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -206,7 +206,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -255,7 +255,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -299,7 +299,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -359,7 +359,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -391,7 +391,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -441,7 +441,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -484,7 +484,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -506,7 +506,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -536,7 +536,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -608,7 +608,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -634,7 +634,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -664,7 +664,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -692,7 +692,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -722,7 +722,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -748,7 +748,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -778,7 +778,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -806,7 +806,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -836,7 +836,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -862,7 +862,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -892,7 +892,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -927,7 +927,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -964,7 +964,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends fixture.AsyncFreeSpecLike {
+      class TestSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         "a feature" - {
@@ -987,7 +987,7 @@ class AsyncFreeSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFreeSpecLike {
+      class TestSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpecLike {
+      class ExampleSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpecLike  {
+      class MySuite extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncFreeSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFreeSpecLike {
+      class TestSpec extends fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec.scala
@@ -33,7 +33,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -98,7 +98,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -155,7 +155,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -206,7 +206,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -255,7 +255,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -299,7 +299,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -359,7 +359,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -391,7 +391,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -441,7 +441,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -484,7 +484,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -510,7 +510,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -540,7 +540,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -575,7 +575,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -612,7 +612,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -638,7 +638,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -668,7 +668,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -752,7 +752,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -782,7 +782,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -810,7 +810,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -840,7 +840,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -866,7 +866,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -896,7 +896,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -931,7 +931,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -968,7 +968,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends fixture.AsyncFreeSpec {
+      class TestSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         "a feature" - {
@@ -991,7 +991,7 @@ class AsyncFreeSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFreeSpec {
+      class TestSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFreeSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFreeSpec {
+      class ExampleSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFreeSpec  {
+      class MySuite extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncFreeSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFreeSpec {
+      class TestSpec extends fixture.AsyncFreeSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec.scala
@@ -29,7 +29,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -506,7 +506,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -536,7 +536,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -608,7 +608,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -634,7 +634,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -664,7 +664,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -692,7 +692,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -722,7 +722,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -748,7 +748,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -778,7 +778,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -806,7 +806,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -836,7 +836,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -862,7 +862,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -892,7 +892,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -927,7 +927,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -964,7 +964,7 @@ class AsyncFunSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSpecLike {
+      class TestSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpecLike {
+      class ExampleSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpecLike  {
+      class MySuite extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncFunSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSpecLike {
+      class TestSpec extends fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec.scala
@@ -33,7 +33,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -98,7 +98,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -155,7 +155,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -206,7 +206,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -255,7 +255,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -299,7 +299,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -359,7 +359,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -391,7 +391,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -441,7 +441,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -484,7 +484,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -510,7 +510,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -540,7 +540,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -575,7 +575,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -612,7 +612,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -638,7 +638,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -668,7 +668,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -752,7 +752,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -782,7 +782,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -810,7 +810,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -840,7 +840,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -866,7 +866,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -896,7 +896,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -931,7 +931,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -968,7 +968,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
-      class TestSpec extends fixture.AsyncFunSpec {
+      class TestSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         describe("a feature") {
@@ -991,7 +991,7 @@ class AsyncFunSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSpec {
+      class TestSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSpec {
+      class ExampleSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSpec  {
+      class MySuite extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncFunSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSpec {
+      class TestSpec extends fixture.AsyncFunSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
@@ -29,7 +29,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -506,7 +506,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -539,7 +539,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -574,7 +574,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -600,7 +600,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -626,7 +626,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -654,7 +654,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -680,7 +680,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -706,7 +706,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -734,7 +734,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -760,7 +760,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -793,7 +793,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -828,7 +828,7 @@ class AsyncFunSuiteLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSuiteLike {
+      class TestSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike with ParallelTestExecution {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends fixture.AsyncFunSuiteLike {
+      class ExampleSuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFunSuiteLike {
+      class ExampleSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -527,7 +527,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -559,7 +559,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -582,7 +582,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -605,7 +605,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -630,7 +630,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -653,7 +653,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -676,7 +676,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -701,7 +701,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -724,7 +724,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -754,7 +754,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncFunSuiteLike  {
+      class MySuite extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -786,7 +786,7 @@ class AsyncFunSuiteLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFunSuiteLike {
+      class TestSpec extends fixture.AsyncFunSuiteLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
@@ -30,7 +30,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -95,7 +95,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -152,7 +152,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -203,7 +203,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -252,7 +252,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -296,7 +296,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -356,7 +356,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -388,7 +388,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -438,7 +438,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -482,7 +482,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
 
     it("should send an InfoProvided event for an info in main spec body") {
 
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -508,7 +508,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -541,7 +541,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -576,7 +576,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -602,7 +602,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -628,7 +628,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -656,7 +656,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -682,7 +682,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -708,7 +708,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -736,7 +736,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -762,7 +762,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -795,7 +795,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -830,7 +830,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
-      class TestSpec extends funsuite.FixtureAsyncFunSuite {
+      class TestSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         test("test 1") { fixture => succeed }
@@ -845,7 +845,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected using ignore") {
-      class TestSpec extends funsuite.FixtureAsyncFunSuite {
+      class TestSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
         test("test 1") { fixture => succeed }
@@ -860,7 +860,7 @@ class AsyncFunSuiteSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends funsuite.FixtureAsyncFunSuite {
+      class TestSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFunSuite") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -436,7 +436,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
+      class ExampleSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -480,7 +480,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -503,7 +503,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -533,7 +533,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -565,7 +565,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -588,7 +588,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -611,7 +611,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -636,7 +636,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -659,7 +659,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -682,7 +682,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -707,7 +707,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -730,7 +730,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -760,7 +760,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends funsuite.FixtureAsyncFunSuite  {
+      class MySuite extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -792,7 +792,7 @@ class AsyncFunSuiteSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends funsuite.FixtureAsyncFunSuite {
+      class TestSpec extends funsuite.FixtureAsyncFunSuite with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
@@ -28,7 +28,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -93,7 +93,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -150,7 +150,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -201,7 +201,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -250,7 +250,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -294,7 +294,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -354,7 +354,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -386,7 +386,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -436,7 +436,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -91,7 +91,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -146,7 +146,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -193,7 +193,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -238,7 +238,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -285,7 +285,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -348,7 +348,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -384,7 +384,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -435,7 +435,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
@@ -28,7 +28,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -93,7 +93,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -150,7 +150,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -201,7 +201,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -250,7 +250,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -294,7 +294,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -354,7 +354,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -386,7 +386,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -436,7 +436,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec2.scala
@@ -22,13 +22,13 @@ import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncPropSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -91,7 +91,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -146,7 +146,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -193,7 +193,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -238,7 +238,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -285,7 +285,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -348,7 +348,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -384,7 +384,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -435,7 +435,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncTestDataFixtureSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncTestDataFixtureSpec.scala
@@ -22,7 +22,7 @@ class AsyncTestDataFixtureSpec extends org.scalatest.FunSpec {
   describe("A AsyncTestDataFixture") {
     it("should pass the test data to each test") {
       val myConfigMap = ConfigMap("hello" -> "world", "salt" -> "pepper")
-      class MySuite extends fixture.AsyncFunSuite with AsyncTestDataFixture {
+      class MySuite extends fixture.AsyncFunSuite with DefaultFutureAssertionConverter with AsyncTestDataFixture {
         var testDataPassed = false
         test("something") { (td: TestData) =>
           if (td.configMap == myConfigMap && td.name == "something")

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
@@ -33,7 +33,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -98,7 +98,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -155,7 +155,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -206,7 +206,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -255,7 +255,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -299,7 +299,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -359,7 +359,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -391,7 +391,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -441,7 +441,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -484,7 +484,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -510,7 +510,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -540,7 +540,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -575,7 +575,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -612,7 +612,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -638,7 +638,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -668,7 +668,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -752,7 +752,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -782,7 +782,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -810,7 +810,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -840,7 +840,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -866,7 +866,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -896,7 +896,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -931,7 +931,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -968,7 +968,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {
@@ -991,7 +991,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {}
@@ -1015,7 +1015,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {
@@ -1038,7 +1038,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {}
@@ -1062,7 +1062,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {
@@ -1085,7 +1085,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {}
@@ -1109,7 +1109,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" that {
@@ -1132,7 +1132,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" which {
@@ -1155,7 +1155,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {
@@ -1178,7 +1178,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {}
@@ -1202,7 +1202,7 @@ class AsyncWordSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncWordSpecLike {
+      class TestSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpecLike {
+      class ExampleSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpecLike  {
+      class MySuite extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncWordSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncWordSpecLike {
+      class TestSpec extends fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
@@ -33,7 +33,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -98,7 +98,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -155,7 +155,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -206,7 +206,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -255,7 +255,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -299,7 +299,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -359,7 +359,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -391,7 +391,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -441,7 +441,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -484,7 +484,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -510,7 +510,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -540,7 +540,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -575,7 +575,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -612,7 +612,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -638,7 +638,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -668,7 +668,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -726,7 +726,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -752,7 +752,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -782,7 +782,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -810,7 +810,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -840,7 +840,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -866,7 +866,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -896,7 +896,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -931,7 +931,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -968,7 +968,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {
@@ -991,7 +991,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {}
@@ -1015,7 +1015,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {
@@ -1038,7 +1038,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {}
@@ -1062,7 +1062,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {
@@ -1085,7 +1085,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {}
@@ -1109,7 +1109,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" that {
@@ -1132,7 +1132,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" which {
@@ -1155,7 +1155,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {
@@ -1178,7 +1178,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {}
@@ -1202,7 +1202,7 @@ class AsyncWordSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncWordSpec {
+      class ExampleSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -497,7 +497,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -524,7 +524,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -556,7 +556,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -590,7 +590,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -613,7 +613,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -640,7 +640,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -665,7 +665,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -692,7 +692,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -715,7 +715,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -742,7 +742,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -767,7 +767,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -794,7 +794,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -817,7 +817,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -844,7 +844,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -876,7 +876,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends fixture.AsyncWordSpec  {
+      class MySuite extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -910,7 +910,7 @@ class AsyncWordSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncWordSpec {
+      class TestSpec extends fixture.AsyncWordSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -29,7 +29,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -504,7 +504,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -535,7 +535,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -609,7 +609,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -636,7 +636,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -667,7 +667,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -727,7 +727,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -754,7 +754,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -785,7 +785,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -814,7 +814,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -845,7 +845,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -872,7 +872,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -903,7 +903,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -939,7 +939,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -977,7 +977,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpecLike {
+      class TestSpec extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with ParallelTestExecution {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -433,7 +433,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class ExampleSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -474,7 +474,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -499,7 +499,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -528,7 +528,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -562,7 +562,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -598,7 +598,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -623,7 +623,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -652,7 +652,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -679,7 +679,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -708,7 +708,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -733,7 +733,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -762,7 +762,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -788,7 +788,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -817,7 +817,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -842,7 +842,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -870,7 +870,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -904,7 +904,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike  {
+      class MySuite extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -940,7 +940,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+      class TestSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec.scala
@@ -29,7 +29,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -94,7 +94,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +151,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -202,7 +202,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -251,7 +251,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -295,7 +295,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -355,7 +355,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -437,7 +437,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -480,7 +480,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -504,7 +504,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -535,7 +535,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -571,7 +571,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -609,7 +609,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -636,7 +636,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -667,7 +667,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -696,7 +696,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -727,7 +727,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -754,7 +754,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -785,7 +785,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -814,7 +814,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -845,7 +845,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -872,7 +872,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -903,7 +903,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -939,7 +939,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpec  {
+      class MySuite extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
@@ -977,7 +977,7 @@ class DeprecatedAsyncFeatureSpecSpec extends org.scalatest.FunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpec {
+      class TestSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -23,13 +23,13 @@ import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
 
-class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec with DefaultFutureAssertionConverter {
 
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -92,7 +92,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec with ParallelTestExecution {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -147,7 +147,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -194,7 +194,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -239,7 +239,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -286,7 +286,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -349,7 +349,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -385,7 +385,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -436,7 +436,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends fixture.AsyncFeatureSpec {
+      class ExampleSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -480,7 +480,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -505,7 +505,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -534,7 +534,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -568,7 +568,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -604,7 +604,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -629,7 +629,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -658,7 +658,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -685,7 +685,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -714,7 +714,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -739,7 +739,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -768,7 +768,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -794,7 +794,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -823,7 +823,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -848,7 +848,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in feature body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -876,7 +876,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -910,7 +910,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by scenario body") {
-      class MySuite extends fixture.AsyncFeatureSpecLike  {
+      class MySuite extends fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter  {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -946,7 +946,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends org.scalatest.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends fixture.AsyncFeatureSpec {
+      class TestSpec extends fixture.AsyncFeatureSpec with DefaultFutureAssertionConverter {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/scalatest-test/src/test/scala/org/scalatest/jmock/AsyncJMockCycleSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/jmock/AsyncJMockCycleSpec.scala
@@ -25,7 +25,7 @@ class AsyncJMockCycleSpec extends FlatSpec with Matchers {
 
   "The AsyncJMockCycle trait" should "work with multiple mocks" in {
 
-    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+    val a = new fixture.AsyncFunSuite with DefaultFutureAssertionConverter with AsyncJMockCycleFixture {
       test("test that should fail") { cycle =>
         import cycle._
         trait OneFish {
@@ -110,7 +110,7 @@ class AsyncJMockCycleSpec extends FlatSpec with Matchers {
   }
 
   it should "provide sugar for invoking with methods that take matchers" in {
-    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+    val a = new fixture.AsyncFunSuite with DefaultFutureAssertionConverter with AsyncJMockCycleFixture {
       test("test that should succeed") { cycle =>
         import cycle._
         trait OneFish {
@@ -161,7 +161,7 @@ class AsyncJMockCycleSpec extends FlatSpec with Matchers {
   }
 
   it should "provide sugar for invoking with methods that take non-matcher values" in {
-    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+    val a = new fixture.AsyncFunSuite with DefaultFutureAssertionConverter with AsyncJMockCycleFixture {
       test("test that should succeed") { cycle =>
         import cycle._
         trait OneFish {

--- a/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
@@ -16,11 +16,12 @@
 package org.scalatest.prop
 
 import org.scalatest.AsyncFunSpec
+import org.scalatest.DefaultFutureAssertionConverter
 import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent.Future
 
-class AsyncGeneratorDrivenPropertyChecksSpec extends AsyncFunSpec with GeneratorDrivenPropertyChecks {
+class AsyncGeneratorDrivenPropertyChecksSpec extends AsyncFunSpec with DefaultFutureAssertionConverter with GeneratorDrivenPropertyChecks {
 
   describe("GeneratorDrivenPropertyChecks") {
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpec.scala
@@ -19,7 +19,7 @@ package org.scalatest
   * This class is deprecated and will be removed in future version of ScalaTest, please use org.scalatest.featurespec.AsyncFeatureSpec instead.
   */
 @deprecated("Please use org.scalatest.featurespec.AsyncFeatureSpec instead")
-abstract class AsyncFeatureSpec extends AsyncFeatureSpecLike {
+abstract class AsyncFeatureSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpec.scala
@@ -2216,7 +2216,7 @@ package org.scalatest
  * <li><code>A Stack actor (when non-empty) should return before and after StackInfo that has existing size - 1 and lastItemAdded as top when Pop is fired at non-empty stack actor: almost full stack actor</code></li>
  * </ul>
  */
-abstract class AsyncFlatSpec extends AsyncFlatSpecLike {
+abstract class AsyncFlatSpec extends AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
@@ -16,7 +16,6 @@
 package org.scalatest
 
 import org.scalactic.{Resources => _, _}
-import scala.concurrent.Future
 import Suite.autoTagClassAnnotations
 import org.scalatest.exceptions._
 import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord, ShouldVerb, MustVerb, CanVerb, StringVerbStringInvocation, StringVerbBehaveLikeInvocation}
@@ -105,11 +104,11 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -132,8 +131,8 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, methodName: String, testTags: List[Tag], testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+  private def registerTestToRun(specText: String, methodName: String, testTags: List[Tag], testFun: () => FutureSystem, pos: source.Position): Unit = {
+    def transformToOutcomeParam: FutureSystem = testFun()
     def testRegistrationClosedMessageFun: String =
       methodName match {
         case "in" => Resources.inCannotAppearInsideAnotherInOrIs
@@ -271,7 +270,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + name.trim, "in", tags, () => testFun, pos)
     }
 
@@ -315,7 +314,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "ignore", () => testFun, pos)
     }
   }
@@ -383,7 +382,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + name.trim, "in", List(), () => testFun, pos)
     }
 
@@ -425,7 +424,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "ignore", () => testFun, pos)
     }
 
@@ -677,7 +676,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "in", () => testFun, pos)
     }
 
@@ -774,7 +773,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "in", () => testFun, pos)
     }
 
@@ -986,7 +985,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + name.trim, "in", tags, () => testFun, pos)
     }
 
@@ -1030,7 +1029,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * the <a href="FlatSpec.html#taggingTests">Tagging tests section</a> in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, tags, "ignore", () => testFun, pos)
     }
   }
@@ -1098,7 +1097,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + name.trim, "in", List(), () => testFun, pos)
     }
 
@@ -1140,7 +1139,7 @@ trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + name.trim, List(), "ignore", () => testFun, pos)
     }
 
@@ -1399,7 +1398,7 @@ import resultOfStringPassedToVerb.verb
      * for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
     }
 
@@ -1420,7 +1419,7 @@ import resultOfStringPassedToVerb.verb
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", () => testFun, pos)
     }
   }
@@ -1497,7 +1496,7 @@ import resultOfStringPassedToVerb.verb
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
     }
 
@@ -1520,7 +1519,7 @@ import resultOfStringPassedToVerb.verb
      * in the main documentation for trait <code>FlatSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", () => testFun, pos)
     }
   }
@@ -1632,14 +1631,14 @@ import resultOfStringPassedToVerb.verb
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => FutureSystem, pos: source.Position): Unit = {
     // SKIP-SCALATESTJS,NATIVE-START
     val stackDepth = 4
     val stackDepthAdjustment = -3
     // SKIP-SCALATESTJS,NATIVE-END
     //SCALATESTJS,NATIVE-ONLY val stackDepth = 6
     //SCALATESTJS,NATIVE-ONLY val stackDepthAdjustment = -5
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+    def transformToOutcomeParam: FutureSystem = testFun()
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(transformToOutcomeParam), Resources.ignoreCannotAppearInsideAnInOrAnIs, None, pos, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpec.scala
@@ -2275,7 +2275,7 @@ package org.scalatest
  * <li><code>A Stack (when non-empty) should return before and after StackInfo that has existing size - 1 and lastItemAdded as top when Pop is fired at non-empty stack actor: almost full stack actor</code></li>
  * </ul>
  */
-abstract class AsyncFreeSpec extends AsyncFreeSpecLike {
+abstract class AsyncFreeSpec extends AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
@@ -16,7 +16,6 @@
 package org.scalatest
 
 import org.scalactic.{Resources => _, FailureMessages => _, UnquotedString => _, _}
-import scala.concurrent.Future
 import Suite.autoTagClassAnnotations
 import org.scalatest.exceptions._
 import words.BehaveWord
@@ -106,11 +105,11 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -133,8 +132,8 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, testTags: List[Tag], testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+  private def registerTestToRun(specText: String, testTags: List[Tag], testFun: () => FutureSystem, pos: source.Position): Unit = {
+    def transformToOutcomeParam: FutureSystem = testFun()
     engine.registerAsyncTest(specText, transformToOutcome(transformToOutcomeParam), Resources.inCannotAppearInsideAnotherIn, None, None, pos, testTags: _*)
   }
 
@@ -161,8 +160,8 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => FutureSystem, pos: source.Position): Unit = {
+    def transformToOutcomeParam: FutureSystem = testFun()
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(transformToOutcomeParam), Resources.ignoreCannotAppearInsideAnIn, None, pos, testTags: _*)
   }
 
@@ -198,7 +197,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion]): Unit = {
+    def in(testFun: => FutureSystem): Unit = {
       registerTestToRun(specText, tags, () => testFun, pos)
     }
 
@@ -238,7 +237,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion]): Unit = {
+    def ignore(testFun: => FutureSystem): Unit = {
       registerTestToIgnore(specText, tags, "ignore", () => testFun, pos)
     }
   }
@@ -289,7 +288,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def in(f: => Future[compatible.Assertion]): Unit = {
+    def in(f: => FutureSystem): Unit = {
       registerTestToRun(string, List(), () => f, pos)
     }
 
@@ -309,7 +308,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
      * For more information and examples of this method's use, see the <a href="FreeSpec.html">main documentation</a> for trait <code>FreeSpec</code>.
      * </p>
      */
-    def ignore(f: => Future[compatible.Assertion]): Unit = {
+    def ignore(f: => FutureSystem): Unit = {
       registerTestToIgnore(string, List(), "ignore", () => f, pos)
     }
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSpec.scala
@@ -19,7 +19,7 @@ package org.scalatest
   * This class is deprecated and will be removed in future version of ScalaTest, please use org.scalatest.funspec.AsyncFunSpec instead.
   */
 @deprecated("Please use org.scalatest.funspec.AsyncFunSpec instead")
-abstract class AsyncFunSpec extends AsyncFunSpecLike {
+abstract class AsyncFunSpec extends DefaultFutureAssertionConverter with AsyncFunSpecLike {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/AsyncPropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncPropSpecLike.scala
@@ -47,7 +47,7 @@ trait AsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
 
   import engine._
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]) {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem) {
     // SKIP-SCALATESTJS,NATIVE-START
     val stackDepthAdjustment = -1
     // SKIP-SCALATESTJS,NATIVE-END
@@ -55,7 +55,7 @@ trait AsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, "PropSpecRegistering.scala", "registerTest", 4, stackDepthAdjustment, None, None, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]) {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem) {
     // SKIP-SCALATESTJS,NATIVE-START
     val stackDepthAdjustment = -2
     // SKIP-SCALATESTJS,NATIVE-END
@@ -77,7 +77,7 @@ trait AsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
    */
-  protected def property(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]) {
+  protected def property(testName: String, testTags: Tag*)(testFun: => FutureSystem) {
     // SKIP-SCALATESTJS,NATIVE-START
     val stackDepth = 4
     val stackDepthAdjustment = -2
@@ -102,7 +102,7 @@ trait AsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with I
    * @throws DuplicateTestNameException if a test with the same name has been registered previously
    * @throws NotAllowedException if <code>testName</code> had been registered previously
    */
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]) {
+  protected def ignore(testName: String, testTags: Tag*)(testFun: => FutureSystem) {
     // SKIP-SCALATESTJS,NATIVE-START
     val stackDepth = 4
     val stackDepthAdjustment = -2

--- a/scalatest/src/main/scala/org/scalatest/AsyncTestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncTestRegistration.scala
@@ -31,7 +31,7 @@ trait AsyncTestRegistration { theSuite: AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position)
 
   /**
    * Registers an ignored test.
@@ -40,5 +40,5 @@ trait AsyncTestRegistration { theSuite: AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position)
 }

--- a/scalatest/src/main/scala/org/scalatest/AsyncTestSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncTestSuite.scala
@@ -211,7 +211,7 @@ import enablers.Futuristic
  * }
  * </pre>
  */
-trait AsyncTestSuite extends Suite with RecoverMethods with CompleteLastly { thisAsyncTestSuite =>
+trait AsyncTestSuite extends Suite with RecoverMethods with CompleteLastly with FutureAssertionConverter { thisAsyncTestSuite =>
 
   /**
    * An implicit execution context used by async styles to transform <code>Future[Assertion]</code> values
@@ -235,9 +235,9 @@ trait AsyncTestSuite extends Suite with RecoverMethods with CompleteLastly { thi
    * @param testFun test function
    * @return function that returns `AsyncOutcome`
    */
-  private[scalatest] def transformToOutcome(testFun: => Future[compatible.Assertion]): () => AsyncOutcome =
+  private[scalatest] def transformToOutcome(testFun: => FutureSystem): () => AsyncOutcome =
     () => {
-      val futureSucceeded: Future[Succeeded.type] = testFun.map(_ => Succeeded)
+      val futureSucceeded: Future[Succeeded.type] = convertToScalaFuture(testFun).map(_ => Succeeded)
       InternalFutureOutcome(
         futureSucceeded.recover {
           case ex: exceptions.TestCanceledException => Canceled(ex)

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
@@ -2291,7 +2291,7 @@ package org.scalatest
  * <li><code>A Stack when non-empty should return before and after StackInfo that has existing size - 1 and lastItemAdded as top when Pop is fired at non-empty stack actor: almost full stack actor</code></li>
  * </ul>
  */
-abstract class AsyncWordSpec extends AsyncWordSpecLike {
+abstract class AsyncWordSpec extends AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
@@ -16,7 +16,6 @@
 package org.scalatest
 
 import org.scalactic.{Resources => _, FailureMessages => _, UnquotedString => _, _}
-import scala.concurrent.Future
 import Suite.autoTagClassAnnotations
 import org.scalatest.exceptions._
 import words.{CanVerb, ResultOfAfterWordApplication, ShouldVerb, BehaveWord,
@@ -101,11 +100,11 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -128,8 +127,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+  private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => FutureSystem, pos: source.Position): Unit = {
+    def transformToOutcomeParam: FutureSystem = testFun()
     engine.registerAsyncTest(specText, transformToOutcome(transformToOutcomeParam), Resources.inCannotAppearInsideAnotherIn, None, None, pos, testTags: _*)
   }
 
@@ -156,8 +155,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
-    def transformToOutcomeParam: Future[compatible.Assertion] = testFun()
+  private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => FutureSystem, pos: source.Position): Unit = {
+    def transformToOutcomeParam: FutureSystem = testFun()
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(transformToOutcomeParam), Resources.ignoreCannotAppearInsideAnIn, None, pos, testTags: _*)
   }
 
@@ -272,7 +271,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(specText, tags, "in", () => testFun, pos)
     }
 
@@ -312,7 +311,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(specText, tags, "ignore", () => testFun, pos)
     }
   }
@@ -350,7 +349,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def in(f: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(f: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToRun(string, List(), "in", () => f, pos)
     }
 
@@ -370,7 +369,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
      * For more information and examples of this method's use, see the <a href="WordSpec.html">main documentation</a> for trait <code>WordSpec</code>.
      * </p>
      */
-    def ignore(f: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(f: => FutureSystem)(implicit pos: source.Position): Unit = {
       registerTestToIgnore(string, List(), "ignore", () => f, pos)
     }
 

--- a/scalatest/src/main/scala/org/scalatest/DefaultFutureAssertionConverter.scala
+++ b/scalatest/src/main/scala/org/scalatest/DefaultFutureAssertionConverter.scala
@@ -1,0 +1,14 @@
+package org.scalatest
+
+import scala.concurrent.Future
+import org.scalatest.compatible
+
+/**
+  * This trait is a default implementation for asynchronous testing with <code>scala.concurrent.Future</code> as a
+  * Future system (which is as default in ScalaTest).
+  * @see <code>FutureAssertionConverter</code> for more information.
+  */
+trait DefaultFutureAssertionConverter extends FutureAssertionConverter {
+  override type FutureSystem = Future[compatible.Assertion]
+  override def convertToScalaFuture(f: FutureSystem): Future[compatible.Assertion] = f
+}

--- a/scalatest/src/main/scala/org/scalatest/FutureAssertionConverter.scala
+++ b/scalatest/src/main/scala/org/scalatest/FutureAssertionConverter.scala
@@ -1,0 +1,42 @@
+package org.scalatest
+
+import scala.concurrent.Future
+import org.scalatest.compatible
+
+/**
+  * This trait is an extension point to testing asynchronous code transparently both
+  * <code>scala.concurrent.Future</code> and other Future systems. To use with <code>scala.concurrent.Future</code>,
+  * create a test class in the same way as existing abstract class (e.g. <code>AsyncFlatSpec</code>,
+  * <code>AsyncWordSpec</code>, etc.) that is mixed-in <code>DefaultFutureAssertionConverter</code>, otherwise create a
+  * custom abstract class that overrides <code>FutureSystem</code> type (the Future system you want to use with) and
+  * <code>convertToScalaFuture</code> method (that transforms to <code>scala.concurrent.Future</code>), then use it in
+  * your test class.
+  *
+  * <p>
+  * Here's an example:
+  * </p>
+  *
+  * <pre class="stHighlight">
+  * package com.example.myawesome.{Future, Return, Throw}
+  *
+  * import org.scalatest.compatible.Assertion
+  * import org.scalatest.{AsyncFlatSpecLike, compatible}
+  *
+  * abstract class MyAwesomeAsyncFlatSpec extends AsyncFlatSpecLike {
+  *   override type FutureSystem = Future[compatible.Assertion]
+  *
+  *   override def convertToScalaFuture(f: FutureSystem): scala.concurrent.Future[compatible.Assertion] = {
+  *     val promise: scala.concurrent.Promise[Assertion] = scala.concurrent.Promise()
+  *     f.respond {
+  *       case Return(value)    => promise.success(value)
+  *       case Throw(exception) => promise.failure(exception)
+  *     }
+  *     promise.future
+  *   }
+  * }
+  * </pre>
+  */
+trait FutureAssertionConverter {
+  type FutureSystem
+  def convertToScalaFuture(f: FutureSystem): Future[compatible.Assertion]
+}

--- a/scalatest/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.featurespec
 
 import org.scalatest.Suite
+import org.scalatest.DefaultFutureAssertionConverter
 
 /**
  * Enables testing of asynchronous code without blocking,
@@ -2239,7 +2240,7 @@ import org.scalatest.Suite
  * <li><code>Pop is fired at non-empty stack actor: almost full stack actor</code></li>
  * </ul>
  */
-abstract class AsyncFeatureSpec extends AsyncFeatureSpecLike {
+abstract class AsyncFeatureSpec extends AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
@@ -97,16 +97,16 @@ trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration wit
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(Resources.scenario(testText.trim), transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(Resources.scenario(testText.trim), transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
   @deprecated("use Scenario instead", "ScalaTest 3.1.1")
-  protected def scenario(specText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit =
+  protected def scenario(specText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit =
     Scenario(specText, testTags: _*)(testFun)(pos)
 
   /**
@@ -127,7 +127,7 @@ trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration wit
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def Scenario(specText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected def Scenario(specText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(Resources.scenario(specText.trim), transformToOutcome(testFun), Resources.scenarioCannotAppearInsideAnotherScenario, None, None, pos, testTags: _*)
   }
 
@@ -149,7 +149,7 @@ trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration wit
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def ignore(specText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected def ignore(specText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(Resources.scenario(specText), transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAScenario, None, pos, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
@@ -18,7 +18,6 @@ package org.scalatest.featurespec
 import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
-import scala.concurrent.Future
 import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.AtomicReference
 import org.scalatest.Suite.anExceptionThatShouldCauseAnAbort
@@ -96,19 +95,19 @@ trait FixtureAsyncFeatureSpecLike extends org.scalatest.fixture.AsyncTestSuite w
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(Resources.scenario(testText.trim), transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(Resources.scenario(testText.trim), transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
   class ResultOfScenarioInvocation(specText: String, testTags: Tag*) {
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(Resources.scenario(specText.trim), transformToOutcome(testFun), Resources.scenarioCannotAppearInsideAnotherScenario, None, None, pos, testTags: _*)
     }
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(Resources.scenario(specText.trim), transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.scenarioCannotAppearInsideAnotherScenario, None, None, pos, testTags: _*)
     }
   }
@@ -138,10 +137,10 @@ trait FixtureAsyncFeatureSpecLike extends org.scalatest.fixture.AsyncTestSuite w
     new ResultOfScenarioInvocation(specText, testTags: _*)
 
   class ResultOfIgnoreInvocation(specText: String, testTags: Tag*) {
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(Resources.scenario(specText), transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAScenario, None, pos, testTags: _*)
     }
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(Resources.scenario(specText), transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideAScenario, None, pos, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpec.scala
@@ -15,11 +15,13 @@
  */
 package org.scalatest.fixture
 
+import org.scalatest.DefaultFutureAssertionConverter
+
 /**
   * This class is deprecated and will be removed in future version of ScalaTest, please use org.scalatest.funsuite.FixtureAsyncFunSuite instead.
   */
 @deprecated("Please use org.scalatest.featurespec.FixtureAsyncFeatureSpec instead")
-abstract class AsyncFeatureSpec extends org.scalatest.fixture.AsyncFeatureSpecLike {
+abstract class AsyncFeatureSpec extends org.scalatest.fixture.AsyncFeatureSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpec.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest.fixture
 
+import org.scalatest.DefaultFutureAssertionConverter
+
 /**
  * A sister class to <code>org.scalatest.AsyncFlatSpec</code> that can pass a fixture object into its tests.
  *
@@ -256,7 +258,7 @@ package org.scalatest.fixture
  *
  * @author Bill Venners
  */
-abstract class AsyncFlatSpec extends org.scalatest.fixture.AsyncFlatSpecLike {
+abstract class AsyncFlatSpec extends org.scalatest.fixture.AsyncFlatSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
@@ -17,7 +17,6 @@ package org.scalatest.fixture
 
 import org.scalatest._
 import org.scalactic.source
-import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations
 import words.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord, ShouldVerb, MustVerb, CanVerb, StringVerbStringInvocation, StringVerbBehaveLikeInvocation}
 
@@ -92,11 +91,11 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -120,7 +119,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
 
-  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     // TODO: This is what was being used before but it is wrong
     def testRegistrationClosedMessageFun: String =
       methodName match {
@@ -267,8 +266,8 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
-      registerAsyncTestToRun(verb.trim + " " + name.trim, tags, "in", new NoArgTestWrapper[FixtureParam, Future[compatible.Assertion]](testFun), pos)
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
+      registerAsyncTestToRun(verb.trim + " " + name.trim, tags, "in", new NoArgTestWrapper[FixtureParam, FutureSystem](testFun), pos)
     }
 
     /**
@@ -290,7 +289,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, tags, "in", testFun, pos)
     }
 
@@ -338,7 +337,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, new NoArgTestWrapper(testFun), pos)
     }
 
@@ -363,7 +362,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, testFun, pos)
     }
   }
@@ -436,7 +435,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, List(), "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -459,7 +458,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, List(), "in", testFun, pos)
     }
 
@@ -505,7 +504,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), new NoArgTestWrapper(testFun), pos)
     }
 
@@ -528,7 +527,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), testFun, pos)
     }
 
@@ -802,7 +801,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, tags, "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -825,7 +824,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, tags, "in", testFun, pos)
     }
 
@@ -873,7 +872,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, new NoArgTestWrapper(testFun), pos)
     }
 
@@ -898,7 +897,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, testFun, pos)
     }
   }
@@ -971,7 +970,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, List(), "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -994,7 +993,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + name.trim, List(), "in", testFun, pos)
     }
 
@@ -1040,7 +1039,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1063,7 +1062,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      (implicit pos: source.Position)*/
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), testFun, pos)
     }
 
@@ -1337,7 +1336,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1362,7 +1361,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, tags, testFun, pos)
     }
 
@@ -1465,7 +1464,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1489,7 +1488,7 @@ trait AsyncFlatSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + name.trim, List(), testFun, pos)
     }
 
@@ -1717,7 +1716,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1740,7 +1739,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1763,7 +1762,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
     }
 
@@ -1786,7 +1785,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos)
     }
   }
@@ -1870,7 +1869,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1895,7 +1894,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, new NoArgTestWrapper(testFun), pos)
     }
 
@@ -1918,7 +1917,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
     }
 
@@ -1943,7 +1942,7 @@ import resultOfStringPassedToVerb.verb
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos)
     }
   }
@@ -2051,7 +2050,7 @@ import resultOfStringPassedToVerb.verb
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAnInOrAnIs, None, pos, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpec.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest.fixture
 
+import org.scalatest.DefaultFutureAssertionConverter
+
 /**
  * A sister class to <code>org.scalatest.AsyncFunSpec</code> that can pass a fixture object into its tests.
  *
@@ -259,7 +261,7 @@ package org.scalatest.fixture
  *
  * @author Bill Venners
  */
-abstract class AsyncFreeSpec extends org.scalatest.fixture.AsyncFreeSpecLike {
+abstract class AsyncFreeSpec extends org.scalatest.fixture.AsyncFreeSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
@@ -18,7 +18,6 @@ package org.scalatest.fixture
 import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
-import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations
 import words.BehaveWord
 
@@ -94,11 +93,11 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -121,7 +120,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.inCannotAppearInsideAnotherIn, None, None, pos, testTags: _*)
   }
 
@@ -148,7 +147,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAnIn, None, pos, testTags: _*)
   }
 
@@ -196,7 +195,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+    def in(testFun: FixtureParam => FutureSystem): Unit = {
       registerAsyncTestToRun(specText, tags, "in", testFun, pos)
     }
 
@@ -218,7 +217,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion]): Unit = {
+    def in(testFun: () => FutureSystem): Unit = {
       registerAsyncTestToRun(specText, tags, "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -262,7 +261,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem): Unit = {
       registerAsyncTestToIgnore(specText, tags, "ignore", testFun, pos)
     }
 
@@ -284,7 +283,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
+    def ignore(testFun: () => FutureSystem): Unit = {
       registerAsyncTestToIgnore(specText, tags, "ignore", new NoArgTestWrapper(testFun), pos)
     }
   }
@@ -346,7 +345,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+    def in(testFun: FixtureParam => FutureSystem): Unit = {
       registerAsyncTestToRun(string, List(), "in", testFun, pos)
     }
 
@@ -368,7 +367,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion]): Unit = {
+    def in(testFun: () => FutureSystem): Unit = {
       registerAsyncTestToRun(string, List(), "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -412,7 +411,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem): Unit = {
       registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos)
     }
 
@@ -434,7 +433,7 @@ trait AsyncFreeSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
+    def ignore(testFun: () => FutureSystem): Unit = {
       registerAsyncTestToIgnore(string, List(), "ignore", new NoArgTestWrapper(testFun), pos)
     }
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpec.scala
@@ -15,11 +15,13 @@
  */
 package org.scalatest.fixture
 
+import org.scalatest.DefaultFutureAssertionConverter
+
 /**
   * This class is deprecated and will be removed in future version of ScalaTest, please use org.scalatest.funspec.FixtureAsyncFunSpec instead.
   */
 @deprecated("Please use org.scalatest.funspec.FixtureAsyncFunSpec instead")
-abstract class AsyncFunSpec extends org.scalatest.fixture.AsyncFunSpecLike {
+abstract class AsyncFunSpec extends org.scalatest.fixture.AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestRegistration.scala
@@ -17,7 +17,6 @@ package org.scalatest.fixture
 
 import org.scalactic._
 import org.scalatest.Tag
-import scala.concurrent.Future
 import org.scalatest.compatible
 
 /**
@@ -33,7 +32,7 @@ trait AsyncTestRegistration { theSuite: org.scalatest.fixture.AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => theSuite.type#FutureSystem)(implicit pos: source.Position)
 
   /**
    * Registers an ignored test.
@@ -42,5 +41,5 @@ trait AsyncTestRegistration { theSuite: org.scalatest.fixture.AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => theSuite.type#FutureSystem)(implicit pos: source.Position)
 }

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestSuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncTestSuite.scala
@@ -199,9 +199,9 @@ trait AsyncTestSuite extends org.scalatest.fixture.Suite with org.scalatest.Asyn
    * @param testFun test function
    * @return function that returns `AsyncOutcome`
    */
-  private[scalatest] def transformToOutcome(testFun: FixtureParam => Future[compatible.Assertion]): FixtureParam => AsyncOutcome =
+  private[scalatest] def transformToOutcome(testFun: FixtureParam => FutureSystem): FixtureParam => AsyncOutcome =
     (fixture: FixtureParam) => {
-      val futureUnit = testFun(fixture)
+      val futureUnit = convertToScalaFuture(testFun(fixture))
       InternalFutureOutcome(
         futureUnit.map(u => Succeeded).recover {
           case ex: exceptions.TestCanceledException => Canceled(ex)

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpec.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest.fixture
 
+import org.scalatest.DefaultFutureAssertionConverter
+
 /**
  * A sister class to <code>org.scalatest.AsyncWordSpec</code> that can pass a fixture object into its tests.
  *
@@ -261,7 +263,7 @@ package org.scalatest.fixture
  *
  * @author Bill Venners
  */
-abstract class AsyncWordSpec extends org.scalatest.fixture.AsyncWordSpecLike {
+abstract class AsyncWordSpec extends org.scalatest.fixture.AsyncWordSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
@@ -18,7 +18,6 @@ package org.scalatest.fixture
 import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
-import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations
 import words.{CanVerb, ResultOfAfterWordApplication, ShouldVerb, BehaveWord, MustVerb,
 StringVerbBlockRegistration, SubjectWithAfterWordRegistration}
@@ -95,11 +94,11 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -122,7 +121,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.inCannotAppearInsideAnotherIn, None, None, pos, testTags: _*)
   }
 
@@ -149,7 +148,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => Future[compatible.Assertion], pos: source.Position): Unit = {
+  private def registerAsyncTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: FixtureParam => FutureSystem, pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(specText, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAnIn, None, pos, testTags: _*)
   }
 
@@ -266,7 +265,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(specText, tags, "in", testFun, pos)
     }
 
@@ -288,7 +287,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(specText, tags, "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -332,7 +331,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(specText, tags, "ignore", testFun, pos)
     }
 
@@ -354,7 +353,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(specText, tags, "ignore", new NoArgTestWrapper(testFun), pos)
     }
   }
@@ -396,7 +395,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(string, List(), "in", testFun, pos)
     }
 
@@ -418,7 +417,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def in(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToRun(string, List(), "in", new NoArgTestWrapper(testFun), pos)
     }
 
@@ -462,7 +461,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos)
     }
 
@@ -484,7 +483,7 @@ trait AsyncWordSpecLike extends org.scalatest.fixture.AsyncTestSuite with org.sc
      *
      * @param testFun the test function
      */
-    def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def ignore(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       registerAsyncTestToIgnore(string, List(), "ignore", new NoArgTestWrapper(testFun), pos)
 
     }

--- a/scalatest/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -16,6 +16,7 @@
 package org.scalatest.funspec
 
 import org.scalatest.Suite
+import org.scalatest.DefaultFutureAssertionConverter
 
 /**
  * Enables testing of asynchronous code without blocking,
@@ -2262,7 +2263,7 @@ import org.scalatest.Suite
  * <li><code>A Stack (when non-empty) should return before and after StackInfo that has existing size - 1 and lastItemAdded as top when Pop is fired at non-empty stack actor: almost full stack actor</code></li>
  * </ul>
  */
-abstract class AsyncFunSpec extends AsyncFunSpecLike {
+abstract class AsyncFunSpec extends AsyncFunSpecLike with DefaultFutureAssertionConverter {
 
   /**
    * Returns a user friendly string for this suite, composed of the

--- a/scalatest/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
@@ -94,11 +94,11 @@ trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with In
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -148,7 +148,7 @@ trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with In
      * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
      * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
      */
-    def apply(specText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(specText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.itCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
     }
 
@@ -260,7 +260,7 @@ trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with In
      * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
      * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
      */
-    def apply(specText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(specText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.theyCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
     }
 
@@ -344,7 +344,7 @@ trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with In
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
    * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
    */
-  protected def ignore(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected def ignore(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAnItOrAThey, None, pos, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
@@ -18,7 +18,6 @@ package org.scalatest.funspec
 import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
-import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations
 import words.BehaveWord
 
@@ -94,11 +93,11 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.fixture.AsyncTestSuite with 
    */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -128,11 +127,11 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.fixture.AsyncTestSuite with 
 
     class ResultOfItWordApplication(specText: String, testTags: Tag*) {
 
-      def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+      def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
         engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.itCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
       }
 
-      def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+      def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
         engine.registerAsyncTest(specText, transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.itCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
       }
     }
@@ -250,10 +249,10 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.fixture.AsyncTestSuite with 
   protected final class TheyWord {
 
     class ResultOfTheyWordApplication(specText: String, testTags: Tag*) {
-      def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+      def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
         engine.registerAsyncTest(specText, transformToOutcome(testFun), Resources.theyCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
       }
-      def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+      def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
         engine.registerAsyncTest(specText, transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.theyCannotAppearInsideAnotherItOrThey, None, None, pos, testTags: _*)
       }
     }
@@ -347,10 +346,10 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.fixture.AsyncTestSuite with 
   protected val they = new TheyWord
 
   class ResultOfIgnoreInvocation(specText: String, testTags: Tag*) {
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(specText, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideAnItOrAThey, None, pos, testTags: _*)
     }
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(specText, transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideAnItOrAThey, None, pos, testTags: _*)
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
@@ -90,11 +90,11 @@ trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with I
     */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
@@ -112,7 +112,7 @@ trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with I
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
     */
-  protected def test(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected def test(testName: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testName, transformToOutcome(testFun), Resources.testCannotAppearInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
@@ -131,7 +131,7 @@ trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with I
     * @throws DuplicateTestNameException if a test with the same name has been registered previously
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     */
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected def ignore(testName: String, testTags: Tag*)(testFun: => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testName, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideATest, None, pos, testTags: _*)
   }
 

--- a/scalatest/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
@@ -17,7 +17,6 @@ package org.scalatest.funsuite
 
 import org.scalatest._
 import org.scalactic.source
-import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations
 
 /**
@@ -91,20 +90,20 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.fixture.AsyncTestSuite with
     */
   protected def markup: Documenter = atomicDocumenter.get
 
-  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, None, pos, testTags: _*)
   }
 
-  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  final def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
     engine.registerIgnoredAsyncTest(testText, transformToOutcome(testFun), Resources.testCannotBeNestedInsideAnotherTest, None, pos, testTags: _*)
   }
 
   class ResultOfTestInvocation(testName: String, testTags: Tag*) {
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(testName, transformToOutcome(testFun), Resources.testCannotAppearInsideAnotherTest, None, None, pos, testTags: _*)
     }
 
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerAsyncTest(testName, transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.testCannotAppearInsideAnotherTest, None, None, pos, testTags: _*)
     }
   }
@@ -137,11 +136,11 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.fixture.AsyncTestSuite with
   */
 
   class ResultOfIgnoreInvocation(testName: String, testTags: Tag*) {
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: FixtureParam => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(testName, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideATest, None, pos, testTags: _*)
     }
 
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    def apply(testFun: () => FutureSystem)(implicit pos: source.Position): Unit = {
       engine.registerIgnoredAsyncTest(testName, transformToOutcome(new fixture.NoArgTestWrapper(testFun)), Resources.ignoreCannotAppearInsideATest, None, pos, testTags: _*)
     }
   }


### PR DESCRIPTION
We are using `com.twitter.util.Future`, and convert it to `scala.concurrent.Future`
when we are testing.

This pull request change `scala.concurrent.Future` dependencies of ScalaTest as
a drop-in replacement for asynchronous testing.

Here's an example:

```scala
    package org.scalatest.plus.example
   
    import com.twitter.util.{Future, Return, Throw}
    import org.scalatest.compatible.Assertion
    import org.scalatest.{AsyncFlatSpecLike, compatible}
   
    abstract class TwitterAsyncFlatSpec extends AsyncFlatSpecLike {
      // TODO: `Suite` is private[scalatest]
      override def toString: String = Suite.suiteToString(None, this)

      override type FutureSystem = Future[compatible.Assertion]
   
      override def convertToScalaFuture(f: FutureSystem): scala.concurrent.Future[compatible.Assertion] = {
        val promise: scala.concurrent.Promise[Assertion] = scala.concurrent.Promise()
        f.respond {
          case Return(value)    => promise.success(value)
          case Throw(exception) => promise.failure(exception)
        }
        promise.future
      }
    }
```
