### PR TITLE
Improve startup performance by O(100)ms

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -1002,7 +1002,7 @@ import java.net.{ServerSocket, InetAddress}
       }
 
     val (runnerInstance, configurationInstance) =
-      if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+      {
         val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
         val runnerModule = runnerCompanionClass.getField("MODULE$")
         val runnerObj = runnerModule.get(runnerCompanionClass)
@@ -1012,17 +1012,6 @@ import java.net.{ServerSocket, InetAddress}
         val configurationObj = configurationModule.get(runnerCompanionClass)
         
         (runnerObj.asInstanceOf[Runner.type], configurationObj.asInstanceOf[Configuration.type])
-      }
-      else {
-        // We need to use the following code to set Runner object instance for different Runner using different class loader.
-        import scala.reflect.runtime._
-
-        val runtimeMirror = universe.runtimeMirror(testClassLoader)
-
-        (
-          runtimeMirror.reflectModule(runtimeMirror.staticModule("org.scalatest.tools.Runner$")).instance.asInstanceOf[Runner.type], 
-          runtimeMirror.reflectModule(runtimeMirror.staticModule("org.scalatest.prop.Configuration$")).instance.asInstanceOf[Configuration.type]
-        )
       }
 
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -218,21 +218,11 @@ class ScalaTestFramework extends SbtFramework {
           val runtimeMirror = universe.runtimeMirror(testLoader)
           
           val runnerInstance =
-            if (ScalaTestVersions.BuiltForScalaVersion == "2.10") {
+            {
               val runnerCompanionClass = testLoader.loadClass("org.scalatest.tools.Runner$")
               val module = runnerCompanionClass.getField("MODULE$")
               val obj = module.get(runnerCompanionClass)
               obj.asInstanceOf[org.scalatest.tools.Runner.type]
-            }
-            else {
-              // We need to use the following code to set Runner object instance for different Runner using different class loader.
-              import scala.reflect.runtime._
-
-              val runtimeMirror = universe.runtimeMirror(testLoader)
-
-              val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-              val obj = runtimeMirror.reflectModule(module)
-              obj.instance.asInstanceOf[org.scalatest.tools.Runner.type]
             }
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 


### PR DESCRIPTION
Scala reflection is very slow because it takes a long time to load all
of the classes needed by the runtime mirror. Java reflection, on the
other hand, is reasonably quick. In unscientific and ad-hoc benchmarkes,
I found that the startup time decreased by about 100ms with this change.
Given java reflection was already used for scala 2.10, the risk of this
change seems minimal.