### PR TITLE
[3.1.X] SNAP7 Deploy Adjustments

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
@@ -38,7 +38,7 @@ case class Classification(val totalGenerated: PosInt, val totals: Map[String, Po
     * @return Exactly what proportion of the values fell into each bucket.
     */
   def portions: Map[String, Double] =
-    totals.mapValues(count => count.toDouble / totalGenerated.toDouble)
+    totals.mapValues(count => count.toDouble / totalGenerated.toDouble).toMap
 
   /**
     * For each bucket, what percentage of the generated values fell into it?
@@ -48,9 +48,9 @@ case class Classification(val totalGenerated: PosInt, val totals: Map[String, Po
     * @return Approximately what proportion of the values fell into each bucket.
     */
   def percentages: Map[String, PosZInt] =
-    totals mapValues { count =>
+    (totals mapValues { count =>
       PosZInt.ensuringValid((count * 100.0 / totalGenerated).round.toInt)
-    }
+    }).toMap
 
   override def toString = {
     val lines = percentages map { case (classification, percentage) => s"${percentage.value}% $classification" }


### PR DESCRIPTION
- Adjustments required to deploy 3.1.0-SNAP7 successfully.
- Fixed broken 2.13 build due to newly added Classification.