### PR TITLE
Build Refactor + Cleanup

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -225,8 +225,8 @@ object ScalatestBuild {
 
   def scalatestTestLibraryDependencies(theScalaVersion: String) =
     Seq(
-      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP2" % "test",
-      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP3" % "test"
+      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP3" % "test",
+      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP4" % "test"
     )
 
   val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.25")
@@ -1418,8 +1418,8 @@ object ScalatestBuild {
   def gentestsLibraryDependencies =
     Seq(
       "org.pegdown" % "pegdown" % pegdownVersion % "optional",
-      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP2" % "test",
-      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP3" % "test"
+      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP3" % "test",
+      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP4" % "test"
     )
 
   def gentestsSharedSettings: Seq[Setting[_]] = Seq(

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -42,6 +42,8 @@ object ScalatestBuild {
 
   val previousReleaseVersion = "3.0.5"
 
+  val plusJUnitVersion = "1.0.0-SNAP4"
+  val plusTestNGVersion = "1.0.0-SNAP3"
   val pegdownVersion = "1.4.2"
 
   val githubTag = "release-3.1.0" // for scaladoc source urls
@@ -225,8 +227,8 @@ object ScalatestBuild {
 
   def scalatestTestLibraryDependencies(theScalaVersion: String) =
     Seq(
-      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP3" % "test",
-      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP4" % "test"
+      "org.scalatestplus" %% "scalatestplus-testng" % plusTestNGVersion % "test",
+      "org.scalatestplus" %% "scalatestplus-junit" % plusJUnitVersion % "test"
     )
 
   val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.25")
@@ -804,8 +806,7 @@ object ScalatestBuild {
         "org.scalatest.time",
         "org.scalatest.tools",
         "org.scalatest.verb",
-        "org.scalatest.words",
-        "org.scalatestplus.scalacheck"
+        "org.scalatest.words"
       ),
       OsgiKeys.importPackage := Seq(
         "org.scalatest.*",
@@ -1418,8 +1419,8 @@ object ScalatestBuild {
   def gentestsLibraryDependencies =
     Seq(
       "org.pegdown" % "pegdown" % pegdownVersion % "optional",
-      "org.scalatestplus" %% "scalatestplus-testng" % "1.0.0-SNAP3" % "test",
-      "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-SNAP4" % "test"
+      "org.scalatestplus" %% "scalatestplus-testng" % plusTestNGVersion % "test",
+      "org.scalatestplus" %% "scalatestplus-junit" % plusJUnitVersion % "test"
     )
 
   def gentestsSharedSettings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
Minor build refactor + cleanup: 

- Refactor version number of scalatestplus-junit and scalatestplus-testng as vals.
- Bumped up to use scalatestplus-junit 1.0.0-SNAP4 and scalatestplus-testng 1.0.0-SNAP3.
- Removed org.scalatestplus.scalacheck from osgi export list.