### PR TITLE
GenGen + MustMatchers Tests for JS and Native

### DIFF
--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -4230,4 +4230,19 @@ $okayAssertions$
     genGeneratorDrivenSuite(dir, false, true, generatorSuiteExpectTemplate, "expect", false)*/
 
   }
+
+  def genTestForNative(dir: File, version: String, scalaVersion: String): Seq[File] = {
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteAssertTemplate, "assert", false) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteAssertTemplate, "assert", false) /*++
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteFutureAssertTemplate, "assert", true) ++
+    genGeneratorDrivenSuite(dir, true, false, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, false, false, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, true, true, generatorSuiteExpectTemplate, "expect", false) ++
+    genGeneratorDrivenSuite(dir, false, true, generatorSuiteExpectTemplate, "expect", false)*/
+  }
 }

--- a/project/GenMustMatchersTests.scala
+++ b/project/GenMustMatchersTests.scala
@@ -120,7 +120,11 @@ trait GenMustMatchersTestsBase {
     genTestImpl(targetBaseDir, version, scalaVersion, false)
   }
 
-  def genTestForScalaJS(targetBaseDir: File, version: String, scalaVersion: String): Unit = {
+  def genTestForScalaJS(targetBaseDir: File, version: String, scalaVersion: String): Seq[File] = {
+    genTestImpl(targetBaseDir, version, scalaVersion, true)
+  }
+
+  def genTestForScalaNative(targetBaseDir: File, version: String, scalaVersion: String): Seq[File] = {
     genTestImpl(targetBaseDir, version, scalaVersion, true)
   }
 


### PR DESCRIPTION
Enabled GenGen's tests in js and native tests, and enabled must matchers tests in js (unable to enable for native as it demands too much memory).