### PR TITLE
GeneratorSpec 2.13.0-M5 Fix

### DIFF
--- a/project/GenColCompatHelper.scala
+++ b/project/GenColCompatHelper.scala
@@ -56,6 +56,8 @@ object GenColCompatHelper {
           |  object Factory {}
           |
           |  def className(col: scala.collection.Iterable[_]): String = org.scalactic.NameUtil.getSimpleNameOfAnObjectsClass(col)
+          |
+          |  def newBuilder[A, C](f: Factory[A, C]): scala.collection.mutable.Builder[A, C] = f.newBuilder
           |}
           |
         """.stripMargin
@@ -115,6 +117,7 @@ object GenColCompatHelper {
           |  }
           |  def className(col: scala.collection.GenTraversable[_]): String = col.stringPrefix
           |
+          |  def newBuilder[A, C](f: Factory[A, C]): scala.collection.mutable.Builder[A, C] = f.apply()
           |}
           |
         """.stripMargin


### PR DESCRIPTION
Make GeneratorSpec to compile again with Scala 2.13.0-M5.