### PR TITLE
Modify the Scaladoc to reflect the current implementation

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpec.scala
@@ -236,10 +236,8 @@ package org.scalatest
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, which is a <em>serial execution context</em>
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>


### PR DESCRIPTION
In fact, the execution context is provided by ScalaText for both JVM and Scala.js:
https://github.com/scalatest/scalatest/blob/57151f83937a4adb23d402efecfe76d4c96c73ac/scalatest/src/main/scala/org/scalatest/AsyncTestSuite.scala#L222