### PR TITLE
[3.0.x] New Home for CheckerAsserting

### DIFF
--- a/project/GenResources.scala
+++ b/project/GenResources.scala
@@ -22,6 +22,8 @@ trait GenResources {
 
   val generatorSource = new File("GenResources.scala")
 
+  def packagePrefix: String
+
   def packageName: String
 
   def resourcesTemplate(methods: String): String
@@ -117,7 +119,7 @@ trait GenResources {
 trait GenResourcesJVM extends GenResources {
 
   def resourcesTemplate(methods: String): String =
-    s"""package org.$packageName
+    s"""package $packagePrefix.$packageName
        |
        |import java.util.ResourceBundle
        |import java.text.MessageFormat
@@ -142,7 +144,7 @@ trait GenResourcesJVM extends GenResources {
     """.stripMargin
 
   def failureMessagesTemplate(methods: String): String =
-    s"""package org.$packageName
+    s"""package $packagePrefix.$packageName
        |
        |private[$packageName] object FailureMessages {
        |
@@ -168,17 +170,19 @@ trait GenResourcesJVM extends GenResources {
 }
 
 object ScalacticGenResourcesJVM extends GenResourcesJVM {
+  def packagePrefix: String = "org"
   def packageName: String = "scalactic"
   def propertiesFile: File = new File("scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties")
 
 }
 
 object ScalaTestGenResourcesJVM extends GenResourcesJVM {
+  def packagePrefix: String = "org"
   def packageName: String = "scalatest"
   def propertiesFile: File = new File("scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties")
 
   override def resourcesTemplate(methods: String): String =
-    s"""package org.$packageName
+    s"""package $packagePrefix.$packageName
         |
         |import java.util.ResourceBundle
         |import java.text.MessageFormat
@@ -210,7 +214,7 @@ object ScalaTestGenResourcesJVM extends GenResourcesJVM {
 trait GenResourcesJSVM extends GenResources {
 
   def resourcesTemplate(methods: String): String =
-    s"""package org.$packageName
+    s"""package $packagePrefix.$packageName
         |
         |private[$packageName] object Resources {
         |
@@ -230,7 +234,7 @@ trait GenResourcesJSVM extends GenResources {
     """.stripMargin
 
   def failureMessagesTemplate(methods: String): String =
-    s"""package org.$packageName
+    s"""package $packagePrefix.$packageName
         |
         |private[$packageName] object FailureMessages {
         |
@@ -269,11 +273,19 @@ trait GenResourcesJSVM extends GenResources {
 }
 
 object ScalacticGenResourcesJSVM extends GenResourcesJSVM {
+  def packagePrefix: String = "org"
   def packageName: String = "scalactic"
   def propertiesFile: File = new File("scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties")
 }
 
 object ScalaTestGenResourcesJSVM extends GenResourcesJSVM {
+  def packagePrefix: String = "org"
   def packageName: String = "scalatest"
   def propertiesFile: File = new File("scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties")
+}
+
+object ScalaTestGenScalaCheckResourcesJSVM extends GenResourcesJSVM {
+  def packagePrefix: String = "org.scalatestplus"
+  def packageName: String = "scalacheck"
+  def propertiesFile: File = new File("scalatest/src/main/resources/org/scalatestplus/scalacheck/MessageBundle.properties")
 }

--- a/project/GenScalaCheckGen.scala
+++ b/project/GenScalaCheckGen.scala
@@ -180,7 +180,6 @@ import org.scalacheck.Prop
 import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.scalatest.exceptions.DiscardedEvaluationException
-import org.scalatest.enablers.CheckerAsserting
 import org.scalactic._
 import org.scalatest.prop.Whenever
 

--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -242,7 +242,12 @@ object GenScalaTestJS {
         "SafariBrowser.scala"  // skipped because selenium not supported.
       )
     ) ++
-    copyDir("scalatest/src/main/scala/org/scalatestplus/scalacheck", "org/scalatestplus/scalacheck", targetDir, List.empty)
+    copyDir("scalatest/src/main/scala/org/scalatestplus/scalacheck", "org/scalatestplus/scalacheck", targetDir, 
+      List(
+        "Resources.scala", 
+        "FailureMessages.scala"
+      )
+    )
   }
 
   def genTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = {

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -693,6 +693,8 @@ object ScalatestBuild extends Build {
           GenVersions.genScalaTestVersions((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
           ScalaTestGenResourcesJSVM.genFailureMessages((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
           ScalaTestGenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
+          ScalaTestGenScalaCheckResourcesJSVM.genFailureMessages((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
+          ScalaTestGenScalaCheckResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
           GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)
         }.taskValue
       },

--- a/scalatest/src/main/resources/org/scalatestplus/scalacheck/MessageBundle.properties
+++ b/scalatest/src/main/resources/org/scalatestplus/scalacheck/MessageBundle.properties
@@ -1,0 +1,12 @@
+propCheckLabel=Label of failing property:
+propCheckLabels=Labels of failing property:
+propertyException={0} was thrown during property evaluation.
+propCheckExhausted=Gave up after {0} successful property evaluations. {1} evaluations were discarded.
+propCheckExhaustedAfterOne=Gave up after 1 successful property evaluation. {0} evaluations were discarded.
+propertyFailed=Falsified after {0} successful property evaluations.
+propertyCheckSucceeded=Property check succeeded
+thrownExceptionsLocation=Location: ({0})
+occurredOnValues=Occurred when passed generated values (
+thrownExceptionsMessage=Message: {0}    
+bigProblems=An exception or error caused a run to abort.
+bigProblemsWithMessage=An exception or error caused a run to abort: {0}

--- a/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/CheckerAsserting.scala
@@ -40,6 +40,7 @@ import org.scalatest.exceptions.StackDepth
  * else it will have result type <code>Unit</code>.
  * </p>
  */
+ @deprecated("CheckerCheckerAssertings has been moved from org.scalatest.enablers to org.scalatestplus.scalacheck. Please update your imports, as this deprecated type will be removed in a future version of ScalaTest.")
 trait CheckerAsserting[T] {
   /**
    * The result type of the <code>check</code> method.
@@ -209,6 +210,7 @@ abstract class UnitCheckerAsserting {
  * Companion object to <code>CheckerAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
  * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
  */
+ @deprecated("CheckerCheckerAssertings has been moved from org.scalatest.enablers to org.scalatestplus.scalacheck. Please update your imports, as this deprecated type will be removed in a future version of ScalaTest.")
 object CheckerAsserting extends UnitCheckerAsserting /*ExpectationCheckerAsserting*/ {
 
   /**

--- a/scalatest/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.scalacheck
+
+import org.scalactic._
+import org.scalactic.NameUtil.getSimpleNameOfAnObjectsClass
+import org.scalacheck.Prop
+import org.scalacheck.Prop.Arg
+import org.scalacheck.Test
+import org.scalacheck.util.Pretty
+import org.scalatest.Assertion
+import org.scalatest.FailureMessages
+import org.scalatest.Resources
+import org.scalatest.Succeeded
+import org.scalatest.UnquotedString
+import org.scalatest.exceptions.StackDepthException
+import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
+import org.scalatest.exceptions.StackDepth
+
+/**
+ * Supertrait for <code>CheckerAsserting</code> typeclasses, which are used to implement and determine the result
+ * type of [[org.scalatest.prop.GeneratorDrivenPropertyChecks GeneratorDrivenPropertyChecks]]'s <code>apply</code> and <code>forAll</code> method.
+ *
+ * <p>
+ * Currently, an [[org.scalatest.prop.GeneratorDrivenPropertyChecks GeneratorDrivenPropertyChecks]] expression will have result type <code>Assertion</code>, if the function passed has result type <code>Assertion</code>,
+ * else it will have result type <code>Unit</code>.
+ * </p>
+ */
+trait CheckerAsserting[T] {
+  /**
+   * The result type of the <code>check</code> method.
+   */
+  type Result
+
+  /**
+   * Perform the property check using the given <code>Prop</code> and <code>Test.Parameters</code>.
+   *
+   * @param p the <code>Prop</code> to be used to check
+   * @param prms the <code>Test.Parameters</code> to be used to check
+   * @param prettifier the <code>Prettifier</code> to be used to prettify error message
+   * @param pos the <code>Position</code> of the caller site
+   * @param argNames the list of argument names
+   * @return the <code>Result</code> of the property check.
+   */
+  def check(p: Prop, prms: Test.Parameters, prettifier: Prettifier, pos: source.Position, argNames: Option[List[String]] = None): Result
+}
+
+/**
+  * Class holding lowest priority <code>CheckerAsserting</code> implicit, which enables [[org.scalatest.prop.GeneratorDrivenPropertyChecks GeneratorDrivenPropertyChecks]] expressions that have result type <code>Unit</code>.
+  */
+abstract class UnitCheckerAsserting {
+
+  /**
+   * Abstract subclass of <code>CheckerAsserting</code> that provides the bulk of the implementations of <code>CheckerAsserting</code>
+   * <code>check</code> method.
+   */
+  /* protected[scalatest]*/ abstract class CheckerAssertingImpl[T] extends CheckerAsserting[T] {
+
+    import CheckerAsserting._
+
+    /**
+     * Check the given <code>Prop</code> and <code>Test.Parameters</code> by calling [[http://www.scalacheck.org ScalaCheck]]'s <code>Test.check</code>.
+     * If the check succeeds, call <code>indicateSuccess</code>, else call <code>indicateFailure</code>.
+     *
+     *
+     * @param p the <code>Prop</code> to be used to check
+     * @param prms the <code>Test.Parameters</code> to be used to check
+     * @param prettifier the <code>Prettifier</code> to be used to prettify error message
+     * @param pos the <code>Position</code> of the caller site
+     * @param argNames the list of argument names
+     * @return the <code>Result</code> of the property check.
+     */
+    def check(p: Prop, prms: Test.Parameters, prettifier: Prettifier, pos: source.Position, argNames: Option[List[String]] = None): Result = {
+
+      val result = Test.check(prms, p)
+      if (!result.passed) {
+
+        val (args, labels) = argsAndLabels(result)
+
+        (result.status: @unchecked) match {
+
+          case Test.Exhausted =>
+
+            val failureMsg =
+              if (result.succeeded == 1)
+                FailureMessages.propCheckExhaustedAfterOne(prettifier, result.discarded)
+              else
+                FailureMessages.propCheckExhausted(prettifier, result.succeeded, result.discarded)
+
+            indicateFailure(
+              sde => failureMsg,
+              failureMsg,
+              args,
+              labels,
+              None,
+              pos
+            )
+
+          case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
+
+            val stackDepth = 1
+            
+            indicateFailure(
+              sde => FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(sde))) + "\n" +
+              ( sde.failedCodeFileNameAndLineNumberString match { case Some(s) => " (" + s + ")"; case None => "" }) + "\n" +
+              "  " + FailureMessages.propertyFailed(prettifier, result.succeeded) + "\n" +
+              (
+                sde match {
+                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
+                  case _ => ""
+                }
+                ) +
+              "  " + FailureMessages.occurredOnValues + "\n" +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs), prettifier) + "\n" +
+              "  )" +
+              getLabelDisplay(scalaCheckLabels),
+              FailureMessages.propertyFailed(prettifier, result.succeeded),
+              scalaCheckArgs,
+              scalaCheckLabels.toList,
+              None,
+              pos
+            )
+
+          case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
+
+            indicateFailure(
+              sde => FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(e))) + "\n" +
+              "  " + FailureMessages.thrownExceptionsMessage(prettifier, if (e.getMessage == null) "None" else UnquotedString(e.getMessage)) + "\n" +
+              (
+                e match {
+                  case sd: StackDepth if sd.failedCodeFileNameAndLineNumberString.isDefined =>
+                    "  " + FailureMessages.thrownExceptionsLocation(prettifier, UnquotedString(sd.failedCodeFileNameAndLineNumberString.get)) + "\n"
+                  case _ => ""
+                }
+              ) +
+              "  " + FailureMessages.occurredOnValues + "\n" +
+              prettyArgs(getArgsWithSpecifiedNames(argNames, scalaCheckArgs), prettifier) + "\n" +
+              "  )" +
+              getLabelDisplay(scalaCheckLabels),
+              FailureMessages.propertyException(prettifier, UnquotedString(e.getClass.getName)),
+              scalaCheckArgs,
+              scalaCheckLabels.toList,
+              Some(e),
+              pos
+            )
+        }
+      } else indicateSuccess(FailureMessages.propertyCheckSucceeded)
+    }
+
+    private[scalacheck] def indicateSuccess(message: => String): Result
+
+    private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Result
+  }
+
+  /**
+   * Provides support of [[org.scalatest.enablers.CheckerAsserting CheckerAsserting]] for Unit.  Do nothing when the check succeeds,
+   * but throw [[org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException GeneratorDrivenPropertyCheckFailedException]]
+   * when check fails.
+   */
+  implicit def assertingNatureOfT[T]: CheckerAsserting[T] { type Result = Unit } =
+    new CheckerAssertingImpl[T] {
+      type Result = Unit
+      private[scalacheck] def indicateSuccess(message: => String): Unit = ()
+      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Unit = {
+        throw new GeneratorDrivenPropertyCheckFailedException(
+          messageFun,
+          optionalCause,
+          pos,
+          None,
+          undecoratedMessage,
+          scalaCheckArgs,
+          None,
+          scalaCheckLabels.toList
+        )
+      }
+    }
+}
+
+/**
+ * Abstract class that in the future will hold an intermediate priority <code>CheckerAsserting</code> implicit, which will enable inspector expressions
+ * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
+ */
+/*abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
+
+  implicit def assertingNatureOfExpectation: CheckerAsserting[Expectation] { type Result = Expectation } = {
+    new CheckerAsserting[Expectation] {
+      type Result = Expectation
+    }
+  }
+
+}*/
+
+/**
+ * Companion object to <code>CheckerAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
+ * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
+ */
+object CheckerAsserting extends UnitCheckerAsserting /*ExpectationCheckerAsserting*/ {
+
+  /**
+    * Provides support of [[org.scalatest.enablers.CheckerAsserting CheckerAsserting]] for Assertion.  Returns [[org.scalatest.Succeeded Succeeded]] when the check succeeds,
+    * but throw [[org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException GeneratorDrivenPropertyCheckFailedException]]
+    * when check fails.
+    */
+  implicit def assertingNatureOfAssertion: CheckerAsserting[Assertion] { type Result = Assertion } = {
+    new CheckerAssertingImpl[Assertion] {
+      type Result = Assertion
+      private[scalacheck] def indicateSuccess(message: => String): Assertion = Succeeded
+      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
+        throw new GeneratorDrivenPropertyCheckFailedException(
+          messageFun,
+          optionalCause,
+          pos,
+          None,
+          undecoratedMessage,
+          scalaCheckArgs,
+          None,
+          scalaCheckLabels.toList
+        )
+      }
+    }
+  }
+
+  private[scalacheck] def getArgsWithSpecifiedNames(argNames: Option[List[String]], scalaCheckArgs: List[Arg[Any]]) = {
+    if (argNames.isDefined) {
+      // length of scalaCheckArgs should equal length of argNames
+      val zipped = argNames.get zip scalaCheckArgs
+      zipped map { case (argName, arg) => arg.copy(label = argName) }
+    }
+    else
+      scalaCheckArgs
+  }
+
+  private[scalacheck] def getLabelDisplay(labels: Set[String]): String =
+    if (labels.size > 0)
+      "\n  " + (if (labels.size == 1) Resources.propCheckLabel else Resources.propCheckLabels) + "\n" + labels.map("    " + _).mkString("\n")
+    else
+      ""
+
+  private[scalacheck] def argsAndLabels(result: Test.Result): (List[Any], List[String]) = {
+
+    val (scalaCheckArgs, scalaCheckLabels) =
+      result.status match {
+        case Test.Proved(args) => (args.toList, List())
+        case Test.Failed(args, labels) => (args.toList, labels.toList)
+        case Test.PropException(args, _, labels) => (args.toList, labels.toList)
+        case _ => (List(), List())
+      }
+
+    val args: List[Any] = for (scalaCheckArg <- scalaCheckArgs.toList) yield scalaCheckArg.arg
+
+    // scalaCheckLabels is a Set[String], I think
+    val labels: List[String] = for (scalaCheckLabel <- scalaCheckLabels.iterator.toList) yield scalaCheckLabel
+
+    (args, labels)
+  }
+
+  // TODO: Internationalize these, and make them consistent with FailureMessages stuff (only strings get quotes around them, etc.)
+  private[scalacheck] def prettyTestStats(result: Test.Result, prettifier: Prettifier) = result.status match {
+
+    case Test.Proved(args) =>
+      "OK, proved property:                   \n" + prettyArgs(args, prettifier)
+
+    case Test.Passed =>
+      "OK, passed " + result.succeeded + " tests."
+
+    case Test.Failed(args, labels) =>
+      "Falsified after " + result.succeeded + " passed tests:\n" + prettyLabels(labels) + prettyArgs(args, prettifier)
+
+    case Test.Exhausted =>
+      "Gave up after only " + result.succeeded + " passed tests. " +
+        result.discarded + " tests were discarded."
+
+    case Test.PropException(args, e, labels) =>
+      FailureMessages.propertyException(prettifier, UnquotedString(getSimpleNameOfAnObjectsClass(e))) + "\n" + prettyLabels(labels) + prettyArgs(args, prettifier)
+  }
+
+  private[scalacheck] def prettyLabels(labels: Set[String]) = {
+    if (labels.isEmpty) ""
+    else if (labels.size == 1) "Label of failing property: " + labels.iterator.next + "\n"
+    else "Labels of failing property: " + labels.mkString("\n") + "\n"
+  }
+
+  //
+  // If scalacheck arg contains a type that
+  // Prettifier processes, then let
+  // Prettifier handle it.  Otherwise use its
+  // prettyArg method to generate the display string.
+  //
+  // Passes 0 as verbosity value to prettyArg function.
+  //
+  private[scalacheck] def decorateArgToStringValue(arg: Arg[_], prettifier: Prettifier): String =
+    arg.arg match {
+      case null         => prettifier(prettifier, arg.arg)
+      case _: Unit      => prettifier(prettifier, arg.arg)
+      case _: String    => prettifier(prettifier, arg.arg)
+      case _: Char      => prettifier(prettifier, arg.arg)
+      case _: Array[_]  => prettifier(prettifier, arg.arg)
+      case _            => arg.prettyArg(new Pretty.Params(0))
+    }
+
+  private[scalacheck] def prettyArgs(args: List[Arg[_]], prettifier: Prettifier) = {
+    val strs = for((a, i) <- args.zipWithIndex) yield (
+      "    " +
+        (if (a.label == "") "arg" + i else a.label) +
+        " = " + decorateArgToStringValue(a, prettifier) + (if (i < args.length - 1) "," else "") +
+        (if (a.shrinks > 0) " // " + a.shrinks + (if (a.shrinks == 1) " shrink" else " shrinks") else "")
+      )
+    strs.mkString("\n")
+  }
+}
+

--- a/scalatest/src/main/scala/org/scalatestplus/scalacheck/Checkers.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/scalacheck/Checkers.scala
@@ -15,7 +15,6 @@
  */
 package org.scalatestplus.scalacheck
 
-import org.scalatest.enablers.CheckerAsserting
 import org.scalacheck.Arbitrary
 import org.scalacheck.Shrink
 import org.scalacheck.util.Pretty

--- a/scalatest/src/main/scala/org/scalatestplus/scalacheck/FailureMessages.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/scalacheck/FailureMessages.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2001-2019 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.scalacheck
+
+private[scalacheck] object FailureMessages {
+
+   def propertyException(prettifier: org.scalactic.Prettifier, param0: Any): String = Resources.propertyException(prettifier.apply(param0))
+
+   def propCheckExhaustedAfterOne(prettifier: org.scalactic.Prettifier, param0: Any): String = Resources.propCheckExhaustedAfterOne(prettifier.apply(param0))
+
+   def propCheckExhausted(prettifier: org.scalactic.Prettifier, param0: Any, param1: Any): String = Resources.propCheckExhausted(prettifier.apply(param0), prettifier.apply(param1))
+
+   def propertyFailed(prettifier: org.scalactic.Prettifier, param0: Any): String = Resources.propertyFailed(prettifier.apply(param0)) 
+
+   def propertyCheckSucceeded(): String = Resources.propertyCheckSucceeded()
+
+   def thrownExceptionsLocation(prettifier: org.scalactic.Prettifier, param0: Any): String = Resources.thrownExceptionsLocation(prettifier.apply(param0))
+
+   def occurredOnValues(): String = Resources.occurredOnValues()
+
+   def thrownExceptionsMessage(prettifier: org.scalactic.Prettifier, param0: Any): String = Resources.thrownExceptionsMessage(prettifier.apply(param0))
+}

--- a/scalatest/src/main/scala/org/scalatestplus/scalacheck/Resources.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/scalacheck/Resources.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2001-2019 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.scalacheck
+
+import java.util.ResourceBundle
+import java.text.MessageFormat
+
+private[scalacheck] object Resources {
+
+  lazy val resourceBundle = ResourceBundle.getBundle("org.scalatestplus.scalacheck.MessageBundle")
+
+  def makeString(resourceName: String, args: Array[Any]): String = {
+    val raw = resourceBundle.getString(resourceName)
+    formatString(raw, args)
+  }
+
+  def formatString(rawString: String, args: Array[Any]): String = {
+    val msgFmt = new MessageFormat(rawString)
+    msgFmt.format(args.toArray)
+  }
+
+  def propCheckLabel(): String = resourceBundle.getString("propCheckLabel")
+
+  def rawPropCheckLabel: String = resourceBundle.getString("propCheckLabel")
+
+  def propCheckLabels(): String = resourceBundle.getString("propCheckLabels")
+
+  def rawPropCheckLabels: String = resourceBundle.getString("propCheckLabels")
+
+  def propertyException(param0: Any): String = makeString("propertyException", Array(param0))
+
+  def rawPropertyException: String = resourceBundle.getString("propertyException")
+
+  def propCheckExhausted(param0: Any, param1: Any): String = makeString("propCheckExhausted", Array(param0, param1))
+
+  def rawPropCheckExhausted: String = resourceBundle.getString("propCheckExhausted")
+
+  def propCheckExhaustedAfterOne(param0: Any): String = makeString("propCheckExhaustedAfterOne", Array(param0))
+
+  def rawPropCheckExhaustedAfterOne: String = resourceBundle.getString("propCheckExhaustedAfterOne")
+
+  def propertyFailed(param0: Any): String = makeString("propertyFailed", Array(param0))
+
+  def rawPropertyFailed: String = resourceBundle.getString("propertyFailed")
+
+  def propertyCheckSucceeded(): String = resourceBundle.getString("propertyCheckSucceeded")
+
+  def rawPropertyCheckSucceeded: String = resourceBundle.getString("propertyCheckSucceeded")
+
+  def thrownExceptionsLocation(param0: Any): String = makeString("thrownExceptionsLocation", Array(param0))
+
+  def rawThrownExceptionsLocation: String = resourceBundle.getString("thrownExceptionsLocation")
+
+  def occurredOnValues(): String = resourceBundle.getString("occurredOnValues")
+
+  def rawOccurredOnValues: String = resourceBundle.getString("occurredOnValues")
+
+  def thrownExceptionsMessage(param0: Any): String = makeString("thrownExceptionsMessage", Array(param0))
+
+  def rawThrownExceptionsMessage: String = resourceBundle.getString("thrownExceptionsMessage")
+}

--- a/scalatest/src/main/scala/org/scalatestplus/scalacheck/UnquotedString.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/scalacheck/UnquotedString.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.scalacheck
+
+// This is used to pass a string to the FailureMessages apply method
+// but prevent it from being quoted. This is useful when using a string
+// to talk about method names, for example.
+private[scalacheck] class UnquotedString(s: String) {
+  override def toString = s
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: UnquotedString => s == that.toString
+      case _ => false
+    }
+  override def hashCode: Int = s.hashCode
+}
+
+private[scalacheck] object UnquotedString {
+  def apply(s: String) = new UnquotedString(s)
+}


### PR DESCRIPTION
Added CheckerAsserting to org.scalatestplus.scalacheck package, and deprecated the old one in org.scalatest.enablers.