### PR TITLE
change firefox driver constructor for compatibility with newer versions

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatest/selenium/WebBrowser.scala
@@ -4509,25 +4509,9 @@ object HtmlUnit extends HtmlUnit
 trait Firefox extends WebBrowser with Driver with ScreenshotCapturer {
 
   /**
-   * The <code>FirefoxProfile</code> passed to the constructor of the <code>FirefoxDriver</code> returned by <code>webDriver</code>.
-   *
-   * <p>
-   * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
-   * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
-   * </p>
+   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>)
    */
-  val firefoxProfile = new FirefoxProfile()
-
-  /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>), with a default
-   * Firefox profile.
-   *
-   * <p>
-   * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
-   * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
-   * </p>
-   */
-  implicit val webDriver: WebDriver = new FirefoxDriver(firefoxProfile)
+  implicit val webDriver: WebDriver = new FirefoxDriver()
 
   /**
    * Captures a screenshot and saves it as a file in the specified directory.

--- a/scalatest/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
+++ b/scalatest/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
@@ -4502,25 +4502,9 @@ object HtmlUnit extends HtmlUnit
 trait Firefox extends WebBrowser with Driver with ScreenshotCapturer {
 
   /**
-   * The <code>FirefoxProfile</code> passed to the constructor of the <code>FirefoxDriver</code> returned by <code>webDriver</code>.
-   *
-   * <p>
-   * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
-   * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
-   * </p>
-   */
-  val firefoxProfile = new FirefoxProfile()
-
-  /**
-   * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>), with a default
-   * Firefox profile.
-   *
-   * <p>
-   * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
-   * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
-   * </p>
-   */
-  implicit val webDriver: WebDriver = new FirefoxDriver(firefoxProfile)
+    * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>)
+    */
+  implicit val webDriver: WebDriver = new FirefoxDriver()
 
   /**
    * Captures a screenshot and saves it as a file in the specified directory.


### PR DESCRIPTION
Hi, discovered that FirefoxDriver contructor
`public FirefoxDriver(FirefoxProfile profile)`
with used in 3.0.x branches is from selenium-firefox-driver:2.45.0 version (which is too old) and no longer exists in newer versions. In modern projects version of selenium-firefox-driver will be higher and when initialisation of [FirefoxDriver](https://github.com/scalatest/scalatest/blob/c35b47a8b32d6f6522690523b7d48d95666b664d/scalatest/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala#L4523) happens, then NoSuchMethodError is thrown.

@bvenners  @cheeseng Maybe we can update selenium versions in scalatest project itself ?