### PR TITLE
Make Equivalence serialisable

### DIFF
--- a/scalactic/src/main/scala/org/scalactic/Equivalence.scala
+++ b/scalactic/src/main/scala/org/scalactic/Equivalence.scala
@@ -104,7 +104,7 @@ package org.scalactic
  * </pre>
  *
  */
-trait Equivalence[T] {
+trait Equivalence[T] extends Serializable {
 
   /**
    * Indicates whether the objects passed as <code>a</code> and <code>b</code> are equal.


### PR DESCRIPTION
This helps when you capture an instance of Equality/Equivalence in some class that has to be serialised.

In my particular case, I use it to match invocation arguments on mocks in mockito-scala and for some scenarios said mocks have to be serialisable.