### PR TITLE
[3.1.x] Scalactic Scala-XML Removal

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -454,7 +454,6 @@ object ScalatestBuild {
       projectTitle := "Scalactic",
       organization := "org.scalactic",
       initialCommands in console := "import org.scalactic._",
-      libraryDependencies ++= scalaXmlDependency(scalaVersion.value),
       sourceGenerators in Compile += {
         Def.task{
           GenVersions.genScalacticVersions((sourceManaged in Compile).value / "org" / "scalactic", version.value, scalaVersion.value) ++
@@ -750,6 +749,7 @@ object ScalatestBuild {
      initialCommands in console := """|import org.scalatest._
                                       |import org.scalactic._
                                       |import Matchers._""".stripMargin,
+     libraryDependencies ++= scalaXmlDependency(scalaVersion.value),
      libraryDependencies ++= scalatestLibraryDependencies,
      genMustMatchersTask,
      genGenTask,

--- a/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -18,9 +18,6 @@ package org.scalactic
 import scala.collection._
 import mutable.WrappedArray
 import scala.util.Success
-// SKIP-SCALATESTJS,NATIVE-START
-import scala.xml
-// SKIP-SCALATESTJS,NATIVE-END
 
 /**
  * A function that given any object will produce a &ldquo;pretty&rdquo; string representation of that object,
@@ -210,11 +207,6 @@ object Prettifier {
               (aGenMap.toIterator.map { case (key, value) => // toIterator is needed for consistent ordering
                 apply(key) + " -> " + apply(value)
               }).mkString(", ") + ")"
-            // SKIP-SCALATESTJS,NATIVE-START
-            case anXMLNodeSeq: xml.NodeSeq => anXMLNodeSeq.toString
-            case anXMLNodeBuffer: xml.NodeBuffer =>
-              xml.NodeSeq.fromSeq(anXMLNodeBuffer).toString
-            // SKIP-SCALATESTJS,NATIVE-END
             case aGenTraversable: GenTraversable[_] =>
               val isSelf =
                 if (aGenTraversable.size == 1) {
@@ -224,13 +216,18 @@ object Prettifier {
                   }
                 }
                 else
-                  false
+                  false    
               if (isSelf)
                 aGenTraversable.toString
-              else
-                ColCompatHelper.className(aGenTraversable) + "(" + aGenTraversable.toIterator.map(apply(_)).mkString(", ") + ")" // toIterator is needed for consistent ordering
-            // SKIP-SCALATESTJS,NATIVE-START
-
+              else {
+                val className = aGenTraversable.getClass.getName
+                if (className.startsWith("scala.xml.NodeSeq$") || className == "scala.xml.NodeBuffer")
+                  aGenTraversable.mkString
+                else
+                  ColCompatHelper.className(aGenTraversable) + "(" + aGenTraversable.toIterator.map(apply(_)).mkString(", ") + ")" // toIterator is needed for consistent ordering
+              }  
+                
+            // SKIP-SCALATESTJS-START
             case javaCol: java.util.Collection[_] =>
               // By default java collection follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractCollection.html#toString()
               // let's do our best to prettify its element when it is not overriden


### PR DESCRIPTION
Backported from 3.0.x, removed scala-xml dependency from Prettifier, thus removing it from scalactic also.