### PR TITLE
[3.1.x] SBT @WrapWith Fix

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -436,9 +436,7 @@ class Framework extends SbtFramework {
       if (accessible || runnable) {
         val suite =
           try {
-            if (accessible)
-              suiteClass.newInstance.asInstanceOf[Suite]
-            else {
+            if (runnable) { // When it is runnable WrapWith is available, this will take precedence and this behavior will be consistent with Runner and the old ScalaTestFramework.
               val wrapWithAnnotation = suiteClass.getAnnotation(classOf[WrapWith])
               val suiteClazz = wrapWithAnnotation.value
               val constructorList = suiteClazz.getDeclaredConstructors()
@@ -448,6 +446,8 @@ class Framework extends SbtFramework {
               }
               constructor.get.newInstance(suiteClass).asInstanceOf[Suite]
             }
+            else
+              suiteClass.newInstance.asInstanceOf[Suite] 
           } catch {
             case t: Throwable => new DeferredAbortedSuite(suiteClass.getName, t)
           }


### PR DESCRIPTION
Changed Framework to flavour @WrapWith when it is available, consistent with behaviour of ScalaTestFramework and Runner.

This fix is cherry-picked from 3.0.x.