### PR TITLE
Publish for Dotty

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.6")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.2.0")
 
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.3")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -601,6 +601,7 @@ object ScalatestBuild {
     .settings(
       projectTitle := "Scalactic",
       organization := "org.scalactic",
+      moduleName := "scalactic",
       initialCommands in console := "import org.scalactic._",
       sourceGenerators in Compile += {
         Def.task{
@@ -622,12 +623,9 @@ object ScalatestBuild {
           GenScalacticDotty.genResource((resourceManaged in Compile).value)
         }.taskValue
       },
-      // include the macro classes and resources in the main jar
-      mappings in (Compile, packageBin) ++= mappings.in(scalacticMacro, Compile, packageBin).value,
-      // include the macro sources in the main source jar
-      mappings in (Compile, packageSrc) ++= mappings.in(scalacticMacro, Compile, packageSrc).value,
-      scalacticDocSourcesSetting,
-      docTaskSetting,
+      //scalacticDocSourcesSetting,
+      //docTaskSetting,
+      publishArtifact in (Compile, packageDoc) := false, // Temporary disable publishing of doc, can't get it to build.
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
@@ -983,7 +981,8 @@ object ScalatestBuild {
           //GenSafeStyles.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)
         }.taskValue
       },
-      scalatestJSDocTaskSetting,
+      //scalatestJSDocTaskSetting,
+      publishArtifact in (Compile, packageDoc) := false, // Temporary disable publishing of doc, can't get it to build.
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar"),
       mimaBinaryIssueFilters ++= {

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -25,6 +25,8 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaCurre
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
+import dotty.tools.sbtplugin.DottyPlugin.autoImport._
+
 object ScalatestBuild {
 
   // To run gentests
@@ -174,8 +176,10 @@ object ScalatestBuild {
 
   def scalaXmlDependency(theScalaVersion: String): Seq[ModuleID] =
     CrossVersion.partialVersion(theScalaVersion) match {
-      case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq("org.scala-lang.modules" %% "scala-xml" % "1.2.0")
-      case other => Seq.empty
+      case Some((scalaEpoch, scalaMajor)) if scalaEpoch != 2 || scalaMajor >= 11 =>
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "1.2.0").withDottyCompat(theScalaVersion))
+      case other =>
+        Seq.empty
     }
 
 
@@ -946,6 +950,7 @@ object ScalatestBuild {
       initialCommands in console := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
+      libraryDependencies ++= scalaXmlDependency(scalaVersion.value),
       libraryDependencies ++= scalatestLibraryDependencies,
       sourceGenerators in Compile += {
         Def.task {
@@ -2133,7 +2138,6 @@ object ScalatestBuild {
       (resourceManaged in Compile).value,
       name.value)
 
-  import dotty.tools.sbtplugin.DottyPlugin.autoImport._
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.14/
   lazy val dottyVersion = dottyLatestNightlyBuild.get
   // lazy val dottyVersion = "0.15.0-bin-20190522-ffb250d-NIGHTLY"


### PR DESCRIPTION
Disabled publishing of scaladoc in dotty build, this allows us to publish for Dotty for now.