### PR TITLE
Privatize Generator

### DIFF
--- a/examples/src/test/scala/org/scalatest/examples/propspec/multi/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/multi/ExampleSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest._
 import prop.PropertyChecks
 import scala.collection.mutable.ListBuffer
 
-class ExampleSpec extends fixture.PropSpec with PropertyChecks with Matchers {
+class ExampleSpec extends fixture.PropSpec with DeprecatedPropertyChecks with Matchers {
 
   case class FixtureParam(builder: StringBuilder, buffer: ListBuffer[String])
 

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -442,7 +442,7 @@ import org.scalatest.enablers.PropCheckerAsserting
  *
  * @author Bill Venners
  */
-trait GeneratorDrivenPropertyChecks extends CommonGenerators with Whenever with Configuration {
+private[org] trait DeprecatedGeneratorDrivenPropertyChecks extends CommonGenerators with Whenever with Configuration {
 
   /**
    * Performs a property check by applying the specified property check function to arguments
@@ -816,7 +816,7 @@ $gens$,
 
   val generatorDrivenPropertyChecksCompanionObjectVerbatimString = """
 
-object GeneratorDrivenPropertyChecks extends GeneratorDrivenPropertyChecks
+private[org] object DeprecatedGeneratorDrivenPropertyChecks extends DeprecatedGeneratorDrivenPropertyChecks
 """
 
   val generatorSuitePreamble = """

--- a/project/templates/GeneratedSpec.template
+++ b/project/templates/GeneratedSpec.template
@@ -1,10 +1,10 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import scala.util.Try
 
-class $typeName$GeneratedSpec extends FunSpec with Matchers with OptionValues with GeneratorDrivenPropertyChecks with $typeName$SpecSupport {
+class $typeName$GeneratedSpec extends FunSpec with Matchers with OptionValues with DeprecatedGeneratorDrivenPropertyChecks with $typeName$SpecSupport {
 
   def areEqualForgivingNaNs(x: AnyVal, y: AnyVal): Assertion = {
     def areEqualDoublesForgivingNaNs(xDouble: Double, yDouble: Double): Assertion = {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -67,7 +67,7 @@ trait FiniteDoubleSpecSupport {
 
 }
 
-class FiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with FiniteDoubleSpecSupport {
+class FiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with FiniteDoubleSpecSupport {
 
   describe("A FiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -63,7 +63,7 @@ trait FiniteFloatSpecSupport {
   }
 }
 
-class FiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with FiniteFloatSpecSupport {
+class FiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with FiniteFloatSpecSupport {
 
   describe("A FiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -49,7 +49,7 @@ trait NegDoubleSpecSupport {
 
 }
 
-class NegDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegDoubleSpecSupport {
+class NegDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegDoubleSpecSupport {
 
   describe("A NegDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -49,7 +49,7 @@ trait NegFiniteDoubleSpecSupport {
 
 }
 
-class NegFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegFiniteDoubleSpecSupport {
+class NegFiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegFiniteDoubleSpecSupport {
 
   describe("A NegFiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -54,7 +54,7 @@ trait NegFiniteFloatSpecSupport {
   }
 }
 
-class NegFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegFiniteFloatSpecSupport {
+class NegFiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegFiniteFloatSpecSupport {
 
   describe("A NegFiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -54,7 +54,7 @@ trait NegFloatSpecSupport {
   }
 }
 
-class NegFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegFloatSpecSupport {
+class NegFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegFloatSpecSupport {
 
   describe("A NegFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
@@ -17,7 +17,7 @@ package org.scalactic.anyvals
 
 import org.scalactic.Equality
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import OptionValues._
 
 import scala.util.{Failure, Success, Try}
@@ -53,7 +53,7 @@ trait NegIntSpecSupport {
 
 }
 
-class NegIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NegIntSpecSupport {
+class NegIntSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NegIntSpecSupport {
 
   describe("A NegInt") {
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.Equality
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -55,7 +55,7 @@ trait NegLongSpecSupport {
 
 }
 
-class NegLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NegLongSpecSupport {
+class NegLongSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NegLongSpecSupport {
 
   describe("A NegLong") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -67,7 +67,7 @@ trait NegZDoubleSpecSupport {
 
 }
 
-class NegZDoubleSpec extends FunSpec with Matchers with PropertyChecks with NegZDoubleSpecSupport {
+class NegZDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with NegZDoubleSpecSupport {
 
   describe("A NegZDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -67,7 +67,7 @@ trait NegZFiniteDoubleSpecSupport {
 
 }
 
-class NegZFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with NegZFiniteDoubleSpecSupport {
+class NegZFiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with NegZFiniteDoubleSpecSupport {
 
   describe("A NegZFiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -75,7 +75,7 @@ trait NegZFiniteFloatSpecSupport {
 
 }
 
-class NegZFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegZFiniteFloatSpecSupport {
+class NegZFiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegZFiniteFloatSpecSupport {
 
   describe("A NegZFiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -75,7 +75,7 @@ trait NegZFloatSpecSupport {
 
 }
 
-class NegZFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NegZFloatSpecSupport {
+class NegZFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NegZFloatSpecSupport {
 
   describe("A NegZFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
@@ -19,7 +19,7 @@ import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import scala.collection.mutable.WrappedArray
 import OptionValues._
 
@@ -53,7 +53,7 @@ trait NegZIntSpecSupport {
 
 }
 
-class NegZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NegZIntSpecSupport {
+class NegZIntSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NegZIntSpecSupport {
 
   describe("A NegZInt") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -56,7 +56,7 @@ trait NegZLongSpecSupport {
 
 }
 
-class NegZLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NegZLongSpecSupport {
+class NegZLongSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NegZLongSpecSupport {
 
   describe("A NegZLong") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -48,7 +48,7 @@ trait NonZeroDoubleSpecSupport {
   }
 }
 
-class NonZeroDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NonZeroDoubleSpecSupport {
+class NonZeroDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NonZeroDoubleSpecSupport {
 
   describe("A NonZeroDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -48,7 +48,7 @@ trait NonZeroFiniteDoubleSpecSupport {
   }
 }
 
-class NonZeroFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NonZeroFiniteDoubleSpecSupport {
+class NonZeroFiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NonZeroFiniteDoubleSpecSupport {
 
   describe("A NonZeroFiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -55,7 +55,7 @@ trait NonZeroFiniteFloatSpecSupport {
   }
 }
 
-class NonZeroFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NonZeroFiniteFloatSpecSupport {
+class NonZeroFiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NonZeroFiniteFloatSpecSupport {
 
   describe("A NonZeroFiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -55,7 +55,7 @@ trait NonZeroFloatSpecSupport {
   }
 }
 
-class NonZeroFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with NonZeroFloatSpecSupport {
+class NonZeroFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with NonZeroFloatSpecSupport {
 
   // Float on either side should widen correctly.
   def areEqualForgivingNaNs(x: Double, y: Double): Assertion = {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
@@ -17,7 +17,7 @@ package org.scalactic.anyvals
 
 import org.scalactic.Equality
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import OptionValues._
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
@@ -51,7 +51,7 @@ trait NonZeroIntSpecSupport {
 
 }
 
-class NonZeroIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NonZeroIntSpecSupport {
+class NonZeroIntSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NonZeroIntSpecSupport {
 
   describe("A NonZeroInt") {
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.Equality
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 
@@ -55,7 +55,7 @@ trait NonZeroLongSpecSupport {
 
 }
 
-class NonZeroLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NonZeroLongSpecSupport {
+class NonZeroLongSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NonZeroLongSpecSupport {
 
   describe("A NonZeroLong") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericCharSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericCharSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest._
 import scala.collection.mutable.WrappedArray
 import OptionValues._
 import org.scalactic.Equality
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 //import org.scalactic.StrictCheckedEquality
 
 import scala.util.{Failure, Success, Try}
@@ -57,7 +57,7 @@ trait NumericCharSpecSupport {
 }
 
 
-class NumericCharSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with NumericCharSpecSupport/* with StrictCheckedEquality*/ {
+class NumericCharSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with NumericCharSpecSupport/* with StrictCheckedEquality*/ {
   describe("A NumericChar") {
     describe("should offer a from factory method that") {
       it("returns Some[NumericChar] if the passed Char is between '0' and '9'") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
@@ -29,7 +29,8 @@ import org.scalactic.{Good, Bad}
 
 import org.scalactic.ColCompatHelper.aggregate
 
-class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+/*
+class NumericStringSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks {
 
   import prop._
 
@@ -2059,4 +2060,5 @@ class NumericStringSpec extends FunSpec with Matchers with GeneratorDrivenProper
     }
   }
 }
+*/
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -49,7 +49,7 @@ trait PosDoubleSpecSupport {
 
 }
 
-class PosDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosDoubleSpecSupport {
+class PosDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosDoubleSpecSupport {
 
   describe("A PosDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -49,7 +49,7 @@ trait PosFiniteDoubleSpecSupport {
 
 }
 
-class PosFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosFiniteDoubleSpecSupport {
+class PosFiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosFiniteDoubleSpecSupport {
 
   describe("A PosFiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -54,7 +54,7 @@ trait PosFiniteFloatSpecSupport {
   }
 }
 
-class PosFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosFiniteFloatSpecSupport {
+class PosFiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosFiniteFloatSpecSupport {
 
   describe("A PosFiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -54,7 +54,7 @@ trait PosFloatSpecSupport {
   }
 }
 
-class PosFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosFloatSpecSupport {
+class PosFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosFloatSpecSupport {
 
   describe("A PosFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
@@ -17,7 +17,7 @@ package org.scalactic.anyvals
 
 import org.scalactic.Equality
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import OptionValues._
 
 import scala.util.{Failure, Success, Try}
@@ -52,7 +52,7 @@ trait PosIntSpecSupport {
 
 }
 
-class PosIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with PosIntSpecSupport {
+class PosIntSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with PosIntSpecSupport {
 
   describe("A PosInt") {
 

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
@@ -18,7 +18,7 @@ package org.scalactic.anyvals
 import org.scalatest._
 import OptionValues._
 import org.scalactic.Equality
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -55,7 +55,7 @@ trait PosLongSpecSupport {
 
 }
 
-class PosLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with PosLongSpecSupport {
+class PosLongSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with PosLongSpecSupport {
 
   describe("A PosLong") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -67,7 +67,7 @@ trait PosZDoubleSpecSupport {
 
 }
 
-class PosZDoubleSpec extends FunSpec with Matchers with PropertyChecks with PosZDoubleSpecSupport {
+class PosZDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with PosZDoubleSpecSupport {
 
   describe("A PosZDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -67,7 +67,7 @@ trait PosZFiniteDoubleSpecSupport {
 
 }
 
-class PosZFiniteDoubleSpec extends FunSpec with Matchers with PropertyChecks with PosZFiniteDoubleSpecSupport {
+class PosZFiniteDoubleSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with PosZFiniteDoubleSpecSupport {
 
   describe("A PosZFiniteDouble") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -75,7 +75,7 @@ trait PosZFiniteFloatSpecSupport {
 
 }
 
-class PosZFiniteFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosZFiniteFloatSpecSupport {
+class PosZFiniteFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosZFiniteFloatSpecSupport {
 
   describe("A PosZFiniteFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
@@ -16,7 +16,7 @@
 package org.scalactic.anyvals
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalactic.TypeCheckedTripleEquals
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
@@ -75,7 +75,7 @@ trait PosZFloatSpecSupport {
 
 }
 
-class PosZFloatSpec extends FunSpec with Matchers with PropertyChecks with TypeCheckedTripleEquals with PosZFloatSpecSupport {
+class PosZFloatSpec extends FunSpec with Matchers with DeprecatedPropertyChecks with TypeCheckedTripleEquals with PosZFloatSpecSupport {
 
   describe("A PosZFloat") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
@@ -19,7 +19,7 @@ import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 import scala.collection.mutable.WrappedArray
 import OptionValues._
 
@@ -55,7 +55,7 @@ trait PosZIntSpecSupport {
 
 }
 
-class PosZIntSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with PosZIntSpecSupport {
+class PosZIntSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with PosZIntSpecSupport {
 
   describe("A PosZInt") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest._
 import org.scalactic.Equality
 import org.scalactic.{Pass, Fail}
 import org.scalactic.{Good, Bad}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.collection.immutable.NumericRange
 // SKIP-SCALATESTJS,NATIVE-END
@@ -58,7 +58,7 @@ trait PosZLongSpecSupport {
 
 }
 
-class PosZLongSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with PosZLongSpecSupport {
+class PosZLongSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with PosZLongSpecSupport {
 
   describe("A PosZLong") {
     describe("should offer a from factory method that") {

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
@@ -24,7 +24,8 @@ import java.util.Locale
 // SKIP-SCALATESTJS,NATIVE-END
 
 
-class RegexStringSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+/*
+class RegexStringSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks {
 
   import prop._
 
@@ -634,4 +635,5 @@ class RegexStringSpec extends FunSpec with Matchers with GeneratorDrivenProperty
     }
   }
 }
+*/
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnySpec.scala
@@ -15,12 +15,12 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 import org.scalactic.Prettifier
 
-class ShouldBeAnySpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldBeAnySpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   // Checking for equality with "be"
   describe("The be token") {

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
@@ -18,11 +18,11 @@ package org.scalatest
 import FailureMessages._
 import Matchers._
 import org.scalactic.Prettifier
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.CompatParColls.Converters._
 
-class ShouldContainElementSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldContainElementSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   private val prettifier = Prettifier.default
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithSubstringSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithSubstringSpec.scala
@@ -15,11 +15,11 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 
-class ShouldEndWithSubstringSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldEndWithSubstringSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   describe("The endWith substring syntax") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldEqualSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldEqualSpec.scala
@@ -15,13 +15,13 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions._
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 import org.scalactic.Good
 
-class ShouldEqualSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldEqualSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   // Checking for equality with "equal"
   describe("The equal token") {

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeSubstringSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeSubstringSpec.scala
@@ -15,11 +15,11 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 
-class ShouldIncludeSubstringSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldIncludeSubstringSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   describe("The include substring syntax") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
@@ -17,14 +17,14 @@ package org.scalatest
 
 import Matchers._
 import org.scalactic.Prettifier
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import Integer.MIN_VALUE
 import org.scalatest.enablers.Length
 import org.scalatest.enablers.Size
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.CompatParColls.Converters._
 
-class ShouldLengthSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldLengthSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   private val prettifier = Prettifier.default
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldOrderedSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldOrderedSpec.scala
@@ -15,13 +15,13 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import Integer.{MAX_VALUE, MIN_VALUE}
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 import org.scalactic.anyvals.PosInt
 
-class ShouldOrderedSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldOrderedSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   // TODO: Fix these tests. They are wasting a bunch of time with discarded values
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(maxDiscardedFactor = 500.0)

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
@@ -18,13 +18,13 @@ package org.scalatest
 import FailureMessages._
 import Matchers._
 import org.scalactic.Prettifier
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import Integer.MIN_VALUE
 import org.scalatest.enablers.Size
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.CompatParColls.Converters._
 
-class ShouldSizeSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldSizeSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   private val prettifier = Prettifier.default
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithSubstringSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithSubstringSpec.scala
@@ -15,11 +15,11 @@
  */
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import org.scalatest.exceptions.TestFailedException
 import Matchers._
 
-class ShouldStartWithSubstringSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldStartWithSubstringSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   describe("The startWith substring syntax") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralLengthSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralLengthSpec.scala
@@ -16,13 +16,13 @@
 
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import Integer.MIN_VALUE
 import Matchers._
 import exceptions.TestFailedException
 import org.scalactic.Prettifier
 
-class ShouldStructuralLengthSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldStructuralLengthSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   private val prettifier = Prettifier.default
   

--- a/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralSizeSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralSizeSpec.scala
@@ -16,13 +16,13 @@
 
 package org.scalatest
 
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 import Integer.MIN_VALUE
 import Matchers._
 import exceptions.TestFailedException
 import org.scalactic.Prettifier
 
-class ShouldStructuralSizeSpec extends FunSpec with PropertyChecks with ReturnsNormallyThrowsAssertion {
+class ShouldStructuralSizeSpec extends FunSpec with DeprecatedPropertyChecks with ReturnsNormallyThrowsAssertion {
 
   private val prettifier = Prettifier.default
   

--- a/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingAsyncSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingAsyncSpec.scala
@@ -18,13 +18,13 @@ package org.scalatest.enablers
 import org.scalatest._
 import org.scalactic.Equality
 import scala.collection.immutable
-import prop.GeneratorDrivenPropertyChecks
+import prop.DeprecatedGeneratorDrivenPropertyChecks
 import org.scalactic.anyvals.PosZInt
 import exceptions.TestFailedException
 import OptionValues._
 import scala.concurrent.Future
 
-class PropCheckerAssertingAsyncSpec extends AsyncFunSpec with Matchers with GeneratorDrivenPropertyChecks with LineNumberHelper {
+class PropCheckerAssertingAsyncSpec extends AsyncFunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with LineNumberHelper {
 
   describe("PropCheckerAsserting") {
     it("The exception reported by an async forAll's Future should include the exception thrown by the property function evaluation as its cause") {

--- a/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingSpec.scala
@@ -18,12 +18,12 @@ package org.scalatest.enablers
 import org.scalatest._
 import org.scalactic.Equality
 import scala.collection.immutable
-import prop.GeneratorDrivenPropertyChecks
+import prop.DeprecatedGeneratorDrivenPropertyChecks
 import org.scalactic.anyvals.PosZInt
 import exceptions.TestFailedException
 import OptionValues._
 
-class PropCheckerAssertingSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks with LineNumberHelper {
+class PropCheckerAssertingSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks with LineNumberHelper {
 
   describe("PropCheckerAsserting") {
     it("The exception thrown by forAll should include the exception thrown by the property function evaluation as its cause") {

--- a/scalatest-test/src/test/scala/org/scalatest/events/OrdinalSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/events/OrdinalSpec.scala
@@ -16,9 +16,9 @@
 package org.scalatest.events
 
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.DeprecatedPropertyChecks
 
-class OrdinalSpec extends FunSpec with Matchers with PropertyChecks {
+class OrdinalSpec extends FunSpec with Matchers with DeprecatedPropertyChecks {
 
   describe("An Ordinal") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent.Future
 
-class AsyncGeneratorDrivenPropertyChecksSpec extends AsyncFunSpec with GeneratorDrivenPropertyChecks {
+class AsyncGeneratorDrivenPropertyChecksSpec extends AsyncFunSpec with DeprecatedGeneratorDrivenPropertyChecks {
 
   describe("GeneratorDrivenPropertyChecks") {
 

--- a/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -34,7 +34,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
   "The CommonGenerators object" should {
     "offer a first1000Primes method" that {
       "produces the first 1000 prime numbers a Ints" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         def isPrime(n: Int): Boolean = {
           if (n <= 1) false
@@ -74,7 +74,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- bytesBetween(Byte.MinValue, Byte.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- bytesBetween((lo + 1).toByte, Byte.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             bytesBetween(hi, lo)
@@ -83,7 +83,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Bytes between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Byte, Byte)] =
           for {
@@ -103,7 +103,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Byte, Byte)] =
           for {
@@ -151,7 +151,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- shortsBetween(Short.MinValue, Short.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- shortsBetween((lo + 1).toShort, Short.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             shortsBetween(hi, lo)
@@ -160,7 +160,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Shorts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Short, Short)] =
           for {
@@ -180,7 +180,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Short, Short)] =
           for {
@@ -228,7 +228,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- intsBetween(Int.MinValue, Int.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- intsBetween(lo + 1, Int.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             intsBetween(hi, lo)
@@ -237,7 +237,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Ints between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Int, Int)] = 
           for {
@@ -257,7 +257,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Int, Int)] = 
           for {
@@ -309,7 +309,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- longsBetween(Long.MinValue, Long.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- longsBetween(lo + 1, Long.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             longsBetween(hi, lo)
@@ -318,7 +318,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Longs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Long, Long)] =
           for {
@@ -338,7 +338,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Long, Long)] =
           for {
@@ -386,7 +386,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- charsBetween(Char.MinValue, Char.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- charsBetween((lo + 1).toChar, Char.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             charsBetween(hi, lo)
@@ -395,7 +395,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Chars between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Char, Char)] =
           for {
@@ -415,7 +415,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Char, Char)] =
           for {
@@ -463,7 +463,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- floatsBetween(Float.MinValue, Float.MaxValue - 1E32f) // Hmm. Using the method to test itself
             hi <- floatsBetween((lo + 1E32f), Float.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             floatsBetween(hi, lo)
@@ -472,7 +472,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Floats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Float, Float)] =
           for {
@@ -492,7 +492,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Float, Float)] =
           for {
@@ -540,7 +540,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- doublesBetween(Double.MinValue, Double.MaxValue - 1E292) // Hmm. Using the method to test itself
             hi <- doublesBetween((lo + 1E292), Double.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             doublesBetween(hi, lo)
@@ -549,7 +549,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces Doubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Double, Double)] =
           for {
@@ -569,7 +569,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(Double, Double)] =
           for {
@@ -619,7 +619,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- intsBetween(PosInt.MinValue, PosInt.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- intsBetween(lo + 1, PosInt.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             intsBetween(hi, lo)
@@ -629,7 +629,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
 
       "produces PosInts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosInt, PosInt)] = 
           for {
@@ -649,7 +649,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosInt, PosInt)] = 
           for {
@@ -701,7 +701,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posLongsBetween(PosLong.MinValue, PosLong.ensuringValid(PosLong.MaxValue - 1)) // Hmm. Using the method to test itself
             hi <- posLongsBetween(PosLong.ensuringValid(lo + 1), PosLong.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             posLongsBetween(hi, lo)
@@ -710,7 +710,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosLongs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosLong, PosLong)] =
           for {
@@ -730,7 +730,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosLong, PosLong)] =
           for {
@@ -778,7 +778,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posFloatsBetween(PosFloat.MinValue, PosFloat.ensuringValid(PosFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
             hi <- posFloatsBetween(PosFloat.ensuringValid(lo + 1E32f), PosFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posFloatsBetween(hi, lo)
@@ -787,7 +787,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFloat, PosFloat)] =
           for {
@@ -807,7 +807,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFloat, PosFloat)] =
           for {
@@ -855,7 +855,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posFiniteFloatsBetween(PosFiniteFloat.MinValue, PosFiniteFloat.ensuringValid(PosFiniteFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
             hi <- posFiniteFloatsBetween(PosFiniteFloat.ensuringValid(lo + 1E32f), PosFiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posFiniteFloatsBetween(hi, lo)
@@ -864,7 +864,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosFiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFiniteFloat, PosFiniteFloat)] =
           for {
@@ -884,7 +884,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFiniteFloat, PosFiniteFloat)] =
           for {
@@ -932,7 +932,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posDoublesBetween(PosDouble.MinValue, PosDouble.ensuringValid(PosDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- posDoublesBetween(PosDouble.ensuringValid(lo + 1E292), PosDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posDoublesBetween(hi, lo)
@@ -941,7 +941,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosDouble, PosDouble)] =
           for {
@@ -961,7 +961,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosDouble, PosDouble)] =
           for {
@@ -1010,7 +1010,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posFiniteDoublesBetween(PosFiniteDouble.MinValue, PosFiniteDouble.ensuringValid(PosFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- posFiniteDoublesBetween(PosFiniteDouble.ensuringValid(lo + 1E292), PosFiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posFiniteDoublesBetween(hi, lo)
@@ -1019,7 +1019,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosFiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFiniteDouble, PosFiniteDouble)] =
           for {
@@ -1039,7 +1039,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosFiniteDouble, PosFiniteDouble)] =
           for {
@@ -1089,7 +1089,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- intsBetween(PosZInt.MinValue, PosZInt.MaxValue - 1) // Hmm. Using the method to test itself
             hi <- intsBetween(lo + 1, PosZInt.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             intsBetween(hi, lo)
@@ -1098,7 +1098,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosZInts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZInt, PosZInt)] =
           for {
@@ -1118,7 +1118,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZInt, PosZInt)] =
           for {
@@ -1166,7 +1166,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posZLongsBetween(PosZLong.MinValue, PosZLong.ensuringValid(PosLong.MaxValue - 1)) // Hmm. Using the method to test itself
             hi <- posZLongsBetween(PosZLong.ensuringValid(lo + 1), PosZLong.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             posZLongsBetween(hi, lo)
@@ -1175,7 +1175,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosZLongs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZLong, PosZLong)] =
           for {
@@ -1195,7 +1195,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZLong, PosZLong)] =
           for {
@@ -1243,7 +1243,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posZFloatsBetween(PosZFloat.MinValue, PosZFloat.ensuringValid(PosZFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
             hi <- posZFloatsBetween(PosZFloat.ensuringValid(lo + 1E32f), PosZFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posZFloatsBetween(hi, lo)
@@ -1252,7 +1252,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosZFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFloat, PosZFloat)] =
           for {
@@ -1272,7 +1272,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFloat, PosZFloat)] =
           for {
@@ -1320,7 +1320,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posZFiniteFloatsBetween(PosZFiniteFloat.MinValue, PosZFiniteFloat.ensuringValid(PosZFiniteFloat.MaxValue - 1E32f)) // Hmm. Using the method to test itself
             hi <- posZFiniteFloatsBetween(PosZFiniteFloat.ensuringValid(lo + 1E32f), PosZFiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posZFiniteFloatsBetween(hi, lo)
@@ -1329,7 +1329,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosZFiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFiniteFloat, PosZFiniteFloat)] =
           for {
@@ -1349,7 +1349,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFiniteFloat, PosZFiniteFloat)] =
           for {
@@ -1397,7 +1397,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posZDoublesBetween(PosZDouble.MinValue, PosZDouble.ensuringValid(PosZDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- posZDoublesBetween(PosZDouble.ensuringValid(lo + 1E292), PosZDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posZDoublesBetween(hi, lo)
@@ -1406,7 +1406,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZDouble, PosZDouble)] =
           for {
@@ -1426,7 +1426,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZDouble, PosZDouble)] =
           for {
@@ -1475,7 +1475,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- posZFiniteDoublesBetween(PosZFiniteDouble.MinValue, PosZFiniteDouble.ensuringValid(PosZFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- posZFiniteDoublesBetween(PosZFiniteDouble.ensuringValid(lo + 1E292), PosZFiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             posZFiniteDoublesBetween(hi, lo)
@@ -1484,7 +1484,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosFiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFiniteDouble, PosZFiniteDouble)] =
           for {
@@ -1504,7 +1504,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(PosZFiniteDouble, PosZFiniteDouble)] =
           for {
@@ -1555,7 +1555,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negIntsBetween(NegInt.MinValue, NegInt.ensuringValid(NegInt.MaxValue - 1)) // Hmm. Using the method to test itself
             hi <- negIntsBetween(NegInt.ensuringValid(lo + 1), NegInt.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             negIntsBetween(hi, lo)
@@ -1565,7 +1565,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
 
       "produces NegInts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegInt, NegInt)] =
           for {
@@ -1585,7 +1585,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegInt, NegInt)] =
           for {
@@ -1633,7 +1633,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negLongsBetween(NegLong.MinValue, NegLong.ensuringValid(NegLong.MaxValue - 1)) // Hmm. Using the method to test itself
             hi <- negLongsBetween(NegLong.ensuringValid(lo + 1), NegLong.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             negLongsBetween(hi, lo)
@@ -1642,7 +1642,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegLongs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegLong, NegLong)] =
           for {
@@ -1662,7 +1662,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegLong, NegLong)] =
           for {
@@ -1710,7 +1710,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negFloatsBetween(NegFloat.MinValue, NegFloat.ensuringValid(NegFloat.MaxValue - 1E32f - 1E32f))
             hi <- negFloatsBetween(NegFloat.ensuringValid(lo + 1E32f), NegFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negFloatsBetween(hi, lo)
@@ -1719,7 +1719,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFloat, NegFloat)] =
           for {
@@ -1739,7 +1739,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFloat, NegFloat)] =
           for {
@@ -1787,7 +1787,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negFiniteFloatsBetween(NegFiniteFloat.MinValue, NegFiniteFloat.ensuringValid(NegFiniteFloat.MaxValue - 1E32f - 1E32f))
             hi <- negFiniteFloatsBetween(NegFiniteFloat.ensuringValid(lo + 1E32f), NegFiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negFiniteFloatsBetween(hi, lo)
@@ -1796,7 +1796,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegFiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFiniteFloat, NegFiniteFloat)] =
           for {
@@ -1816,7 +1816,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFiniteFloat, NegFiniteFloat)] =
           for {
@@ -1864,7 +1864,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negDoublesBetween(NegDouble.MinValue, NegDouble.ensuringValid(NegDouble.MaxValue - 1E292 - 1E292)) // Hmm. Using the method to test itself
             hi <- negDoublesBetween(NegDouble.ensuringValid(lo + 1E292), NegDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negDoublesBetween(hi, lo)
@@ -1873,7 +1873,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegDouble, NegDouble)] =
           for {
@@ -1893,7 +1893,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegDouble, NegDouble)] =
           for {
@@ -1942,7 +1942,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negFiniteDoublesBetween(NegFiniteDouble.MinValue, NegFiniteDouble.ensuringValid(NegFiniteDouble.MaxValue - 1E292 - 1E292)) // Hmm. Using the method to test itself
             hi <- negFiniteDoublesBetween(NegFiniteDouble.ensuringValid(lo + 1E292), NegFiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negFiniteDoublesBetween(hi, lo)
@@ -1951,7 +1951,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegFiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFiniteDouble, NegFiniteDouble)] =
           for {
@@ -1971,7 +1971,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegFiniteDouble, NegFiniteDouble)] =
           for {
@@ -2021,7 +2021,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZIntsBetween(NegZInt.MinValue, NegZInt.ensuringValid(NegZInt.MaxValue - 1))
             hi <- negZIntsBetween(NegZInt.ensuringValid(lo + 1), NegZInt.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             negZIntsBetween(hi, lo)
@@ -2030,7 +2030,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegZInts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZInt, NegZInt)] =
           for {
@@ -2050,7 +2050,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZInt, NegZInt)] =
           for {
@@ -2098,7 +2098,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZLongsBetween(NegZLong.MinValue, NegZLong.ensuringValid(NegLong.MaxValue - 1)) // Hmm. Using the method to test itself
             hi <- negZLongsBetween(NegZLong.ensuringValid(lo + 1), NegZLong.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             negZLongsBetween(hi, lo)
@@ -2107,7 +2107,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegZLongs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZLong, NegZLong)] =
           for {
@@ -2127,7 +2127,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZLong, NegZLong)] =
           for {
@@ -2175,7 +2175,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZFloatsBetween(NegZFloat.MinValue, NegZFloat.ensuringValid(NegZFloat.MaxValue - 1E32f - 1E32f)) // Hmm. Using the method to test itself
             hi <- negZFloatsBetween(NegZFloat.ensuringValid(lo + 1E32f), NegZFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negZFloatsBetween(hi, lo)
@@ -2184,7 +2184,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegZFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFloat, NegZFloat)] =
           for {
@@ -2204,7 +2204,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFloat, NegZFloat)] =
           for {
@@ -2252,7 +2252,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZFiniteFloatsBetween(NegZFiniteFloat.MinValue, NegZFiniteFloat.ensuringValid(NegZFiniteFloat.MaxValue - 1E32f - 1E32f)) // Hmm. Using the method to test itself
             hi <- negZFiniteFloatsBetween(NegZFiniteFloat.ensuringValid(lo + 1E32f), NegZFiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negZFiniteFloatsBetween(hi, lo)
@@ -2261,7 +2261,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegZFiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFiniteFloat, NegZFiniteFloat)] =
           for {
@@ -2281,7 +2281,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFiniteFloat, NegZFiniteFloat)] =
           for {
@@ -2329,7 +2329,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZDoublesBetween(NegZDouble.MinValue, NegZDouble.ensuringValid(NegZDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- negZDoublesBetween(NegZDouble.ensuringValid(lo + 1E292), NegZDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negZDoublesBetween(hi, lo)
@@ -2338,7 +2338,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZDouble, NegZDouble)] =
           for {
@@ -2358,7 +2358,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZDouble, NegZDouble)] =
           for {
@@ -2407,7 +2407,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- negZFiniteDoublesBetween(NegZFiniteDouble.MinValue, NegZFiniteDouble.ensuringValid(NegZFiniteDouble.MaxValue - 1E292)) // Hmm. Using the method to test itself
             hi <- negZFiniteDoublesBetween(NegZFiniteDouble.ensuringValid(lo + 1E292), NegZFiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             negZFiniteDoublesBetween(hi, lo)
@@ -2416,7 +2416,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NegZFiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFiniteDouble, NegZFiniteDouble)] =
           for {
@@ -2436,7 +2436,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NegZFiniteDouble, NegZFiniteDouble)] =
           for {
@@ -2487,7 +2487,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- nonZeroIntsBetween(NonZeroInt.MinValue, NonZeroInt.ensuringValid(NonZeroInt.MaxValue - 1))
             hi <- nonZeroIntsBetween(if (lo.value == -1) NonZeroInt(1) else NonZeroInt.ensuringValid(lo + 1), NonZeroInt.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             nonZeroIntsBetween(hi, lo)
@@ -2497,7 +2497,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
 
       "produces NonZeroInts between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroInt, NonZeroInt)] =
           for {
@@ -2517,7 +2517,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroInt, NonZeroInt)] =
           for {
@@ -2565,7 +2565,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- nonZeroLongsBetween(NonZeroLong.MinValue, NonZeroLong.ensuringValid(NonZeroLong.MaxValue - 1L)) // Hmm. Using the method to test itself
             hi <- nonZeroLongsBetween(if (lo.value == -1L) NonZeroLong(1L) else NonZeroLong.ensuringValid(lo + 1L), NonZeroLong.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an [IllegalArgumentException] should be thrownBy {
             nonZeroLongsBetween(hi, lo)
@@ -2574,7 +2574,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NonZeroLongs between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroLong, NonZeroLong)] =
           for {
@@ -2594,7 +2594,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroLong, NonZeroLong)] =
           for {
@@ -2642,7 +2642,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- nonZeroFloatsBetween(NonZeroFloat.MinValue, NonZeroFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
             hi <- nonZeroFloatsBetween(if (lo + 1E32f == 0.0f) NonZeroFloat(1.0f) else NonZeroFloat.ensuringValid(lo + 1E32f), NonZeroFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             nonZeroFloatsBetween(hi, lo)
@@ -2651,7 +2651,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces PosFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFloat, NonZeroFloat)] =
           for {
@@ -2671,7 +2671,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFloat, NonZeroFloat)] =
           for {
@@ -2719,7 +2719,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
             lo <- nonZeroFiniteFloatsBetween(NonZeroFiniteFloat.MinValue, NonZeroFiniteFloat.ensuringValid(NonZeroFiniteFloat.MaxValue - 1E32f))
             hi <- nonZeroFiniteFloatsBetween(if (lo + 1E32f == 0.0f) NonZeroFiniteFloat(1.0f) else NonZeroFiniteFloat.ensuringValid(lo + 1E32f), NonZeroFiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             nonZeroFiniteFloatsBetween(hi, lo)
@@ -2728,7 +2728,7 @@ class CommonGeneratorsSpec extends WordSpec with Matchers {
       }
       "produces NonZeroFiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFiniteFloat, NonZeroFiniteFloat)] =
           for {
@@ -2768,7 +2768,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFiniteFloat, NonZeroFiniteFloat)] =
           for {
@@ -2816,7 +2816,7 @@ If it doesn't show up for a while, please delete this comment.
             lo <- nonZeroDoublesBetween(NonZeroDouble.MinValue, NonZeroDouble.ensuringValid(NonZeroDouble.MaxValue - 1E292))
             hi <- nonZeroDoublesBetween(if (lo + 1E292 == 0.0) NonZeroDouble(1.0) else NonZeroDouble.ensuringValid(lo + 1E292), NonZeroDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             nonZeroDoublesBetween(hi, lo)
@@ -2825,7 +2825,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces NonZeroDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroDouble, NonZeroDouble)] =
           for {
@@ -2845,7 +2845,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroDouble, NonZeroDouble)] =
           for {
@@ -2894,7 +2894,7 @@ If it doesn't show up for a while, please delete this comment.
             lo <- nonZeroFiniteDoublesBetween(NonZeroFiniteDouble.MinValue, NonZeroFiniteDouble.ensuringValid(NonZeroFiniteDouble.MaxValue - 1E292))
             hi <- nonZeroFiniteDoublesBetween(if (lo + 1E292 == 0.0) NonZeroFiniteDouble(1.0) else NonZeroFiniteDouble.ensuringValid(lo + 1E292), NonZeroFiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             nonZeroFiniteDoublesBetween(hi, lo)
@@ -2903,7 +2903,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces NonZeroFiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFiniteDouble, NonZeroFiniteDouble)] =
           for {
@@ -2923,7 +2923,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(NonZeroFiniteDouble, NonZeroFiniteDouble)] =
           for {
@@ -2972,7 +2972,7 @@ If it doesn't show up for a while, please delete this comment.
             lo <- finiteFloatsBetween(FiniteFloat.MinValue, FiniteFloat.ensuringValid(NonZeroFloat.MaxValue - 1E32f))
             hi <- finiteFloatsBetween(FiniteFloat.ensuringValid(lo + 1E32f), FiniteFloat.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             finiteFloatsBetween(hi, lo)
@@ -2981,7 +2981,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces FiniteFloats between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(FiniteFloat, FiniteFloat)] =
           for {
@@ -3001,7 +3001,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(FiniteFloat, FiniteFloat)] =
           for {
@@ -3049,7 +3049,7 @@ If it doesn't show up for a while, please delete this comment.
             lo <- finiteDoublesBetween(FiniteDouble.MinValue, FiniteDouble.ensuringValid(FiniteDouble.MaxValue - 1E292))
             hi <- finiteDoublesBetween(FiniteDouble.ensuringValid(lo + 1E292), FiniteDouble.MaxValue)
           } yield (lo, hi)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (loHiPairs) { case (lo, hi) =>
           an[IllegalArgumentException] should be thrownBy {
             finiteDoublesBetween(hi, lo)
@@ -3058,7 +3058,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces FiniteDoubles between min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(FiniteDouble, FiniteDouble)] =
           for {
@@ -3078,7 +3078,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a generator whose initEdges method includes min and max" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minMaxPairs: Generator[(FiniteDouble, FiniteDouble)] =
           for {
@@ -3122,7 +3122,7 @@ If it doesn't show up for a while, please delete this comment.
 
     "offer a specificValues method" that {
       "returns a generator that produces from a given set of specific objects for any type T" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val values123 = specificValues(1, 2, 3)
         // forAll (values123) { x => x should be oneOf (1, 2, 3) }
         forAll (values123) { x => x should (be (1) or be (2) or be (3)) }
@@ -3138,7 +3138,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a specificValue method" that {
       "returns a generator that produces from a given single specific object for any type T" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val specificValue42 = specificValue(42)
         forAll (specificValue42) { x => x shouldBe (42) }
         forAll (specificValue("nice")) { x =>
@@ -3148,7 +3148,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a frequency method that takes a varargs of Int weights to generators and produces a generator" that {
       "returns values from each specific generator with a probability determined by the weights" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         // import specificValue
         val evenInts = for { i <- intsBetween(2, 100000) } yield 2 * i
         val oddInts = for { i <- intsBetween(0, 100000) } yield 2 * i + 1
@@ -3181,7 +3181,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer an evenly method that takes a varargs of generators and produces a generator" that {
       "returns values from each specific generator with an equal probability" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         sealed trait Numero extends Product with Serializable {
           val value: Int
         }
@@ -3239,7 +3239,7 @@ If it doesn't show up for a while, please delete this comment.
 
     "offer a booleans method" that {
       "returns the default implicit generator that produces arbitrary Booleans" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Boolean]]
         val namedGen = booleans
         val rnd = Randomizer.default
@@ -3263,7 +3263,7 @@ If it doesn't show up for a while, please delete this comment.
 
     "offer a bytes method" that {
       "returns the default implicit generator that produces arbitrary Bytes" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Byte]]
         val namedGen = bytes
         val rnd = Randomizer.default
@@ -3277,7 +3277,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a shorts method" that {
       "returns the default implicit generator that produces arbitrary Shorts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Short]]
         val namedGen = shorts
         val rnd = Randomizer.default
@@ -3291,7 +3291,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer an ints method" that {
       "returns the default implicit generator that produces arbitrary Ints" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Int]]
         val namedGen = ints
         val rnd = Randomizer.default
@@ -3305,7 +3305,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a longs method" that {
       "returns the default implicit generator that produces arbitrary Longs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Long]]
         val namedGen = longs
         val rnd = Randomizer.default
@@ -3319,7 +3319,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a chars method" that {
       "returns the default implicit generator that produces arbitrary Chars" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Char]]
         val namedGen = chars
         val rnd = Randomizer.default
@@ -3333,7 +3333,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a floats method" that {
       "returns the default implicit generator that produces arbitrary Floats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Float]]
         val namedGen = floats
         val rnd = Randomizer.default
@@ -3347,7 +3347,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a doubles method" that {
       "returns the default implicit generator that produces arbitrary Doubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Double]]
         val namedGen = doubles
         val rnd = Randomizer.default
@@ -3361,7 +3361,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a strings method" that {
       "returns the default implicit generator that produces arbitrary Strings" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[String]]
         val namedGen = strings
         val rnd = Randomizer.default
@@ -3417,7 +3417,7 @@ If it doesn't show up for a while, please delete this comment.
 
     "offer a lists method" that {
       "returns the default implicit generator that produces arbitrary Lists" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[List[Int]]]
         val namedGen = lists[Int]
         val rnd = Randomizer.default
@@ -3429,14 +3429,14 @@ If it doesn't show up for a while, please delete this comment.
         implicitGenSamples shouldEqual namedGenSamples
       }
       "returns a type that also offers a havingLength method that provides a generator for lists of a specific length" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (posIntsBetween(1, 100)) { len => 
           forAll (lists[Int].havingLength(len)) { xs => xs.length shouldEqual len.value }
         }
       }
       "returns a type that also offers a havingLengthsBetween method that provides a generator for lists of a range of lengths" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minsAndMaxes: Generator[(PosZInt, PosZInt)] =
           for {
@@ -3457,7 +3457,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a type that also offers a havingLengthsDeterminedBy method that provides a generator for lists whose length is determined by a function" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val upperLimits: Generator[PosZInt] = posZIntsBetween(0, 99)
 
@@ -3471,14 +3471,14 @@ If it doesn't show up for a while, please delete this comment.
         }
       }
       "returns a type that also offers a havingSize method that provides a generator for lists of a specific size" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (posIntsBetween(1, 100)) { sz => 
           forAll (lists[Int].havingSize(sz)) { xs => xs.size shouldEqual sz.value }
         }
       }
       "returns a type that also offers a havingSizesBetween method that provides a generator for lists of a range of sizes" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val minsAndMaxes: Generator[(PosZInt, PosZInt)] =
           for {
@@ -3499,7 +3499,7 @@ If it doesn't show up for a while, please delete this comment.
       }
       "returns a type that also offers a havingSizesDeterminedBy method that provides a generator for lists whose size is determined by a function" in {
 
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
 
         val upperLimits: Generator[PosZInt] = posZIntsBetween(0, 99)
 
@@ -3515,7 +3515,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posInts method" that {
       "returns the default implicit generator that produces arbitrary PosInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosInt]]
         val namedGen = posInts
         val rnd = Randomizer.default
@@ -3529,7 +3529,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZInts method" that {
       "returns the default implicit generator that produces arbitrary PosZInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZInt]]
         val namedGen = posZInts
         val rnd = Randomizer.default
@@ -3543,7 +3543,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posLongs method" that {
       "returns the default implicit generator that produces arbitrary PosLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosLong]]
         val namedGen = posLongs
         val rnd = Randomizer.default
@@ -3557,7 +3557,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZLongs method" that {
       "returns the default implicit generator that produces arbitrary PosZLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZLong]]
         val namedGen = posZLongs
         val rnd = Randomizer.default
@@ -3571,7 +3571,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFloats method" that {
       "returns the default implicit generator that produces arbitrary PosFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFloat]]
         val namedGen = posFloats
         val rnd = Randomizer.default
@@ -3585,7 +3585,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFiniteFloats method" that {
       "returns the default implicit generator that produces arbitrary PosFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFiniteFloat]]
         val namedGen = posFiniteFloats
         val rnd = Randomizer.default
@@ -3599,7 +3599,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFloats method" that {
       "returns the default implicit generator that produces arbitrary PosZFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFloat]]
         val namedGen = posZFloats
         val rnd = Randomizer.default
@@ -3613,7 +3613,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFiniteFloats method" that {
       "returns the default implicit generator that produces arbitrary PosZFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFiniteFloat]]
         val namedGen = posZFiniteFloats
         val rnd = Randomizer.default
@@ -3627,7 +3627,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posDoubles method" that {
       "returns the default implicit generator that produces arbitrary PosDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosDouble]]
         val namedGen = posDoubles
         val rnd = Randomizer.default
@@ -3641,7 +3641,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFiniteDoubles method" that {
       "returns the default implicit generator that produces arbitrary PosFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFiniteDouble]]
         val namedGen = posFiniteDoubles
         val rnd = Randomizer.default
@@ -3655,7 +3655,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZDoubles method" that {
       "returns the default implicit generator that produces arbitrary PosZDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZDouble]]
         val namedGen = posZDoubles
         val rnd = Randomizer.default
@@ -3669,7 +3669,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFiniteDoubles method" that {
       "returns the default implicit generator that produces arbitrary PosZFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFiniteDouble]]
         val namedGen = posZFiniteDoubles
         val rnd = Randomizer.default
@@ -3683,7 +3683,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posIntValues method" that {
       "returns the default implicit generator that produces arbitrary positive Ints" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosInt]]
         val namedGen = posIntValues
         val rnd = Randomizer.default
@@ -3697,7 +3697,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZIntValues method" that {
       "returns the default implicit generator that produces arbitrary zero and positive Ints" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZInt]]
         val namedGen = posZIntValues
         val rnd = Randomizer.default
@@ -3711,7 +3711,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posLongValues method" that {
       "returns the default implicit generator that produces arbitrary positive Longs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosLong]]
         val namedGen = posLongValues
         val rnd = Randomizer.default
@@ -3725,7 +3725,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZLongValues method" that {
       "returns the default implicit generator that produces arbitrary zero and positive Longs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZLong]]
         val namedGen = posZLongValues
         val rnd = Randomizer.default
@@ -3739,7 +3739,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFloatValues method" that {
       "returns the default implicit generator that produces arbitrary positive Floats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFloat]]
         val namedGen = posFloatValues
         val rnd = Randomizer.default
@@ -3753,7 +3753,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFiniteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary PosFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFiniteFloat]]
         val namedGen = posFiniteFloatValues
         val rnd = Randomizer.default
@@ -3767,7 +3767,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFloatValues method" that {
       "returns the default implicit generator that produces arbitrary zero and positive Floats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFloat]]
         val namedGen = posZFloatValues
         val rnd = Randomizer.default
@@ -3781,7 +3781,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFiniteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary zero and PosZFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFiniteFloat]]
         val namedGen = posZFiniteFloatValues
         val rnd = Randomizer.default
@@ -3795,7 +3795,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary positive Doubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosDouble]]
         val namedGen = posDoubleValues
         val rnd = Randomizer.default
@@ -3809,7 +3809,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posFiniteDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary PosFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosFiniteDouble]]
         val namedGen = posFiniteDoubleValues
         val rnd = Randomizer.default
@@ -3823,7 +3823,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary zero and positive Doubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZDouble]]
         val namedGen = posZDoubleValues
         val rnd = Randomizer.default
@@ -3837,7 +3837,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a posZFiniteDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary zero and PosZFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[PosZFiniteDouble]]
         val namedGen = posZFiniteDoubleValues
         val rnd = Randomizer.default
@@ -3851,7 +3851,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negInts method" that {
       "returns the default implicit generator that produces arbitrary NegInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegInt]]
         val namedGen = negInts
         val rnd = Randomizer.default
@@ -3865,7 +3865,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZInts method" that {
       "returns the default implicit generator that produces arbitrary NegZInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZInt]]
         val namedGen = negZInts
         val rnd = Randomizer.default
@@ -3879,7 +3879,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negLongs method" that {
       "returns the default implicit generator that produces arbitrary NegLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegLong]]
         val namedGen = negLongs
         val rnd = Randomizer.default
@@ -3893,7 +3893,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZLongs method" that {
       "returns the default implicit generator that produces arbitrary NegZLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZLong]]
         val namedGen = negZLongs
         val rnd = Randomizer.default
@@ -3907,7 +3907,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFloats method" that {
       "returns the default implicit generator that produces arbitrary NegFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFloat]]
         val namedGen = negFloats
         val rnd = Randomizer.default
@@ -3921,7 +3921,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFiniteFloats method" that {
       "returns the default implicit generator that produces arbitrary NegFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFiniteFloat]]
         val namedGen = negFiniteFloats
         val rnd = Randomizer.default
@@ -3935,7 +3935,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFloats method" that {
       "returns the default implicit generator that produces arbitrary NegZFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFloat]]
         val namedGen = negZFloats
         val rnd = Randomizer.default
@@ -3949,7 +3949,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFiniteFloats method" that {
       "returns the default implicit generator that produces arbitrary NegZFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFiniteFloat]]
         val namedGen = negZFiniteFloats
         val rnd = Randomizer.default
@@ -3963,7 +3963,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negDoubles method" that {
       "returns the default implicit generator that produces arbitrary NegDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegDouble]]
         val namedGen = negDoubles
         val rnd = Randomizer.default
@@ -3977,7 +3977,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFiniteDoubles method" that {
       "returns the default implicit generator that produces arbitrary NegFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFiniteDouble]]
         val namedGen = negFiniteDoubles
         val rnd = Randomizer.default
@@ -3991,7 +3991,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZDoubles method" that {
       "returns the default implicit generator that produces arbitrary NegZDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZDouble]]
         val namedGen = negZDoubles
         val rnd = Randomizer.default
@@ -4005,7 +4005,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFiniteDoubles method" that {
       "returns the default implicit generator that produces arbitrary NegZFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFiniteDouble]]
         val namedGen = negZFiniteDoubles
         val rnd = Randomizer.default
@@ -4019,7 +4019,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negIntValues method" that {
       "returns the default implicit generator that produces arbitrary NegInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegInt]]
         val namedGen = negIntValues
         val rnd = Randomizer.default
@@ -4033,7 +4033,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZIntValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZInt]]
         val namedGen = negZIntValues
         val rnd = Randomizer.default
@@ -4047,7 +4047,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negLongValues method" that {
       "returns the default implicit generator that produces arbitrary NegLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegLong]]
         val namedGen = negLongValues
         val rnd = Randomizer.default
@@ -4061,7 +4061,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZLongValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZLong]]
         val namedGen = negZLongValues
         val rnd = Randomizer.default
@@ -4075,7 +4075,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFloatValues method" that {
       "returns the default implicit generator that produces arbitrary NegFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFloat]]
         val namedGen = negFloatValues
         val rnd = Randomizer.default
@@ -4089,7 +4089,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFiniteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary NegFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFiniteFloat]]
         val namedGen = negFiniteFloatValues
         val rnd = Randomizer.default
@@ -4103,7 +4103,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFloatValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFloat]]
         val namedGen = negZFloatValues
         val rnd = Randomizer.default
@@ -4117,7 +4117,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFiniteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFiniteFloat]]
         val namedGen = negZFiniteFloatValues
         val rnd = Randomizer.default
@@ -4131,7 +4131,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary NegDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegDouble]]
         val namedGen = negDoubleValues
         val rnd = Randomizer.default
@@ -4145,7 +4145,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negFiniteDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary NegFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegFiniteDouble]]
         val namedGen = negFiniteDoubleValues
         val rnd = Randomizer.default
@@ -4159,7 +4159,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZDouble]]
         val namedGen = negZDoubleValues
         val rnd = Randomizer.default
@@ -4173,7 +4173,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a negZFiniteDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary zero and NegZFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NegZFiniteDouble]]
         val namedGen = negZFiniteDoubleValues
         val rnd = Randomizer.default
@@ -4187,7 +4187,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroInts method" that {
       "returns the default implicit generator that produces arbitrary NonZeroInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroInt]]
         val namedGen = nonZeroInts
         val rnd = Randomizer.default
@@ -4201,7 +4201,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroLongs method" that {
       "returns the default implicit generator that produces arbitrary NonZeroLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroLong]]
         val namedGen = nonZeroLongs
         val rnd = Randomizer.default
@@ -4215,7 +4215,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFloats method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFloat]]
         val namedGen = nonZeroFloats
         val rnd = Randomizer.default
@@ -4229,7 +4229,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFiniteFloats method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFiniteFloat]]
         val namedGen = nonZeroFiniteFloats
         val rnd = Randomizer.default
@@ -4243,7 +4243,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroDoubles method" that {
       "returns the default implicit generator that produces arbitrary NonZeroDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroDouble]]
         val namedGen = nonZeroDoubles
         val rnd = Randomizer.default
@@ -4257,7 +4257,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFiniteDoubles method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFiniteDouble]]
         val namedGen = nonZeroFiniteDoubles
         val rnd = Randomizer.default
@@ -4271,7 +4271,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroIntValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroInts" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroInt]]
         val namedGen = nonZeroIntValues
         val rnd = Randomizer.default
@@ -4285,7 +4285,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroLongValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroLongs" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroLong]]
         val namedGen = nonZeroLongValues
         val rnd = Randomizer.default
@@ -4299,7 +4299,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFloatValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFloat]]
         val namedGen = nonZeroFloatValues
         val rnd = Randomizer.default
@@ -4313,7 +4313,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFiniteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFiniteFloat]]
         val namedGen = nonZeroFiniteFloatValues
         val rnd = Randomizer.default
@@ -4327,7 +4327,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroDouble]]
         val namedGen = nonZeroDoubleValues
         val rnd = Randomizer.default
@@ -4341,7 +4341,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a nonZeroFiniteDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary NonZeroFiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NonZeroFiniteDouble]]
         val namedGen = nonZeroFiniteDoubleValues
         val rnd = Randomizer.default
@@ -4355,7 +4355,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a finiteFloats method" that {
       "returns the default implicit generator that produces arbitrary FiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[FiniteFloat]]
         val namedGen = finiteFloats
         val rnd = Randomizer.default
@@ -4369,7 +4369,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a finiteDoubles method" that {
       "returns the default implicit generator that produces arbitrary FiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[FiniteDouble]]
         val namedGen = finiteDoubles
         val rnd = Randomizer.default
@@ -4383,7 +4383,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a numericChars method" that {
       "returns the default implicit generator that produces arbitrary NumericChars" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NumericChar]]
         val namedGen = numericChars
         val rnd = Randomizer.default
@@ -4397,7 +4397,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a finiteFloatValues method" that {
       "returns the default implicit generator that produces arbitrary FiniteFloats" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[FiniteFloat]]
         val namedGen = finiteFloatValues
         val rnd = Randomizer.default
@@ -4411,7 +4411,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a finiteZeroDoubleValues method" that {
       "returns the default implicit generator that produces arbitrary FiniteDoubles" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[FiniteDouble]]
         val namedGen = finiteDoubleValues
         val rnd = Randomizer.default
@@ -4425,7 +4425,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a numericCharValues method" that {
       "returns the default implicit generator that produces arbitrary NumericChars" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[NumericChar]]
         val namedGen = numericCharValues
         val rnd = Randomizer.default
@@ -4440,7 +4440,7 @@ If it doesn't show up for a while, please delete this comment.
 
     "offer a tuple2s method" that {
       "returns the default implicit generator that produces arbitrary Tuple2s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int)]]
         val namedGen = tuple2s[String, Int]
         val rnd = Randomizer.default
@@ -4454,7 +4454,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple3s method" that {
       "returns the default implicit generator that produces arbitrary Tuple3s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long)]]
         val namedGen = tuple3s[String, Int, Long]
         val rnd = Randomizer.default
@@ -4468,7 +4468,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple4s method" that {
       "returns the default implicit generator that produces arbitrary Tuple4s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float)]]
         val namedGen = tuple4s[String, Int, Long, Float]
         val rnd = Randomizer.default
@@ -4482,7 +4482,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple5s method" that {
       "returns the default implicit generator that produces arbitrary Tuple5s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double)]]
         val namedGen = tuple5s[String, Int, Long, Float, Double]
         val rnd = Randomizer.default
@@ -4496,7 +4496,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple6s method" that {
       "returns the default implicit generator that produces arbitrary Tuple6s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String)]]
         val namedGen = tuple6s[String, Int, Long, Float, Double, String]
         val rnd = Randomizer.default
@@ -4510,7 +4510,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple7s method" that {
       "returns the default implicit generator that produces arbitrary Tuple7s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int)]]
         val namedGen = tuple7s[String, Int, Long, Float, Double, String, Int]
         val rnd = Randomizer.default
@@ -4524,7 +4524,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple8s method" that {
       "returns the default implicit generator that produces arbitrary Tuple8s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long)]]
         val namedGen = tuple8s[String, Int, Long, Float, Double, String, Int, Long]
         val rnd = Randomizer.default
@@ -4538,7 +4538,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple9s method" that {
       "returns the default implicit generator that produces arbitrary Tuple9s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float)]]
         val namedGen = tuple9s[String, Int, Long, Float, Double, String, Int, Long, Float]
         val rnd = Randomizer.default
@@ -4552,7 +4552,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple10s method" that {
       "returns the default implicit generator that produces arbitrary Tuple10s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
         val namedGen = tuple10s[String, Int, Long, Float, Double, String, Int, Long, Float, Double]
         val rnd = Randomizer.default
@@ -4566,7 +4566,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple11s method" that {
       "returns the default implicit generator that produces arbitrary Tuple11s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
         val namedGen = tuple11s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
         val rnd = Randomizer.default
@@ -4580,7 +4580,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple12s method" that {
       "returns the default implicit generator that produces arbitrary Tuple12s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
         val namedGen = tuple12s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
         val rnd = Randomizer.default
@@ -4594,7 +4594,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple13s method" that {
       "returns the default implicit generator that produces arbitrary Tuple13s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long)]]
         val namedGen = tuple13s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
         val rnd = Randomizer.default
@@ -4608,7 +4608,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple14s method" that {
       "returns the default implicit generator that produces arbitrary Tuple14s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float)]]
         val namedGen = tuple14s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
         val rnd = Randomizer.default
@@ -4622,7 +4622,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple15s method" that {
       "returns the default implicit generator that produces arbitrary Tuple15s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
         val namedGen = tuple15s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
         val rnd = Randomizer.default
@@ -4636,7 +4636,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple16s method" that {
       "returns the default implicit generator that produces arbitrary Tuple16s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
         val namedGen = tuple16s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
         val rnd = Randomizer.default
@@ -4650,7 +4650,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple17s method" that {
       "returns the default implicit generator that produces arbitrary Tuple17s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
         val namedGen = tuple17s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
         val rnd = Randomizer.default
@@ -4664,7 +4664,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple18s method" that {
       "returns the default implicit generator that produces arbitrary Tuple18s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long)]]
         val namedGen = tuple18s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long]
         val rnd = Randomizer.default
@@ -4678,7 +4678,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple19s method" that {
       "returns the default implicit generator that produces arbitrary Tuple19s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float)]]
         val namedGen = tuple19s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float]
         val rnd = Randomizer.default
@@ -4692,7 +4692,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple20s method" that {
       "returns the default implicit generator that produces arbitrary Tuple20s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double)]]
         val namedGen = tuple20s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double]
         val rnd = Randomizer.default
@@ -4706,7 +4706,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple21s method" that {
       "returns the default implicit generator that produces arbitrary Tuple21s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String)]]
         val namedGen = tuple21s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String]
         val rnd = Randomizer.default
@@ -4720,7 +4720,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a tuple22s method" that {
       "returns the default implicit generator that produces arbitrary Tuple22s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[(String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int)]]
         val namedGen = tuple22s[String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int, Long, Float, Double, String, Int]
         val rnd = Randomizer.default
@@ -4734,7 +4734,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a function0s method" that {
       "returns the default implicit generator that produces arbitrary Function0s" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[() => Int]]
         val namedGen = function0s[Int]
         val rnd = Randomizer.default
@@ -4789,7 +4789,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a vectors method" that {
       "returns the default implicit generator that produces arbitrary Vectors" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Vector[Int]]]
         val namedGen = vectors[Int]
         val rnd = Randomizer.default
@@ -4803,7 +4803,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a sets method" that {
       "returns the default implicit generator that produces arbitrary Sets" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Set[Int]]]
         val namedGen = sets[Int]
         val rnd = Randomizer.default
@@ -4817,7 +4817,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a sortedSets method" that {
       "returns the default implicit generator that produces arbitrary Sets" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[SortedSet[Int]]]
         val namedGen = sortedSets[Int]
         val rnd = Randomizer.default
@@ -4831,7 +4831,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a maps method" that {
       "returns the default implicit generator that produces arbitrary Maps" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[Map[Int, String]]]
         val namedGen = maps[Int, String]
         val rnd = Randomizer.default
@@ -4845,7 +4845,7 @@ If it doesn't show up for a while, please delete this comment.
     }
     "offer a sortedMaps method" that {
       "returns the default implicit generator that produces arbitrary SortedMaps" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         val implicitGen = implicitly[Generator[SortedMap[Int, String]]]
         val namedGen = sortedMaps[Int, String]
         val rnd = Randomizer.default
@@ -4883,7 +4883,7 @@ If it doesn't show up for a while, please delete this comment.
         totals should (contain key "zero" and contain key "positive")
       }
       "offer a method that gives back the total number of trials performed" in {
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (posIntsBetween(100, 1000)) { (count: PosInt) =>
           val fullClassification: Classification =
             classify(count, ints) {
@@ -4950,7 +4950,7 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 1 type" in {
         case class Person(age: Int)
         val persons = instancesOf(Person) { p => p.age } (posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(ag) => ag should be >= 0 } // A contrived property check to do something with the generator
       }
       "produces generators given construct and deconstruct functions for 2 types" in {
@@ -4958,7 +4958,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age)
         } (strings, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag) => ag should be >= 0 } // A contrived property check to do something with the generator
       }
       "produces generators given construct and deconstruct functions for 3 types" in {
@@ -4966,7 +4966,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3)
         } (strings, posZIntValues, posZLongValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -4977,7 +4977,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -4989,7 +4989,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5002,7 +5002,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5016,7 +5016,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5031,7 +5031,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5047,7 +5047,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5064,7 +5064,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5082,7 +5082,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5101,7 +5101,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5121,7 +5121,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5142,7 +5142,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5164,7 +5164,7 @@ If it doesn't show up for a while, please delete this comment.
         val persons = instancesOf(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5189,7 +5189,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5215,7 +5215,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5242,7 +5242,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5270,7 +5270,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5299,7 +5299,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5329,7 +5329,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21) =>
           ag should be >= 0
           attr3 should be >= 0L
@@ -5360,7 +5360,7 @@ If it doesn't show up for a while, please delete this comment.
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21, p.attr22)
         } (strings, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues,
           posZDoubleValues, posZFloatValues, posZIntValues, posZLongValues, posZDoubleValues, posZFloatValues, posZIntValues)
-        import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+        import org.scalatest.prop.DeprecatedGeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21, attr22) =>
           ag should be >= 0
           attr3 should be >= 0L

--- a/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
@@ -18,7 +18,7 @@ package org.scalatest.prop
 import org.scalactic.anyvals._
 import org.scalatest._
 
-class ConfigurationSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+class ConfigurationSpec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks {
 
   describe("Configuration.Parameter") {
     implicit val configGen: Generator[Configuration.Parameter] =

--- a/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -128,7 +128,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       a3 shouldEqual b3
     }
     it("should be usable in a forAll") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       forAll { (i: Int) => 
         i + i shouldEqual i * 2
       }
@@ -139,7 +139,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       }
     }
     it("should be used at least minSuccessful times in a forAll") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       var count = 0
       forAll { (i: Int) => 
         count += 1
@@ -158,7 +158,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       }
     }
     it("should be used at least maxDiscarded times in a forAll") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       var count = 0
       a [TestFailedException] should be thrownBy {
         forAll { (i: Int) => 
@@ -327,7 +327,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3).map(_.toByte)
       }
       it("should shrink Bytes by repeatedly halving and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (b: Byte) =>
           val generator = implicitly[Generator[Byte]]
           val (shrinkIt, _) = generator.shrink(b, Randomizer.default)
@@ -395,7 +395,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3).map(_.toShort)
       }
       it("should shrink Shorts by repeatedly halving and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (n: Short) =>
           val generator = implicitly[Generator[Short]]
           val (shrinkIt, _) = generator.shrink(n, Randomizer.default)
@@ -463,7 +463,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0, 1, -1, 2, -2, 3, -3)
       }
       it("should shrink Ints by repeatedly halving and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (i: Int) =>
           val generator = implicitly[Generator[Int]]
           val (shrinkIt, _) = generator.shrink(i, Randomizer.default)
@@ -531,7 +531,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0L, 1L, -1L, 2L, -2L, 3L, -3L)
       }
       it("should shrink Longs by repeatedly halving and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (n: Long) =>
           val generator = implicitly[Generator[Long]]
           val (shrinkIt, _) = generator.shrink(n, Randomizer.default)
@@ -601,7 +601,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals(2) should (be >= '0' and be <= '9')
       }
       it("should shrink Chars by trying selected printable characters") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val expectedChars = "abcdefghikjlmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toList
         val generator = implicitly[Generator[Char]]
         forAll { (c: Char) =>
@@ -669,7 +669,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0.0f, 1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f)
       }
       it("should shrink Floats by dropping the fraction part then repeatedly 'square-rooting' and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (f: Float) =>
           val generator = implicitly[Generator[Float]]
           val (shrinkIt, _) = generator.shrink(f, Randomizer.default)
@@ -748,7 +748,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(0.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0)
       }
       it("should shrink Doubles by dropping the fraction part then repeatedly 'square-rooting' and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
   // try with -173126.1489439121
         forAll { (d: Double) =>
           val generator = implicitly[Generator[Double]]
@@ -1961,7 +1961,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         canonicals.toList shouldBe List(NonZeroInt(1), NonZeroInt(-1), NonZeroInt(2), NonZeroInt(-2), NonZeroInt(3), NonZeroInt(-3))
       }
       it("should shrink NonZeroInts by repeatedly halving and negating") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (i: NonZeroInt) =>
           val generator = implicitly[Generator[NonZeroInt]]
           val (shrinkIt, _) = generator.shrink(i, Randomizer.default)
@@ -2396,7 +2396,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         s5.length shouldBe 100
       }
       it("should shrink Strings using strategery") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (s: String) =>
           val generator = implicitly[Generator[String]]
           val (shrinkIt, _) = generator.shrink(s, Randomizer.default)
@@ -2645,7 +2645,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       * @tparam F the collection type we are testing
       */
     def shrinkByStrategery[F[Int] <: GenTraversable[Int]](factory: ColCompatHelper.Factory[Int, F[Int]])(implicit generator: Generator[F[Int]]): Unit = {  
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       val intGenerator = Generator.intGenerator
       val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
       val intCanonicals = intCanonicalsIt.toList
@@ -2744,7 +2744,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method uses the canonical method of the underlying T") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -2757,7 +2757,7 @@ class GeneratorSpec extends FunSpec with Matchers {
     describe("for Function0s") {
       it("should offer an implicit provider for constant function0's with a pretty toString") {
         val function0s = Generator.function0Generator[Int]
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll (function0s) { (f: () => Int) =>
           val constantResult = f()
           import org.scalactic.TimesOnInt._
@@ -2786,7 +2786,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       it("should offer an implicit provider for constant function0's that returns the shrinks of the result type") {
         val ints = Generator.intGenerator
         val function0s = Generator.function0Generator[Int]
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll (ints) { (i: Int) =>
           val (intShrinksIt, rnd1) = ints.shrink(i, Randomizer.default)
           val (function0ShrinksIt, _) = function0s.shrink(() => i, rnd1)
@@ -2829,7 +2829,7 @@ class GeneratorSpec extends FunSpec with Matchers {
     }
     describe("for Int => Ints") {
       it("should have toString and simpleName that doesn't include org.scalatest.prop.valueOf") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         forAll { (f: Int => Int) =>
           f.toString should startWith ("(i: Int) => ")
           f.toString should not include "org.scalatest.prop.valueOf"
@@ -2872,7 +2872,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingSize(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.size shouldBe 3
@@ -2882,7 +2882,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingLength(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.length shouldBe 3
@@ -2892,7 +2892,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.size should (be >= 3 and be <= 5)
@@ -2912,7 +2912,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.length should (be >= 3 and be <= 5)
@@ -2932,7 +2932,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.size shouldBe 5
@@ -2942,7 +2942,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.vectorGenerator[Int]
         implicit val sGen = aGen.havingLengthsDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { v: Vector[Int] =>
           v.length shouldBe 5
@@ -2982,7 +2982,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Vector generator whose canonical method uses the canonical method of the underlying T") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toVector
@@ -3029,7 +3029,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.setGenerator[Int]
         implicit val sGen = aGen.havingSize(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Set[Int] =>
           s.size shouldBe 3
@@ -3039,7 +3039,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.setGenerator[Int]
         implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Set[Int] =>
           s.size should (be >= 3 and be <= 5)
@@ -3059,7 +3059,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.setGenerator[Int]
         implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Set[Int] =>
           s.size shouldBe 5
@@ -3101,7 +3101,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Set generator whose canonical method uses the canonical method of the underlying T") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -3148,7 +3148,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedSetGenerator[Int]
         implicit val sGen = aGen.havingSize(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedSet[Int] =>
           s.size shouldBe 3
@@ -3158,7 +3158,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedSetGenerator[Int]
         implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedSet[Int] =>
           s.size should (be >= 3 and be <= 5)
@@ -3178,7 +3178,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedSetGenerator[Int]
         implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedSet[Int] =>
           s.size shouldBe 5
@@ -3188,7 +3188,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       it("should shrink SortedSets using strategery") {
         // Due to what I can only assume is an oversight in the standard library, SortedSet's
         // companion object is not a GenericCompanion, so we can't use the common function here:
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val generator = implicitly[Generator[SortedSet[Int]]]
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
@@ -3258,7 +3258,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Set generator whose canonical method uses the canonical method of the underlying T") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -3305,7 +3305,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.mapGenerator[Int, String]
         implicit val sGen = aGen.havingSize(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Map[Int, String] =>
           s.size shouldBe 3
@@ -3315,7 +3315,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.mapGenerator[Int, String]
         implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Map[Int, String] =>
           s.size should (be >= 3 and be <= 5)
@@ -3335,7 +3335,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.mapGenerator[Int, String]
         implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: Map[Int, String] =>
           s.size shouldBe 5
@@ -3343,7 +3343,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       }
 
       it("should shrink Maps using strategery") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val generator = implicitly[Generator[Map[PosInt, Int]]]
         val tupleGenerator = Generator.tuple2Generator[PosInt, Int]
         val (tupleCanonicalsIt, _) = tupleGenerator.canonicals(Randomizer.default)
@@ -3418,7 +3418,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Map generator whose canonical method uses the canonical method of the underlying types") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val tupleGenerator = Generator.tuple2Generator[PosInt, Int]
         val (tupleCanonicalsIt, _) = tupleGenerator.canonicals(Randomizer.default)
         val tupleCanonicals = tupleCanonicalsIt.toList
@@ -3465,7 +3465,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedMapGenerator[Int, String]
         implicit val sGen = aGen.havingSize(PosZInt(3))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedMap[Int, String] =>
           s.size shouldBe 3
@@ -3475,7 +3475,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedMapGenerator[Int, String]
         implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedMap[Int, String] =>
           s.size should (be >= 3 and be <= 5)
@@ -3495,7 +3495,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val aGen= Generator.sortedMapGenerator[Int, String]
         implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
 
         forAll { s: SortedMap[Int, String] =>
           s.size shouldBe 5
@@ -3503,7 +3503,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       }
 
       it("should shrink SortedMaps using strategery") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val generator = implicitly[Generator[SortedMap[PosInt, Int]]]
         val tupleGenerator = Generator.tuple2Generator[PosInt, Int]
         val (tupleCanonicalsIt, _) = tupleGenerator.canonicals(Randomizer.default)
@@ -3578,7 +3578,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a SortedMap generator whose canonical method uses the canonical method of the underlying types") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val tupleGenerator = Generator.tuple2Generator[PosInt, Int]
         val (tupleCanonicalsIt, _) = tupleGenerator.canonicals(Randomizer.default)
         val tupleCanonicals = tupleCanonicalsIt.toList

--- a/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -48,7 +48,7 @@ class HavingLengthsBetweenSpec extends FunSpec with Matchers {
         lstGen.shrink(xss, Randomizer.default)._1.toList should not contain xss
       }
       it("should shrink Lists using strategery") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -120,7 +120,7 @@ class HavingLengthsBetweenSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method uses the canonical method of the underlying T if min is 0 or 1") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -132,7 +132,7 @@ class HavingLengthsBetweenSpec extends FunSpec with Matchers {
     }
     describe("where from is 1") {
       it("should offer a list generator whose canonical method uses the canonical method of the underlying T if min is 0 or 1") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -180,7 +180,7 @@ class HavingLengthsBetweenSpec extends FunSpec with Matchers {
         lstGen.shrink(xss, Randomizer.default)._1.toList should not contain xss
       }
       it("should shrink Lists using strategery") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList
@@ -252,7 +252,7 @@ class HavingLengthsBetweenSpec extends FunSpec with Matchers {
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method is empty if from is greater than 1") {
-        import GeneratorDrivenPropertyChecks._
+        import DeprecatedGeneratorDrivenPropertyChecks._
         val intGenerator = Generator.intGenerator
         val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
         val intCanonicals = intCanonicalsIt.toList

--- a/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.exceptions.TestFailedException
 import scala.annotation.tailrec
 import org.scalatest.Resources
 
-class OrgScalaTestPropSpec extends WordSpec with Matchers with GeneratorDrivenPropertyChecks {
+class OrgScalaTestPropSpec extends WordSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks {
 
   ///////////////////////////////
   //

--- a/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
@@ -20,7 +20,7 @@ import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.scalatest.exceptions.TestFailedException
 
-class PrettyFunction0Spec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+class PrettyFunction0Spec extends FunSpec with Matchers with DeprecatedGeneratorDrivenPropertyChecks {
   describe("A PrettyFunction0") {
     it("should return the constant passed to its constructor") {
       forAll { (i: Int) =>

--- a/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
@@ -54,7 +54,7 @@ class RandomizerSpec extends FunSpec with Matchers {
     }
 
     it("should offer a chooseInt method that initially produces Int values between from and to") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       var rnd = Randomizer.default
       forAll { (i: Int, j: Int) =>
         val (k, nextRandomizer) = rnd.chooseInt(i, j)
@@ -67,7 +67,7 @@ class RandomizerSpec extends FunSpec with Matchers {
       }
     }
     it("should offer a chooseLong method that initially produces Long values between from and to") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       var rnd = Randomizer.default
       forAll { (i: Long, j: Long) =>
         val (k, nextRandomizer) = rnd.chooseLong(i, j)
@@ -118,7 +118,7 @@ class RandomizerSpec extends FunSpec with Matchers {
       ld.distinct shouldNot have size 1
     }
     it("should offer a shuffle method in its companion object that shuffles a list.") {
-      import GeneratorDrivenPropertyChecks._
+      import DeprecatedGeneratorDrivenPropertyChecks._
       var nextRnd = Randomizer.default
       forAll { (xs: List[Int]) =>
         val (shuffled, nr) = Randomizer.shuffle(xs, nextRnd)

--- a/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
@@ -21,7 +21,7 @@ import org.scalactic.anyvals._
 /*
 It looks like sizeRange = maxSize - minSize
 */
-class SizeParamSpec extends WordSpec with Matchers with PropertyChecks {
+class SizeParamSpec extends WordSpec with Matchers with DeprecatedPropertyChecks {
   "A SizeParam" should {
     "have a minimum, range, and size" in {
       val sp = SizeParam(33, 20, 35)

--- a/scalatest/src/main/scala/org/scalatest/prop/Chooser.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Chooser.scala
@@ -27,7 +27,7 @@ import org.scalactic.anyvals._
   *
   * @tparam T A type to choose a value of.
   */
-trait Chooser[T] {
+private[scalatest] trait Chooser[T] {
   /**
     * Choose a value in the given range.
     *

--- a/scalatest/src/main/scala/org/scalatest/prop/Chooser.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Chooser.scala
@@ -59,7 +59,7 @@ private[scalatest] trait Chooser[T] {
   * should use that for randomization, but will not usually be direct calls to its
   * built-in "choose" functions.
   */
-object Chooser {
+private[scalatest] object Chooser {
   // The order of the following typeclass instances is arbitrary, but matches the order
   // of the declarations in Randomizer.
 

--- a/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Classification.scala
@@ -30,7 +30,7 @@ import org.scalactic.anyvals.{PosInt,PosZInt}
   * @param totalGenerated How many values were actually created by the Generator overall.
   * @param totals For each of the buckets defined in the PartialFunction, how many values belonged in each one.
   */
-case class Classification(val totalGenerated: PosInt, val totals: Map[String, PosZInt]) {
+private[scalatest] case class Classification(val totalGenerated: PosInt, val totals: Map[String, PosZInt]) {
 
   /**
     * For each bucket, what fraction of the generated values fell into it?

--- a/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -86,7 +86,7 @@ import scala.collection.immutable.SortedMap
   *
   * @group Others
   */
-trait CommonGenerators {
+private[scalatest] trait CommonGenerators {
 
   /////////////////////////////////////////////////
   //
@@ -2456,7 +2456,7 @@ trait CommonGenerators {
   * You should not usually need to import this directly, since it is mixed into
   * [[GeneratorDrivenPropertyChecks]] and [[TableDrivenPropertyChecks]].
   */
-object CommonGenerators extends CommonGenerators {
+private[scalatest] object CommonGenerators extends CommonGenerators {
   private val primeNumbers =
     Vector(
       2,     3,     5,     7,    11,    13,    17,    19,    23,    29,

--- a/scalatest/src/main/scala/org/scalatest/prop/DeprecatedPropertyChecks.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/DeprecatedPropertyChecks.scala
@@ -95,7 +95,8 @@ package prop
  *
  * @author Bill Venners
  */
-trait PropertyChecks extends TableDrivenPropertyChecks with GeneratorDrivenPropertyChecks
+// TODO: add deprecation annotation 
+private[org] trait DeprecatedPropertyChecks extends TableDrivenPropertyChecks with DeprecatedGeneratorDrivenPropertyChecks
 
 /**
  * Companion object that facilitates the importing of <code>PropertyChecks</code> members as 
@@ -104,5 +105,5 @@ trait PropertyChecks extends TableDrivenPropertyChecks with GeneratorDrivenPrope
  *
  * @author Bill Venners
  */
-object PropertyChecks extends PropertyChecks
+private[org] object DeprecatedPropertyChecks extends DeprecatedPropertyChecks
 

--- a/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Generator.scala
@@ -134,7 +134,7 @@ import scala.collection.immutable.SortedMap
   *
   * @tparam T the type that this Generator produces
   */
-trait Generator[T] { thisGeneratorOfT =>
+private[scalatest] trait Generator[T] { thisGeneratorOfT =>
 
   /**
     * Prepare a list of edge-case values ("edges") for testing this type.
@@ -497,7 +497,7 @@ trait Generator[T] { thisGeneratorOfT =>
   * Note that this provides `Generator`s for the common Scalactic types, as well as the common standard
   * library ones.
   */
-object Generator {
+private[scalatest] object Generator {
 
   import scala.language.implicitConversions
 

--- a/scalatest/src/main/scala/org/scalatest/prop/HavingLength.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/HavingLength.scala
@@ -34,7 +34,7 @@ import org.scalatest.Resources
   *
   * @tparam T the type that this [[Generator]] produces
   */
-trait HavingLength[T] extends HavingSize[T] {
+private[scalatest] trait HavingLength[T] extends HavingSize[T] {
   /**
     * Create a version of this [[Generator]] that produces values of exactly the specified
     * length.

--- a/scalatest/src/main/scala/org/scalatest/prop/HavingSize.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/HavingSize.scala
@@ -29,7 +29,7 @@ import org.scalactic.anyvals.PosZInt
   *
   * @tparam T the type that this [[Generator]] produces
   */
-trait HavingSize[T] {
+private[scalatest] trait HavingSize[T] {
   /**
     * Create a version of this [[Generator]] that produces values of exactly the specified
     * size.

--- a/scalatest/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
@@ -31,7 +31,7 @@ package org.scalatest.prop
   * @param result the value that will be returned by this function
   * @tparam A the type that is returned by this function
   */
-class PrettyFunction0[A](private val result: A) extends (() => A) {
+private[scalatest] class PrettyFunction0[A](private val result: A) extends (() => A) {
   def apply(): A = result
   override def toString = s"() => $result"
   override def hashCode: Int = result.hashCode
@@ -43,7 +43,7 @@ class PrettyFunction0[A](private val result: A) extends (() => A) {
   }
 }
 
-object PrettyFunction0 {
+private[scalatest] object PrettyFunction0 {
   /**
     * Create a [[PrettyFunction0]].
     *

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyArgument.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyArgument.scala
@@ -24,4 +24,4 @@ package org.scalatest.prop
   * @param label The label provided for that argument, if any.
   * @param value The value of the argument.
   */
-case class PropertyArgument(label: Option[String], value: Any)
+private[scalatest] case class PropertyArgument(label: Option[String], value: Any)

--- a/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
@@ -22,9 +22,9 @@ package org.scalatest.prop
   * [[org.scalatest.prop.PropertyCheckResult.Exhausted]], or [[org.scalatest.prop.PropertyCheckResult.Failure]].
   * See those subclasses for details on what each one means.
   */
-sealed trait PropertyCheckResult
+private[scalatest] sealed trait PropertyCheckResult
 
-object PropertyCheckResult {
+private[scalatest] object PropertyCheckResult {
 
   /**
     * This Property Check was successful -- after running for the desired number of times, it was not falsified.
@@ -82,5 +82,4 @@ object PropertyCheckResult {
     *                 test your fixes.
     */
   case class Failure(succeeded: Long, ex: Option[Throwable], names: List[String], argsPassed: List[PropertyArgument], initSeed: Long) extends PropertyCheckResult
-
 }

--- a/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -47,7 +47,7 @@ import java.lang.Double.{longBitsToDouble, doubleToLongBits}
   *
   * @param seed
   */
-class Randomizer(val seed: Long) { thisRandomizer =>
+private[scalatest] class Randomizer(val seed: Long) { thisRandomizer =>
 
   private[scalatest] lazy val scrambledSeed: Long =  seed
 
@@ -2197,7 +2197,7 @@ class Randomizer(val seed: Long) { thisRandomizer =>
   }
 }
 
-object Randomizer {
+private[scalatest] object Randomizer {
 
   import java.util.concurrent.atomic.AtomicReference
 

--- a/scalatest/src/main/scala/org/scalatest/prop/SizeParam.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/SizeParam.scala
@@ -52,7 +52,7 @@ import org.scalactic.Requirements._
   * @param sizeRange the range above [[minSize]] to consider allowable
   * @param size the actual size to use for this specific invocation of [[Generator.next()]]
   */
-case class SizeParam(minSize: PosZInt, sizeRange: PosZInt, size: PosZInt) {
+private[scalatest] case class SizeParam(minSize: PosZInt, sizeRange: PosZInt, size: PosZInt) {
   require(size >= minSize, s"the passed size ($size.value) must be greater than or equal to the passed minSize ($minSize.value)")
   require(size.value <= minSize + sizeRange, s"the passed size (${size.value}) must be less than or equal to passed minSize plus the passed sizeRange ($minSize + $sizeRange = ${minSize + sizeRange})")
 

--- a/scalatest/src/main/scala/org/scalatest/prop/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/prop/package.scala
@@ -19,7 +19,7 @@ import org.scalactic.anyvals._
 
 import prop._
 
-/**
+/*
   * Scalatest support for Property-based testing.
   *
   * ==Introduction to Property-based Testing==
@@ -455,7 +455,7 @@ package object prop {
     * @tparam A The type of the Generator.
     * @return An instance of A, computed by feeding the calculated seed into the Generator.
     */
-  def valueOf[A](first: Any, others: Any*)(multiplier: Int)(implicit genOfA: Generator[A]): A = {
+  private[scalatest] def valueOf[A](first: Any, others: Any*)(multiplier: Int)(implicit genOfA: Generator[A]): A = {
     val combinedHashCode: Int =
       others.foldLeft(first.hashCode) { (acc, next) =>
         (37 * (acc + 37)) + next.hashCode


### PR DESCRIPTION
@cheeseng One problem here is that I commented out the test classes for NumericString and RegexString, because they can't access Generator now that it is private[scalatest]. The other test classes are using implicit generators that are defined in the Generator companion, and they don't have any trouble accessing. I don't see why they can access. My theory is we should need to make Generator private[org]. Anyway, please take a look at that. We want to resurrect the RegexString and NumericString test classes.