### PR TITLE
Dropped or deprecated /: and :\ methods on all non-empty anyvals

### DIFF
--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
@@ -185,21 +185,9 @@ class NonEmptyArraySpec extends UnitSpec {
     pf1.isDefinedAt(0) shouldBe true
     pf1.isDefinedAt(1) shouldBe false
   }
-  it should "have a /: method" in {
-    (0 /: NonEmptyArray(1))(_ + _) shouldBe 1
-    (1 /: NonEmptyArray(1))(_ + _) shouldBe 2
-    (0 /: NonEmptyArray(1, 2, 3))(_ + _) shouldBe 6
-    (1 /: NonEmptyArray(1, 2, 3))(_ + _) shouldBe 7
-  }
   it should "have a :+ method" in {
     NonEmptyArray(1) :+ 2 shouldBe NonEmptyArray(1, 2)
     NonEmptyArray(1, 2) :+ 3 shouldBe NonEmptyArray(1, 2, 3)
-  }
-  it should "have a :\\ method" in {
-    (NonEmptyArray(1) :\ 0)(_ + _) shouldBe 1
-    (NonEmptyArray(1) :\ 1)(_ + _) shouldBe 2
-    (NonEmptyArray(1, 2, 3) :\ 0)(_ + _) shouldBe 6
-    (NonEmptyArray(1, 2, 3) :\ 1)(_ + _) shouldBe 7
   }
   it should "have 3 addString methods" in {
     NonEmptyArray("hi").addString(new StringBuilder) shouldBe new StringBuilder("hi")

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyMapSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyMapSpec.scala
@@ -182,18 +182,6 @@ class NonEmptyMapSpec extends UnitSpec {
     pf1.isDefinedAt(1) shouldBe true
     pf1.isDefinedAt(0) shouldBe false
   }
-  it should "have a /: method" in {
-    (0 /: NonEmptyMap(1 -> "one"))(_ + _._1) shouldBe 1
-    (1 /: NonEmptyMap(2 -> "two"))(_ + _._1) shouldBe 3
-    (0 /: NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three"))(_ + _._1) shouldBe 6
-    (1 /: NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three"))(_ + _._1) shouldBe 7
-  }
-  it should "have a :\\ method" in {
-    (NonEmptyMap(1 -> "one") :\ 0)(_._1 + _) shouldBe 1
-    (NonEmptyMap(1 -> "one") :\ 1)(_._1 + _) shouldBe 2
-    (NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three") :\ 0)(_._1 + _) shouldBe 6
-    (NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three") :\ 1)(_._1 + _) shouldBe 7
-  }
   it should "have 3 addString methods" in {
     NonEmptyMap("hi" -> "hello").addString(new StringBuilder) shouldBe new StringBuilder("hi -> hello")
     NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three").addString(new StringBuilder) shouldBe new StringBuilder("2 -> two3 -> three1 -> one")

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptySetSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptySetSpec.scala
@@ -160,18 +160,6 @@ class NonEmptySetSpec extends UnitSpec {
     NonEmptySet(1, 2) + 0 shouldBe NonEmptySet(0, 1, 2)
     NonEmptySet("one", "two") + "zero" shouldBe NonEmptySet("zero", "one", "two")
   }
-  it should "have a /: method" in {
-    (0 /: NonEmptySet(1))(_ + _) shouldBe 1
-    (1 /: NonEmptySet(1))(_ + _) shouldBe 2
-    (0 /: NonEmptySet(1, 2, 3))(_ + _) shouldBe 6
-    (1 /: NonEmptySet(1, 2, 3))(_ + _) shouldBe 7
-  }
-  it should "have a :\\ method" in {
-    (NonEmptySet(1) :\ 0)(_ + _) shouldBe 1
-    (NonEmptySet(1) :\ 1)(_ + _) shouldBe 2
-    (NonEmptySet(1, 2, 3) :\ 0)(_ + _) shouldBe 6
-    (NonEmptySet(1, 2, 3) :\ 1)(_ + _) shouldBe 7
-  }
   it should "have 3 addString methods" in {
     NonEmptySet("hi").addString(new StringBuilder) shouldBe new StringBuilder("hi")
     NonEmptySet(1, 2, 3).addString(new StringBuilder) shouldBe new StringBuilder("231")

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
@@ -121,21 +121,9 @@ class NonEmptyStringSpec extends UnitSpec {
     pf1.isDefinedAt(0) shouldBe true
     pf1.isDefinedAt(1) shouldBe false
   }
-  it should "have a /: method" in {
-    (0 /: NonEmptyString("1"))(_ + _) shouldBe 49
-    (1 /: NonEmptyString("1"))(_ + _) shouldBe 50
-    (0 /: NonEmptyString("123"))(_ + _) shouldBe 150
-    (1 /: NonEmptyString("123"))(_ + _) shouldBe 151
-  }
   it should "have a :+ method" in {
     NonEmptyString("1") :+ '2' shouldBe NonEmptyString("12")
     NonEmptyString("12") :+ '3' shouldBe NonEmptyString("123")
-  }
-  it should "have a :\\ method" in {
-    (NonEmptyString("1") :\ 0)(_ + _) shouldBe 49
-    (NonEmptyString("1") :\ 1)(_ + _) shouldBe 50
-    (NonEmptyString("123") :\ 0)(_ + _) shouldBe 150
-    (NonEmptyString("123") :\ 1)(_ + _) shouldBe 151
   }
   it should "have 3 addString methods" in {
     NonEmptyString("hi").addString(new StringBuilder) shouldBe new StringBuilder("hi")

--- a/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyVectorSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyVectorSpec.scala
@@ -187,21 +187,9 @@ class NonEmptyVectorSpec extends UnitSpec {
     pf1.isDefinedAt(0) shouldBe true
     pf1.isDefinedAt(1) shouldBe false
   }
-  it should "have a /: method" in {
-    (0 /: NonEmptyVector(1))(_ + _) shouldBe 1
-    (1 /: NonEmptyVector(1))(_ + _) shouldBe 2
-    (0 /: NonEmptyVector(1, 2, 3))(_ + _) shouldBe 6
-    (1 /: NonEmptyVector(1, 2, 3))(_ + _) shouldBe 7
-  }
   it should "have a :+ method" in {
     NonEmptyVector(1) :+ 2 shouldBe NonEmptyVector(1, 2)
     NonEmptyVector(1, 2) :+ 3 shouldBe NonEmptyVector(1, 2, 3)
-  }
-  it should "have a :\\ method" in {
-    (NonEmptyVector(1) :\ 0)(_ + _) shouldBe 1
-    (NonEmptyVector(1) :\ 1)(_ + _) shouldBe 2
-    (NonEmptyVector(1, 2, 3) :\ 0)(_ + _) shouldBe 6
-    (NonEmptyVector(1, 2, 3) :\ 1)(_ + _) shouldBe 7
   }
   it should "have 3 addString methods" in {
     NonEmptyVector("hi").addString(new StringBuilder) shouldBe new StringBuilder("hi")

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
@@ -29,11 +29,11 @@ import org.scalactic.Every
 
 // Can't be a LinearSeq[T] because Builder would be able to create an empty one.
 /**
-  * A non-empty list: an ordered, immutable, non-empty collection of elements with <code>LinearSeq</code> performance characteristics.
+  * A non-empty array: an ordered, mutable, non-empty collection of elements with <code>IndexedSeq</code> performance characteristics.
   *
   * <p>
-  * The purpose of <code>NonEmptyArray</code> is to allow you to express in a type that a <code>Array</code> is non-empty, thereby eliminating the
-  * need for (and potential exception from) a run-time check for non-emptiness. For a non-empty sequence with <code>IndexedSeq</code>
+  * The purpose of <code>NonEmptyArray</code> is to allow you to express in a type that an <code>Array</code> is non-empty, thereby eliminating the
+  * need for (and potential exception from) a run-time check for non-emptiness. For a non-empty immutable sequence with <code>IndexedSeq</code>
   * performance, see <a href="Every.html"><code>Every</code></a>.
   * </p>
   *
@@ -46,36 +46,6 @@ import org.scalactic.Every
   * <pre class="stHighlight">
   * scala&gt; NonEmptyArray(1, 2, 3)
   * res0: org.scalactic.anyvals.NonEmptyArray[Int] = NonEmptyArray(1, 2, 3)
-  * </pre>
-  *
-  * <p>
-  * Alternatively you can <em>cons</em> elements onto the <code>End</code> singleton object, similar to making a <code>Array</code> starting with <code>Nil</code>:
-  * </p>
-  *
-  * <pre class="stHighlight">
-  * scala&gt; 1 :: 2 :: 3 :: Nil
-  * res0: Array[Int] = Array(1, 2, 3)
-  *
-  * scala&gt; 1 :: 2 :: 3 :: End
-  * res1: org.scalactic.NonEmptyArray[Int] = NonEmptyArray(1, 2, 3)
-  * </pre>
-  *
-  * <p>
-  * Note that although <code>Nil</code> is a <code>Array[Nothing]</code>, <code>End</code> is
-  * not a <code>NonEmptyArray[Nothing]</code>, because no empty <code>NonEmptyArray</code> exists. (A non-empty list is a series
-  * of connected links; if you have no links, you have no non-empty list.)
-  * </p>
-  *
-  * <pre class="stHighlight">
-  * scala&gt; val nil: Array[Nothing] = Nil
-  * nil: Array[Nothing] = Array()
-  *
-  * scala&gt; val nada: NonEmptyArray[Nothing] = End
-  * &lt;console&gt;:16: error: type mismatch;
-  * found   : org.scalactic.anyvals.End.type
-  * required: org.scalactic.anyvals.NonEmptyArray[Nothing]
-  *        val nada: NonEmptyArray[Nothing] = End
-  *                                          ^
   * </pre>
   *
   * <h2>Working with <code>NonEmptyArray</code>s</h2>
@@ -187,54 +157,6 @@ final class NonEmptyArray[T] private (val toArray: Array[T]) extends AnyVal {
     */
   def ++[U >: T](other: org.scalactic.ColCompatHelper.IterableOnce[U])(implicit classTag: ClassTag[U]): NonEmptyArray[U] =
     new NonEmptyArray((toArray ++ other.toStream).toArray)
-
-  /**
-    * Fold left: applies a binary operator to a start value, <code>z</code>, and all elements of this <code>NonEmptyArray</code>, going left to right.
-    *
-    * <p>
-    * Note: <code>/:</code> is alternate syntax for the <code>foldLeft</code> method; <code>z</code> <code>/:</code> <code>non-empty list</code> is the
-    * same as <code>non-empty list</code> <code>foldLeft</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyArray</code>, going left to right, with the start value,
-    *     <code>z</code>, on the left:
-    *
-    * <pre>
-    * op(...op(op(z, x_1), x_2), ..., x_n)
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyArray</code>. 
-    * </p>
-    */
-  final def /:[B](z: B)(op: (B, T) => B): B = toArray./:(z)(op)
-
-  /**
-    * Fold right: applies a binary operator to all elements of this <code>NonEmptyArray</code> and a start value, going right to left.
-    *
-    * <p>
-    * Note: <code>:\</code> is alternate syntax for the <code>foldRight</code> method; <code>non-empty list</code> <code>:\</code> <code>z</code> is the same
-    * as <code>non-empty list</code> <code>foldRight</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyArray</code>, going right to left, with the start value,
-    *     <code>z</code>, on the right:
-    *
-    * <pre>
-    * op(x_1, op(x_2, ... op(x_n, z)...))
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyArray</code>. 
-    * </p>
-    */
-  final def :\[B](z: B)(op: (T, B) => B): B = toArray.:\(z)(op)
 
   /**
     * Returns a new <code>NonEmptyArray</code> with the given element prepended.

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
@@ -210,6 +210,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyList</code>. 
    * </p>
    */
+  @deprecated("Please use foldLeft instead")
   final def /:[B](z: B)(op: (B, T) => B): B = toList./:(z)(op)
 
   /**
@@ -234,6 +235,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyList</code>. 
    * </p>
    */
+  @deprecated("Please use foldRight instead.")
   final def :\[B](z: B)(op: (T, B) => B): B = toList.:\(z)(op)
 
   /**

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
@@ -142,54 +142,6 @@ final class NonEmptyMap[K, +V] private (val toMap: Map[K, V]) extends AnyVal {
     if (other.isEmpty) this else new NonEmptyMap(toMap ++ other.toMap)
 
   /**
-    * Fold left: applies a binary operator to a start value, <code>z</code>, and all entries of this <code>NonEmptyMap</code>, going left to right.
-    *
-    * <p>
-    * Note: <code>/:</code> is alternate syntax for the <code>foldLeft</code> method; <code>z</code> <code>/:</code> <code>non-empty map</code> is the
-    * same as <code>non-empty map</code> <code>foldLeft</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyMap</code>, going left to right, with the start value,
-    *     <code>z</code>, on the left:
-    *
-    * <pre>
-    * op(...op(op(z, x_1), x_2), ..., x_n)
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyMap</code>. 
-    * </p>
-    */
-  final def /:[B](z: B)(op: (B, (K, V)) => B): B = toMap./:(z)(op)
-
-  /**
-    * Fold right: applies a binary operator to all entries of this <code>NonEmptyMap</code> and a start value, going right to left.
-    *
-    * <p>
-    * Note: <code>:\</code> is alternate syntax for the <code>foldRight</code> method; <code>non-empty map</code> <code>:\</code> <code>z</code> is the same
-    * as <code>non-empty map</code> <code>foldRight</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyMap</code>, going right to left, with the start value,
-    *     <code>z</code>, on the right:
-    *
-    * <pre>
-    * op(x_1, op(x_2, ... op(x_n, z)...))
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyMap</code>. 
-    * </p>
-    */
-  final def :\[B](z: B)(op: ((K, V), B) => B): B = toMap.:\(z)(op)
-
-  /**
     * Returns a new <code>NonEmptyMap</code> with the given entry added.
     *
     * <p>

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
@@ -188,54 +188,6 @@ final class NonEmptySet[T] private (val toSet: Set[T]) extends AnyVal {
     if (other.isEmpty) this else new NonEmptySet(toSet ++ other.toSet)
 
   /**
-    * Fold left: applies a binary operator to a start value, <code>z</code>, and all elements of this <code>NonEmptySet</code>, going left to right.
-    *
-    * <p>
-    * Note: <code>/:</code> is alternate syntax for the <code>foldLeft</code> method; <code>z</code> <code>/:</code> <code>non-empty Set</code> is the
-    * same as <code>non-empty Set</code> <code>foldLeft</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptySet</code>, going left to right, with the start value,
-    *     <code>z</code>, on the left:
-    *
-    * <pre>
-    * op(...op(op(z, x_1), x_2), ..., x_n)
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptySet</code>. 
-    * </p>
-    */
-  final def /:[B](z: B)(op: (B, T) => B): B = toSet./:(z)(op)
-
-  /**
-    * Fold right: applies a binary operator to all elements of this <code>NonEmptySet</code> and a start value, going right to left.
-    *
-    * <p>
-    * Note: <code>:\</code> is alternate syntax for the <code>foldRight</code> method; <code>non-empty Set</code> <code>:\</code> <code>z</code> is the same
-    * as <code>non-empty Set</code> <code>foldRight</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptySet</code>, going right to left, with the start value,
-    *     <code>z</code>, on the right:
-    *
-    * <pre>
-    * op(x_1, op(x_2, ... op(x_n, z)...))
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptySet</code>. 
-    * </p>
-    */
-  final def :\[B](z: B)(op: (T, B) => B): B = toSet.:\(z)(op)
-
-  /**
     * Returns a new <code>NonEmptySet</code> with the given element added.
     *
     *

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
@@ -182,54 +182,6 @@ final class NonEmptyString private (val theString: String) extends AnyVal {
     if (other.isEmpty) this else new NonEmptyString(theString ++ other.mkString)
 
   /**
-    * Fold left: applies a binary operator to a start value, <code>z</code>, and all elements of this <code>NonEmptyString</code>, going left to right.
-    *
-    * <p>
-    * Note: <code>/:</code> is alternate syntax for the <code>foldLeft</code> method; <code>z</code> <code>/:</code> <code>non-empty string</code> is the
-    * same as <code>non-empty string</code> <code>foldLeft</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyString</code>, going left to right, with the start value,
-    *     <code>z</code>, on the left:
-    *
-    * <pre>
-    * op(...op(op(z, x_1), x_2), ..., x_n)
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyString</code>. 
-    * </p>
-    */
-  final def /:[B](z: B)(op: (B, Char) => B): B = theString./:(z)(op)
-
-  /**
-    * Fold right: applies a binary operator to all elements of this <code>NonEmptyString</code> and a start value, going right to left.
-    *
-    * <p>
-    * Note: <code>:\</code> is alternate syntax for the <code>foldRight</code> method; <code>non-empty string</code> <code>:\</code> <code>z</code> is the same
-    * as <code>non-empty string</code> <code>foldRight</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyString</code>, going right to left, with the start value,
-    *     <code>z</code>, on the right:
-    *
-    * <pre>
-    * op(x_1, op(x_2, ... op(x_n, z)...))
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyString</code>. 
-    * </p>
-    */
-  final def :\[B](z: B)(op: (Char, B) => B): B = theString.:\(z)(op)
-
-  /**
     * Returns a new <code>NonEmptyString</code> with the given character prepended.
     *
     * <p>

--- a/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
+++ b/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
@@ -189,54 +189,6 @@ final class NonEmptyVector[+T] private (val toVector: Vector[T]) extends AnyVal 
     if (other.isEmpty) this else new NonEmptyVector(toVector ++ other.toIterable)
 
   /**
-    * Fold left: applies a binary operator to a start value, <code>z</code>, and all elements of this <code>NonEmptyVector</code>, going left to right.
-    *
-    * <p>
-    * Note: <code>/:</code> is alternate syntax for the <code>foldLeft</code> method; <code>z</code> <code>/:</code> <code>non-empty list</code> is the
-    * same as <code>non-empty list</code> <code>foldLeft</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyVector</code>, going left to right, with the start value,
-    *     <code>z</code>, on the left:
-    *
-    * <pre>
-    * op(...op(op(z, x_1), x_2), ..., x_n)
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyVector</code>. 
-    * </p>
-    */
-  final def /:[B](z: B)(op: (B, T) => B): B = toVector./:(z)(op)
-
-  /**
-    * Fold right: applies a binary operator to all elements of this <code>NonEmptyVector</code> and a start value, going right to left.
-    *
-    * <p>
-    * Note: <code>:\</code> is alternate syntax for the <code>foldRight</code> method; <code>non-empty list</code> <code>:\</code> <code>z</code> is the same
-    * as <code>non-empty list</code> <code>foldRight</code> <code>z</code>.
-    * </p>
-    *
-    * @tparam B the result of the binary operator
-    * @param z the start value
-    * @param op the binary operator
-    * @return the result of inserting <code>op</code> between consecutive elements of this <code>NonEmptyVector</code>, going right to left, with the start value,
-    *     <code>z</code>, on the right:
-    *
-    * <pre>
-    * op(x_1, op(x_2, ... op(x_n, z)...))
-    * </pre>
-    *
-    * <p>
-    * where x<sub>1</sub>, ..., x<sub>n</sub> are the elements of this <code>NonEmptyVector</code>. 
-    * </p>
-    */
-  final def :\[B](z: B)(op: (T, B) => B): B = toVector.:\(z)(op)
-
-  /**
     * Returns a new <code>NonEmptyVector</code> with the given element prepended.
     *
     * <p>


### PR DESCRIPTION
Also cleaned up a some NonEmptyArray anyvals.