### PR TITLE
ScalaDoc for org.scalatest.path Package

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/path/package.scala
+++ b/scalatest/src/main/scala/org/scalatest/path/package.scala
@@ -20,6 +20,11 @@ package org.scalatest
  */
 package object path {
 
+  /**
+   * This is here to force scaladoc generation of org.scalatest.path package.
+   */
+  class ForceScaladocGeneration
+
   @deprecated("The org.scalatest.path.FreeSpecLike trait has been moved and renamed. Please use org.scalatest.freespec.PathAnyFreeSpecLike instead.")
   type FreeSpecLike = org.scalatest.freespec.PathAnyFreeSpecLike
 


### PR DESCRIPTION
Added an empty class in org.scalatest.path package object to force scaladoc to include the package.