### PR TITLE
Update to Dotty syntax

### DIFF
--- a/common-test/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/common-test/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -2403,7 +2403,7 @@ trait CommonGenerators {
   // classify will need to use the same sizing algo as forAll, and same edges approach
   def classify[A](count: PosInt, genOfA: Generator[A])(pf: PartialFunction[A, String]): Classification = {
 
-    val (initEdges, rnd1) = genOfA.initEdges(100, Randomizer.default())
+    val (initEdges, rnd1) = genOfA.initEdges(100, Randomizer.default)
     @tailrec
     def loop(currentCount: Int, edges: List[A], rnd: Randomizer, acc: Map[String, PosZInt]): Map[String, PosZInt] = {
       if (currentCount >= count) acc

--- a/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -2267,7 +2267,7 @@ object Randomizer {
     val buf = ArrayBuffer.empty[T]
     buf ++= xs
 
-    def swap(i: Int, j: Int) {
+    def swap(i: Int, j: Int): Unit = {
       val tmp = buf(i)
       buf(i) = buf(j)
       buf(j) = tmp

--- a/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -2204,7 +2204,7 @@ object Randomizer {
   /**
     * This seed is empty under ordinary circumstances. It is here so that the test
     * Runner can poke in a seed value to be used during a test run. If set, it will be used
-    * as the seed for all calls to [[Randomizer.default()]].
+    * as the seed for all calls to [[Randomizer.default]].
     */
   private[scalatest] val defaultSeed: AtomicReference[Option[Long]] = new AtomicReference(None)
 
@@ -2216,7 +2216,7 @@ object Randomizer {
     *
     * @return A Randomizer, ready to begin producing random values.
     */
-  def default(): Randomizer =
+  def default: Randomizer =
     apply(
       defaultSeed.get() match {
         case Some(seed) => seed
@@ -2236,7 +2236,7 @@ object Randomizer {
     * your "random" events.
     *
     * If you want to create an adequate seed to feed into here, the value of [[System.currentTimeMillis()]] is
-    * reasonable (and is used in [[Randomizer.default()]]). It's a somewhat weak seed, but decent for most
+    * reasonable (and is used in [[Randomizer.default]]). It's a somewhat weak seed, but decent for most
     * purposes.
     *
     * @param seed A number that will be used to initialize a new Randomizer.

--- a/project/GenResources.scala
+++ b/project/GenResources.scala
@@ -158,12 +158,16 @@ trait GenResourcesJVM extends GenResources {
       if (paramCount > 0)
         "def " + kv.key + "(" + (for (i <- 0 until paramCount) yield s"param$i: Any").mkString(", ") + "): String = makeString(\"" + kv.key + "\", Array(" + (for (i <- 0 until paramCount) yield s"param$i").mkString(", ") + "))"
       else
-        "def " + kv.key + "(): String = resourceBundle.getString(\"" + kv.key + "\")"
+        "def " + kv.key + ": String = resourceBundle.getString(\"" + kv.key + "\")"
     ) + "\n\n" +
     "def raw" + kv.key.capitalize + ": String = resourceBundle.getString(\"" + kv.key + "\")"
 
-  def failureMessagesKeyValueTemplate(kv: KeyValue, paramCount: Int): String =
-    "def " + kv.key + (if (paramCount == 0) "(" else "(prettifier: org.scalactic.Prettifier, ") + (for (i <- 0 until paramCount) yield s"param$i: Any").mkString(", ") + "): String = Resources." + kv.key + "(" + (for (i <- 0 until paramCount) yield s"prettifier.apply(param$i)").mkString(", ") + ")"
+  def failureMessagesKeyValueTemplate(kv: KeyValue, paramCount: Int): String = {
+    if (paramCount == 0)
+      "def " + kv.key + ": String = Resources." + kv.key
+    else
+      "def " + kv.key + "(prettifier: org.scalactic.Prettifier, " + (for (i <- 0 until paramCount) yield s"param$i: Any").mkString(", ") + "): String = Resources." + kv.key + "(" + (for (i <- 0 until paramCount) yield s"prettifier.apply(param$i)").mkString(", ") + ")"
+  }
 
 }
 

--- a/scalactic.dotty/src/main/scala/org/scalactic/source/Position.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/source/Position.scala
@@ -72,8 +72,8 @@ object Position {
 
     val file = refl.rootPosition.sourceFile
     val fileName: String = file.jpath.getFileName.toString
-    val filePath: String = if (showScalacticFillFilePathnames) file.toString else Resources.pleaseDefineScalacticFillFilePathnameEnvVar()
-    val lineNo: Int = refl.rootPosition.startLine
+    val filePath: String = if (showScalacticFillFilePathnames) file.toString else Resources.pleaseDefineScalacticFillFilePathnameEnvVar
+    val lineNo: Int = rootPosition.startLine
     '{ Position(${fileName.toExpr}, ${filePath.toExpr}, ${lineNo.toExpr}) }
   }
 

--- a/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -98,11 +98,11 @@ class GeneratorSpec extends FunSpec with Matchers {
     it("should offer a filter method that throws an exception if too many objects are filtered out") {
       val doNotDoThisAtHome = CommonGenerators.ints.filter(i => i == 0) // Only keep zero
       a [IllegalStateException] should be thrownBy {
-        doNotDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default())
+        doNotDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default)
       }
       val okToDoThisAtHome = CommonGenerators.ints.filter(i => i != 0) // Only keep non-zeros
       noException should be thrownBy {
-        okToDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default())
+        okToDoThisAtHome.next(SizeParam(PosZInt(0), 100, 100), Nil, Randomizer.default)
       }
     }
     it("should mix up both i and d when used in a for expression") {
@@ -2808,7 +2808,7 @@ class GeneratorSpec extends FunSpec with Matchers {
       it("should offer a tuple2 generator") {
         val gen = implicitly[Generator[(Int, Int)]]
         val intGen = implicitly[Generator[Int]]
-        val (it8, rnd1) = intGen.shrink(8, Randomizer.default())
+        val (it8, rnd1) = intGen.shrink(8, Randomizer.default)
         val (it18, rnd2)= intGen.shrink(18, rnd1)
         val list8 = it8.toList
         val list18 = it18.toList
@@ -2823,7 +2823,7 @@ class GeneratorSpec extends FunSpec with Matchers {
         val tupGen: Generator[(String, Int)] = Generator.tuple2Generator[String, Int]
         case class Person(name: String, age: Int)
         val persons = for (tup <- tupGen) yield Person(tup._1, tup._2)
-        val (it, _) = persons.shrink(Person("Harry Potter", 32), Randomizer.default())
+        val (it, _) = persons.shrink(Person("Harry Potter", 32), Randomizer.default)
         it.toList should not be empty
       }
     }

--- a/scalatest/src/main/scala/org/scalatest/AsyncTestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncTestRegistration.scala
@@ -31,7 +31,7 @@ trait AsyncTestRegistration { theSuite: AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit
 
   /**
    * Registers an ignored test.
@@ -40,5 +40,5 @@ trait AsyncTestRegistration { theSuite: AsyncTestSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/DistributedSuiteSorter.scala
+++ b/scalatest/src/main/scala/org/scalatest/DistributedSuiteSorter.scala
@@ -34,12 +34,12 @@ trait DistributedSuiteSorter {
     *
     * @param suiteId the <code>suiteId</code> for the suite that's starting to execute its tests
     */
-  def distributingTests(suiteId: String)
+  def distributingTests(suiteId: String): Unit
 
   /**
     * This method is called after all tests in the suite completed execution
     *
     * @param suiteId the <code>suiteId</code> for the suite that's completed its tests execution
     */
-  def completedTests(suiteId: String)
+  def completedTests(suiteId: String): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/DistributedTestSorter.scala
+++ b/scalatest/src/main/scala/org/scalatest/DistributedTestSorter.scala
@@ -44,7 +44,7 @@ trait DistributedTestSorter {
    *
    * @param testName the name of the test that has completed
    */
-  def distributingTest(testName: String)
+  def distributingTest(testName: String): Unit
 
   /**
    * Report an event for a distributed test.
@@ -53,7 +53,7 @@ trait DistributedTestSorter {
    * @param event the event to report
    * @throws NullArgumentException if either <code>testName</code> or <code>event</code> is null.
    */
-  def apply(testName: String, event: Event)
+  def apply(testName: String, event: Event): Unit
 
   /**
    * Indicates the events for the distributed test with the specified name have all been fired.
@@ -65,5 +65,5 @@ trait DistributedTestSorter {
    *
    * @param testName the name of the test that has completed
    */
-  def completedTest(testName: String)
+  def completedTest(testName: String): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -66,7 +66,7 @@ private[scalatest] sealed abstract class Fact {
    *
    * @return a simplified version of this Fact
    */
-  def unary_!(): Fact = Fact.Unary_!(this)
+  def unary_! : Fact = Fact.Unary_!(this)
 
   final def ||(rhs: => Fact): Fact = if (isYes) this else Fact.Binary_||(this, rhs)
 
@@ -846,7 +846,7 @@ private[scalatest] object Fact {
     val isYes: Boolean = !(underlying.isYes)
     val isVacuousYes: Boolean = false
 
-    override def unary_!(): org.scalatest.Fact = underlying
+    override def unary_! : org.scalatest.Fact = underlying
 
     override def factDiagram(level: Int): String = {
       val padding = "  " * level

--- a/scalatest/src/main/scala/org/scalatest/FixtureAsyncTestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/FixtureAsyncTestRegistration.scala
@@ -33,7 +33,7 @@ trait FixtureAsyncTestRegistration { theSuite: org.scalatest.FixtureAsyncTestSui
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit
 
   /**
    * Registers an ignored test.
@@ -42,5 +42,5 @@ trait FixtureAsyncTestRegistration { theSuite: org.scalatest.FixtureAsyncTestSui
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position)
+  def registerIgnoredAsyncTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/FixtureTestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/FixtureTestRegistration.scala
@@ -31,7 +31,7 @@ trait FixtureTestRegistration { theSuite: org.scalatest.FixtureSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position)
+  def registerTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit
 
   /**
    * Registers an ignored test.
@@ -40,5 +40,5 @@ trait FixtureTestRegistration { theSuite: org.scalatest.FixtureSuite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position)
+  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/scalatest/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -68,7 +68,7 @@ private[scalatest] trait TimerTask extends Runnable {
 
   val timerTaskRef: AtomicReference[Option[java.util.TimerTask]] = new AtomicReference(None)
 
-  def run()
+  def run(): Unit
 
   def cancel(): Unit = {
     timerTaskRef.get match {

--- a/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
+++ b/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
@@ -155,7 +155,7 @@ trait ParallelTestExecution extends OneInstancePerTest { this: Suite =>
             sorter.distributingTest(testName)
 
           // It will be oneInstance, testName, args.copy(reporter = ...)
-          distribute(new DistributedTestRunnerSuite(newInstance, testName, args), args.copy(tracker = args.tracker.nextTracker))
+          distribute(new DistributedTestRunnerSuite(newInstance, testName, args), args.copy(tracker = args.tracker.nextTracker()))
         }
         else {
           // In test-specific (distributed) instance, so just run the test. (RTINI was

--- a/scalatest/src/main/scala/org/scalatest/Reporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/Reporter.scala
@@ -116,7 +116,7 @@ trait Reporter {
    *
    * @param event the event being reported
    */
-  def apply(event: Event)
+  def apply(event: Event): Unit
 }
 
 private[scalatest] object Reporter {

--- a/scalatest/src/main/scala/org/scalatest/ResourcefulReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/ResourcefulReporter.scala
@@ -31,5 +31,5 @@ trait ResourcefulReporter extends Reporter {
    * usable anymore. If the <code>Reporter</code> holds no resources, it may do nothing when
    * this method is invoked, however, in that case, it probably won't implement <code>ResourcefulReporter</code>.
    */
-  def dispose()
+  def dispose(): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/Stopper.scala
+++ b/scalatest/src/main/scala/org/scalatest/Stopper.scala
@@ -53,7 +53,7 @@ trait Stopper {
    * and if a stop has been requested, terminates gracefully.
    * </p>
    */
-  def requestStop()
+  def requestStop(): Unit
 }
 
 /**

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -1226,7 +1226,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
           }
         case Some(distribute) =>
           for (nestedSuite <- nestedSuitesArray) 
-            statusBuffer += distribute(nestedSuite, args.copy(tracker = tracker.nextTracker))
+            statusBuffer += distribute(nestedSuite, args.copy(tracker = tracker.nextTracker()))
       }
     }
     new CompositeStatus(Set.empty ++ statusBuffer)

--- a/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
+++ b/scalatest/src/main/scala/org/scalatest/TestRegistration.scala
@@ -30,7 +30,7 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerTest(testText: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position)
+  def registerTest(testText: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit
 
   /**
    * Registers an ignored test.
@@ -39,5 +39,5 @@ trait TestRegistration { theSuite: Suite =>
    * @param testTags the test tags
    * @param testFun the test function
    */
-  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position)
+  def registerIgnoredTest(testText: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit
 }

--- a/scalatest/src/main/scala/org/scalatest/concurrent/Conductors.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/Conductors.scala
@@ -571,7 +571,7 @@ trait Conductors extends PatienceConfiguration {
           testThreadsStartingCounter.decrement()
 
           // wait for the main thread to say its ok to go.
-          greenLightForTestThreads.await
+          greenLightForTestThreads.await()
 
           // go
           f()

--- a/scalatest/src/main/scala/org/scalatest/time/Span.scala
+++ b/scalatest/src/main/scala/org/scalatest/time/Span.scala
@@ -335,7 +335,7 @@ import Span.totalNanosForLongLength
  */
 final class Span private (totNanos: Long, lengthString: String, unitsMessageFun: String => String, unitsName: String) extends Serializable {
 
-  private[time] def this(length: Long, units: Units) {
+  private[time] def this(length: Long, units: Units) = {
     this(
       totalNanosForLongLength(length, units),
       length.toString,
@@ -344,7 +344,7 @@ final class Span private (totNanos: Long, lengthString: String, unitsMessageFun:
     )
   }
 
-  private def this(length: Double, units: Units) {
+  private def this(length: Double, units: Units) = {
     this(
       totalNanosForDoubleLength(length, units),
       length.toString,

--- a/scalatest/src/main/scala/org/scalatest/tools/Durations.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Durations.scala
@@ -106,7 +106,7 @@ private[scalatest] case class Durations(file: File) {
     }
 
     def getTest(): Test = {
-      val suite = getSuite
+      val suite = getSuite()
       val testOption = suite.tests.find(test => test.name == testName)
 
       if (testOption.isDefined) {

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -983,7 +983,7 @@ import java.net.{ServerSocket, InetAddress}
         propertiesMap + (Suite.CHOSEN_STYLES -> chosenStyleSet)
 
     if (chosenStyleSet.nonEmpty)
-      println(Resources.deprecatedChosenStyleWarning())
+      println(Resources.deprecatedChosenStyleWarning)
       
     val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")
     val tagsToExclude: Set[String] = parseCompoundArgIntoSet(tagsToExcludeArgs, "-l")

--- a/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
@@ -951,7 +951,7 @@ object Runner {
         propertiesMap + (CHOSEN_STYLES -> chosenStyleSet)
 
     if (chosenStyleSet.nonEmpty)
-      println(Resources.deprecatedChosenStyleWarning())
+      println(Resources.deprecatedChosenStyleWarning)
 
     val (detectSlowpokes: Boolean, slowpokeDetectionDelay: Long, slowpokeDetectionPeriod: Long) =
       slowpokeConfig match {
@@ -1333,7 +1333,7 @@ object Runner {
                   val statuses = for (suiteConfig <- suiteInstances) yield {
                     val tagsToInclude = if (suiteConfig.requireSelectedTag) tagsToIncludeSet ++ Set(SELECTED_TAG) else tagsToIncludeSet
                     val filter = Filter(if (tagsToInclude.isEmpty) None else Some(tagsToInclude), tagsToExcludeSet, suiteConfig.excludeNestedSuites, suiteConfig.dynaTags)
-                    val runArgs = Args(concurrentDispatch, stopper, filter, configMap, Some(distributor), tracker.nextTracker, chosenStyleSet, false, None, distributedSuiteSorter)
+                    val runArgs = Args(concurrentDispatch, stopper, filter, configMap, Some(distributor), tracker.nextTracker(), chosenStyleSet, false, None, distributedSuiteSorter)
                     distributor.apply(suiteConfig.suite, runArgs)
                   }
                   distributor.waitUntilDone()
@@ -1344,7 +1344,7 @@ object Runner {
                 val statuses = for (suiteConfig <- suiteInstances) yield {
                   val tagsToInclude = if (suiteConfig.requireSelectedTag) tagsToIncludeSet ++ Set(SELECTED_TAG) else tagsToIncludeSet
                   val filter = Filter(if (tagsToInclude.isEmpty) None else Some(tagsToInclude), tagsToExcludeSet, suiteConfig.excludeNestedSuites, suiteConfig.dynaTags)
-                  val runArgs = Args(concurrentDispatch, stopper, filter, configMap, Some(distributor), tracker.nextTracker, chosenStyleSet, false, None, distributedSuiteSorter)
+                  val runArgs = Args(concurrentDispatch, stopper, filter, configMap, Some(distributor), tracker.nextTracker(), chosenStyleSet, false, None, distributedSuiteSorter)
                   distributor.apply(suiteConfig.suite, runArgs)
                 }
                 distributor.waitUntilDone()
@@ -1430,7 +1430,7 @@ object Runner {
     for (memento <- unrerunnables)
       reporter.apply(
         AlertProvided(
-          tracker.nextOrdinal,
+          tracker.nextOrdinal(),
           Resources.cannotRerun(memento.eventName, memento.suiteId,
                     memento.testName),
           None))

--- a/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
@@ -125,7 +125,7 @@ private[scalatest] class RunnerJFrame(
   // This should only be updated by the event handler thread.
   private var viewOptions = runsAndFailures
 
-  private val optionsMap: Map[EventToPresent, JCheckBoxMenuItem] = initializeOptionsMap
+  private val optionsMap: Map[EventToPresent, JCheckBoxMenuItem] = initializeOptionsMap()
 
   private val aboutBox: AboutJDialog = initializeAboutBox()
 

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -189,7 +189,7 @@ class ScalaTestFramework extends SbtFramework {
           configMap.getAndSet(Some(if (chosenStyleSet.isEmpty) propertiesMap else propertiesMap + (Suite.CHOSEN_STYLES -> chosenStyleSet)))
 
           if (chosenStyleSet.nonEmpty)
-            println(Resources.deprecatedChosenStyleWarning())
+            println(Resources.deprecatedChosenStyleWarning)
 
           val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")
           val tagsToExclude: Set[String] = parseCompoundArgIntoSet(tagsToExcludeArgs, "-l")

--- a/scalatest/src/main/scala/org/scalatest/tools/TestSortingReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/TestSortingReporter.scala
@@ -242,7 +242,7 @@ private[scalatest] class TestSortingReporter(suiteId: String, dispatch: Reporter
         if (newHead.ready)
           fireReadyEvents()
         else
-          scheduleTimeoutTask
+          scheduleTimeoutTask()
       }
     }
     else if (waitingBuffer.size == 1) {

--- a/scalatest/src/main/scala/org/scalatest/tools/XmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/XmlReporter.scala
@@ -311,7 +311,7 @@ private[scalatest] class XmlReporter(directory: String) extends Reporter {
   //
   // Creates an xml string describing a run of a test suite.
   //
-  def xmlify(testsuite: Testsuite): String = {
+  private def xmlify(testsuite: Testsuite): String = {
     val xmlVal =
       <testsuite
         errors    = { "" + testsuite.errors         }

--- a/scalatest/src/main/scala/org/scalatest/verbs/ResultOfStringPassedToVerb.scala
+++ b/scalatest/src/main/scala/org/scalatest/verbs/ResultOfStringPassedToVerb.scala
@@ -86,7 +86,7 @@ abstract class ResultOfStringPassedToVerb(val verb: String, val rest: String) {
    * for trait <code>FlatSpec</code>.
    * </p>
    */
-  def is(fun: => PendingStatement)
+  def is(fun: => PendingStatement): Unit
 
   /**
    * Supports the registration of tagged tests in <code>FlatSpec</code> and <code>fixture.FlatSpec</code>.

--- a/scalatest/src/main/scala/org/scalatest/verbs/ResultOfTaggedAsInvocation.scala
+++ b/scalatest/src/main/scala/org/scalatest/verbs/ResultOfTaggedAsInvocation.scala
@@ -79,5 +79,5 @@ abstract class ResultOfTaggedAsInvocation(val verb: String, val rest: String, va
    * in the main documentation for trait <code>FlatSpec</code>.
    * </p>
    */
-  def is(testFun: => PendingStatement)
+  def is(testFun: => PendingStatement): Unit
 }


### PR DESCRIPTION
Update syntax to align with Scala 3 syntax.

The short term goal of this change is to be able to remove the `-language:Scala:2` for the Dotty configuration. Long term, it will make the cross-compilation simpler between Scala2 and Scala3 sources.