### PR TITLE
Bump ScalaCheck to 1.14.1

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -29,7 +29,7 @@ object ScalatestBuild extends Build {
 
   val previousReleaseVersion = "3.0.5"
 
-  val scalacheckVersion = "1.14.0"
+  val scalacheckVersion = "1.14.1"
   val easyMockVersion = "3.2"
   val jmockVersion = "2.8.3"
   val mockitoVersion = "1.10.19"


### PR DESCRIPTION
Greetings,

ScalaCheck 1.14.1 was released this week.  It is a minor update from ScalaCheck 1.14.0, and it is binary compatible.  

I'm not sure if ScalaTest has another 3.0.x release in its future, but it would be nice to get this bumped if you do happen to circle back.

Release notes:
https://github.com/typelevel/scalacheck/releases/tag/1.14.1

Change log:
https://github.com/typelevel/scalacheck/blob/1.14.1/CHANGELOG.markdown

Thanks for ScalaTest,
Aaron