### PR TITLE
Bump ScalaCheck to 1.14.2

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -29,7 +29,7 @@ object ScalatestBuild extends Build {
 
   val previousReleaseVersion = "3.0.5"
 
-  val scalacheckVersion = "1.14.0"
+  val scalacheckVersion = "1.14.2"
   val easyMockVersion = "3.2"
   val jmockVersion = "2.8.3"
   val mockitoVersion = "1.10.19"


### PR DESCRIPTION
Greetings,

ScalaCheck 1.14.2 was released today.  It is a bug fix release to 1.14.1, released a week ago, that was a minor update to ScalaCheck 1.14.0.  Both are binary compatible to the current version, 1.14.0, that is specified in ScalaTest 3.0.  

I'm not sure if ScalaTest has another 3.0.x release in its future, but it would be nice to get this bumped if you do happen to circle back.

Release notes:
https://github.com/typelevel/scalacheck/releases/tag/1.14.1
https://github.com/typelevel/scalacheck/releases/tag/1.14.2

Thanks for ScalaTest,
Aaron