### PR TITLE
Add EitherValuable

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -58,6 +58,40 @@ class EitherValuesSpec extends FunSpec {
       caught.message.value should be (Resources.eitherRightValueNotDefined)
     }
 
+    it("should return the left value inside an either if leftValue is defined") {
+      val e: Either[String, String] = Left("hi there")
+      e.leftValue should === ("hi there")
+      e.leftValue should startWith ("hi")
+    }
+
+    it("should throw TestFailedException if leftValue is empty") {
+      val e: Either[String, String] = Right("hi there")
+      val caught =
+        the [TestFailedException] thrownBy {
+          e.leftValue should startWith ("hi")
+        }
+      caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
+      caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
+      caught.message.value should be (Resources.eitherLeftValueNotDefined)
+    }
+
+    it("should return the right value inside an either if rightValue is defined") {
+      val e: Either[String, String] = Right("hi there")
+      e.rightValue should === ("hi there")
+      e.rightValue should startWith ("hi")
+    }
+
+    it("should throw TestFailedException if rightValue is empty") {
+      val e: Either[String, String] = Left("hi there")
+      val caught =
+        the [TestFailedException] thrownBy {
+          e.rightValue should startWith ("hi")
+        }
+      caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
+      caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
+      caught.message.value should be (Resources.eitherRightValueNotDefined)
+    }
+
     it("should allow an immediate application of parens to invoke apply on the type contained in the Left") {
       val lefty: Either[Map[String, Int], String] = Left(Map("I" -> 1, "II" -> 2))
       lefty.left.value("II") shouldBe 2

--- a/scalatest/src/main/scala/org/scalatest/EitherValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/EitherValues.scala
@@ -112,13 +112,25 @@ trait EitherValues {
       * Returns the <code>Left</code> value contained in the wrapped <code>LeftProjection</code>, if defined as a <code>Left</code>, else throws <code>TestFailedException</code> with
       * a detail message indicating the <code>Either</code> was defined as a <code>Right</code>, not a <code>Left</code>.
       */
-    def leftValue: L = either.swap.getOrElse(throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(new NoSuchElementException), pos))
+    def leftValue: L = {
+      try {
+        either.left.get
+      }
+      catch {
+        case cause: NoSuchElementException =>
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(cause), pos)
+      }
+    }
 
     /**
       * Returns the <code>Right</code> value contained in the wrapped <code>Either</code>, if defined as a <code>Right</code>, else throws <code>TestFailedException</code> with
       * a detail message indicating the <code>Either</code> was defined as a <code>Left</code>, not a <code>Right</code>.
       */
-    def rightValue: R = either.getOrElse(throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(new NoSuchElementException), pos))
+    def rightValue: R = either match {
+      case Right(x) => x
+      case Left(_) =>
+        throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(new NoSuchElementException), pos)
+    }
   }
 
   /**

--- a/scalatest/src/main/scala/org/scalatest/EitherValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/EitherValues.scala
@@ -112,25 +112,13 @@ trait EitherValues {
       * Returns the <code>Left</code> value contained in the wrapped <code>LeftProjection</code>, if defined as a <code>Left</code>, else throws <code>TestFailedException</code> with
       * a detail message indicating the <code>Either</code> was defined as a <code>Right</code>, not a <code>Left</code>.
       */
-    def leftValue: L = {
-      try {
-        either.left.get
-      }
-      catch {
-        case cause: NoSuchElementException =>
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(cause), pos)
-      }
-    }
+    def leftValue: L = either.swap.getOrElse(throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(new NoSuchElementException), pos))
 
     /**
       * Returns the <code>Right</code> value contained in the wrapped <code>Either</code>, if defined as a <code>Right</code>, else throws <code>TestFailedException</code> with
       * a detail message indicating the <code>Either</code> was defined as a <code>Left</code>, not a <code>Right</code>.
       */
-    def rightValue: R = either match {
-      case Right(x) => x
-      case Left(_) =>
-        throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(new NoSuchElementException), pos)
-    }
+    def rightValue: R = either.getOrElse(throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(new NoSuchElementException), pos))
   }
 
   /**


### PR DESCRIPTION
In Scala 2.13.x, the `RightProjection` is deprecated (this time for good: https://github.com/scalatest/scalatest/pull/975).

So you can no longer write (without a deprecation warning about `right`):

```scala
val either: Either[String, Int] = Right(5)

either.value.right should ===(5)
```

So I added `EitherValuable` which has `rightValue` and `leftValue`.