### PR TITLE
RefSpec Module

### DIFF
--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -593,6 +593,7 @@ trait DottyBuild { this: BuildCommons =>
       scalatestFunSuiteDotty, 
       scalatestFunSpecDotty, 
       scalatestPropSpecDotty, 
+      scalatestRefSpecDotty, 
       scalatestWordSpecDotty, 
       scalatestDiagramsDotty, 
       scalatestMatchersCoreDotty, 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -1064,6 +1064,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       scalatestFunSpec, 
       scalatestPropSpec, 
       scalatestWordSpec, 
+      scalatestRefSpec, 
       scalatestDiagrams, 
       scalatestMatchersCore, 
       scalatestShouldMatchers, 


### PR DESCRIPTION
Added the missing scalatestRefSpec in the scalatest's aggregation list in jvm and dotty build.