### PR TITLE
Publish for Scala.js 1.0.0-RC1 instead of 1.0.0-M8.

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -2,7 +2,7 @@ sbt clean
 sbt "project scalactic" clean +publishSigned
 export SCALAJS_VERSION=0.6.31
 sbt "project scalacticJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-M8
+export SCALAJS_VERSION=1.0.0-RC1
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.10 "project scalacticJS" clean publishSigned
 sbt ++2.13.1 "project scalacticJS" clean publishSigned
@@ -15,7 +15,7 @@ sbt scalatestCompatible/clean scalatestCompatible/publishSigned
 sbt "project scalatest" clean +publishSigned
 export SCALAJS_VERSION=0.6.31
 sbt "project scalatestJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-M8
+export SCALAJS_VERSION=1.0.0-RC1
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.10 "project scalatestJS" clean publishSigned
 sbt ++2.13.1 "project scalatestJS" clean publishSigned
@@ -27,7 +27,7 @@ sbt clean
 sbt "project scalatestApp" clean +publishSigned
 export SCALAJS_VERSION=0.6.31
 sbt "project scalatestAppJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-M8
+export SCALAJS_VERSION=1.0.0-RC1
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.10 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.1 "project scalatestAppJS" clean publishSigned


### PR DESCRIPTION
These are the only lines in the codebase that `git grep M8` found. I am surprised not to see anything in the CI, but perhaps the CI is not run with 1.x.