### PR TITLE
Report actual value of unexpected Either & Try projections

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -38,7 +38,7 @@ class EitherValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
-      caught.message.value should be (Resources.eitherLeftValueNotDefined)
+      caught.message.value should be (Resources.eitherLeftValueNotDefined(e))
     }
     
     it("should return the right value inside an either if right.value is defined") {
@@ -55,7 +55,7 @@ class EitherValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
-      caught.message.value should be (Resources.eitherRightValueNotDefined)
+      caught.message.value should be (Resources.eitherRightValueNotDefined(e))
     }
 
     it("should allow an immediate application of parens to invoke apply on the type contained in the Left") {

--- a/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
@@ -42,7 +42,7 @@ class TryValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("TryValuesSpec.scala")
-      caught.message.value should be (Resources.tryNotAFailure)
+      caught.message.value should be (Resources.tryNotAFailure(t))
     }
 
     it("should return the value inside a Try if it is a Success") {
@@ -59,7 +59,7 @@ class TryValuesSpec extends FunSpec {
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("TryValuesSpec.scala")
-      caught.message.value should be (Resources.tryNotASuccess)
+      caught.message.value should be (Resources.tryNotASuccess(t))
     }
   } 
 }

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -571,8 +571,8 @@ concurrentDocSpecMod=Two threads attempted to modify Doc's internal data, which 
 tryNotAFailure=The Try on which failure was invoked was not a Failure.
 tryNotASuccess=The Try on which success was invoked was not a Success.
 optionValueNotDefined=The Option on which value was invoked was not defined.
-eitherLeftValueNotDefined=The Either on which left.value was invoked was not defined as a Left.
-eitherRightValueNotDefined=The Either on which right.value was invoked was not defined as a Right.
+eitherLeftValueNotDefined=The Either on which left.value was invoked was not defined as a Left; it was {0}.
+eitherRightValueNotDefined=The Either on which right.value was invoked was not defined as a Right; it was {0}. 
 partialFunctionValueNotDefined=The PartialFunction on which valueAt( {0} ) was invoked was not defined.
 
 insidePartialFunctionNotDefined=The partial function passed as the second parameter to inside was not defined at the value passed as the first parameter to inside, which was: {0}

--- a/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/scalatest/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -568,8 +568,8 @@ concurrentFeatureSpecMod=Two threads attempted to modify FeatureSpec's internal 
 concurrentFixtureFeatureSpecMod=Two threads attempted to modify FixtureFeatureSpec's internal data, which should only be modified by the thread that constructs the object. This likely means that a subclass has allowed the this reference to escape during construction, and some other thread attempted to invoke the "feature" or "scenario" methods on the object before the first thread completed its construction.
 concurrentDocSpecMod=Two threads attempted to modify Doc's internal data, which should only be modified by the thread that constructs the object. This likely means that a subclass has allowed the this reference to escape during construction, and some other thread attempted to invoke the "body" method on the object before the first thread completed its construction.
 
-tryNotAFailure=The Try on which failure was invoked was not a Failure.
-tryNotASuccess=The Try on which success was invoked was not a Success.
+tryNotAFailure=The Try on which failure was invoked was not a Failure; it was {0}.
+tryNotASuccess=The Try on which success was invoked was not a Success; it was {0}.
 optionValueNotDefined=The Option on which value was invoked was not defined.
 eitherLeftValueNotDefined=The Either on which left.value was invoked was not defined as a Left; it was {0}.
 eitherRightValueNotDefined=The Either on which right.value was invoked was not defined as a Right; it was {0}. 

--- a/scalatest/src/main/scala/org/scalatest/EitherValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/EitherValues.scala
@@ -121,7 +121,7 @@ trait EitherValues {
       }
       catch {
         case cause: NoSuchElementException => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined), Some(cause), pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherLeftValueNotDefined(leftProj.e)), Some(cause), pos)
       }
     }
   }
@@ -149,7 +149,7 @@ trait EitherValues {
       }
       catch {
         case cause: NoSuchElementException => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined), Some(cause), pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.eitherRightValueNotDefined(rightProj.e)), Some(cause), pos)
       }
     }
   }

--- a/scalatest/src/main/scala/org/scalatest/TryValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/TryValues.scala
@@ -119,7 +119,7 @@ trait TryValues {
       theTry match {
         case failure: Failure[T] => failure
         case _ => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotAFailure), None, pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotAFailure(theTry)), None, pos)
       }
     }
 
@@ -131,7 +131,7 @@ trait TryValues {
       theTry match {
         case success: Success[T] => success
         case _ => 
-          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotASuccess), None, pos)
+          throw new TestFailedException((_: StackDepthException) => Some(Resources.tryNotASuccess(theTry)), None, pos)
       }
     }
   }


### PR DESCRIPTION
More often than not when a test fails with "The Either on which
[left/right].value was invoked was not defined as a [Left/Right]"
or "The Try on which [failure/success] was invoked was not
defined as a [Failure/Success]" I immediately want to know what
it actually was - so why not report it?
