### PR TITLE
Backport 3.1.x test framework optimization for reflectively loading a Scala module.

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -979,14 +979,10 @@ import java.net.{ServerSocket, InetAddress}
         case _ => (false, 60000L, 60000L)
       }
 
-    // We need to use the following code to set Runner object instance for different Runner using different class loader.
-    import scala.reflect.runtime._
-
-    val runtimeMirror = universe.runtimeMirror(testClassLoader)
-
-    val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
-    val obj = runtimeMirror.reflectModule(module)
-    val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+    val runnerCompanionClass = testClassLoader.loadClass("org.scalatest.tools.Runner$")
+    val module = runnerCompanionClass.getField("MODULE$")
+    val obj = module.get(runnerCompanionClass)
+    val runnerInstance = obj.asInstanceOf[Runner.type]
 
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 


### PR DESCRIPTION
I don't know if you're accepting backports for 3.0.x but I thought it was worth a shot nevertheless. Feel free to close this PR.

This commit is a backport of 15af09c5838b674ecb7e896569b4e42623a58899 from the 3.1.x series in order to allow users on 3.0.x to speed up forked test runs by 1-2 seconds when using the ScalaTest Framework. Profiles from running forked tests with ScalaTest v3.0.x show that every run has 1-2 second overhead from loading up scala-reflect.

<img width="1435" alt="Screenshot 2019-12-13 at 13 50 00" src="https://user-images.githubusercontent.com/1408093/70990801-313a4980-20be-11ea-8a87-d13460d7fe0a.png">

I have already worked around this issue by publishing to Maven Central a module as `com.geirsson:scalatest-framework_2.12:0.1.0` that contains a custom `org.scalatest.tools.FasterFramework` implementation, see repo https://github.com/olafurpg/scalatest-framework. 