### PR TITLE
[#1767] correcting text content of property elements of jUnit result files

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -459,8 +459,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
     <properties> {
       for (name <- propertyNames(sysprops))
         yield
-          <property name={ name } value = { sysprops.getProperty(name) }>
-          </property>
+          <property name={ name } value = { sysprops.getProperty(name) }/>
     }
     </properties>
   }


### PR DESCRIPTION
* property elements are now non-text elements instead of empty-text
see `https://github.com/scalatest/scalatest/issues/1767` for more info.