### PR TITLE
[3.1.x] Scala-js 1.0.0 Support

### DIFF
--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -15,7 +15,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 trait JsBuild { this: BuildCommons =>
 
   val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
-  val sjsPrefix = if (scalaJSVersion.startsWith("1.0.")) "_sjs1.0_" else "_sjs0.6_"
+  val sjsPrefix = if (scalaJSVersion.startsWith("1.")) "_sjs1_" else "_sjs0.6_"
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")
 

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -15,6 +15,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 trait JsBuild { this: BuildCommons =>
 
   val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+  val sjsPrefix = if (scalaJSVersion.startsWith("1.0.")) "_sjs1.0_" else "_sjs0.6_"
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")
 
@@ -80,7 +81,7 @@ trait JsBuild { this: BuildCommons =>
       // include the macro sources in the main source jar
       mappings in (Compile, packageSrc) ++= mappings.in(scalacticMacroJS, Compile, packageSrc).value,
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalactic",
@@ -148,7 +149,7 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       scalatestJSDocTaskSetting,
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest",
@@ -224,7 +225,7 @@ trait JsBuild { this: BuildCommons =>
         }.taskValue
       },
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest",
@@ -450,7 +451,7 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       scalatestJSDocTaskSetting,
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest",
@@ -499,7 +500,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.featurespec"
@@ -531,7 +532,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.flatspec"
@@ -563,7 +564,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.freespec"
@@ -595,7 +596,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.funsuite"
@@ -627,7 +628,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.funspec"
@@ -659,7 +660,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.propspec"
@@ -691,7 +692,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.wordspec"
@@ -723,7 +724,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.diagrams"
@@ -756,7 +757,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.matchers", 
@@ -789,7 +790,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.matchers.should"
@@ -821,7 +822,7 @@ trait JsBuild { this: BuildCommons =>
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
       mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % previousReleaseVersion),
-      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + "_" + "sjs0.6_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
+      mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (moduleName.value + sjsPrefix + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
     ).settings(osgiSettings: _*).settings(
       OsgiKeys.exportPackage := Seq(
         "org.scalatest.matchers.must"

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -14,7 +14,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 trait JsBuild { this: BuildCommons =>
 
-  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,8 @@
 sbt clean
 sbt "project scalactic" clean +publishSigned
-export SCALAJS_VERSION=0.6.31
+export SCALAJS_VERSION=0.6.32
 sbt "project scalacticJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-RC2
+export SCALAJS_VERSION=1.0.0
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.10 "project scalacticJS" clean publishSigned
 sbt ++2.13.1 "project scalacticJS" clean publishSigned
@@ -13,9 +13,9 @@ sbt "project scalactic" sonatypeBundleUpload
 sbt clean
 sbt scalatestCompatible/clean scalatestCompatible/publishSigned
 sbt "project scalatest" clean +publishSigned
-export SCALAJS_VERSION=0.6.31
+export SCALAJS_VERSION=0.6.32
 sbt "project scalatestJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-RC2
+export SCALAJS_VERSION=1.0.0
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.10 "project scalatestJS" clean publishSigned
 sbt ++2.13.1 "project scalatestJS" clean publishSigned
@@ -24,9 +24,9 @@ sbt "project scalatestDotty" clean publishSigned
 
 sbt clean
 sbt "project scalatestApp" clean +publishSigned
-export SCALAJS_VERSION=0.6.31
+export SCALAJS_VERSION=0.6.32
 sbt "project scalatestAppJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.0-RC2
+export SCALAJS_VERSION=1.0.0
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.10 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.1 "project scalatestAppJS" clean publishSigned

--- a/scalactic.js/src/main/scala/org/scalactic/source/ObjectMeta.scala
+++ b/scalactic.js/src/main/scala/org/scalactic/source/ObjectMeta.scala
@@ -55,14 +55,23 @@ object ObjectMeta {
           replaceAllLiterally("$$und", "_").
           replaceAllLiterally("$mcI", "").
           replaceAllLiterally("$sp", "").
-          replaceAllLiterally("$f", "")
+          replaceAllLiterally("$f", "").
+          replace(".*__f_", "")  // For scala-js 1.0
 
-      Some((filterDollarNumberAtTheEnd(decodedKey), value))
+      val decodedKey10 = {
+        val idx = decodedKey.indexOf("__f_")
+        if (idx >= 0)
+          decodedKey.drop(idx + 4)
+        else
+          decodedKey
+      }    
+
+      Some((filterDollarNumberAtTheEnd(decodedKey10), value))
     }.flatten.toMap
 
     new ObjectMeta {
 
-      lazy val fieldNames = dict.keys.toVector.filter(_ != "$$outer")
+      lazy val fieldNames = dict.keys.toVector.filter(k => k != "$$outer" && k != "$outer")
 
       def value(name: String): Any = {
         dict.get(name) match {

--- a/scalactic.js/src/main/scala/org/scalactic/source/ObjectMeta.scala
+++ b/scalactic.js/src/main/scala/org/scalactic/source/ObjectMeta.scala
@@ -55,8 +55,7 @@ object ObjectMeta {
           replaceAllLiterally("$$und", "_").
           replaceAllLiterally("$mcI", "").
           replaceAllLiterally("$sp", "").
-          replaceAllLiterally("$f", "").
-          replace(".*__f_", "")  // For scala-js 1.0
+          replaceAllLiterally("$f", "")
 
       val decodedKey10 = {
         val idx = decodedKey.indexOf("__f_")


### PR DESCRIPTION
Fixed failing tests for ObjectMeta when built with Scala-js 1.0.0, now all tests passed for Scala-js 1.0.0.