### PR TITLE
Fix stray timer in SuiteSortingReporter & TestSortingReporter

### DIFF
--- a/common-test.js/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
+++ b/common-test.js/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
@@ -2,7 +2,7 @@ package org.scalatest
 
 import _root_.org.scalatest.tools.SuiteRunner
 
-class TestConcurrentDistributor(poolSize: Int) extends Distributor {
+class TestConcurrentDistributor extends Distributor {
   def apply(suite: Suite, tracker: Tracker) {
     throw new UnsupportedOperationException("Please use apply with args.")
   }

--- a/common-test.native/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
+++ b/common-test.native/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
@@ -2,7 +2,7 @@ package org.scalatest
 
 import _root_.org.scalatest.tools.SuiteRunner
 
-class TestConcurrentDistributor(poolSize: Int) extends Distributor {
+class TestConcurrentDistributor extends Distributor {
   def apply(suite: Suite, tracker: Tracker) {
     throw new UnsupportedOperationException("Please use apply with args.")
   }

--- a/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
+++ b/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
@@ -24,7 +24,6 @@ import scala.collection.GenTraversable
 import scala.collection.SortedMap
 import scala.collection.SortedSet
 import FailureMessages.decorateToStringValue
-import java.util.concurrent.Executors
 import org.scalactic.Prettifier
 import org.scalactic.ArrayHelper.deep
 

--- a/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
+++ b/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
@@ -1,9 +1,9 @@
 package org.scalatest
 
 import org.scalatest.SharedHelpers.SilentReporter
-import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
 
-class TestConcurrentDistributor(poolSize: Int) extends tools.ConcurrentDistributor(Args(reporter = SilentReporter), Executors.newFixedThreadPool(poolSize)) {
+class TestConcurrentDistributor(execService: ExecutorService) extends tools.ConcurrentDistributor(Args(reporter = SilentReporter), execService) {
   override def apply(suite: Suite, tracker: Tracker): Unit = {
     throw new UnsupportedOperationException("Please use apply with args.")
   }

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllConfigMapSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllConfigMapSpec.scala
@@ -106,49 +106,71 @@ class BeforeAndAfterAllConfigMapSpec extends FunSpec {
 
   describe("BeforeAndAfterAll") {
     it ("should call beforeAll before any test starts, and call afterAll after all tests completed") {
-      val suite = new ExampleSuite()
-      val rep = new EventRecordingReporter()
-      val dist = new TestConcurrentDistributor(2)
-      suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-      dist.waitUntilDone()
+      // SKIP-SCALATESTJS,NATIVE-START
+      val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+      val dist = new TestConcurrentDistributor(execService)
+      // SKIP-SCALATESTJS,NATIVE-END
+      //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+      try {
+        val suite = new ExampleSuite()
+        val rep = new EventRecordingReporter()
+        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+        dist.waitUntilDone()
       
-      // should call beforeAll before any test starts
-      val beforeAllTime = suite.beforeAllTime
-      val testStartingEvents = rep.testStartingEventsReceived
-      testStartingEvents should have size 3
-      testStartingEvents.foreach { testStarting =>
-        beforeAllTime should be <= testStarting.timeStamp
+        // should call beforeAll before any test starts
+        val beforeAllTime = suite.beforeAllTime
+        val testStartingEvents = rep.testStartingEventsReceived
+        testStartingEvents should have size 3
+        testStartingEvents.foreach { testStarting =>
+          beforeAllTime should be <= testStarting.timeStamp
+        }
+      
+        // should call afterAll after all tests completed
+        val afterAllTime = suite.afterAllTime
+        val testSucceededEvents = rep.testSucceededEventsReceived
+        testSucceededEvents should have size 3
+        testSucceededEvents.foreach { testSucceeded =>
+          afterAllTime should be >= testSucceeded.timeStamp
+        }
       }
-      
-      // should call afterAll after all tests completed
-      val afterAllTime = suite.afterAllTime
-      val testSucceededEvents = rep.testSucceededEventsReceived
-      testSucceededEvents should have size 3
-      testSucceededEvents.foreach { testSucceeded =>
-        afterAllTime should be >= testSucceeded.timeStamp
+      finally {
+        // SKIP-SCALATESTJS,NATIVE-START
+        execService.shutdown()
+        // SKIP-SCALATESTJS,NATIVE-END
       }
     }
     it ("should call beforeAll before any test starts in nested suite, and call afterAll after all tests in nested suites completed") {
-      val suite = new ExampleSuites
-      val rep = new EventRecordingReporter
-      val dist = new TestConcurrentDistributor(2)
-      suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-      dist.waitUntilDone()
+      // SKIP-SCALATESTJS,NATIVE-START
+      val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+      val dist = new TestConcurrentDistributor(execService)
+      // SKIP-SCALATESTJS,NATIVE-END
+      //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+      try {
+        val suite = new ExampleSuites
+        val rep = new EventRecordingReporter
+        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+        dist.waitUntilDone()
       
-      // should call beforeAll before any test in nested suite starts
-      val beforeAllTime = suite.beforeAllTime
-      val testStartingEvents = rep.testStartingEventsReceived
-      testStartingEvents should have size 3
-      testStartingEvents.foreach { testStarting =>
-        beforeAllTime should be <= testStarting.timeStamp
+        // should call beforeAll before any test in nested suite starts
+        val beforeAllTime = suite.beforeAllTime
+        val testStartingEvents = rep.testStartingEventsReceived
+        testStartingEvents should have size 3
+        testStartingEvents.foreach { testStarting =>
+          beforeAllTime should be <= testStarting.timeStamp
+        }
+      
+        // should call afterAll after all tests completed
+        val afterAllTime = suite.afterAllTime
+        val testSucceededEvents = rep.testSucceededEventsReceived
+        testSucceededEvents should have size 3
+        testSucceededEvents.foreach { testSucceeded =>
+          afterAllTime should be >= testSucceeded.timeStamp
+        }
       }
-      
-      // should call afterAll after all tests completed
-      val afterAllTime = suite.afterAllTime
-      val testSucceededEvents = rep.testSucceededEventsReceived
-      testSucceededEvents should have size 3
-      testSucceededEvents.foreach { testSucceeded =>
-        afterAllTime should be >= testSucceeded.timeStamp
+      finally {
+        // SKIP-SCALATESTJS,NATIVE-START
+        execService.shutdown()
+        // SKIP-SCALATESTJS,NATIVE-END
       }
     }
     it ("should be called once for beforeAll and afterAll when used with OneInstancePerTest") {

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
@@ -57,25 +57,36 @@ class BeforeAndAfterAllProp extends AllSuiteProp {
   test("BeforeAndAfterAll should call beforeAll before any test starts, and call afterAll after all tests completed") {
     forAll(examples.filter(_.included)) { suite =>
       if (suite.included) {
-        val rep = new EventRecordingReporter()
-        val dist = new TestConcurrentDistributor(2)
-        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-        dist.waitUntilDone()
+        // SKIP-SCALATESTJS,NATIVE-START
+        val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val dist = new TestConcurrentDistributor(execService)
+        // SKIP-SCALATESTJS,NATIVE-END
+        //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+        try {
+          val rep = new EventRecordingReporter()
+          suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+          dist.waitUntilDone()
 
-        // should call beforeAll before any test starts
-        val beforeAllTime = suite.beforeAllTime
-        val testStartingEvents = rep.testStartingEventsReceived
-        testStartingEvents should have size 3
-        testStartingEvents.foreach { testStarting =>
-          beforeAllTime should be <= testStarting.timeStamp
+          // should call beforeAll before any test starts
+          val beforeAllTime = suite.beforeAllTime
+          val testStartingEvents = rep.testStartingEventsReceived
+          testStartingEvents should have size 3
+          testStartingEvents.foreach { testStarting =>
+            beforeAllTime should be <= testStarting.timeStamp
+          }
+
+          // should call afterAll after all tests completed
+          val afterAllTime = suite.afterAllTime
+          val testSucceededEvents = rep.testSucceededEventsReceived
+          testSucceededEvents should have size 3
+          testSucceededEvents.foreach { testSucceeded =>
+            afterAllTime should be >= testSucceeded.timeStamp
+          }
         }
-
-        // should call afterAll after all tests completed
-        val afterAllTime = suite.afterAllTime
-        val testSucceededEvents = rep.testSucceededEventsReceived
-        testSucceededEvents should have size 3
-        testSucceededEvents.foreach { testSucceeded =>
-          afterAllTime should be >= testSucceeded.timeStamp
+        finally {
+          // SKIP-SCALATESTJS,NATIVE-START
+          execService.shutdown()
+          // SKIP-SCALATESTJS,NATIVE-END
         }
       }
     }

--- a/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllSpec.scala
@@ -107,49 +107,74 @@ class BeforeAndAfterAllSpec extends FunSpec {
 
   describe("BeforeAndAfterAll") {
     it ("should call beforeAll before any test starts, and call afterAll after all tests completed") {
-      val suite = new ExampleSuite()
-      val rep = new EventRecordingReporter()
-      val dist = new TestConcurrentDistributor(2)
-      suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-      dist.waitUntilDone()
+      // SKIP-SCALATESTJS,NATIVE-START
+      val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+      val dist = new TestConcurrentDistributor(execService)
+      // SKIP-SCALATESTJS,NATIVE-END
+      //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+      try {
+        val suite = new ExampleSuite()
+        val rep = new EventRecordingReporter()
+        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+        dist.waitUntilDone()
       
-      // should call beforeAll before any test starts
-      val beforeAllTime = suite.beforeAllTime
-      val testStartingEvents = rep.testStartingEventsReceived
-      testStartingEvents should have size 3
-      testStartingEvents.foreach { testStarting =>
-        beforeAllTime should be <= testStarting.timeStamp
+        // should call beforeAll before any test starts
+        val beforeAllTime = suite.beforeAllTime
+        val testStartingEvents = rep.testStartingEventsReceived
+        testStartingEvents should have size 3
+        testStartingEvents.foreach { testStarting =>
+          beforeAllTime should be <= testStarting.timeStamp
+        }
+      
+        // should call afterAll after all tests completed
+        val afterAllTime = suite.afterAllTime
+        val testSucceededEvents = rep.testSucceededEventsReceived
+        testSucceededEvents should have size 3
+        testSucceededEvents.foreach { testSucceeded =>
+          afterAllTime should be >= testSucceeded.timeStamp
+        }
+      }
+      finally {
+        // SKIP-SCALATESTJS,NATIVE-START
+        execService.shutdown()
+        // SKIP-SCALATESTJS,NATIVE-END
       }
       
-      // should call afterAll after all tests completed
-      val afterAllTime = suite.afterAllTime
-      val testSucceededEvents = rep.testSucceededEventsReceived
-      testSucceededEvents should have size 3
-      testSucceededEvents.foreach { testSucceeded =>
-        afterAllTime should be >= testSucceeded.timeStamp
-      }
     }
     it ("should call beforeAll before any test starts in nested suite, and call afterAll after all tests in nested suites completed") {
       val suite = new ExampleSuites
       val rep = new EventRecordingReporter
-      val dist = new TestConcurrentDistributor(2)
-      suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-      dist.waitUntilDone()
+
+      // SKIP-SCALATESTJS,NATIVE-START
+      val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+      val dist = new TestConcurrentDistributor(execService)
+      // SKIP-SCALATESTJS,NATIVE-END
+      //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+
+      try {
+        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+        dist.waitUntilDone()
       
-      // should call beforeAll before any test in nested suite starts
-      val beforeAllTime = suite.beforeAllTime
-      val testStartingEvents = rep.testStartingEventsReceived
-      testStartingEvents should have size 3
-      testStartingEvents.foreach { testStarting =>
-        beforeAllTime should be <= testStarting.timeStamp
+        // should call beforeAll before any test in nested suite starts
+        val beforeAllTime = suite.beforeAllTime
+        val testStartingEvents = rep.testStartingEventsReceived
+        testStartingEvents should have size 3
+        testStartingEvents.foreach { testStarting =>
+          beforeAllTime should be <= testStarting.timeStamp
+        }
+      
+        // should call afterAll after all tests completed
+        val afterAllTime = suite.afterAllTime
+        val testSucceededEvents = rep.testSucceededEventsReceived
+        testSucceededEvents should have size 3
+        testSucceededEvents.foreach { testSucceeded =>
+          afterAllTime should be >= testSucceeded.timeStamp
+        }
       }
-      
-      // should call afterAll after all tests completed
-      val afterAllTime = suite.afterAllTime
-      val testSucceededEvents = rep.testSucceededEventsReceived
-      testSucceededEvents should have size 3
-      testSucceededEvents.foreach { testSucceeded =>
-        afterAllTime should be >= testSucceeded.timeStamp
+      finally {
+        // SKIP-SCALATESTJS,NATIVE-START
+        execService.shutdown()
+        // SKIP-SCALATESTJS,NATIVE-END
       }
     }
     it ("should be called once for beforeAll and afterAll when used with OneInstancePerTest") {

--- a/scalatest-test/src/test/scala/org/scalatest/DeprecatedBeforeAndAfterAllProp.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/DeprecatedBeforeAndAfterAllProp.scala
@@ -57,25 +57,36 @@ class DeprecatedBeforeAndAfterAllProp extends AllSuiteProp {
   test("BeforeAndAfterAll should call beforeAll before any test starts, and call afterAll after all tests completed") {
     forAll(examples.filter(_.included)) { suite =>
       if (suite.included) {
-        val rep = new EventRecordingReporter()
-        val dist = new TestConcurrentDistributor(2)
-        suite.run(None, Args(reporter = rep, distributor = Some(dist)))
-        dist.waitUntilDone()
+        // SKIP-SCALATESTJS,NATIVE-START
+        val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val dist = new TestConcurrentDistributor(execService)
+        // SKIP-SCALATESTJS,NATIVE-END
+        //SCALATESTJS,NATIVE-ONLY val dist = new TestConcurrentDistributor()
+        try {
+          val rep = new EventRecordingReporter()
+          suite.run(None, Args(reporter = rep, distributor = Some(dist)))
+          dist.waitUntilDone()
 
-        // should call beforeAll before any test starts
-        val beforeAllTime = suite.beforeAllTime
-        val testStartingEvents = rep.testStartingEventsReceived
-        testStartingEvents should have size 3
-        testStartingEvents.foreach { testStarting =>
-          beforeAllTime should be <= testStarting.timeStamp
+          // should call beforeAll before any test starts
+          val beforeAllTime = suite.beforeAllTime
+          val testStartingEvents = rep.testStartingEventsReceived
+          testStartingEvents should have size 3
+          testStartingEvents.foreach { testStarting =>
+            beforeAllTime should be <= testStarting.timeStamp
+          }
+
+          // should call afterAll after all tests completed
+          val afterAllTime = suite.afterAllTime
+          val testSucceededEvents = rep.testSucceededEventsReceived
+          testSucceededEvents should have size 3
+          testSucceededEvents.foreach { testSucceeded =>
+            afterAllTime should be >= testSucceeded.timeStamp
+          }
         }
-
-        // should call afterAll after all tests completed
-        val afterAllTime = suite.afterAllTime
-        val testSucceededEvents = rep.testSucceededEventsReceived
-        testSucceededEvents should have size 3
-        testSucceededEvents.foreach { testSucceeded =>
-          afterAllTime should be >= testSucceeded.timeStamp
+        finally {
+          // SKIP-SCALATESTJS,NATIVE-START
+          execService.shutdown()
+          // SKIP-SCALATESTJS,NATIVE-END
         }
       }
     }

--- a/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSpec.scala
@@ -85,7 +85,7 @@ class ParallelTestExecutionSpec extends FunSpec with EventHelpers {
       private val futureQueue = new java.util.concurrent.LinkedBlockingQueue[Future[T] forSome { type T }]
       
       val buf = ListBuffer.empty[SuiteRunner]
-      val execSvc: ExecutorService = Executors.newFixedThreadPool(2)
+      val execSvc: ExecutorService = Executors.newFixedThreadPool(poolSize)
       def apply(suite: Suite, args: Args): Status = {
         val status = new ScalaTestStatefulStatus
         buf += new SuiteRunner(suite, args, status)
@@ -110,6 +110,10 @@ class ParallelTestExecutionSpec extends FunSpec with EventHelpers {
 
       def apply(suite: Suite, tracker: Tracker): Unit = {
         throw new UnsupportedOperationException("Hey, we're not supposed to be calling this anymore!")
+      }
+
+      def shutdown(): Unit = {
+        execSvc.shutdown()
       }
     }
     // SKIP-SCALATESTJS,NATIVE-END
@@ -200,34 +204,39 @@ class ParallelTestExecutionSpec extends FunSpec with EventHelpers {
     // SKIP-SCALATESTJS,NATIVE-START
     it("should have the blocking test's events fired without waiting when timeout reaches, and when the missing event finally reach later, it should just get fired") {
       def withDistributor(fun: ControlledOrderConcurrentDistributor => Unit): Unit = {
-        val recordingReporter = new EventRecordingReporter
-        val args = Args(recordingReporter)
         val outOfOrderConcurrentDistributor = new ControlledOrderConcurrentDistributor(2)
-        (new ExampleTimeoutParallelSpec).run(None, Args(recordingReporter, distributor = Some(outOfOrderConcurrentDistributor)))
-        fun(outOfOrderConcurrentDistributor)
+        try {
+          val recordingReporter = new EventRecordingReporter
+          val args = Args(recordingReporter)
+          (new ExampleTimeoutParallelSpec).run(None, Args(recordingReporter, distributor = Some(outOfOrderConcurrentDistributor)))
+          fun(outOfOrderConcurrentDistributor)
 
-        val eventRecorded = recordingReporter.eventsReceived
-        assert(eventRecorded.size === 16)
+          val eventRecorded = recordingReporter.eventsReceived
+          assert(eventRecorded.size === 16)
 
-        checkScopeOpened(eventRecorded(0), "Thing 1")
-        checkTestStarting(eventRecorded(1), "Thing 1 do thing 1a")
-        checkTestSucceeded(eventRecorded(2), "Thing 1 do thing 1a")
-        checkTestStarting(eventRecorded(3), "Thing 1 do thing 1b")        
-        checkTestStarting(eventRecorded(4), "Thing 1 do thing 1c")
-        checkTestSucceeded(eventRecorded(5), "Thing 1 do thing 1c")
-        checkScopeClosed(eventRecorded(6), "Thing 1")
+          checkScopeOpened(eventRecorded(0), "Thing 1")
+          checkTestStarting(eventRecorded(1), "Thing 1 do thing 1a")
+          checkTestSucceeded(eventRecorded(2), "Thing 1 do thing 1a")
+          checkTestStarting(eventRecorded(3), "Thing 1 do thing 1b")        
+          checkTestStarting(eventRecorded(4), "Thing 1 do thing 1c")
+          checkTestSucceeded(eventRecorded(5), "Thing 1 do thing 1c")
+          checkScopeClosed(eventRecorded(6), "Thing 1")
         
-        checkScopeOpened(eventRecorded(7), "Thing 2")
-        checkTestStarting(eventRecorded(8), "Thing 2 do thing 2a")
-        checkTestSucceeded(eventRecorded(9), "Thing 2 do thing 2a")
-        checkTestStarting(eventRecorded(10), "Thing 2 do thing 2b")
-        checkTestSucceeded(eventRecorded(11), "Thing 2 do thing 2b")
-        checkTestStarting(eventRecorded(12), "Thing 2 do thing 2c")
-        checkTestSucceeded(eventRecorded(13), "Thing 2 do thing 2c")
-        checkScopeClosed(eventRecorded(14), "Thing 2")
+          checkScopeOpened(eventRecorded(7), "Thing 2")
+          checkTestStarting(eventRecorded(8), "Thing 2 do thing 2a")
+          checkTestSucceeded(eventRecorded(9), "Thing 2 do thing 2a")
+          checkTestStarting(eventRecorded(10), "Thing 2 do thing 2b")
+          checkTestSucceeded(eventRecorded(11), "Thing 2 do thing 2b")
+          checkTestStarting(eventRecorded(12), "Thing 2 do thing 2c")
+          checkTestSucceeded(eventRecorded(13), "Thing 2 do thing 2c")
+          checkScopeClosed(eventRecorded(14), "Thing 2")
         
-        // Now the missing one.
-        checkTestSucceeded(eventRecorded(15), "Thing 1 do thing 1b")
+          // Now the missing one.
+          checkTestSucceeded(eventRecorded(15), "Thing 1 do thing 1b")
+        }
+        finally {
+          outOfOrderConcurrentDistributor.shutdown()
+        }
       }
 
       withDistributor(_.executeInOrder())
@@ -237,25 +246,29 @@ class ParallelTestExecutionSpec extends FunSpec with EventHelpers {
     // TODO: Check with Chee Seng. I'm not sure what this is supposed to be testing, and it fails.
     it("should have the events reported in correct order when multiple suite's tests are executed in parallel") {
       def withDistributor(fun: ControlledOrderConcurrentDistributor => Unit) = {
-        val recordingReporter = new EventRecordingReporter
         val outOfOrderConcurrentDistributor = new ControlledOrderConcurrentDistributor(2)
-        val suiteSortingReporter = new SuiteSortingReporter(recordingReporter, Span(5, Seconds), new PrintStream(new ByteArrayOutputStream))
-        val spec1 = new ExampleParallelSpec()
-        val spec2 = new ExampleBeforeAfterParallelSpec()
+        try {
+          val recordingReporter = new EventRecordingReporter
+          val suiteSortingReporter = new SuiteSortingReporter(recordingReporter, Span(5, Seconds), new PrintStream(new ByteArrayOutputStream))
+          val spec1 = new ExampleParallelSpec()
+          val spec2 = new ExampleBeforeAfterParallelSpec()
         
-        val tracker = new Tracker()
-        suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
-        suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
+          val tracker = new Tracker()
+          suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
+          suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
         
-        spec1.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
-        spec2.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
+          spec1.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
+          spec2.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
         
-        suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
-        suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
+          suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
+          suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
         
-        fun(outOfOrderConcurrentDistributor)
-        
-        recordingReporter.eventsReceived
+          fun(outOfOrderConcurrentDistributor)
+          recordingReporter.eventsReceived
+        }
+        finally {
+          outOfOrderConcurrentDistributor.shutdown()
+        }
       }
       
       val spec1SuiteId = new ExampleParallelSpec().suiteId
@@ -375,74 +388,80 @@ class ParallelTestExecutionSpec extends FunSpec with EventHelpers {
     }
     
     it("should have the blocking suite's events fired without waiting when timeout reaches, and when the missing event finally reach later, it should just get fired") {
-      val recordingReporter = new EventRecordingReporter
-      val args = Args(recordingReporter)
       val outOfOrderConcurrentDistributor = new ControlledOrderConcurrentDistributor(2)
-      val suiteSortingReporter = new SuiteSortingReporter(recordingReporter, Span(1, Second), new PrintStream(new ByteArrayOutputStream))
-      val spec1 = new ExampleSuiteTimeoutSpec()
-      val spec2 = new ExampleSuiteTimeoutSpec2()
-        
-      val tracker = new Tracker()
+      try {
+        val recordingReporter = new EventRecordingReporter
+        val args = Args(recordingReporter)
       
-      suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
-      suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
+        val suiteSortingReporter = new SuiteSortingReporter(recordingReporter, Span(1, Second), new PrintStream(new ByteArrayOutputStream))
+        val spec1 = new ExampleSuiteTimeoutSpec()
+        val spec2 = new ExampleSuiteTimeoutSpec2()
+        
+        val tracker = new Tracker()
       
-      spec1.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
-      spec2.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
-        
-      suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
-      suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
+        suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
+        suiteSortingReporter(SuiteStarting(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
       
-      outOfOrderConcurrentDistributor.executeInOrder()
+        spec1.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
+        spec2.run(None, Args(suiteSortingReporter, distributor = Some(outOfOrderConcurrentDistributor), distributedSuiteSorter = Some(suiteSortingReporter)))
         
-      val eventRecorded = recordingReporter.eventsReceived
-      println(eventRecorded.map(e => e.getClass.getName).mkString("\n"))
+        suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec1.suiteName, spec1.suiteId, Some(spec1.getClass.getName), None))
+        suiteSortingReporter(SuiteCompleted(tracker.nextOrdinal, spec2.suiteName, spec2.suiteId, Some(spec2.getClass.getName), None))
+      
+        outOfOrderConcurrentDistributor.executeInOrder()
         
-      assert(eventRecorded.size === 34)
+        val eventRecorded = recordingReporter.eventsReceived
+        println(eventRecorded.map(e => e.getClass.getName).mkString("\n"))
+        
+        assert(eventRecorded.size === 34)
 
-      checkSuiteStarting(eventRecorded(0), spec1.suiteId)
+        checkSuiteStarting(eventRecorded(0), spec1.suiteId)
         
-      checkScopeOpened(eventRecorded(1), "Thing 1")
-      checkTestStarting(eventRecorded(2), "Thing 1 do thing 1a")
-      checkTestSucceeded(eventRecorded(3), "Thing 1 do thing 1a")
-      checkTestStarting(eventRecorded(4), "Thing 1 do thing 1b")
-      checkTestSucceeded(eventRecorded(5), "Thing 1 do thing 1b")
-      checkTestStarting(eventRecorded(6), "Thing 1 do thing 1c")
-      checkTestSucceeded(eventRecorded(7), "Thing 1 do thing 1c")
-      checkScopeClosed(eventRecorded(8), "Thing 1")
+        checkScopeOpened(eventRecorded(1), "Thing 1")
+        checkTestStarting(eventRecorded(2), "Thing 1 do thing 1a")
+        checkTestSucceeded(eventRecorded(3), "Thing 1 do thing 1a")
+        checkTestStarting(eventRecorded(4), "Thing 1 do thing 1b")
+        checkTestSucceeded(eventRecorded(5), "Thing 1 do thing 1b")
+        checkTestStarting(eventRecorded(6), "Thing 1 do thing 1c")
+        checkTestSucceeded(eventRecorded(7), "Thing 1 do thing 1c")
+        checkScopeClosed(eventRecorded(8), "Thing 1")
         
-      checkScopeOpened(eventRecorded(9), "Thing 2")
-      checkTestStarting(eventRecorded(10), "Thing 2 do thing 2a")
-      checkTestSucceeded(eventRecorded(11), "Thing 2 do thing 2a")
-      // SuiteSortingReporter timeout should hit here.
-      checkSuiteCompleted(eventRecorded(12), spec1.suiteId)
+        checkScopeOpened(eventRecorded(9), "Thing 2")
+        checkTestStarting(eventRecorded(10), "Thing 2 do thing 2a")
+        checkTestSucceeded(eventRecorded(11), "Thing 2 do thing 2a")
+        // SuiteSortingReporter timeout should hit here.
+        checkSuiteCompleted(eventRecorded(12), spec1.suiteId)
        
-      checkSuiteStarting(eventRecorded(13), spec2.suiteId)
+        checkSuiteStarting(eventRecorded(13), spec2.suiteId)
         
-      checkScopeOpened(eventRecorded(14), "Subject 1")
-      checkTestStarting(eventRecorded(15), "Subject 1 content 1a")
-      checkTestSucceeded(eventRecorded(16), "Subject 1 content 1a")
-      checkTestStarting(eventRecorded(17), "Subject 1 content 1b")
-      checkTestSucceeded(eventRecorded(18), "Subject 1 content 1b")
-      checkTestStarting(eventRecorded(19), "Subject 1 content 1c")
-      checkTestSucceeded(eventRecorded(20), "Subject 1 content 1c")
-      checkScopeClosed(eventRecorded(21), "Subject 1")
+        checkScopeOpened(eventRecorded(14), "Subject 1")
+        checkTestStarting(eventRecorded(15), "Subject 1 content 1a")
+        checkTestSucceeded(eventRecorded(16), "Subject 1 content 1a")
+        checkTestStarting(eventRecorded(17), "Subject 1 content 1b")
+        checkTestSucceeded(eventRecorded(18), "Subject 1 content 1b")
+        checkTestStarting(eventRecorded(19), "Subject 1 content 1c")
+        checkTestSucceeded(eventRecorded(20), "Subject 1 content 1c")
+        checkScopeClosed(eventRecorded(21), "Subject 1")
         
-      checkScopeOpened(eventRecorded(22), "Subject 2")
-      checkTestStarting(eventRecorded(23), "Subject 2 content 2a")
-      checkTestSucceeded(eventRecorded(24), "Subject 2 content 2a")
-      checkTestStarting(eventRecorded(25), "Subject 2 content 2b")
-      checkTestSucceeded(eventRecorded(26), "Subject 2 content 2b")
-      checkTestStarting(eventRecorded(27), "Subject 2 content 2c")
-      checkTestSucceeded(eventRecorded(28), "Subject 2 content 2c")
-      checkScopeClosed(eventRecorded(29), "Subject 2")
+        checkScopeOpened(eventRecorded(22), "Subject 2")
+        checkTestStarting(eventRecorded(23), "Subject 2 content 2a")
+        checkTestSucceeded(eventRecorded(24), "Subject 2 content 2a")
+        checkTestStarting(eventRecorded(25), "Subject 2 content 2b")
+        checkTestSucceeded(eventRecorded(26), "Subject 2 content 2b")
+        checkTestStarting(eventRecorded(27), "Subject 2 content 2c")
+        checkTestSucceeded(eventRecorded(28), "Subject 2 content 2c")
+        checkScopeClosed(eventRecorded(29), "Subject 2")
         
-      checkSuiteCompleted(eventRecorded(30), spec2.suiteId)
+        checkSuiteCompleted(eventRecorded(30), spec2.suiteId)
        
-      // Now the missing ones.
-      checkTestStarting(eventRecorded(31), "Thing 2 do thing 2b")
-      checkTestSucceeded(eventRecorded(32), "Thing 2 do thing 2b")
-      checkScopeClosed(eventRecorded(33), "Thing 2")
+        // Now the missing ones.
+        checkTestStarting(eventRecorded(31), "Thing 2 do thing 2b")
+        checkTestSucceeded(eventRecorded(32), "Thing 2 do thing 2b")
+        checkScopeClosed(eventRecorded(33), "Thing 2")
+      }
+      finally {
+        outOfOrderConcurrentDistributor.shutdown()
+      }
     }
     // SKIP-SCALATESTJS,NATIVE-END
     

--- a/scalatest-test/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
@@ -52,17 +52,39 @@ class SequentialNestedSuiteExecutionSpec extends FunSpec {
         class SeqSubSuite extends SuperSuite with SequentialNestedSuiteExecution
         val par = new ParSubSuite
         val seq = new SeqSubSuite
-        val parStatus = par.run(None, Args(SilentReporter, distributor = Some(new TestConcurrentDistributor(2))))
+
         // SKIP-SCALATESTJS,NATIVE-START
-        parStatus.waitUntilCompleted()
+        val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val execService2 = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val distributor = new TestConcurrentDistributor(execService)
         // SKIP-SCALATESTJS,NATIVE-END
-        assert(par.distributorWasDefined)
-        assert(par.distributorWasPropagated)
-        val seqStatus = seq.run(None, Args(SilentReporter, distributor = Some(new TestConcurrentDistributor(2))))
-        assert(seqStatus.isCompleted) // When a seqential execution returns, the whole thing should be completed already
-        assert(!seq.distributorWasDefined)
-        assert(!seq.distributorWasPropagated)
-        assert(seq.lastNestedSuiteWasRunAfterFirst)
+        //SCALATESTJS,NATIVE-ONLY val distributor = new TestConcurrentDistributor()
+
+        try {
+          val parStatus = par.run(None, Args(SilentReporter, distributor = Some(distributor)))
+          // SKIP-SCALATESTJS,NATIVE-START
+          parStatus.waitUntilCompleted()
+          // SKIP-SCALATESTJS,NATIVE-END
+          assert(par.distributorWasDefined)
+          assert(par.distributorWasPropagated)
+
+          // SKIP-SCALATESTJS,NATIVE-START
+          val distributor2 = new TestConcurrentDistributor(execService2)
+          // SKIP-SCALATESTJS,NATIVE-END
+          //SCALATESTJS,NATIVE-ONLY val distributor2 = new TestConcurrentDistributor()
+
+          val seqStatus = seq.run(None, Args(SilentReporter, distributor = Some(distributor2)))
+          assert(seqStatus.isCompleted) // When a seqential execution returns, the whole thing should be completed already
+          assert(!seq.distributorWasDefined)
+          assert(!seq.distributorWasPropagated)
+          assert(seq.lastNestedSuiteWasRunAfterFirst)
+        }
+        finally {
+          // SKIP-SCALATESTJS,NATIVE-START
+          execService.shutdown()
+          execService2.shutdown()
+          // SKIP-SCALATESTJS,NATIVE-END
+        }
       }
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
@@ -54,19 +54,40 @@ class StepwiseNestedSuiteExecutionSpec extends FunSpec {
         class SeqSubSuite extends SuperSuite with StepwiseNestedSuiteExecution
         val par = new ParSubSuite
         val stp = new SeqSubSuite
-        val parStatus = par.run(None, Args(SilentReporter, distributor = Some(new TestConcurrentDistributor(2))))
+
         // SKIP-SCALATESTJS,NATIVE-START
-        parStatus.waitUntilCompleted()
+        val execService = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val execService2 = java.util.concurrent.Executors.newFixedThreadPool(2)
+        val distributor = new TestConcurrentDistributor(execService)
         // SKIP-SCALATESTJS,NATIVE-END
-        assert(par.superRunNestedSuitesWasInvoked )
-        assert(par.distributorWasDefined)
-        assert(par.distributorWasPropagated) // This flickers. Is this a problem with volatile?
-        val stpStatus = stp.run(None, Args(SilentReporter, distributor = Some(new TestConcurrentDistributor(2))))
-        assert(stpStatus.isCompleted) // When a stepwise execution returns, the whole thing should be completed already, even though some of it may have run in parallel
-        assert(!stp.superRunNestedSuitesWasInvoked )
-        assert(!stp.distributorWasDefined)
-        assert(stp.distributorWasPropagated)
-        assert(stp.lastNestedSuiteWasRunAfterFirst)
+        //SCALATESTJS,NATIVE-ONLY val distributor = new TestConcurrentDistributor()
+        try {
+          val parStatus = par.run(None, Args(SilentReporter, distributor = Some(distributor)))
+          // SKIP-SCALATESTJS,NATIVE-START
+          parStatus.waitUntilCompleted()
+          // SKIP-SCALATESTJS,NATIVE-END
+          assert(par.superRunNestedSuitesWasInvoked )
+          assert(par.distributorWasDefined)
+          assert(par.distributorWasPropagated) // This flickers. Is this a problem with volatile?
+
+          // SKIP-SCALATESTJS,NATIVE-START
+          val distributor2 = new TestConcurrentDistributor(execService2)
+          // SKIP-SCALATESTJS,NATIVE-END
+          //SCALATESTJS,NATIVE-ONLY val distributor2 = new TestConcurrentDistributor()
+
+          val stpStatus = stp.run(None, Args(SilentReporter, distributor = Some(distributor2)))
+          assert(stpStatus.isCompleted) // When a stepwise execution returns, the whole thing should be completed already, even though some of it may have run in parallel
+          assert(!stp.superRunNestedSuitesWasInvoked )
+          assert(!stp.distributorWasDefined)
+          assert(stp.distributorWasPropagated)
+          assert(stp.lastNestedSuiteWasRunAfterFirst)
+        }
+        finally {
+          // SKIP-SCALATESTJS,NATIVE-START
+          execService.shutdown()
+          execService2.shutdown()
+          // SKIP-SCALATESTJS,NATIVE-END
+        }
       }
     }
   }

--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
@@ -98,16 +98,19 @@ class ConductorSuite extends FunSuite with Matchers with Conductors with Severed
           "must have a unique name") {
 
     val conductor = new Conductor
-    conductor.threadNamed("Fiesta del Mar") { 1 should be (1) }
-    val caught =
-      intercept[NotAllowedException] {
-        conductor.threadNamed("Fiesta del Mar") { 2 should be (2) }
+    try {
+      conductor.threadNamed("Fiesta del Mar") { 1 should be (1) }
+      val caught =
+        intercept[NotAllowedException] {
+          conductor.threadNamed("Fiesta del Mar") { 2 should be (2) }
+        }
+      caught.getMessage should be ("Cannot register two threads with the same name. Duplicate name: Fiesta del Mar.")
+      caught.failedCodeFileNameAndLineNumberString match {
+        case Some(s) => s should equal ("ConductorSuite.scala:" + (thisLineNumber - 4))
+        case None => fail("Didn't produce a file name and line number string: ", caught)
       }
-    caught.getMessage should be ("Cannot register two threads with the same name. Duplicate name: Fiesta del Mar.")
-    caught.failedCodeFileNameAndLineNumberString match {
-      case Some(s) => s should equal ("ConductorSuite.scala:" + (thisLineNumber - 4))
-      case None => fail("Didn't produce a file name and line number string: ", caught)
     }
+    finally conductor.conduct
   }
 
   test("waitForBeat throws NotAllowedException if is called with zero or a negative number") {

--- a/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -1052,8 +1052,13 @@ class FrameworkSuite extends FunSuite {
                                      new TaskDef("org.scalatest.SuiteSuite", subclassFingerprint, false, Array(new SuiteSelector))))
       assert(tasks.size === 1)
       val runner2 = framework.runner(Array("-m", "org.scalatest.concurrent"), Array.empty, testClassLoader)
-      val tasks2 = runner2.tasks(Array(new TaskDef("org.scalatest.enablers.NoParamSpec", subclassFingerprint, false, Array(new SuiteSelector))))
-      assert(tasks2.size === 0)
+      try {
+        val tasks2 = runner2.tasks(Array(new TaskDef("org.scalatest.enablers.NoParamSpec", subclassFingerprint, false, Array(new SuiteSelector))))
+        assert(tasks2.size === 0)
+      }
+      finally {
+        runner2.done()
+      }
     }
     finally {
       runner.done()
@@ -1097,7 +1102,8 @@ class FrameworkSuite extends FunSuite {
   }
 
   test("Framework.runner accept without problem when -P 4 is passed in") {
-    framework.runner(Array("-P4"), Array.empty, testClassLoader)
+    val runner = framework.runner(Array("-P4"), Array.empty, testClassLoader)
+    runner.done()
   }
 
   test("Framework.runner should throw IllegalArgumentException when -P0 is passed in") {
@@ -1143,7 +1149,8 @@ class FrameworkSuite extends FunSuite {
   }
 
   test("Framework.runner should be able to pass in test sorting timeout with -T") {
-    framework.runner(Array("-T", "100"), Array.empty, testClassLoader)
+    val runner = framework.runner(Array("-T", "100"), Array.empty, testClassLoader)
+    runner.done()
   }
   
   private def makeSureDone(runners: Runner*)(fun: => Unit): Unit = {

--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
@@ -45,8 +45,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
     }
   }
   
-  private val timer = new Timer
-  private var timeoutTask: Option[TimeoutTask] = None
+  private var timeoutTask: Option[(TimeoutTask, Timer)] = None
 
   def doApply(event: Event): Unit = {
     synchronized {
@@ -177,6 +176,8 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
         slotListBuf = fireReadySuiteEvents(slotListBuf.tail)
         if (slotListBuf.size > 0) 
           scheduleTimeoutTask()
+        else 
+          cancelTimeoutTask()
       }
     }
   }
@@ -283,23 +284,38 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
   private def scheduleTimeoutTask(): Unit = {
     val head = slotListBuf.head  // Assumes waitingBuffer is non-empty. Put a require there to make that obvious.
     timeoutTask match {
-        case Some(task) => 
-          if (head.suiteId != task.slot.suiteId) {
-            task.cancel()
-            timeoutTask = Some(new TimeoutTask(head)) // Replace the old with the new
-            timer.schedule(timeoutTask.get, testSortingTimeout.millisPart)
+        case Some((oldTask, oldTimer)) => 
+          if (head.suiteId != oldTask.slot.suiteId) {
+            oldTask.cancel()
+            oldTimer.cancel()
+            val (task, timer) = (new TimeoutTask(head), new Timer)
+            timeoutTask = Some((task, timer)) // Replace the old with the new
+            timer.schedule(task, testSortingTimeout.millisPart)
           }
         case None => 
-          timeoutTask = Some(new TimeoutTask(head)) // Just create a new one
-          timer.schedule(timeoutTask.get, testSortingTimeout.millisPart)
+          val (task, timer) = (new TimeoutTask(head), new Timer)
+          timeoutTask = Some((task, timer)) // Just create a new one
+          timer.schedule(task, testSortingTimeout.millisPart)
       }
+  }
+
+  // Also happening inside synchronized block
+  private def cancelTimeoutTask(): Unit = {
+    timeoutTask match { // Waiting buffer is zero, so no timeout needed
+      case Some((task, timer)) => 
+        task.cancel()
+        timer.cancel()
+        timeoutTask = None
+      case None =>
+    }
   }
   
   private def timeout(): Unit = {
     synchronized {
       if (slotListBuf.size > 0) {
         val head = slotListBuf.head
-        if (timeoutTask.get.slot.suiteId == head.suiteId) { // Probably a double check, or just in case there's race condition
+        val (task, _) = timeoutTask.get
+        if (task.slot.suiteId == head.suiteId) { // Probably a double check, or just in case there's race condition
           val newSlot = head.copy(ready = true) // Essentially, if time out, just say that one is ready. This test's events go out, and
           slotListBuf.update(0, newSlot)
         }


### PR DESCRIPTION
This is to address the same issue as this PR: 

https://github.com/scalatest/scalatest/pull/1591

In addition, we also added the missing shutdown calls to ExecutorService created in tests.