### PR TITLE
Support right-bias of `Either` in `EitherValues`

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -43,15 +43,15 @@ class EitherValuesSpec extends FunSpec {
     
     it("should return the right value inside an either if right.value is defined") {
       val e: Either[String, String] = Right("hi there")
-      e.right.value should === ("hi there")
-      e.right.value should startWith ("hi")
+      e.value should === ("hi there")
+      e.value should startWith ("hi")
     }
     
     it("should throw TestFailedException if right.value is empty") {
       val e: Either[String, String] = Left("hi there")
       val caught = 
         the [TestFailedException] thrownBy {
-          e.right.value should startWith ("hi")
+          e.value should startWith ("hi")
         }
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
@@ -65,7 +65,7 @@ class EitherValuesSpec extends FunSpec {
 
     it("should allow an immediate application of parens to invoke apply on the type contained in the Right") {
       val righty: Either[String, Map[String, Int]] = Right(Map("I" -> 1, "II" -> 2))
-      righty.right.value("II") shouldBe 2
+      righty.value("II") shouldBe 2
     }
   } 
 }

--- a/scalatest/src/main/scala/org/scalatest/EitherValues.scala
+++ b/scalatest/src/main/scala/org/scalatest/EitherValues.scala
@@ -20,9 +20,9 @@ import org.scalatest.exceptions.StackDepthException
 import org.scalatest.exceptions.TestFailedException
 
 /**
- * Trait that provides an implicit conversion that adds <code>left.value</code> and <code>right.value</code> methods
- * to <code>Either</code>, which will return the selected value of the <code>Either</code> if defined,
- * or throw <code>TestFailedException</code> if not.
+ * Trait that provides an implicit conversion that adds <code>value</code>, <code>left.value</code> and
+ * <code>right.value</code> methods to <code>Either</code>, which will return the selected value of the
+ * <code>Either</code> if defined, or throw <code>TestFailedException</code> if not.
  *
  * <p>
  * This construct allows you to express in one statement that an <code>Either</code> should be <em>left</em> or <em>right</em>
@@ -30,6 +30,7 @@ import org.scalatest.exceptions.TestFailedException
  * </p>
  *
  * <pre class="stHighlight">
+ * either1.value should be &gt; 9 // Either is right-biased since Scala 2.12)
  * either1.right.value should be &gt; 9
  * either2.left.value should be ("Muchas problemas")
  * </pre>
@@ -39,6 +40,7 @@ import org.scalatest.exceptions.TestFailedException
  * </p>
  *
  * <pre class="stHighlight">
+ * assert(either1.value &gt; 9)
  * assert(either1.right.value &gt; 9)
  * assert(either2.left.value === "Muchas problemas")
  * </pre>
@@ -83,6 +85,14 @@ import org.scalatest.exceptions.TestFailedException
 trait EitherValues {
 
   import scala.language.implicitConversions
+
+  /**
+   * Implicit conversion that adds a (right) biased <code>value</code> method to <code>Either</code>
+   * (which since Scala 2.12 has been right-biased).
+   *
+   * @param either the <code>Either</code> on which to add the <code>value</code> method
+   */
+  implicit def convertEitherToValuable[L, R](either: Either[L, R])(implicit pos: source.Position): RightValuable[L, R] = new RightValuable(either.right, pos)
 
   /**
    * Implicit conversion that adds a <code>value</code> method to <code>LeftProjection</code>.
@@ -141,7 +151,7 @@ trait EitherValues {
 
     /**
      * Returns the <code>Right</code> value contained in the wrapped <code>RightProjection</code>, if defined as a <code>Right</code>, else throws <code>TestFailedException</code> with
-     * a detail message indicating the <code>Either</code> was defined as a <code>Right</code>, not a <code>Left</code>.
+     * a detail message indicating the <code>Either</code> was defined as a <code>Left</code>, not a <code>Right</code>.
      */
     def value: R = {
       try {


### PR DESCRIPTION
* https://github.com/scala/scala/pull/5135 - `Either` became right-biased in Scala 2.12
* https://github.com/scala/scala/pull/6682 - `either.right` becomes a **deprecated** field with Scala 2.13

With Scala 2.13, it's no longer possible to test an `Either`'s right value using ScalaTest's `EitherValues` without getting a deprecating warning - ie writing:

```
either.right.value should be > 9
```

will give you this error/warning on compile (for our project, deprecation warnings are fatal):

```
method right in class Either is deprecated (since 2.13.0): Either is now
right-biased, use methods directly on Either
```

Given that `Either` is now right-biased, this PR gives us the ability to write:

```
either.value should be > 9
```