### PR TITLE
[3.2] correcting text content of property elements of jUnit result files

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -459,8 +459,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
     <properties> {
       for (name <- propertyNames(sysprops))
         yield
-          <property name={ name } value = { sysprops.getProperty(name) }>
-          </property>
+          <property name={ name } value = { sysprops.getProperty(name) }/>
     }
     </properties>
   }


### PR DESCRIPTION
Cherry-picks fix from the following PR into 3.2:

https://github.com/scalatest/scalatest/pull/1768