### PR TITLE
be Scala 2.13.3 friendly (Symbol#toString changed)

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
+++ b/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
@@ -160,7 +160,7 @@ trait PrivateMethodTester {
       import invocation._
 
       // If 'getMessage passed as methodName, methodNameToInvoke would be "getMessage"
-      val methodNameToInvoke = methodName.toString.substring(1)
+      val methodNameToInvoke = methodName.name
 
       def isMethodToInvoke(m: Method) = {
 


### PR DESCRIPTION
the old code relied on this assumption:
`mySymbol.name == mySymbol.toString.drop(1)`
but Scala 2.13.3 is changing `Symbol#toString` to be
e.g. `Symbol(foo)` instead of `'foo`

the new code works fine on any Scala version.  I cannot see
any reason for the old code to be the way it was