### PR TITLE
Use overload instead of override to implement Assertions.{assert, assume}

### DIFF
--- a/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
@@ -468,7 +468,7 @@ trait Assertions extends TripleEquals  {
    * @throws TestFailedException if the condition is <code>false</code>.
    */
   inline def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
-    ${ AssertionsMacro.assert('this, 'condition, 'prettifier, 'pos, '{""}) }
+    ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{""}) }
 
   private[scalatest] def newAssertionFailedException(optionalMessage: Option[String], optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Throwable =
     new org.scalatest.exceptions.TestFailedException(toExceptionFunction(optionalMessage), optionalCause, Left(pos), None, analysis)
@@ -527,7 +527,7 @@ trait Assertions extends TripleEquals  {
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
   inline def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
-    ${ AssertionsMacro.assert('this, 'condition, 'prettifier, 'pos, 'clue) }
+    ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{clue}) }
 
   /**
    * Assume that a boolean condition is true.
@@ -575,7 +575,7 @@ trait Assertions extends TripleEquals  {
    * @throws TestCanceledException if the condition is <code>false</code>.
    */
   inline def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
-    ${ AssertionsMacro.assume('this, 'condition, 'prettifier, 'pos, '{""}) }
+    ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{""}) }
 
   /**
    * Assume that a boolean condition, described in <code>String</code>
@@ -628,7 +628,7 @@ trait Assertions extends TripleEquals  {
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
   inline def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
-    ${ AssertionsMacro.assume('this, 'condition, 'prettifier, 'pos, 'clue) }
+    ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{clue}) }
 
   /**
    * Asserts that a given string snippet of code does not pass the Scala type checker, failing if the given

--- a/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
@@ -419,6 +419,8 @@ import ArrayHelper.deep
  * @author Bill Venners
  */
 trait Assertions extends TripleEquals  {
+  // https://github.com/lampepfl/dotty/pull/8601#pullrequestreview-380646858
+  implicit object UseDefaultAssertions
 
   //implicit val prettifier = Prettifier.default
 
@@ -467,7 +469,7 @@ trait Assertions extends TripleEquals  {
    * @param condition the boolean condition to assert
    * @throws TestFailedException if the condition is <code>false</code>.
    */
-  inline def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{""}) }
 
   private[scalatest] def newAssertionFailedException(optionalMessage: Option[String], optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Throwable =
@@ -526,7 +528,7 @@ trait Assertions extends TripleEquals  {
    * @throws TestFailedException if the condition is <code>false</code>.
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
-  inline def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{clue}) }
 
   /**
@@ -574,7 +576,7 @@ trait Assertions extends TripleEquals  {
    * @param condition the boolean condition to assume
    * @throws TestCanceledException if the condition is <code>false</code>.
    */
-  inline def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{""}) }
 
   /**
@@ -627,7 +629,7 @@ trait Assertions extends TripleEquals  {
    * @throws TestCanceledException if the condition is <code>false</code>.
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
-  inline def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{clue}) }
 
   /**

--- a/scalatest.dotty/src/main/scala/org/scalatest/AssertionsMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/AssertionsMacro.scala
@@ -29,11 +29,8 @@ object AssertionsMacro {
    * @param condition original condition expression
    * @return transformed expression that performs the assertion check and throw <code>TestFailedException</code> with rich error message if assertion failed
    */
-  def assert(ths: Expr[Assertions], condition: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position], clue: Expr[Any])(implicit qctx: QuoteContext): Expr[Assertion] =
-    ths match {
-      case '{ $ths: diagrams.Diagrams } => org.scalatest.DiagrammedAssertionsMacro.assert(condition, prettifier, pos, clue)
-      case _ => transform('{Assertions.assertionsHelper.macroAssert}, condition, prettifier, pos, clue)
-    }
+  def assert(condition: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position], clue: Expr[Any])(implicit qctx: QuoteContext): Expr[Assertion] =
+    transform('{Assertions.assertionsHelper.macroAssert}, condition, prettifier, pos, clue)
 
   /**
    * Provides implementation for <code>Assertions.assume(booleanExpr: Boolean)</code>, with rich error message.
@@ -42,12 +39,8 @@ object AssertionsMacro {
    * @param condition original condition expression
    * @return transformed expression that performs the assumption check and throw <code>TestCanceledException</code> with rich error message if assumption failed
    */
-  def assume(ths: Expr[Assertions], condition: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position], clue: Expr[Any])(implicit qctx: QuoteContext): Expr[Assertion] =
-    ths match {
-      case '{ $ths: diagrams.Diagrams } => org.scalatest.DiagrammedAssertionsMacro.assume(condition, prettifier, pos, clue)
-      case _ => transform('{Assertions.assertionsHelper.macroAssume}, condition, prettifier, pos, clue)
-    }
-
+  def assume(condition: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position], clue: Expr[Any])(implicit qctx: QuoteContext): Expr[Assertion] =
+    transform('{Assertions.assertionsHelper.macroAssume}, condition, prettifier, pos, clue)
 
   def transform(
     helper:Expr[(Bool, Any, source.Position) => Assertion],

--- a/scalatest.dotty/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -155,6 +155,8 @@ import org.scalatest.compatible.Assertion
  * <p>Trait <code>DiagrammedAssertions</code> was inspired by Peter Niederwieser's work in <a href="http://code.google.com/p/spock/">Spock</a> and <a href="https://github.com/pniederw/expecty">Expecty</a>.
  */
 trait Diagrams extends Assertions {
+  // https://github.com/lampepfl/dotty/pull/8601#pullrequestreview-380646858
+  implicit object UseDiagram
 
   import scala.tasty._
   import scala.quoted._
@@ -177,7 +179,7 @@ trait Diagrams extends Assertions {
    * @param condition the boolean condition to assert
    * @throws TestFailedException if the condition is <code>false</code>.
    */
-  inline override def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDiagram.type): Assertion =
     ${ DiagrammedAssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{""}) }
 
   /**
@@ -199,7 +201,7 @@ trait Diagrams extends Assertions {
    * @throws TestFailedException if the condition is <code>false</code>.
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
-  inline override def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDiagram.type): Assertion =
     ${ DiagrammedAssertionsMacro.assert('condition, 'prettifier, 'pos, 'clue) }
 
   /**
@@ -220,7 +222,7 @@ trait Diagrams extends Assertions {
    * @param condition the boolean condition to assume
    * @throws TestCanceledException if the condition is <code>false</code>.
    */
-  inline override def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDiagram.type): Assertion =
     ${ DiagrammedAssertionsMacro.assume('condition, 'prettifier, 'pos, '{""}) }
 
   /**
@@ -242,7 +244,7 @@ trait Diagrams extends Assertions {
    * @throws TestCanceledException if the condition is <code>false</code>.
    * @throws NullArgumentException if <code>message</code> is <code>null</code>.
    */
-  inline override def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+  inline def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDiagram.type): Assertion =
     ${ DiagrammedAssertionsMacro.assume('condition, 'prettifier, 'pos, 'clue) }
 }
 

--- a/scalatest.dotty/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -154,7 +154,97 @@ import org.scalatest.compatible.Assertion
  *
  * <p>Trait <code>DiagrammedAssertions</code> was inspired by Peter Niederwieser's work in <a href="http://code.google.com/p/spock/">Spock</a> and <a href="https://github.com/pniederw/expecty">Expecty</a>.
  */
-trait Diagrams extends Assertions
+trait Diagrams extends Assertions {
+
+  import scala.tasty._
+  import scala.quoted._
+
+  /**
+   * Assert that a boolean condition is true.
+   * If the condition is <code>true</code>, this method returns normally.
+   * Else, it throws <code>TestFailedException</code>.
+   *
+   * <p>
+   * This method is implemented in terms of a Scala macro that will generate a more helpful error message that includes
+   * a diagram showing expression values.
+   * </p>
+   *
+   * <p>
+   * If multi-line <code>Boolean</code> is passed in, it will fallback to the macro implementation of <code>Assertions</code>
+   * that does not contain diagram.
+   * </p>
+   *
+   * @param condition the boolean condition to assert
+   * @throws TestFailedException if the condition is <code>false</code>.
+   */
+  inline override def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+    ${ DiagrammedAssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{""}) }
+
+  /**
+   * Assert that a boolean condition, described in <code>String</code>
+   * <code>message</code>, is true.
+   * If the condition is <code>true</code>, this method returns normally.
+   * Else, it throws <code>TestFailedException</code> with the
+   * <code>String</code> obtained by invoking <code>toString</code> on the
+   * specified <code>clue</code> as the exception's detail message and a
+   * diagram showing expression values.
+   *
+   * <p>
+   * If multi-line <code>Boolean</code> is passed in, it will fallback to the macro implementation of <code>Assertions</code>
+   * that does not contain diagram.
+   * </p>
+   *
+   * @param condition the boolean condition to assert
+   * @param clue An objects whose <code>toString</code> method returns a message to include in a failure report.
+   * @throws TestFailedException if the condition is <code>false</code>.
+   * @throws NullArgumentException if <code>message</code> is <code>null</code>.
+   */
+  inline override def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+    ${ DiagrammedAssertionsMacro.assert('condition, 'prettifier, 'pos, 'clue) }
+
+  /**
+   * Assume that a boolean condition is true.
+   * If the condition is <code>true</code>, this method returns normally.
+   * Else, it throws <code>TestCanceledException</code>.
+   *
+   * <p>
+   * This method is implemented in terms of a Scala macro that will generate a more helpful error message that includes
+   * a diagram showing expression values.
+   * </p>
+   *
+   * <p>
+   * If multi-line <code>Boolean</code> is passed in, it will fallback to the macro implementation of <code>Assertions</code>
+   * that does not contain diagram.
+   * </p>
+   *
+   * @param condition the boolean condition to assume
+   * @throws TestCanceledException if the condition is <code>false</code>.
+   */
+  inline override def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+    ${ DiagrammedAssertionsMacro.assume('condition, 'prettifier, 'pos, '{""}) }
+
+  /**
+   * Assume that a boolean condition, described in <code>String</code>
+   * <code>message</code>, is true.
+   * If the condition is <code>true</code>, this method returns normally.
+   * Else, it throws <code>TestCanceledException</code> with the
+   * <code>String</code> obtained by invoking <code>toString</code> on the
+   * specified <code>clue</code> as the exception's detail message and a
+   * diagram showing expression values.
+   *
+   * <p>
+   * If multi-line <code>Boolean</code> is passed in, it will fallback to the macro implementation of <code>Assertions</code>
+   * that does not contain diagram.
+   * </p>
+   *
+   * @param condition the boolean condition to assume
+   * @param clue An objects whose <code>toString</code> method returns a message to include in a failure report.
+   * @throws TestCanceledException if the condition is <code>false</code>.
+   * @throws NullArgumentException if <code>message</code> is <code>null</code>.
+   */
+  inline override def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion =
+    ${ DiagrammedAssertionsMacro.assume('condition, 'prettifier, 'pos, 'clue) }
+}
 
 /**
  * Companion object that facilitates the importing of <code>DiagrammedAssertions</code> members as


### PR DESCRIPTION
+ Background
Because dotty don't permit `inline def` override `inline def`,  so in commit 3cfd618, in `Assertions.{assert, assume}`, we [pass](https://github.com/scalatest/scalatest/commit/3cfd6181bf1036ae046d269841b7518e0c35141a#diff-bf48f34ea897c0a7226a9493c8fb9789R471) `'this` to `AssertionsMacro`. And in `AssertionsMacro`, we [switch the implementation logic](https://github.com/scalatest/scalatest/commit/3cfd6181bf1036ae046d269841b7518e0c35141a#diff-547915506e8d905952154b3226aac560R33) of assert/ assume based on type of the passed param.

+ Problem
The solution above is not flexible enough if we want to [extends Assertions](https://github.com/scalatest/scalatestplus-junit/pull/12/files#diff-27382c1a71508ac8d6b28dc59afeb5a8R7) as in scalatest/scalatestplus-junit project.

+ Solution in this PR
As suggested in https://github.com/lampepfl/dotty/pull/8601#pullrequestreview-380646858, I use overload instead of override to implement `Assertions.{assert, assume}`