### PR TITLE
Fix IllegalAccessException when comparing 2 instances of class has private fields

### DIFF
--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DifferSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DifferSpec.scala
@@ -262,7 +262,7 @@ class DifferSpec extends funspec.AnyFunSpec {
   val EOL = scala.compat.Platform.EOL
 
   sealed trait Parent
-  case class Bar( s: String, i: Int ) extends Parent
+  case class Bar( s: String, private val i: Int ) extends Parent
   case class Foo( bar: Bar, b: List[Int], parent: Option[Parent] ) extends Parent
 
   // SKIP-SCALATESTNATIVE-START

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
@@ -21,7 +21,7 @@ class ObjectMetaSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
 
   case class Person(name: String, private val age: Int) {
     val otherField = "test other field"
-    val privateField = "test private field"
+    private val privateField = "test private field"
   }
 
   describe("ObjectMeta") {

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
@@ -19,14 +19,15 @@ import org.scalatest._
 
 class ObjectMetaSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
 
-  case class Person(name: String, age: Int) {
+  case class Person(name: String, private val age: Int) {
     val otherField = "test other field"
+    val privateField = "test private field"
   }
 
   describe("ObjectMeta") {
 
     it("should extract case class attribute names correctly") {
-      ObjectMeta(Person("test", 33)).fieldNames should contain theSameElementsAs Set("name", "age", "otherField")
+      ObjectMeta(Person("test", 33)).fieldNames should contain theSameElementsAs Set("name", "age", "otherField", "privateField")
     }
 
     it("should extract dynamically field value correctly") {
@@ -34,6 +35,7 @@ class ObjectMetaSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
       meta.value("name") shouldBe "test"
       meta.value("age") shouldBe 33
       meta.value("otherField") shouldBe "test other field"
+      meta.value("privateField") shouldBe "test private field"
     }
 
     it("should throw IllegalArgumentException when invalid attribute name is used to retrieve value") {


### PR DESCRIPTION
Fix an issue https://github.com/scalatest/scalatest/issues/1788

When comparing two instances of class which contains private fields, `IllegalAccessException: cannot access a member with modifiers "private"` occurs at ObjectMeta.
It caused because `Differ` try to access to the instance's value for generating differences analysis message.

I fixed this problem by setting the field accessible to true temporarily.