### PR TITLE
ParallelTestExecution - Fix Wrong Expected Test Count

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -515,7 +515,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
                 case Some(ssr: SuiteSortingReporter) => ssr.testSortingTimeout
                 case _ => Span(Suite.defaultTestSortingReporterTimeoutInSeconds, Seconds)
               }
-            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.testNames.size, passedInArgs.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.expectedTestCount(passedInArgs.filter), passedInArgs.distributedSuiteSorter, System.err)
             passedInArgs.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           }
           else

--- a/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
+++ b/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
@@ -83,7 +83,7 @@ trait ParallelTestExecution extends OneInstancePerTest { this: Suite =>
       else {
         args.distributor match {  // This is the initial instance
           case Some(distributor) =>
-            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
             args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           case None =>
             args

--- a/scalatest/src/main/scala/org/scalatest/RandomTestOrder.scala
+++ b/scalatest/src/main/scala/org/scalatest/RandomTestOrder.scala
@@ -184,7 +184,7 @@ trait RandomTestOrder extends OneInstancePerTest { this: Suite =>
       case (Some(name), Some(sorter)) =>
         super.run(testName, args.copy(reporter = createTestSpecificReporter(sorter, name)))
       case _ =>
-        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
         val newArgs = args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
         val status = super.run(testName, newArgs)
         // Random shuffle the deferred suite list, before executing them.


### PR DESCRIPTION
In ParallelTestExecution, changed to use expectedTestCount when creating TestSortingReporter, to fix the problem where TestSortingReporter expects wrong number of tests when used with test selection arguments like -l and -n.