### PR TITLE
3.0: only expect non-filtered Async tests to be reported as completed

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -514,7 +514,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
                 case Some(ssr: SuiteSortingReporter) => ssr.testSortingTimeout
                 case _ => Span(Suite.defaultTestSortingReporterTimeoutInSeconds, Seconds)
               }
-            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.testNames.size, passedInArgs.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.expectedTestCount(passedInArgs.filter), passedInArgs.distributedSuiteSorter, System.err)
             passedInArgs.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           }
           else

--- a/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
+++ b/scalatest/src/main/scala/org/scalatest/ParallelTestExecution.scala
@@ -83,7 +83,7 @@ trait ParallelTestExecution extends OneInstancePerTest { this: Suite =>
       else {
         args.distributor match {  // This is the initial instance
           case Some(distributor) =>
-            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
             args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           case None =>
             args

--- a/scalatest/src/main/scala/org/scalatest/RandomTestOrder.scala
+++ b/scalatest/src/main/scala/org/scalatest/RandomTestOrder.scala
@@ -184,7 +184,7 @@ trait RandomTestOrder extends OneInstancePerTest { this: Suite =>
       case (Some(name), Some(sorter)) =>
         super.run(testName, args.copy(reporter = createTestSpecificReporter(sorter, name)))
       case _ =>
-        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
         val newArgs = args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
         val status = super.run(testName, newArgs)
         // Random shuffle the deferred suite list, before executing them.


### PR DESCRIPTION
We have noticed the SuiteCompleted event is not fired to the reporters when there is an ignored test or a filtered test in an ASync test suite.

After investigation, it seems that the TestSortingReporter has a `completedTestCount` which is tracked off against the tests executed, however tests ignored don't count towards this total.  The ignored/excluded tests are added to the suite as tests with an ignore tag, so we need to also use the filtering that we use during execution when we create the total.

I was also considering just making the TestIgnored handler in the TestSortingReporter add one to the completed count, however that seemed like the wrong fix.  It did work though.

The overall aim is to fix the problem we are seeing with our test run where lots of test status output appears after the test run finished, meaning it's hard to tell whether the run passed or failed.
https://github.com/guardian/support-frontend/pull/2555 is the original issue workaround.

I have targeted this against 3.0.x but I notice the same bug appears in the main dev branch. Happy to raise a fix there as well if it helps?

Also, I haven't added any tests, I am not sure if that is required (being scalatest you'd expect so!!) and if so where they would go.