### PR TITLE
3.2: only expect non-filtered Async tests to be reported as completed

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -515,7 +515,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
                 case Some(ssr: SuiteSortingReporter) => ssr.testSortingTimeout
                 case _ => Span(Suite.defaultTestSortingReporterTimeoutInSeconds, Seconds)
               }
-            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.testNames.size, passedInArgs.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(theSuite.suiteId, passedInArgs.reporter, testSortingTimeout, theSuite.expectedTestCount(passedInArgs.filter), passedInArgs.distributedSuiteSorter, System.err)
             passedInArgs.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           }
           else

--- a/jvm/core/src/main/scala/org/scalatest/ParallelTestExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ParallelTestExecution.scala
@@ -83,7 +83,7 @@ trait ParallelTestExecution extends OneInstancePerTest { this: Suite =>
       else {
         args.distributor match {  // This is the initial instance
           case Some(distributor) =>
-            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+            val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
             args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
           case None =>
             args

--- a/jvm/core/src/main/scala/org/scalatest/RandomTestOrder.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RandomTestOrder.scala
@@ -184,7 +184,7 @@ trait RandomTestOrder extends OneInstancePerTest { this: Suite =>
       case (Some(name), Some(sorter)) =>
         super.run(testName, args.copy(reporter = createTestSpecificReporter(sorter, name)))
       case _ =>
-        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, testNames.size, args.distributedSuiteSorter, System.err)
+        val testSortingReporter = new TestSortingReporter(suiteId, args.reporter, sortingTimeout, expectedTestCount(args.filter), args.distributedSuiteSorter, System.err)
         val newArgs = args.copy(reporter = testSortingReporter, distributedTestSorter = Some(testSortingReporter))
         val status = super.run(testName, newArgs)
         // Random shuffle the deferred suite list, before executing them.


### PR DESCRIPTION
forward port to 3.2 of https://github.com/scalatest/scalatest/pull/1841

This is the version we discovered the bug in originally - workaround in https://github.com/guardian/support-frontend/pull/2555 ,
I reproduced it on the release branch at the time (3.0.x) and did a fix there in 1841 but I have confirmed the fix in the original context and done a PR onto 3.2.