### PR TITLE
3.0: Keep suite reporter in map until the SuiteCompleted message is dealt with

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
@@ -174,6 +174,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
           dispatch(doneEvent)
           dispatchToRegisteredSuiteReporter(head.suiteId, doneEvent)
         }
+        suiteReporterMap -= (head.suiteId)
         slotListBuf = fireReadySuiteEvents(slotListBuf.tail)
         if (slotListBuf.size > 0) 
           scheduleTimeoutTask()
@@ -212,6 +213,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
         fireSuiteEvents(slot.suiteId)
         dispatch(slot.doneEvent.get)
         dispatchToRegisteredSuiteReporter(slot.suiteId, slot.doneEvent.get)
+        suiteReporterMap -= (slot.suiteId)
     }
     undone
   }
@@ -230,7 +232,6 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
       if (slotIdx >= 0)
         slotListBuf.update(slotIdx, newSlot)
       fireReadyEvents()
-      suiteReporterMap -= (suiteId)
     }
   }
 


### PR DESCRIPTION
When running Async tests, scalatest buffers the output for all but the earliest test that's still running, outputting the remaining tests when the first test completes.
However there is a bug in that when all the tests in the suite are completed, and we fire the completed event, the reporter removes the  underlying reporter for the test.
This means when the SuiteCompleted event comes in later, there is no reporter to receive it and the test goes unreported (although the pass/fail status is still retained)  We found this was confusing when looking at our test results.
It looks like the removal from the map was a measure to save memory.

This PR moves the call to when the suite has really finished rather than just the tests inside the suite.  This seems to have fixed the bug in local testing.