### PR TITLE
3.2: Keep suite reporter in map until the SuiteCompleted message is dealt with

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
@@ -173,6 +173,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
           dispatch(doneEvent)
           dispatchToRegisteredSuiteReporter(head.suiteId, doneEvent)
         }
+        suiteReporterMap -= (head.suiteId)
         slotListBuf = fireReadySuiteEvents(slotListBuf.tail)
         if (slotListBuf.size > 0) 
           scheduleTimeoutTask()
@@ -213,6 +214,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
         fireSuiteEvents(slot.suiteId)
         dispatch(slot.doneEvent.get)
         dispatchToRegisteredSuiteReporter(slot.suiteId, slot.doneEvent.get)
+        suiteReporterMap -= (slot.suiteId)
     }
     undone
   }
@@ -231,7 +233,6 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
       if (slotIdx >= 0)
         slotListBuf.update(slotIdx, newSlot)
       fireReadyEvents()
-      suiteReporterMap -= (suiteId)
     }
   }
 


### PR DESCRIPTION
This is a forward port of https://github.com/scalatest/scalatest/pull/1843
The same issue is occurring in 3.2, when running two trivial ASync tests from SBT only one of the tests is reported, the other is not because the underlying Reporter is being removed when all of the child tests are complete, and not waiting for the SuiteCompleted event.  This means that when the second test is flushed to the reporter, there is no reporter, so the output is lost (although the failing test is still failing)