### PR TITLE
3.1: Keep suite reporter in map until the SuiteCompleted message is dealt with

### DIFF
--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
@@ -173,6 +173,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
           dispatch(doneEvent)
           dispatchToRegisteredSuiteReporter(head.suiteId, doneEvent)
         }
+        suiteReporterMap -= (head.suiteId)
         slotListBuf = fireReadySuiteEvents(slotListBuf.tail)
         if (slotListBuf.size > 0) 
           scheduleTimeoutTask()
@@ -213,6 +214,7 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
         fireSuiteEvents(slot.suiteId)
         dispatch(slot.doneEvent.get)
         dispatchToRegisteredSuiteReporter(slot.suiteId, slot.doneEvent.get)
+        suiteReporterMap -= (slot.suiteId)
     }
     undone
   }
@@ -231,7 +233,6 @@ private[scalatest] class SuiteSortingReporter(dispatch: Reporter, val testSortin
       if (slotIdx >= 0)
         slotListBuf.update(slotIdx, newSlot)
       fireReadyEvents()
-      suiteReporterMap -= (suiteId)
     }
   }
 


### PR DESCRIPTION
This is cherry-picked from the other 2 PRs for 3.0 and 3.2: 

https://github.com/scalatest/scalatest/pull/1843
https://github.com/scalatest/scalatest/pull/1844