### PR TITLE
[3.1] Versions Update

### DIFF
--- a/common-test.dotty/src/main/scala/org/scalatest/LineNumberHelper.scala
+++ b/common-test.dotty/src/main/scala/org/scalatest/LineNumberHelper.scala
@@ -1,7 +1,6 @@
 package org.scalatest
 
 import scala.quoted._
-import scala.tasty._
 
 private[scalatest] trait LineNumberHelper {
   inline def thisLineNumber = ${ LineNumberMacro.thisLineNumberImpl }

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -5,7 +5,9 @@ import scala.io.Source
 
 trait BuildCommons {
 
-  lazy val supportedScalaVersions = List("2.13.2", "2.12.11", "2.11.12", "2.10.7")
+  val defaultScalaVersion = "2.13.3"
+
+  val supportedScalaVersions = List("2.13.3", "2.12.12", "2.11.12", "2.10.7")
 
   val releaseVersion = "3.1.2"
 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -13,7 +13,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.14/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = "0.25.0-RC2"
+  lazy val dottyVersion = "0.25.0"
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -13,7 +13,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.14/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = "0.24.0-RC1"
+  lazy val dottyVersion = "0.25.0-RC2"
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -14,7 +14,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 trait JsBuild { this: BuildCommons =>
 
-  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
+  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.1.1")
   val sjsPrefix = if (scalaJSVersion.startsWith("1.")) "_sjs1_" else "_sjs0.6_"
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.1.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -140,7 +140,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   def sharedSettings: Seq[Setting[_]] = 
     commonSharedSettings ++ Seq(
-      scalaVersion := "2.13.1",
+      scalaVersion := defaultScalaVersion,
       crossScalaVersions := supportedScalaVersions,
       libraryDependencies ++= {
         if (isDotty.value)
@@ -1218,7 +1218,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   def gentestsSharedSettings: Seq[Setting[_]] = Seq(
     javaHome := getJavaHome(scalaBinaryVersion.value),
-    scalaVersion := "2.13.0",
+    scalaVersion := defaultScalaVersion,
     crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-feature") ++ (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty else Seq("-Ypartial-unification")),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",

--- a/publish.sh
+++ b/publish.sh
@@ -6,8 +6,8 @@ sbt "project scalacticJS" clean +publishSigned
 export SCALAJS_VERSION=1.1.1
 sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
-sbt ++2.12.11 "project scalacticJS" clean publishSigned
-sbt ++2.13.2 "project scalacticJS" clean publishSigned
+sbt ++2.12.12 "project scalacticJS" clean publishSigned
+sbt ++2.13.3 "project scalacticJS" clean publishSigned
 sbt ++2.11.12 "project scalacticNative" clean publishSigned
 sbt "project scalacticDotty" clean publishSigned
 sbt "project scalactic" sonatypeBundleUpload
@@ -21,8 +21,8 @@ export SCALAJS_VERSION=1.1.1
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
-sbt ++2.12.11 "project scalatestJS" clean publishSigned
-sbt ++2.13.2 "project scalatestJS" clean publishSigned
+sbt ++2.12.12 "project scalatestJS" clean publishSigned
+sbt ++2.13.3 "project scalatestJS" clean publishSigned
 sbt ++2.11.12 "project scalatestNative" clean publishSigned
 sbt "project scalatestDotty" clean publishSigned
 
@@ -34,7 +34,7 @@ export SCALAJS_VERSION=1.1.1
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
-sbt ++2.12.11 "project scalatestAppJS" clean publishSigned
-sbt ++2.13.2 "project scalatestAppJS" clean publishSigned
+sbt ++2.12.12 "project scalatestAppJS" clean publishSigned
+sbt ++2.13.3 "project scalatestAppJS" clean publishSigned
 sbt ++2.11.12 "project scalatestAppNative" clean publishSigned
 sbt "project scalatest" sonatypeBundleUpload

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ sbt "project scalactic" clean +publishSigned
 export SCALAJS_VERSION=0.6.32
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.1
+export SCALAJS_VERSION=1.1.1
 sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.11 "project scalacticJS" clean publishSigned
@@ -17,7 +17,9 @@ sbt scalatestCompatible/clean scalatestCompatible/publishSigned
 sbt "project scalatest" clean +publishSigned
 export SCALAJS_VERSION=0.6.32
 sbt "project scalatestJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.1
+export SCALAJS_VERSION=1.1.1
+sbt "project scalacticMacroJS" clean
+sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.11 "project scalatestJS" clean publishSigned
 sbt ++2.13.2 "project scalatestJS" clean publishSigned
@@ -28,7 +30,9 @@ sbt clean
 sbt "project scalatestApp" clean +publishSigned
 export SCALAJS_VERSION=0.6.32
 sbt "project scalatestAppJS" clean +publishSigned
-export SCALAJS_VERSION=1.0.1
+export SCALAJS_VERSION=1.1.1
+sbt "project scalacticMacroJS" clean
+sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.11 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.2 "project scalatestAppJS" clean publishSigned

--- a/scalactic.dotty/src/main/scala/org/scalactic/Requirements.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/Requirements.scala
@@ -270,8 +270,7 @@ object RequirementsMacro {
       case Typed(Repeated(args, _), _) => // only sequence literal
         args.map(arg => Expr(arg.seal.cast[Any].show))
       case _ =>
-        qctx.error("requireNonNull can only be used with sequence literal, not `seq : _*`")
-        return '{}
+        Reporting.throwError("requireNonNull can only be used with sequence literal, not `seq : _*`")
     }
 
     // generate AST that create array containing the argument name in source (get from calling 'show')

--- a/scalactic.dotty/src/main/scala/org/scalactic/Snapshots.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/Snapshots.scala
@@ -220,7 +220,7 @@ object Snapshots extends Snapshots
 
 object SnapshotsMacro {
 
-  def snap(expressions: Expr[Seq[Any]])(implicit qctx: QuoteContext): Expr[SnapshotSeq] = {
+  def snap(expressions: Expr[Seq[Any]])(using QuoteContext): Expr[SnapshotSeq] = {
     import qctx.tasty._
 
     def liftSeq(args: Seq[Expr[Snapshot]]): Expr[Seq[Snapshot]] = args match {
@@ -235,8 +235,7 @@ object SnapshotsMacro {
           '{ Snapshot($str, ${ arg.seal.cast[Any] }) }
         }
       case arg =>
-        qctx.error("snap can only be used with sequence literal, not `seq : _*`")
-        return '{???}
+        Reporting.throwError("snap can only be used with sequence literal, not `seq : _*`")
     }
 
     val argumentsS: Expr[Seq[Snapshot]] = liftSeq(snapshots)

--- a/scalactic.dotty/src/main/scala/org/scalactic/source/Position.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/source/Position.scala
@@ -67,7 +67,7 @@ object Position {
    * Helper method for Position macro.
    */
   private def genPosition(implicit qctx: QuoteContext): Expr[Position] = {
-    import qctx.tasty._
+    import qctx.tasty.rootPosition
 
     val file = rootPosition.sourceFile
     val fileName: String = file.jpath.getFileName.toString

--- a/scalactic.dotty/src/main/scala/org/scalactic/source/TypeInfo.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/source/TypeInfo.scala
@@ -16,7 +16,6 @@
 package org.scalactic.source
 
 import scala.quoted._
-import scala.tasty._
 
 class TypeInfo[T](val name: String)
 

--- a/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -195,6 +195,7 @@ object Prettifier {
             case Success(e) => "Success(" + apply(e) + ")"
             case Left(e) => "Left(" + apply(e) + ")"
             case Right(e) => "Right(" + apply(e) + ")"
+            case s: Symbol => "'" + s.name
             case Good(e) => "Good(" + apply(e) + ")"
             case Bad(e) => "Bad(" + apply(e) + ")"
             case One(e) => "One(" + apply(e) + ")"

--- a/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/Assertions.scala
@@ -1341,7 +1341,6 @@ trait Assertions extends TripleEquals  {
  */
 object Assertions extends Assertions {
   import scala.quoted._
-  import scala.quoted.matching.Const
 
   def stripMarginImpl(x: Expr[String])(implicit qctx: QuoteContext): Expr[String] = x match {
     case Const(str) => Expr(new scala.collection.immutable.StringOps(str).stripMargin)

--- a/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
@@ -27,7 +27,7 @@ object CompileMacro {
   def assertTypeErrorImpl(code: Expr[String], typeChecked: Expr[Boolean], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Assertion] = {
     import qctx.tasty._
 
-    if (!typeChecked.value) '{ Succeeded }
+    if (!typeChecked.unliftOrError) '{ Succeeded }
     else '{
       val messageExpr = Resources.expectedTypeErrorButGotNone($code)
       throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
@@ -37,7 +37,7 @@ object CompileMacro {
   def expectTypeErrorImpl(code: Expr[String], typeChecked: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Fact] = {
     import qctx.tasty._
 
-    if (typeChecked.value)
+    if (typeChecked.unliftOrError)
       '{
           val messageExpr = Resources.expectedTypeErrorButGotNone($code)
           Fact.No(
@@ -72,7 +72,7 @@ object CompileMacro {
   def assertDoesNotCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Assertion] = {
     import qctx.tasty._
 
-    if (!typeChecked.value) '{ Succeeded }
+    if (!typeChecked.unliftOrError) '{ Succeeded }
     else '{
       val messageExpr = Resources.expectedCompileErrorButGotNone($code)
       throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
@@ -83,7 +83,7 @@ object CompileMacro {
   def expectDoesNotCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Fact] = {
     import qctx.tasty._
 
-    if (typeChecked.value)
+    if (typeChecked.unliftOrError)
       '{
           val messageExpr = Resources.expectedCompileErrorButGotNone($code)
           Fact.No(
@@ -118,7 +118,7 @@ object CompileMacro {
   def assertCompilesImpl(code: Expr[String], typeChecked: Expr[Boolean], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Assertion] = {
     import qctx.tasty._
 
-    if (typeChecked.value) '{ Succeeded }
+    if (typeChecked.unliftOrError) '{ Succeeded }
     else '{
       val messageExpr = Resources.expectedNoErrorButGotTypeError("unknown", $code)
       throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
@@ -128,7 +128,7 @@ object CompileMacro {
   def expectCompilesImpl(code: Expr[String], typeChecked: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position])(implicit qctx: QuoteContext): Expr[Fact] = {
     import qctx.tasty._
 
-    if (typeChecked.value)
+    if (typeChecked.unliftOrError)
       '{
           val messageExpr = Resources.compiledSuccessfully($code)
           Fact.Yes(

--- a/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
@@ -197,8 +197,7 @@ object CompileMacro {
         checkNotCompile(code)
 
       case other =>
-        qctx.error("The '" + shouldOrMust + " compile' syntax only works with String literals.")
-        '{???}
+        Reporting.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }
   }
 
@@ -250,8 +249,7 @@ object CompileMacro {
         checkNotTypeCheck(code.toString)
 
       case _ =>
-        qctx.error("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")
-        '{???}
+        Reporting.throwError("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")
     }
   }
 
@@ -302,9 +300,7 @@ object CompileMacro {
         checkCompile(code.toString)
 
       case other =>
-        println("###other: " + other)
-        qctx.error("The '" + shouldOrMust + " compile' syntax only works with String literals.")
-        '{???}
+        Reporting.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }
   }
 

--- a/scalatest.dotty/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
@@ -18,7 +18,6 @@ package org.scalatest.matchers
 import org.scalatest.Resources
 import org.scalatest.matchers.dsl.ResultOfNotWordForAny
 import scala.quoted._
-import scala.tasty._
 
 private[scalatest] object MatchPatternMacro {
 

--- a/scalatest.dotty/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
@@ -22,7 +22,6 @@ import org.scalatest.matchers.dsl.{ResultOfAnTypeInvocation, MatcherWords, Resul
 // import org.scalatest.{UnquotedString, Resources, Suite, FailureMessages, Assertions}
 
 import scala.quoted._
-import scala.tasty._
 
 object TypeMatcherMacro {
 


### PR DESCRIPTION
- Backport Dotty Changes in 3.2 to support Dotty 0.25.0.
- Scala 2.13.3 and 2.12.12.
- Symbol support in Prettifier
- Scala-js 1.1.1
- SBT 1.3.13.