### PR TITLE
Enabled async test at scala-native build

### DIFF
--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
@@ -45,7 +45,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -107,7 +106,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -162,7 +160,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -209,7 +206,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(30)
@@ -411,7 +407,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -457,7 +452,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -539,7 +533,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -571,7 +564,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -624,7 +616,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           note(
@@ -655,7 +646,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -690,7 +680,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -715,7 +704,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -761,7 +749,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           alert(
@@ -790,7 +777,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -827,7 +813,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -852,7 +837,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -898,7 +882,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           markup(
@@ -925,7 +908,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -957,7 +939,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -995,7 +976,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -1023,7 +1003,6 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
@@ -45,7 +45,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -107,7 +106,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -162,7 +160,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -209,7 +206,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(3000)
@@ -376,7 +372,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -421,7 +416,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -478,7 +472,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           info(
@@ -505,7 +498,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -537,7 +529,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -590,7 +581,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           note(
@@ -617,7 +607,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -642,7 +631,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -688,7 +676,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           alert(
@@ -715,7 +702,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -740,7 +726,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -786,7 +771,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           markup(
@@ -813,7 +797,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -845,7 +828,6 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
@@ -36,7 +36,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -101,7 +100,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -159,7 +157,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -210,7 +207,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -395,7 +391,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -445,7 +440,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -512,7 +506,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -543,7 +536,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -579,7 +571,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -617,7 +608,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -644,7 +634,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -675,7 +664,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -704,7 +692,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -735,7 +722,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -762,7 +748,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -793,7 +778,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -822,7 +806,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -853,7 +836,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -880,7 +862,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -911,7 +892,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -947,7 +927,6 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
@@ -36,7 +36,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -101,7 +100,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -159,7 +157,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -210,7 +207,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -395,7 +391,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -445,7 +440,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -512,7 +506,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -543,7 +536,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -579,7 +571,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -617,7 +608,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -644,7 +634,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -675,7 +664,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -704,7 +692,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -735,7 +722,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -762,7 +748,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -793,7 +778,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -822,7 +806,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -853,7 +836,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -880,7 +862,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -911,7 +892,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -947,7 +927,6 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
@@ -39,7 +39,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -101,7 +100,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -154,7 +152,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -190,7 +187,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           Future {
@@ -237,7 +233,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           SleepHelper.sleep(30)
@@ -406,7 +401,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           Future {
@@ -452,7 +446,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           SleepHelper.sleep(60)
@@ -510,7 +503,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           info("hi there")
@@ -540,7 +532,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -591,7 +582,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           note("hi there")
@@ -614,7 +604,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -658,7 +647,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           alert("hi there")
@@ -681,7 +669,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -725,7 +712,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           markup("hi there")
@@ -755,7 +741,6 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
@@ -40,7 +40,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -101,7 +100,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -153,7 +151,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -189,7 +186,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           Future {
@@ -236,7 +232,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           SleepHelper.sleep(30)
@@ -405,7 +400,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           Future {
@@ -451,7 +445,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it should "test 1" in {
           SleepHelper.sleep(60)
@@ -509,7 +502,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           info("hi there")
@@ -539,7 +531,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -590,7 +581,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           note("hi there")
@@ -613,7 +603,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -657,7 +646,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           alert("hi there")
@@ -680,7 +668,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {
@@ -724,7 +711,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           markup("hi there")
@@ -754,7 +740,6 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should "test 1" in {
           Future {

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
@@ -36,7 +36,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike with ParallelTestExecution {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -101,7 +100,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike with ParallelTestExecution {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -159,7 +157,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -210,7 +207,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -395,7 +391,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -445,7 +440,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class ExampleSpec extends flatspec.FixtureAsyncFlatSpecLike {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -512,7 +506,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -546,7 +539,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -582,7 +574,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -608,7 +599,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -634,7 +624,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -662,7 +651,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -688,7 +676,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -714,7 +701,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -742,7 +728,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -768,7 +753,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -801,7 +785,6 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        class MySuite extends flatspec.FixtureAsyncFlatSpecLike  {
 
          //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
@@ -37,7 +37,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -102,7 +101,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -160,7 +158,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -211,7 +208,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -396,7 +392,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -446,7 +441,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends flatspec.FixtureAsyncFlatSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -489,7 +483,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -516,7 +509,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -550,7 +542,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -586,7 +577,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -612,7 +602,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -638,7 +627,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -666,7 +654,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -692,7 +679,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -718,7 +704,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -746,7 +731,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -772,7 +756,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -805,7 +788,6 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends flatspec.FixtureAsyncFlatSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
@@ -44,7 +44,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -105,7 +104,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -157,7 +155,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -193,7 +190,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -240,7 +236,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -409,7 +404,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -455,7 +449,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -513,7 +506,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           info(
@@ -540,7 +532,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -572,7 +563,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -625,7 +615,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           note(
@@ -652,7 +641,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -677,7 +665,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -723,7 +710,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           alert(
@@ -750,7 +736,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -775,7 +760,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -821,7 +805,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           markup(
@@ -848,7 +831,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -880,7 +862,6 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
@@ -44,7 +44,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -105,7 +104,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -157,7 +155,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -193,7 +190,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -240,7 +236,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -409,7 +404,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -455,7 +449,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -513,7 +506,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           info(
@@ -540,7 +532,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -572,7 +563,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -625,7 +615,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           note(
@@ -652,7 +641,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -677,7 +665,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -723,7 +710,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           alert(
@@ -750,7 +736,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -775,7 +760,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -821,7 +805,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           markup(
@@ -848,7 +831,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {
@@ -880,7 +862,6 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" - {
           "test 1" in {

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
@@ -40,7 +40,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -105,7 +104,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -163,7 +161,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -214,7 +211,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -399,7 +395,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -449,7 +444,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -514,7 +508,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -544,7 +537,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -579,7 +571,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -616,7 +607,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -642,7 +632,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -672,7 +661,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -700,7 +688,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -730,7 +717,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -756,7 +742,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -786,7 +771,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -814,7 +798,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -844,7 +827,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -870,7 +852,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -900,7 +881,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -935,7 +915,6 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
@@ -40,7 +40,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -105,7 +104,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -163,7 +161,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -214,7 +211,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -399,7 +395,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -449,7 +444,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends freespec.FixtureAsyncFreeSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -492,7 +486,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -518,7 +511,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -548,7 +540,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -583,7 +574,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -620,7 +610,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -646,7 +635,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -676,7 +664,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -704,7 +691,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -734,7 +720,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -760,7 +745,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -790,7 +774,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -818,7 +801,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -848,7 +830,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -874,7 +855,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -904,7 +884,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -939,7 +918,6 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends freespec.FixtureAsyncFreeSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
@@ -37,7 +37,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -98,7 +97,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -152,7 +150,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           Future {
@@ -199,7 +196,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           SleepHelper.sleep(3000)
@@ -368,7 +364,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           Future {
@@ -414,7 +409,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           SleepHelper.sleep(60)
@@ -472,7 +466,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           info(
@@ -499,7 +492,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -531,7 +523,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -584,7 +575,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           note(
@@ -611,7 +601,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -636,7 +625,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -682,7 +670,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           alert(
@@ -709,7 +696,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -734,7 +720,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -780,7 +765,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           markup(
@@ -807,7 +791,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -839,7 +822,6 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
@@ -43,7 +43,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with expectations.Expectations */ { // Can resurrect expectations.Expectations tests later
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -123,7 +122,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec with ParallelTestExecution /* with expectations.Expectations */ {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -193,7 +191,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           Future {
@@ -240,7 +237,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           SleepHelper.sleep(30)
@@ -409,7 +405,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           Future {
@@ -455,7 +450,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class ExampleSpec extends AsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         it("test 1") {
           SleepHelper.sleep(60)
@@ -513,7 +507,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           info(
@@ -540,7 +533,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -572,7 +564,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -625,7 +616,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           note(
@@ -652,7 +642,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -677,7 +666,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -723,7 +711,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           alert(
@@ -750,7 +737,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -775,7 +761,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -821,7 +806,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           markup(
@@ -848,7 +832,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {
@@ -880,7 +863,6 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       class MySuite extends AsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         describe("test feature") {
           it("test 1") {

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
@@ -35,7 +35,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -100,7 +99,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -158,7 +156,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -209,7 +206,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -394,7 +390,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -444,7 +439,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -487,7 +481,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -513,7 +506,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -543,7 +535,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -578,7 +569,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -615,7 +605,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -641,7 +630,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -671,7 +659,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -699,7 +686,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -729,7 +715,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -755,7 +740,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -785,7 +769,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -813,7 +796,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -843,7 +825,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -869,7 +850,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -899,7 +879,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -934,7 +913,6 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
@@ -39,7 +39,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -104,7 +103,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -163,7 +161,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -214,7 +211,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -399,7 +395,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -449,7 +444,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funspec.FixtureAsyncFunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -492,7 +486,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -518,7 +511,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -548,7 +540,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -583,7 +574,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -620,7 +610,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -646,7 +635,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -676,7 +664,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -704,7 +691,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -734,7 +720,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -760,7 +745,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -790,7 +774,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -818,7 +801,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -848,7 +830,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -874,7 +855,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -904,7 +884,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -939,7 +918,6 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funspec.FixtureAsyncFunSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteLikeSpec.scala
@@ -33,7 +33,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -94,7 +93,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuiteLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -147,7 +145,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -194,7 +191,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           SleepHelper.sleep(30)
@@ -363,7 +359,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -409,7 +404,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           SleepHelper.sleep(60)
@@ -467,7 +461,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           info("hi there")
@@ -497,7 +490,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -548,7 +540,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           note("hi there")
@@ -571,7 +562,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -615,7 +605,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           alert("hi there")
@@ -638,7 +627,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -682,7 +670,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           markup("hi there")
@@ -712,7 +699,6 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFunSuiteSpec.scala
@@ -34,7 +34,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -96,7 +95,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuite with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -149,7 +147,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -196,7 +193,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSuite extends AsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           SleepHelper.sleep(30)
@@ -365,7 +361,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -411,7 +406,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           SleepHelper.sleep(60)
@@ -469,7 +463,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           info("hi there")
@@ -499,7 +492,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -550,7 +542,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           note("hi there")
@@ -573,7 +564,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -617,7 +607,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           alert("hi there")
@@ -640,7 +629,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {
@@ -684,7 +672,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           markup("hi there")
@@ -714,7 +701,6 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       class MySuite extends AsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         test("test 1") {
           Future {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecLikeSpec.scala
@@ -30,7 +30,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -91,7 +90,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -144,7 +142,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           Future {
@@ -191,7 +188,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           SleepHelper.sleep(30)
@@ -360,7 +356,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           Future {
@@ -406,7 +401,6 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           SleepHelper.sleep(60)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncPropSpecSpec.scala
@@ -30,7 +30,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -91,7 +90,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -144,7 +142,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           Future {
@@ -191,7 +188,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           SleepHelper.sleep(30)
@@ -360,7 +356,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           Future {
@@ -406,7 +401,6 @@ class AsyncPropSpecSpec extends FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         property("test 1") {
           SleepHelper.sleep(60)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecLikeSpec.scala
@@ -37,7 +37,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -98,7 +97,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -149,7 +147,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -185,7 +182,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -232,7 +228,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(30)
@@ -401,7 +396,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -447,7 +441,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -505,7 +498,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           info(
@@ -532,7 +524,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -564,7 +555,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -617,7 +607,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           note(
@@ -644,7 +633,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -669,7 +657,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -715,7 +702,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           alert(
@@ -742,7 +728,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -767,7 +752,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -813,7 +797,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           markup(
@@ -840,7 +823,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -872,7 +854,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncWordSpecSpec.scala
@@ -37,7 +37,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -98,7 +97,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -149,7 +147,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-        //SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -185,7 +182,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -232,7 +228,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(3000)
@@ -400,7 +395,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           Future {
@@ -446,7 +440,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test 1" in {
           SleepHelper.sleep(60)
@@ -504,7 +497,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           info(
@@ -531,7 +523,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -563,7 +554,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -616,7 +606,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           note(
@@ -643,7 +632,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -668,7 +656,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -714,7 +701,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           alert(
@@ -741,7 +727,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -766,7 +751,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -812,7 +796,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           markup(
@@ -839,7 +822,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {
@@ -871,7 +853,6 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         "test feature" should {
           "test 1" in {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
@@ -37,7 +37,6 @@ class CompleteLastlySpec extends AsyncFunSpec {
         override def executionContext: ExecutionContext = ExecutionContext.Implicits.global
 // SKIP-SCALATESTJS,NATIVE-END
 //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
       }
 */
     describe("when an exception is immediately thrown") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -37,7 +37,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -99,7 +98,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -153,7 +151,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -200,7 +197,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(30)
@@ -402,7 +398,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -448,7 +443,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -530,7 +524,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -562,7 +555,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -615,7 +607,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           note(
@@ -646,7 +637,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -681,7 +671,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -706,7 +695,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -752,7 +740,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           alert(
@@ -781,7 +768,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -818,7 +804,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -843,7 +828,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -889,7 +873,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           markup(
@@ -916,7 +899,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -948,7 +930,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -986,7 +967,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed
@@ -1014,7 +994,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           succeed

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
@@ -37,7 +37,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -99,7 +98,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         val a = 1
 
@@ -153,7 +151,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -200,7 +197,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(3000)
@@ -367,7 +363,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           Future {
@@ -412,7 +407,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class ExampleSpec extends AsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Scenario("test 1") {
           SleepHelper.sleep(60)
@@ -469,7 +463,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           info(
@@ -496,7 +489,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -528,7 +520,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -581,7 +572,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           note(
@@ -608,7 +598,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -633,7 +622,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -679,7 +667,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           alert(
@@ -706,7 +693,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -731,7 +717,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -777,7 +762,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           markup(
@@ -804,7 +788,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {
@@ -836,7 +819,6 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       class MySuite extends AsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         Feature("test feature") {
           Scenario("test 1") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteLikeSpec.scala
@@ -34,7 +34,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuiteLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -99,7 +98,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuiteLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -156,7 +154,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -207,7 +204,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -392,7 +388,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funsuite.FixtureAsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -442,7 +437,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funsuite.FixtureAsyncFunSuiteLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -485,7 +479,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -511,7 +504,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -544,7 +536,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -579,7 +570,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -605,7 +595,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -631,7 +620,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -659,7 +647,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -685,7 +672,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -711,7 +697,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -739,7 +724,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -765,7 +749,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -798,7 +781,6 @@ class AsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuiteLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFunSuiteSpec.scala
@@ -34,7 +34,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -99,7 +98,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuite with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -156,7 +154,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -207,7 +204,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSuite extends funsuite.FixtureAsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -392,7 +388,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -442,7 +437,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends funsuite.FixtureAsyncFunSuite {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -486,7 +480,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -512,7 +505,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -545,7 +537,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -580,7 +571,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -606,7 +596,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -632,7 +621,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -660,7 +648,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -686,7 +673,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -712,7 +698,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -740,7 +725,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -766,7 +750,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -799,7 +782,6 @@ class AsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends funsuite.FixtureAsyncFunSuite  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecLikeSpec.scala
@@ -31,7 +31,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -96,7 +95,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -153,7 +151,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -204,7 +201,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -389,7 +385,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -439,7 +434,6 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncPropSpecSpec.scala
@@ -31,7 +31,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -96,7 +95,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -153,7 +151,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -204,7 +201,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -389,7 +385,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -439,7 +434,6 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
       class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecLikeSpec.scala
@@ -38,7 +38,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -103,7 +102,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -160,7 +158,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -211,7 +208,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -396,7 +392,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -446,7 +441,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -489,7 +483,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -515,7 +508,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -545,7 +537,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -580,7 +571,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -617,7 +607,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -643,7 +632,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -673,7 +661,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -701,7 +688,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -731,7 +717,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -757,7 +742,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -787,7 +771,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -815,7 +798,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -845,7 +827,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -871,7 +852,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -901,7 +881,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -936,7 +915,6 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncWordSpecSpec.scala
@@ -38,7 +38,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -103,7 +102,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -160,7 +158,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -211,7 +208,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -396,7 +392,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -446,7 +441,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -489,7 +483,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -515,7 +508,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -545,7 +537,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -580,7 +571,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -617,7 +607,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -643,7 +632,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -673,7 +661,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -701,7 +688,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -731,7 +717,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -757,7 +742,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -787,7 +771,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -815,7 +798,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -845,7 +827,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -871,7 +852,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -901,7 +881,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -936,7 +915,6 @@ class AsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -34,7 +34,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -99,7 +98,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -156,7 +154,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -207,7 +204,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -392,7 +388,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -442,7 +437,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -509,7 +503,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -540,7 +533,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -576,7 +568,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -614,7 +605,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -641,7 +631,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -672,7 +661,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -701,7 +689,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -732,7 +719,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -759,7 +745,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -790,7 +775,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -819,7 +803,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -850,7 +833,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -877,7 +859,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -908,7 +889,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -944,7 +924,6 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpecLike  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/DeprecatedAsyncFeatureSpecSpec.scala
@@ -34,7 +34,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -99,7 +98,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -156,7 +154,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -207,7 +204,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -392,7 +388,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -442,7 +437,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class ExampleSpec extends featurespec.FixtureAsyncFeatureSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -509,7 +503,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -540,7 +533,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -576,7 +568,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -614,7 +605,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -641,7 +631,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -672,7 +661,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -701,7 +689,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -732,7 +719,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -759,7 +745,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -790,7 +775,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -819,7 +803,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -850,7 +833,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -877,7 +859,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -908,7 +889,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -944,7 +924,6 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       class MySuite extends featurespec.FixtureAsyncFeatureSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-//SCALATESTNATIVE-ONLY implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/project/GenScalaTestNative.scala
+++ b/project/GenScalaTestNative.scala
@@ -113,15 +113,7 @@ object GenScalaTestNative {
     copyResourceDir("jvm/core/src/main/html", "html", targetDir, List.empty)
   }
 
-  def asyncs(sourceDirName: String): List[String] = {
-    new File(sourceDirName).listFiles.toList.map(_.getName).filter(_.toLowerCase.contains("async"))
-  }
-
-  def nonAsyncs(sourceDirName: String): List[String] = {
-    new File(sourceDirName).listFiles.toList.map(_.getName).filter(!_.toLowerCase.contains("async"))
-  }
-
-  val genScalaPackages: Map[String, List[String]] = 
+  val genScalaPackages: Map[String, List[String]] =
     Map(
       "org/scalatest" -> (List(
         "DispatchReporter.scala",
@@ -131,12 +123,12 @@ object GenScalaTestNative {
         "SuiteRerunner.scala",
         "SuiteRerunner.scala",
         "run.scala"
-      ) ++ asyncs("jvm/core/src/main/scala/org/scalatest")), 
+      )),
       "org/scalatest/diagrams" -> List.empty, 
       "org/scalatest/fixture" -> (List(
         "Spec.scala",
         "SpecLike.scala"
-      ) ++ asyncs("jvm/core/src/main/scala/org/scalatest/fixture")), 
+      )),
       "org/scalatest/events" -> List.empty, 
       "org/scalatest/expectations" -> List.empty, 
       "org/scalatest/matchers" -> List.empty, 
@@ -202,14 +194,14 @@ object GenScalaTestNative {
       "org/scalatest/time" -> List.empty, 
       "org/scalatest/words" -> List.empty, 
       "org/scalatest/enablers" -> List.empty, 
-      "org/scalatest/funsuite" -> asyncs("jvm/funsuite/src/main/scala/org/scalatest/funsuite"), 
-      "org/scalatest/featurespec" -> asyncs("jvm/featurespec/src/main/scala/org/scalatest/featurespec"), 
-      "org/scalatest/funspec" -> asyncs("jvm/funspec/src/main/scala/org/scalatest/funspec"), 
-      "org/scalatest/freespec" -> asyncs("jvm/freespec/src/main/scala/org/scalatest/freespec"), 
-      "org/scalatest/flatspec" -> asyncs("jvm/flatspec/src/main/scala/org/scalatest/flatspec"), 
+      "org/scalatest/funsuite" -> List.empty,
+      "org/scalatest/featurespec" -> List.empty,
+      "org/scalatest/funspec" -> List.empty,
+      "org/scalatest/freespec" -> List.empty,
+      "org/scalatest/flatspec" -> List.empty,
       "org/scalatest/prop" -> List.empty, 
-      "org/scalatest/propspec" -> asyncs("jvm/propspec/src/main/scala/org/scalatest/propspec"), 
-      "org/scalatest/wordspec" -> asyncs("jvm/wordspec/src/main/scala/org/scalatest/wordspec"), 
+      "org/scalatest/propspec" -> List.empty,
+      "org/scalatest/wordspec" -> List.empty,
       "org/scalatest/concurrent" -> (List(
         "Waiters.scala",        // skipeed because doesn't really make sense on js's single-thread environment.
         "Conductors.scala",             // skipped because depends on PimpedReadWriteLock
@@ -229,7 +221,7 @@ object GenScalaTestNative {
         "DeprecatedTimeLimitedTests.scala",       // skipped because js is single-threaded and does not share memory, there's no practical way to interrupt in js.
         "Timeouts.scala",               // skipped because js is single-threaded and does not share memory, there's no practical way to interrupt in js.
         "TimeoutTask.scala"            // skipped because timeout is not supported.,
-      ) ++ asyncs("jvm/core/src/main/scala/org/scalatest/concurrent")), 
+      )),
       "org/scalatest/path" -> List.empty, 
       "org/scalatest/tagobjects" -> List(
         "ChromeBrowser.scala",  // skipped because selenium not supported.
@@ -568,7 +560,7 @@ object GenScalaTestNative {
         "WordSpecImportedMatchersSpec.scala",
         "WordSpecMixedInMatchersSpec.scala",
         "WordSpecSpec.scala"
-      ) ++ asyncs("jvm/scalatest-test/src/test/scala/org/scalatest")) ++
+      )) ++
     // Invalid LLVM: "error: value doesn't match function result type 'void' ret i8* %_38"
     // copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/concurrent", "org/scalatest/concurrent", targetDir,
     //   List(
@@ -588,11 +580,7 @@ object GenScalaTestNative {
     //     "DeprecatedTimeLimitedTestsSpec.scala",   // skipped because DeprecatedTimeLimitedTests not supported.
     //     "TimeoutsSpec.scala"            // skipped because Timeouts not supported.
     //   )) ++
-    copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/enablers", "org/scalatest/enablers", targetDir,
-      List(
-        "PropCheckerAssertingAsyncSpec.scala"
-      )
-    ) ++
+    copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/enablers", "org/scalatest/enablers", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/events/examples", "org/scalatest/events/examples", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/events", "org/scalatest/events", targetDir,
       List(
@@ -612,7 +600,7 @@ object GenScalaTestNative {
       List(
         "SpecSpec.scala",     // skipped because depends on java reflections
         "SuiteSpec.scala"    // skipped because depends on java reflections
-      ) ++ asyncs("jvm/scalatest-test/src/test/scala/org/scalatest/fixture")) ++
+      )) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir,
       List(
@@ -652,16 +640,16 @@ object GenScalaTestNative {
   def genDiagramsTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/diagrams-test/src/test/scala/org/scalatest/diagrams", "org/scalatest/diagrams", targetDir, List.empty)
 
-  def genFeatureSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyFiles("jvm/featurespec-test/src/test/scala/org/scalatest/featurespec", "org/scalatest/featurespec", nonAsyncs("jvm/featurespec-test/src/test/scala/org/scalatest/featurespec"), targetDir)
+  def genFeatureSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
+    copyDir("jvm/featurespec-test/src/test/scala/org/scalatest/featurespec", "org/scalatest/featurespec", targetDir, List.empty)
 
-  def genFlatSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyFiles("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", nonAsyncs("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec"),  targetDir)
+  def genFlatSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
+    copyDir("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", targetDir, List.empty)
 
-  def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyFiles("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", nonAsyncs("jvm/freespec-test/src/test/scala/org/scalatest/freespec"),  targetDir)
+  def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
+    copyDir("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, List.empty)
 
-  def genFunSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyFiles("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", nonAsyncs("jvm/funspec-test/src/test/scala/org/scalatest/funspec"),  targetDir)      
+  def genFunSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
+    copyDir("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, List.empty)
 
 }


### PR DESCRIPTION
This commit is closing https://github.com/scalatest/scalatest/issues/1847

This commit working well on scala-native 0.4.0-M2 with Apple's clang `11.0.3 (clang-1103.0.32.62)` with unti tests that is using `wordspec.AsyncWordSpec`

I expect that everything will be fine on another backends.

Looks like this was disabled for a while ago, before 0.4.0-M2, and now it is safe assume that this tests is same to run ;)