### PR TITLE
Scala-js futureValueImpl Fix

### DIFF
--- a/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
@@ -102,11 +102,13 @@ class ScalaFuturesSpec extends FunSpec with Matchers with OptionValues with Scal
         futureIsNow.isReadyWithin(Span(1, Second)) should be (true)
       }
 
+      // SKIP-SCALATESTJS-START
       it("should query a never-ready future by at least the specified timeout") {
         var startTime = System.currentTimeMillis
         neverReadyFuture.isReadyWithin(Span(1250, Milliseconds)) should be (false)
         (System.currentTimeMillis - startTime).toInt should be >= (1250)
       }
+      // SKIP-SCALATESTJS-END
 
       it("should wrap any exception that normally causes a test to fail to propagate back wrapped in a TFE") {
 
@@ -202,6 +204,7 @@ class ScalaFuturesSpec extends FunSpec with Matchers with OptionValues with Scal
         caught4.failedCodeFileName.value should be ("ScalaFuturesSpec.scala")
       }
 
+      // SKIP-SCALATESTJS-START
       it("should by default query a never-ready future for at least 1 second") {
         var startTime = System.currentTimeMillis
         a [TestFailedException] should be thrownBy {
@@ -237,6 +240,7 @@ class ScalaFuturesSpec extends FunSpec with Matchers with OptionValues with Scal
         }
         (System.currentTimeMillis - startTime).toInt should be >= (1388)
       }
+      // SKIP-SCALATESTJS-END
 
       it("should wrap any exception that normally causes a test to fail to propagate back wrapped in a TFE") {
 
@@ -363,6 +367,7 @@ class ScalaFuturesSpec extends FunSpec with Matchers with OptionValues with Scal
         caught4.failedCodeFileName.value should be ("ScalaFuturesSpec.scala")
       }
 
+      // SKIP-SCALATESTJS-START
       it("should by default query a never-ready future for at least 1 second") {
         var startTime = System.currentTimeMillis
         a [TestFailedException] should be thrownBy {
@@ -406,6 +411,7 @@ class ScalaFuturesSpec extends FunSpec with Matchers with OptionValues with Scal
         }
         (System.currentTimeMillis - startTime).toInt should be >= (1388)
       }
+      // SKIP-SCALATESTJS-END
 
       it("should wrap any exception that normally causes a test to fail to propagate back wrapped in a TFE") {
 

--- a/scalatest/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
@@ -289,7 +289,10 @@ trait ScalaFutures extends Futures {
 
       override private[concurrent] def futureValueImpl(pos: source.Position)(implicit config: PatienceConfig): T = {
         try {
+          // SKIP-SCALATESTJS-START
           Await.ready(scalaFuture, Duration.fromNanos(config.timeout.totalNanos)).eitherValue.get match {
+          // SKIP-SCALATESTJS-END
+          //SCALATESTJS-ONLY scalaFuture.value.getOrElse(throw new TimeoutException("Wait is useless in js.")).transform(s => Success(Right(s)), f => Success(Left(f))).get match {   
             case Right(v) => v
             case Left(tpe: TestPendingException) => throw tpe
             case Left(tce: TestCanceledException) => throw tce


### PR DESCRIPTION
Scala-js does not work with Await.ready (won't link), this changes the behavior of Scala's futureValueImpl to throw TimeoutException directly when the future at the point of calling futureValueImpl does not have a value, because waiting for a value in future in scala-js simply does not make sense.