### PR TITLE
[3.1] Dotty 0.26 support

### DIFF
--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -5,9 +5,10 @@ import scala.io.Source
 
 trait BuildCommons {
 
-  val defaultScalaVersion = "2.13.3"
-
-  val supportedScalaVersions = List("2.13.3", "2.12.12", "2.11.12", "2.10.7")
+  lazy val scalaVersionsSettings: Seq[Setting[_]] = Seq(
+    crossScalaVersions := Seq("2.13.3", "2.12.12", "2.11.12", "2.10.7"),
+    scalaVersion := crossScalaVersions.value.head,
+  )
 
   val releaseVersion = "3.1.2"
 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -11,9 +11,9 @@ import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 
 trait DottyBuild { this: BuildCommons =>
 
-  // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.14/
+  // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.27/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = "0.25.0"
+  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "0.26.0-RC1")
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -20,7 +20,17 @@ trait DottyBuild { this: BuildCommons =>
     scalacOptions ++= List("-language:implicitConversions", "-noindent", "-Xprint-suspension")
   )
 
-  lazy val scalacticDotty = Project("scalacticDotty", file("scalactic.dotty"))
+  // https://github.com/sbt/sbt/issues/2205#issuecomment-144375501
+  private lazy val packageManagedSources =
+    mappings in (Compile, packageSrc) ++= { // publish generated sources
+      val srcs = (managedSources in Compile).value
+      val sdirs = (managedSourceDirectories in Compile).value
+      val base = baseDirectory.value
+      import Path._
+      (srcs --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)
+    }
+
+  lazy val scalacticDotty = project.in(file("scalactic.dotty"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -78,7 +88,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   )
 
-  lazy val scalatestDotty = Project("scalatestDotty", file("scalatest.dotty"))
+  lazy val scalatestDotty = project.in(file("scalatest.dotty"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -182,7 +192,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticDotty)
 
-  lazy val scalatestCoreDotty = Project("scalatestCoreDotty", file("modules/dotty/scalatest-core"))
+  lazy val scalatestCoreDotty = project.in(file("modules/dotty/scalatest-core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -265,7 +275,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticDotty)
 
-  lazy val scalatestFeatureSpecDotty = Project("scalatestFeatureSpecDotty", file("modules/dotty/scalatest-featurespec"))
+  lazy val scalatestFeatureSpecDotty = project.in(file("modules/dotty/scalatest-featurespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -295,7 +305,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestFlatSpecDotty = Project("scalatestFlatSpecDotty", file("modules/dotty/scalatest-flatspec"))
+  lazy val scalatestFlatSpecDotty = project.in(file("modules/dotty/scalatest-flatspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -325,7 +335,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestFreeSpecDotty = Project("scalatestFreeSpecDotty", file("modules/dotty/scalatest-freespec"))
+  lazy val scalatestFreeSpecDotty = project.in(file("modules/dotty/scalatest-freespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -355,7 +365,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestFunSuiteDotty = Project("scalatestFunSuiteDotty", file("modules/dotty/scalatest-funsuite"))
+  lazy val scalatestFunSuiteDotty = project.in(file("modules/dotty/scalatest-funsuite"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -385,7 +395,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestFunSpecDotty = Project("scalatestFunSpecDotty", file("modules/dotty/scalatest-funspec"))
+  lazy val scalatestFunSpecDotty = project.in(file("modules/dotty/scalatest-funspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -415,7 +425,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestPropSpecDotty = Project("scalatestPropSpecDotty", file("modules/dotty/scalatest-propspec"))
+  lazy val scalatestPropSpecDotty = project.in(file("modules/dotty/scalatest-propspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -445,7 +455,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestRefSpecDotty = Project("scalatestRefSpecDotty", file("modules/dotty/scalatest-refspec"))
+  lazy val scalatestRefSpecDotty = project.in(file("modules/dotty/scalatest-refspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -475,7 +485,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestWordSpecDotty = Project("scalatestWordSpecDotty", file("modules/dotty/scalatest-wordspec"))
+  lazy val scalatestWordSpecDotty = project.in(file("modules/dotty/scalatest-wordspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -505,7 +515,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestDiagramsDotty = Project("scalatestDiagramsDotty", file("modules/dotty/scalatest-diagrams"))
+  lazy val scalatestDiagramsDotty = project.in(file("modules/dotty/scalatest-diagrams"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -535,7 +545,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestMatchersCoreDotty = Project("scalatestMatchersCoreDotty", file("modules/dotty/scalatest-matchers-core"))
+  lazy val scalatestMatchersCoreDotty = project.in(file("modules/dotty/scalatest-matchers-core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -567,7 +577,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreDotty)
 
-  lazy val scalatestShouldMatchersDotty = Project("scalatestShouldMatchersDotty", file("modules/dotty/scalatest-shouldmatchers"))
+  lazy val scalatestShouldMatchersDotty = project.in(file("modules/dotty/scalatest-shouldmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -597,7 +607,7 @@ trait DottyBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestMatchersCoreDotty)
 
-  lazy val scalatestMustMatchersDotty = Project("scalatestMustMatchersDotty", file("modules/dotty/scalatest-mustmatchers"))
+  lazy val scalatestMustMatchersDotty = project.in(file("modules/dotty/scalatest-mustmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
@@ -651,9 +661,29 @@ trait DottyBuild { this: BuildCommons =>
       scalatestMustMatchersDotty
     )
 
-  lazy val commonTestDotty = Project("commonTestDotty", file("common-test.dotty"))
+  private lazy val noPublishSettings = Seq(
+    publishArtifact := false,
+    publish := {},
+    publishLocal := {},
+  )  
+
+  def sharedTestSettingsDotty: Seq[Setting[_]] = 
+    Seq(
+      organization := "org.scalatest",
+      libraryDependencies ++= scalatestLibraryDependencies,
+      //libraryDependencies ++= scalatestTestLibraryDependencies(scalaVersion.value),
+      testOptions in Test := scalatestTestOptions,
+      logBuffered in Test := false,
+      //fork in Test := true,
+      //parallelExecution in Test := true,
+      //testForkedParallel in Test := true,
+      baseDirectory in Test := file("./"),
+    ) ++ noPublishSettings 
+
+  lazy val commonTestDotty = project.in(file("common-test.dotty"))
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
+    .settings(sharedTestSettingsDotty: _*)
     .settings(
       projectTitle := "Common test classes used by scalactic and scalatest",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
@@ -664,14 +694,12 @@ trait DottyBuild { this: BuildCommons =>
           GenCompatibleClasses.genTest((sourceManaged in Compile).value, version.value, scalaVersion.value)
         }.taskValue
       },
-      publishArtifact := false,
-      publish := {},
-      publishLocal := {}
     ).dependsOn(scalacticDotty, LocalProject("scalatestDotty"))
 
   lazy val scalacticTestDotty = Project("scalacticTestDotty", file("scalactic-test.dotty"))
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
+    .settings(sharedTestSettingsDotty: _*)
     .settings(
       projectTitle := "Scalactic Test",
       organization := "org.scalactic",
@@ -680,34 +708,24 @@ trait DottyBuild { this: BuildCommons =>
           "-oDIF",
           "-W", "120", "60")),
       logBuffered in Test := false,
-      publishArtifact := false,
-      publish := {},
-      publishLocal := {},
       sourceGenerators in Test += Def.task {
         GenScalacticDotty.genTest((sourceManaged in Test).value, version.value, scalaVersion.value) /*++
         GenAnyVals.genTest((sourceManaged in Test).value / "scala" / "org" / "scalactic" / "anyvals", version.value, scalaVersion.value)*/
       }.taskValue
     ).dependsOn(scalacticDotty, scalatestDotty % "test", commonTestDotty % "test")
+ 
 
-  lazy val scalatestTestDotty = Project("scalatestTestDotty", file("scalatest-test.dotty"))
+  lazy val scalatestTestDotty = project.in(file("scalatest-test.dotty"))
     .settings(sharedSettings: _*)
     .settings(dottySettings: _*)
+    .settings(sharedTestSettingsDotty: _*)
     .settings(
       projectTitle := "ScalaTest Test",
-      organization := "org.scalatest",
-      libraryDependencies ++= scalatestLibraryDependencies,
-      //libraryDependencies ++= scalatestTestLibraryDependencies(scalaVersion.value),
-      testOptions in Test := scalatestTestOptions,
-      logBuffered in Test := false,
-      //fork in Test := true,
-      //parallelExecution in Test := true,
-      //testForkedParallel in Test := true,
       sourceGenerators in Test += {
         Def.task {
           GenScalaTestDotty.genTest((sourceManaged in Test).value, version.value, scalaVersion.value)
         }.taskValue
       },
-      baseDirectory in Test := file("./"),
       publishArtifact := false,
       publish := {},
       publishLocal := {}

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -401,7 +401,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val examplesJS = Project("examplesJS", file("examples.js"))
     .settings(
-      crossScalaVersions := supportedScalaVersions,
+      scalaVersionsSettings,
       sourceGenerators in Test += {
         Def.task {
           GenExamplesJS.genScala((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -24,7 +24,7 @@ trait JsBuild { this: BuildCommons =>
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  lazy val scalacticMacroJS = Project("scalacticMacroJS", file("scalactic-macro.js"))
+  lazy val scalacticMacroJS = project.in(file("scalactic-macro.js"))
     .settings(sharedSettings: _*)
     .settings(
       projectTitle := "Scalactic Macro.js",
@@ -54,7 +54,7 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions in (Compile, doc) := List.empty
     ).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalacticJS = Project("scalacticJS", file("scalactic.js"))
+  lazy val scalacticJS = project.in(file("scalactic.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalacticDocSettings: _*)
@@ -105,7 +105,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestJS = Project("scalatestJS", file("scalatest.js"))
+  lazy val scalatestJS = project.in(file("scalatest.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -200,7 +200,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalacticJS).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestAppJS = Project("scalatestAppJS", file("scalatest-app.js"))
+  lazy val scalatestAppJS = project.in(file("scalatest-app.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -308,7 +308,7 @@ trait JsBuild { this: BuildCommons =>
       "-m", "org.scalatest.diagrams",
       "-oDIF"))  
 
-  lazy val commonTestJS = Project("commonTestJS", file("common-test.js"))
+  lazy val commonTestJS = project.in(file("common-test.js"))
     .settings(sharedSettings: _*)
     .settings(
       projectTitle := "Common test classes used by scalactic.js and scalatest.js",
@@ -326,7 +326,7 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions in (Compile, doc) := List.empty
     ).dependsOn(scalacticMacroJS, LocalProject("scalatestJS")).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalacticTestJS = Project("scalacticTestJS", file("scalactic-test.js"))
+  lazy val scalacticTestJS = project.in(file("scalactic-test.js"))
     .settings(sharedSettings: _*)
     .settings(
       projectTitle := "Scalactic Test.js",
@@ -356,10 +356,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification"))
     ).dependsOn(scalacticJS, scalatestJS % "test", commonTestJS % "test").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestTestJS = Project("scalatestTestJS", file("scalatest-test.js"))
-    .settings(sharedSettings: _*)
-    .settings(
-      projectTitle := "ScalaTest Test",
+  def sharedTestSettingsJS: Seq[Setting[_]] = 
+    Seq(
       organization := "org.scalatest",
       //jsDependencies += RuntimeDOM % "test",
       scalaJSLinkerConfig ~= { _.withOptimizer(false) },
@@ -378,7 +376,14 @@ trait JsBuild { this: BuildCommons =>
       publishArtifact := false,
       publish := {},
       publishLocal := {},
-      scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),
+      scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification"))
+    )
+
+  lazy val scalatestTestJS = Project("scalatestTestJS", file("scalatest-test.js"))
+    .settings(sharedSettings: _*)
+    .settings(sharedTestSettingsJS: _*)
+    .settings(
+      projectTitle := "ScalaTest Test",
       sourceGenerators in Test += {
         Def.task {
           GenScalaTestJS.genTest((sourceManaged in Test).value, version.value, scalaVersion.value)
@@ -399,7 +404,7 @@ trait JsBuild { this: BuildCommons =>
       (resourceManaged in Compile).value,
       name.value)
 
-  lazy val examplesJS = Project("examplesJS", file("examples.js"))
+  lazy val examplesJS = project.in(file("examples.js"))
     .settings(
       scalaVersionsSettings,
       sourceGenerators in Test += {
@@ -409,7 +414,7 @@ trait JsBuild { this: BuildCommons =>
       }
     ).dependsOn(scalacticMacroJS, scalacticJS, scalatestJS).enablePlugins(ScalaJSPlugin)      
 
-  lazy val scalatestCoreJS = Project("scalatestCoreJS", file("modules/js/scalatest-core.js"))
+  lazy val scalatestCoreJS = project.in(file("modules/js/scalatest-core.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -485,7 +490,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalacticJS).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestFeatureSpecJS = Project("scalatestFeatureSpecJS", file("modules/js/scalatest-featurespec.js"))
+  lazy val scalatestFeatureSpecJS = project.in(file("modules/js/scalatest-featurespec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -517,7 +522,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestFlatSpecJS = Project("scalatestFlatSpecJS", file("modules/js/scalatest-flatspec.js"))
+  lazy val scalatestFlatSpecJS = project.in(file("modules/js/scalatest-flatspec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -549,7 +554,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestFreeSpecJS = Project("scalatestFreeSpecJS", file("modules/js/scalatest-freespec.js"))
+  lazy val scalatestFreeSpecJS = project.in(file("modules/js/scalatest-freespec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -581,7 +586,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)      
 
-  lazy val scalatestFunSuiteJS = Project("scalatestFunSuiteJS", file("modules/js/scalatest-funsuite.js"))
+  lazy val scalatestFunSuiteJS = project.in(file("modules/js/scalatest-funsuite.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -613,7 +618,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestFunSpecJS = Project("scalatestFunSpecJS", file("modules/js/scalatest-funspec.js"))
+  lazy val scalatestFunSpecJS = project.in(file("modules/js/scalatest-funspec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -645,7 +650,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)  
 
-  lazy val scalatestPropSpecJS = Project("scalatestPropSpecJS", file("modules/js/scalatest-propspec.js"))
+  lazy val scalatestPropSpecJS = project.in(file("modules/js/scalatest-propspec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -677,7 +682,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestWordSpecJS = Project("scalatestWordSpecJS", file("modules/js/scalatest-wordspec.js"))
+  lazy val scalatestWordSpecJS = project.in(file("modules/js/scalatest-wordspec.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -709,7 +714,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalatestCoreJS, scalacticMacroJS % "compile-internal, test-internal").enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestDiagramsJS = Project("scalatestDiagramsJS", file("modules/js/scalatest-diagrams.js"))
+  lazy val scalatestDiagramsJS = project.in(file("modules/js/scalatest-diagrams.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -741,7 +746,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalatestCoreJS).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestMatchersCoreJS = Project("scalatestMatchersCoreJS", file("modules/js/scalatest-matchers-core.js"))
+  lazy val scalatestMatchersCoreJS = project.in(file("modules/js/scalatest-matchers-core.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -775,7 +780,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalatestCoreJS).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestShouldMatchersJS = Project("scalatestShouldMatchersJS", file("modules/js/scalatest-shouldmatchers.js"))
+  lazy val scalatestShouldMatchersJS = project.in(file("modules/js/scalatest-shouldmatchers.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -807,7 +812,7 @@ trait JsBuild { this: BuildCommons =>
       )
     ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalatestMatchersCoreJS).enablePlugins(ScalaJSPlugin)
 
-  lazy val scalatestMustMatchersJS = Project("scalatestMustMatchersJS", file("modules/js/scalatest-mustmatchers.js"))
+  lazy val scalatestMustMatchersJS = project.in(file("modules/js/scalatest-mustmatchers.js"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(
@@ -837,9 +842,9 @@ trait JsBuild { this: BuildCommons =>
         "Bundle-DocURL" -> "http://www.scalatest.org/",
         "Bundle-Vendor" -> "Artima, Inc."
       )
-    ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalatestMatchersCoreJS).enablePlugins(ScalaJSPlugin)              
+    ).dependsOn(scalacticMacroJS % "compile-internal, test-internal", scalatestMatchersCoreJS).enablePlugins(ScalaJSPlugin)    
 
-  lazy val scalatestModulesJS = (project in file("modules/js/modules-aggregation"))
+  lazy val scalatestModulesJS = project.in(file("modules/js/modules-aggregation"))
     .settings(sharedSettings: _*)
     .settings(
       publishArtifact := false,
@@ -859,6 +864,6 @@ trait JsBuild { this: BuildCommons =>
       scalatestMatchersCoreJS, 
       scalatestShouldMatchersJS, 
       scalatestMustMatchersJS
-    )
+    )            
 
 }

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -27,8 +27,14 @@ trait NativeBuild { this: BuildCommons =>
     }
   }
 
-  lazy val scalacticMacroNative = Project("scalacticMacroNative", file("scalactic-macro.native"))
-    .settings(sharedSettings: _*)
+  private lazy val sharedNativeSettings = Seq(
+    // scala-native only available for scala 2.11
+    crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.11.")),
+    scalaVersion := crossScalaVersions.value.head,
+  )
+
+  lazy val scalacticMacroNative = project.in(file("scalactic-macro.native"))
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(
       projectTitle := "Scalactic Macro.native",
       organization := "org.scalactic",
@@ -49,9 +55,9 @@ trait NativeBuild { this: BuildCommons =>
       scalacOptions in (Compile, doc) := List.empty
     ).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalacticNative = Project("scalacticNative", file("scalactic.native"))
+  lazy val scalacticNative = project.in(file("scalactic.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalacticDocSettings: _*)
     .settings(
       projectTitle := "Scalactic.native",
@@ -92,9 +98,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestNative = Project("scalatestNative", file("scalatest.native"))
+  lazy val scalatestNative = project.in(file("scalatest.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest",
@@ -186,9 +192,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalacticNative).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestAppNative = Project("scalatestAppNative", file("scalatest-app.native"))
+  lazy val scalatestAppNative = project.in(file("scalatest-app.native"))
       .enablePlugins(SbtOsgi)
-      .settings(sharedSettings: _*)
+      .settings(sharedSettings ++ sharedNativeSettings)
       .settings(
         projectTitle := "ScalaTest App",
         name := "scalatest-app",
@@ -264,9 +270,9 @@ trait NativeBuild { this: BuildCommons =>
         )
       ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalacticNative % "compile-internal", scalatestNative % "compile-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestCoreNative = Project("scalatestCoreNative", file("modules/native/scalatest-core.native"))
+  lazy val scalatestCoreNative = project.in(file("modules/native/scalatest-core.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Core Native",
@@ -336,9 +342,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalacticNative).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestFeatureSpecNative = Project("scalatestFeatureSpecNative", file("modules/native/scalatest-featurespec.native"))
+  lazy val scalatestFeatureSpecNative = project.in(file("modules/native/scalatest-featurespec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FeatureSpec Native",
@@ -365,9 +371,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestFlatSpecNative = Project("scalatestFlatSpecNative", file("modules/native/scalatest-flatspec.native"))
+  lazy val scalatestFlatSpecNative = project.in(file("modules/native/scalatest-flatspec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FlatSpec Native",
@@ -394,9 +400,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestFreeSpecNative = Project("scalatestFreeSpecNative", file("modules/native/scalatest-freespec.native"))
+  lazy val scalatestFreeSpecNative = project.in(file("modules/native/scalatest-freespec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FreeSpec Native",
@@ -423,9 +429,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestFunSuiteNative = Project("scalatestFunSuiteNative", file("modules/native/scalatest-funsuite.native"))
+  lazy val scalatestFunSuiteNative = project.in(file("modules/native/scalatest-funsuite.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSuite Native",
@@ -452,9 +458,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestFunSpecNative = Project("scalatestFunSpecNative", file("modules/native/scalatest-funspec.native"))
+  lazy val scalatestFunSpecNative = project.in(file("modules/native/scalatest-funspec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSpec Native",
@@ -481,9 +487,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestPropSpecNative = Project("scalatestPropSpecNative", file("modules/native/scalatest-propspec.native"))
+  lazy val scalatestPropSpecNative = project.in(file("modules/native/scalatest-propspec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec Native",
@@ -510,9 +516,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestWordSpecNative = Project("scalatestWordSpecNative", file("modules/native/scalatest-wordspec.native"))
+  lazy val scalatestWordSpecNative = project.in(file("modules/native/scalatest-wordspec.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest WordSpec Native",
@@ -539,9 +545,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalatestCoreNative, scalacticMacroNative % "compile-internal, test-internal").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestDiagramsNative = Project("scalatestDiagramsNative", file("modules/native/scalatest-diagrams.native"))
+  lazy val scalatestDiagramsNative = project.in(file("modules/native/scalatest-diagrams.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Diagrams Native",
@@ -568,9 +574,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalatestCoreNative).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestMatchersCoreNative = Project("scalatestMatchersCoreNative", file("modules/native/scalatest-matchers-core.native"))
+  lazy val scalatestMatchersCoreNative = project.in(file("modules/native/scalatest-matchers-core.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Matchers Core Native",
@@ -599,9 +605,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalatestCoreNative).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestShouldMatchersNative = Project("scalatestShouldMatchersNative", file("modules/native/scalatest-shouldmatchers.native"))
+  lazy val scalatestShouldMatchersNative = project.in(file("modules/native/scalatest-shouldmatchers.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Should Matchers Native",
@@ -628,9 +634,9 @@ trait NativeBuild { this: BuildCommons =>
     )
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalatestMatchersCoreNative).enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestMustMatchersNative = Project("scalatestMustMatchersNative", file("modules/native/scalatest-mustmatchers.native"))
+  lazy val scalatestMustMatchersNative = project.in(file("modules/native/scalatest-mustmatchers.native"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings: _*)
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Must Matchers Native",
@@ -686,8 +692,8 @@ trait NativeBuild { this: BuildCommons =>
       "-m", "org.scalatest.diagrams",
       "-oDIF"))
 
-  lazy val commonTestNative = Project("commonTestNative", file("common-test.native"))
-      .settings(sharedSettings: _*)
+  lazy val commonTestNative = project.in(file("common-test.native"))
+      .settings(sharedSettings ++ sharedNativeSettings)
       .settings(
         projectTitle := "Common test classes used by scalactic.native and scalatest.native",
         sourceGenerators in Compile += {
@@ -703,8 +709,8 @@ trait NativeBuild { this: BuildCommons =>
         scalacOptions in (Compile, doc) := List.empty
       ).dependsOn(scalacticMacroNative, LocalProject("scalatestNative")).enablePlugins(ScalaNativePlugin)      
 
-  lazy val scalacticTestNative = Project("scalacticTestNative", file("scalactic-test.native"))
-    .settings(sharedSettings: _*)
+  lazy val scalacticTestNative = project.in(file("scalactic-test.native"))
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(
       projectTitle := "Scalactic Test.native",
       organization := "org.scalactic",
@@ -725,10 +731,8 @@ trait NativeBuild { this: BuildCommons =>
       publishLocal := {}
     ).dependsOn(scalacticNative, scalatestNative % "test", commonTestNative % "test").enablePlugins(ScalaNativePlugin)  
 
-  lazy val scalatestTestNative = Project("scalatestTestNative", file("scalatest-test.native"))
-    .settings(sharedSettings: _*)
-    .settings(
-      projectTitle := "ScalaTest Test",
+  def sharedTestSettingsNative: Seq[Setting[_]] = 
+    Seq(
       organization := "org.scalatest",
       libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
       // libraryDependencies += "io.circe" %%% "circe-parser" % "0.7.1" % "test",
@@ -752,7 +756,14 @@ trait NativeBuild { this: BuildCommons =>
       testOptions in Test := scalatestTestNativeOptions,
       publishArtifact := false,
       publish := {},
-      publishLocal := {},
+      publishLocal := {}
+    )    
+
+  lazy val scalatestTestNative = Project("scalatestTestNative", file("scalatest-test.native"))
+    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedTestSettingsNative: _*)
+    .settings(
+      projectTitle := "ScalaTest Test",
       sourceGenerators in Test += {
         Def.task {
           GenScalaTestNative.genTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
@@ -768,8 +779,8 @@ trait NativeBuild { this: BuildCommons =>
         }*/
     ).dependsOn(scalatestNative % "test", commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
-  lazy val scalatestModulesNative = (project in file("modules/native/modules-aggregation"))
-    .settings(sharedSettings: _*)
+  lazy val scalatestModulesNative = project.in(file("modules/native/modules-aggregation"))
+    .settings(sharedSettings ++ sharedNativeSettings)
     .settings(
       publishArtifact := false,
       publish := {},

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -30,7 +30,6 @@ trait NativeBuild { this: BuildCommons =>
   private lazy val sharedNativeSettings = Seq(
     // scala-native only available for scala 2.11
     crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.11.")),
-    scalaVersion := crossScalaVersions.value.head,
   )
 
   lazy val scalacticMacroNative = project.in(file("scalactic-macro.native"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -317,7 +317,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       scalacOptions in (Compile, doc) := List.empty
     ).dependsOn(scalacticMacro, LocalProject("scalatest"))
 
-  lazy val scalacticMacro = Project("scalacticMacro", file("scalactic-macro"))
+  lazy val scalacticMacro = project.in(file("scalactic-macro"))
     .settings(sharedSettings: _*)
     .settings(
       projectTitle := "Scalactic Macro",
@@ -338,7 +338,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       scalacOptions in (Compile, doc) := List.empty
     )
 
-  lazy val scalactic = Project("scalactic", file("scalactic"))
+  lazy val scalactic = project.in(file("scalactic"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalacticDocSettings: _*)
@@ -404,7 +404,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification"))
     ).dependsOn(scalactic, scalatest % "test", commonTest % "test")
 
-  lazy val scalatest = Project("scalatest", file("scalatest"))
+  lazy val scalatest = project.in(file("scalatest"))
    .enablePlugins(SbtOsgi)
    .settings(sharedSettings: _*)
    .settings(scalatestDocSettings: _*)
@@ -499,7 +499,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
    ).dependsOn(scalacticMacro % "compile-internal, test-internal", scalactic)
 
-  lazy val scalatestTest = Project("scalatest-test", file("scalatest-test"))
+  lazy val scalatestTest = project.in(file("scalatest-test"))
     .settings(sharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest Test",
@@ -518,7 +518,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification"))
     ).dependsOn(scalatest % "test", commonTest % "test")
 
-  lazy val scalatestApp = Project("scalatestApp", file("scalatest-app"))
+  lazy val scalatestApp = project.in(file("scalatest-app"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -600,9 +600,9 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalacticMacro % "compile-internal, test-internal", scalactic % "compile-internal", scalatest % "compile-internal")
 
-  lazy val rootProject = Project("root", file(".")).aggregate(scalacticMacro, scalactic, scalatest, commonTest, scalacticTest, scalatestTest)
+  lazy val rootProject = project.in(file(".")).aggregate(scalacticMacro, scalactic, scalatest, commonTest, scalacticTest, scalatestTest)
 
-  lazy val scalatestCompatible = Project("scalatestCompatible", file("modules/jvm/scalatest-compatible"))
+  lazy val scalatestCompatible = project.in(file("modules/jvm/scalatest-compatible"))
     .enablePlugins(SbtOsgi)
     .settings(commonSharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -644,7 +644,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     )
 
-  lazy val scalatestCore = Project("scalatestCore", file("modules/jvm/scalatest-core"))
+  lazy val scalatestCore = project.in(file("modules/jvm/scalatest-core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -714,7 +714,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCompatible, scalacticMacro % "compile-internal, test-internal", scalactic)  
 
-  lazy val scalatestFeatureSpec = Project("scalatestFeatureSpec", file("modules/jvm/scalatest-featurespec"))
+  lazy val scalatestFeatureSpec = project.in(file("modules/jvm/scalatest-featurespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -753,7 +753,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestFlatSpec = Project("scalatestFlatSpec", file("modules/jvm/scalatest-flatspec"))
+  lazy val scalatestFlatSpec = project.in(file("modules/jvm/scalatest-flatspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -792,7 +792,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestFreeSpec = Project("scalatestFreeSpec", file("modules/jvm/scalatest-freespec"))
+  lazy val scalatestFreeSpec = project.in(file("modules/jvm/scalatest-freespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -831,7 +831,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestFunSuite = Project("scalatestFunSuite", file("modules/jvm/scalatest-funsuite"))
+  lazy val scalatestFunSuite = project.in(file("modules/jvm/scalatest-funsuite"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -870,7 +870,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal") 
 
-  lazy val scalatestFunSpec = Project("scalatestFunSpec", file("modules/jvm/scalatest-funspec"))
+  lazy val scalatestFunSpec = project.in(file("modules/jvm/scalatest-funspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -909,7 +909,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")     
 
-  lazy val scalatestPropSpec = Project("scalatestPropSpec", file("modules/jvm/scalatest-propspec"))
+  lazy val scalatestPropSpec = project.in(file("modules/jvm/scalatest-propspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -948,7 +948,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestRefSpec = Project("scalatestRefSpec", file("modules/jvm/scalatest-refspec"))
+  lazy val scalatestRefSpec = project.in(file("modules/jvm/scalatest-refspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -987,7 +987,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal") 
 
-  lazy val scalatestWordSpec = Project("scalatestWordSpec", file("modules/jvm/scalatest-wordspec"))
+  lazy val scalatestWordSpec = project.in(file("modules/jvm/scalatest-wordspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -1026,7 +1026,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestDiagrams = Project("scalatestDiagrams", file("modules/jvm/scalatest-diagrams"))
+  lazy val scalatestDiagrams = project.in(file("modules/jvm/scalatest-diagrams"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -1065,7 +1065,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestMatchersCore = Project("scalatestMatchersCore", file("modules/jvm/scalatest-matchers-core"))
+  lazy val scalatestMatchersCore = project.in(file("modules/jvm/scalatest-matchers-core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -1106,7 +1106,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestCore, scalacticMacro % "compile-internal, test-internal") 
 
-  lazy val scalatestShouldMatchers = Project("scalatestShouldMatchers", file("modules/jvm/scalatest-shouldmatchers"))
+  lazy val scalatestShouldMatchers = project.in(file("modules/jvm/scalatest-shouldmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -1145,7 +1145,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       )
     ).dependsOn(scalatestMatchersCore, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val scalatestMustMatchers = Project("scalatestMustMatchers", file("modules/jvm/scalatest-mustmatchers"))
+  lazy val scalatestMustMatchers = project.in(file("modules/jvm/scalatest-mustmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
     .settings(scalatestDocSettings: _*)
@@ -1222,7 +1222,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/html"))
   )
 
-  lazy val genRegularTests1 = Project("genRegularTests1", file("gentests/GenRegular1"))
+  lazy val genRegularTests1 = project.in(file("gentests/GenRegular1"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genRegularTask1,
@@ -1233,7 +1233,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genRegularTests2 = Project("genRegularTests2", file("gentests/GenRegular2"))
+  lazy val genRegularTests2 = project.in(file("gentests/GenRegular2"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genRegularTask2,
@@ -1244,7 +1244,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genRegularTests3 = Project("genRegularTests3", file("gentests/GenRegular3"))
+  lazy val genRegularTests3 = project.in(file("gentests/GenRegular3"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genRegularTask3,
@@ -1255,7 +1255,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genRegularTests4 = Project("genRegularTests4", file("gentests/GenRegular4"))
+  lazy val genRegularTests4 = project.in(file("gentests/GenRegular4"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genRegularTask4,
@@ -1275,7 +1275,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genRegularTests5 = Project("genRegularTests5", file("gentests/GenRegular5"))
+  lazy val genRegularTests5 = project.in(file("gentests/GenRegular5"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genRegularTask5,
@@ -1296,7 +1296,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genMustMatchersTests1 = Project("genMustMatchersTests1", file("gentests/MustMatchers1"))
+  lazy val genMustMatchersTests1 = project.in(file("gentests/MustMatchers1"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genMustMatchersTask,
@@ -1307,7 +1307,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genMustMatchersTests2 = Project("genMustMatchersTests2", file("gentests/MustMatchers2"))
+  lazy val genMustMatchersTests2 = project.in(file("gentests/MustMatchers2"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genMustMatchersTask,
@@ -1318,7 +1318,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genMustMatchersTests3 = Project("genMustMatchersTests3", file("gentests/MustMatchers3"))
+  lazy val genMustMatchersTests3 = project.in(file("gentests/MustMatchers3"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genMustMatchersTask,
@@ -1329,7 +1329,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genMustMatchersTests4 = Project("genMustMatchersTests4", file("gentests/MustMatchers4"))
+  lazy val genMustMatchersTests4 = project.in(file("gentests/MustMatchers4"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genMustMatchersTask,
@@ -1340,7 +1340,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genGenTests = Project("genGenTests", file("gentests/GenGen"))
+  lazy val genGenTests = project.in(file("gentests/GenGen"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genGenTask,
@@ -1351,7 +1351,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genTablesTests = Project("genTablesTests", file("gentests/GenTables"))
+  lazy val genTablesTests = project.in(file("gentests/GenTables"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genTablesTask,
@@ -1362,7 +1362,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genInspectorsTests = Project("genInspectorsTests", file("gentests/GenInspectors"))
+  lazy val genInspectorsTests = project.in(file("gentests/GenInspectors"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genInspectorsTask,
@@ -1373,7 +1373,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genInspectorsShorthandsTests1 = Project("genInspectorsShorthandsTests1", file("gentests/GenInspectorsShorthands1"))
+  lazy val genInspectorsShorthandsTests1 = project.in(file("gentests/GenInspectorsShorthands1"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genInspectorsShorthandsTask1,
@@ -1384,7 +1384,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genInspectorsShorthandsTests2 = Project("genInspectorsShorthandsTests2", file("gentests/GenInspectorsShorthands2"))
+  lazy val genInspectorsShorthandsTests2 = project.in(file("gentests/GenInspectorsShorthands2"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genInspectorsShorthandsTask2,
@@ -1395,7 +1395,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genTheyTests = Project("genTheyTests", file("gentests/GenThey"))
+  lazy val genTheyTests = project.in(file("gentests/GenThey"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genTheyWordTask,
@@ -1406,7 +1406,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genContainTests1 = Project("genContainTests1", file("gentests/GenContain1"))
+  lazy val genContainTests1 = project.in(file("gentests/GenContain1"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genContainTask1,
@@ -1417,7 +1417,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genContainTests2 = Project("genContainTests2", file("gentests/GenContain2"))
+  lazy val genContainTests2 = project.in(file("gentests/GenContain2"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genContainTask2,
@@ -1428,7 +1428,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genSortedTests = Project("genSortedTests", file("gentests/GenSorted"))
+  lazy val genSortedTests = project.in(file("gentests/GenSorted"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genSortedTask,
@@ -1439,7 +1439,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genLoneElementTests = Project("genLoneElementTests", file("gentests/GenLoneElement"))
+  lazy val genLoneElementTests = project.in(file("gentests/GenLoneElement"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genLoneElementTask,
@@ -1450,7 +1450,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  lazy val genEmptyTests = Project("genEmptyTests", file("gentests/GenEmpty"))
+  lazy val genEmptyTests = project.in(file("gentests/GenEmpty"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genEmptyTask,
@@ -1461,7 +1461,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")
 
-  /*lazy val genSafeStyleTests = Project("genSafeStyleTests", file("gentests/GenSafeStyles"))
+  /*lazy val genSafeStyleTests = project.in(file("gentests/GenSafeStyles"))
     .settings(gentestsSharedSettings: _*)
     .settings(
       genSafeStyleTestsTask,
@@ -1472,11 +1472,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       }
     ).dependsOn(scalatest, commonTest, scalacticMacro % "compile-internal, test-internal")*/
 
-  lazy val gentests = Project("gentests", file("gentests"))
+  lazy val gentests = project.in(file("gentests"))
     .aggregate(genMustMatchersTests1, genMustMatchersTests2, genMustMatchersTests3, genMustMatchersTests4, genGenTests, genTablesTests, genInspectorsTests, genInspectorsShorthandsTests1,
                genInspectorsShorthandsTests2, genTheyTests, genContainTests1, genContainTests2, genSortedTests, genLoneElementTests, genEmptyTests/*, genSafeStyleTests*/)
 
-  lazy val examples = Project("examples", file("examples"))
+  lazy val examples = project.in(file("examples"))
     .settings(
       scalaVersionsSettings
     ).dependsOn(scalacticMacro, scalactic, scalatest)

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -139,9 +139,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
   )
 
   def sharedSettings: Seq[Setting[_]] = 
-    commonSharedSettings ++ Seq(
-      scalaVersion := defaultScalaVersion,
-      crossScalaVersions := supportedScalaVersions,
+    commonSharedSettings ++ scalaVersionsSettings ++ Seq(
       libraryDependencies ++= {
         if (isDotty.value)
           Seq()
@@ -1216,10 +1214,8 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       "org.scalatestplus" %% "scalatestplus-junit" % plusJUnitVersion % "test"
     )
 
-  def gentestsSharedSettings: Seq[Setting[_]] = Seq(
+  def gentestsSharedSettings: Seq[Setting[_]] = scalaVersionsSettings ++ Seq(
     javaHome := getJavaHome(scalaBinaryVersion.value),
-    scalaVersion := defaultScalaVersion,
-    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-feature") ++ (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty else Seq("-Ypartial-unification")),
     resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public",
     libraryDependencies ++= gentestsLibraryDependencies,
@@ -1482,7 +1478,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   lazy val examples = Project("examples", file("examples"))
     .settings(
-      crossScalaVersions := supportedScalaVersions
+      scalaVersionsSettings
     ).dependsOn(scalacticMacro, scalactic, scalatest)
 
   def genFiles(name: String, generatorSource: String)(gen: (File, String, String) => Unit)(basedir: File, outDir: File, theVersion: String, theScalaVersion: String): Seq[File] = {

--- a/scalactic.dotty/src/main/scala/org/scalactic/Requirements.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/Requirements.scala
@@ -270,7 +270,7 @@ object RequirementsMacro {
       case Typed(Repeated(args, _), _) => // only sequence literal
         args.map(arg => Expr(arg.seal.cast[Any].show))
       case _ =>
-        Reporting.throwError("requireNonNull can only be used with sequence literal, not `seq : _*`")
+        report.throwError("requireNonNull can only be used with sequence literal, not `seq : _*`")
     }
 
     // generate AST that create array containing the argument name in source (get from calling 'show')

--- a/scalactic.dotty/src/main/scala/org/scalactic/Snapshots.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/Snapshots.scala
@@ -235,7 +235,7 @@ object SnapshotsMacro {
           '{ Snapshot($str, ${ arg.seal.cast[Any] }) }
         }
       case arg =>
-        Reporting.throwError("snap can only be used with sequence literal, not `seq : _*`")
+        report.throwError("snap can only be used with sequence literal, not `seq : _*`")
     }
 
     val argumentsS: Expr[Seq[Snapshot]] = liftSeq(snapshots)

--- a/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest.dotty/src/main/scala/org/scalatest/CompileMacro.scala
@@ -197,7 +197,7 @@ object CompileMacro {
         checkNotCompile(code)
 
       case other =>
-        Reporting.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
+        report.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }
   }
 
@@ -249,7 +249,7 @@ object CompileMacro {
         checkNotTypeCheck(code.toString)
 
       case _ =>
-        Reporting.throwError("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")
+        report.throwError("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")
     }
   }
 
@@ -300,7 +300,7 @@ object CompileMacro {
         checkCompile(code.toString)
 
       case other =>
-        Reporting.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
+        report.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }
   }
 


### PR DESCRIPTION
Backported Dotty 0.26 support from the following PR for 3.2.x-new: 

https://github.com/scalatest/scalatest/pull/1862/commits

Please note that some build refactoring commits are not backported, as in 3.1.x the modules are being generated from main source, which is different from 3.2.x-new.