### PR TITLE
[3.0] Green with Scala 2.13.3

### DIFF
--- a/common-test/src/main/scala/org/scalatest/OperatorNames.scala
+++ b/common-test/src/main/scala/org/scalatest/OperatorNames.scala
@@ -35,7 +35,7 @@ class OperatorNames {
   def op_5e_^ : Boolean = true
   def op_7c_| : Boolean = true
   def op_7e_~ : Boolean = true
-  def op_7f_\u007f : Boolean = true
+  def `op_7f_\u007f` : Boolean = true
 
   def !!! : Boolean = true
   def ### : Boolean = true

--- a/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
@@ -505,10 +505,10 @@ class ChainSpec extends UnitSpec {
     num shouldBe 60
   }
   it should "have a groupBy method" in {
-    Chain(1, 2, 3, 4, 5).groupBy(_ % 2) shouldBe Map(1 -> Chain(1, 3, 5), 0 -> Chain(2, 4))
-    Chain(1, 2, 3, 3, 3).groupBy(_ % 2) shouldBe Map(1 -> Chain(1, 3, 3, 3), 0 -> Chain(2))
-    Chain(1, 1, 3, 3, 3).groupBy(_ % 2) shouldBe Map(1 -> Chain(1, 1, 3, 3, 3))
-    Chain(1, 2, 3, 5, 7).groupBy(_ % 2) shouldBe Map(1 -> Chain(1, 3, 5, 7), 0 -> Chain(2))
+    Chain(1, 2, 3, 4, 5).groupBy(_ % 2).toMap shouldBe Map(1 -> Chain(1, 3, 5), 0 -> Chain(2, 4))
+    Chain(1, 2, 3, 3, 3).groupBy(_ % 2).toMap shouldBe Map(1 -> Chain(1, 3, 3, 3), 0 -> Chain(2))
+    Chain(1, 1, 3, 3, 3).groupBy(_ % 2).toMap shouldBe Map(1 -> Chain(1, 1, 3, 3, 3))
+    Chain(1, 2, 3, 5, 7).groupBy(_ % 2).toMap shouldBe Map(1 -> Chain(1, 3, 5, 7), 0 -> Chain(2))
   }
   it should "have a grouped method" in {
     Chain(1, 2, 3).grouped(2).toList shouldBe List(Chain(1, 2), Chain(3))

--- a/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
@@ -133,9 +133,12 @@ class EverySpec extends UnitSpec {
     Every(1, 2, 3)(1) shouldEqual 2 
     One("hi")(0) shouldEqual "hi"
     Many(7, 8, 9)(2) shouldEqual 9
+    val vectorOutOfBoundsException = intercept[IndexOutOfBoundsException] {
+      Vector(1, 2, 3)(3)
+    }
     the [IndexOutOfBoundsException] thrownBy {
       Every(1, 2, 3)(3)
-    } should have message "3"
+    } should have message vectorOutOfBoundsException.getMessage
   }
   it should "have an length method" in {
     One(1).length shouldBe 1

--- a/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -191,6 +191,7 @@ object Prettifier {
             case Success(e) => "Success(" + apply(e) + ")"
             case Left(e) => "Left(" + apply(e) + ")"
             case Right(e) => "Right(" + apply(e) + ")"
+            case s: Symbol => "'" + s.name
             case Good(e) => "Good(" + apply(e) + ")"
             case Bad(e) => "Bad(" + apply(e) + ")"
             case One(e) => "One(" + apply(e) + ")"

--- a/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
@@ -105,19 +105,21 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () and contain only ("fie", "fee", "fum", "foe"))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() and contain only("fie", "fee", "fum", "foe"))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fie", "fee", "fum", "foe") and contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only("fie", "fee", "fum", "foe") and contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -189,12 +191,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (equal (fumList) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (equal(fumList) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,12 +259,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (be(fumList) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -321,12 +327,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () and be (fumList))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() and be(fumList))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -629,19 +637,21 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only () and contain only (1, 3, 2))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only() and contain only(1, 3, 2))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only (1, 3, 2) and contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only(1, 3, 2) and contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -737,12 +747,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(3, 2, 1)) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (be(Many(3, 2, 1)) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
@@ -99,19 +99,21 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () or contain only ("fie", "fee", "fum", "foe"))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() or contain only("fie", "fee", "fum", "foe"))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fie", "fee", "fum", "foe") or contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only("fie", "fee", "fum", "foe") or contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -173,12 +175,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (equal (fumList) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (equal(fumList) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -233,12 +237,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (be(fumList) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -293,12 +299,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () or be (fumList))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() or be(fumList))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -568,19 +576,21 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only () or contain only (1, 3, 2))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only() or contain only(1, 3, 2))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only (1, 3, 2) or contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only(1, 3, 2) or contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -645,12 +655,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (Many(3, 2, 1)) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (be(Many(3, 2, 1)) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
@@ -82,12 +82,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should contain only()
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -137,12 +139,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only())
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -299,12 +303,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          toList shouldNot contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            toList shouldNot contain only()
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -354,12 +360,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          toList shouldNot (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            toList shouldNot (contain only())
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -439,12 +447,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should contain only()
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -519,12 +529,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only())
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -699,12 +711,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (toLists) shouldNot contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(toLists) shouldNot contain only()
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -759,12 +773,14 @@ class EveryShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (toLists) shouldNot (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(toLists) shouldNot (contain only())
+          }
+          e1.failedCodeFileName.get should be("EveryShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("EveryShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {

--- a/scalatest-test/src/test/scala/org/scalatest/InsideMixinSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InsideMixinSpec.scala
@@ -20,7 +20,7 @@ import Matchers._
 import Inside._
 import OptionValues._
 import org.scalatest.exceptions.TestFailedException
-import org.scalactic._
+import org.scalactic.{Resources => _, _}
 import org.scalatest.exceptions.StackDepthException
 
 class InsideMixinSpec extends FunSpec {

--- a/scalatest-test/src/test/scala/org/scalatest/InsideSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/InsideSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.SharedHelpers.thisLineNumber
 import Matchers._
 import OptionValues._
 import org.scalatest.exceptions.TestFailedException
-import org.scalactic._
+import org.scalactic.{Resources => _, _}
 import org.scalatest.exceptions.StackDepthException
 
 class InsideSpec extends FunSpec {

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -107,19 +107,21 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () and contain only ("fie", "fee", "fum", "foe"))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() and contain only("fie", "fee", "fum", "foe"))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fie", "fee", "fum", "foe") and contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only("fie", "fee", "fum", "foe") and contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,12 +193,14 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (equal (fumList) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (equal(fumList) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -257,12 +261,14 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (be(fumList) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -323,12 +329,14 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () and be (fumList))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() and be(fumList))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -633,19 +641,21 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only () and contain only (1, 3, 2))
-        }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only() and contain only(1, 3, 2))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
 
-        val e2 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only (1, 3, 2) and contain only ())
+          val e2 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only(1, 3, 2) and contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -753,12 +763,14 @@ class ListShouldContainOnlyLogicalAndSpec extends FunSpec {
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1)) and contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (be(List(3, 2, 1)) and contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -101,19 +101,21 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () or contain only ("fie", "fee", "fum", "foe"))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() or contain only("fie", "fee", "fum", "foe"))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
+
+          val e2 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only("fie", "fee", "fum", "foe") or contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
-        
-        val e2 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ("fie", "fee", "fum", "foe") or contain only ())
-        }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -175,12 +177,14 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (equal (fumList) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (equal(fumList) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -235,12 +239,14 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (be (fumList) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (be(fumList) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -295,12 +301,14 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only () or be (fumList))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only() or be(fumList))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -572,19 +580,21 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only () or contain only (1, 3, 2))
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only() or contain only(1, 3, 2))
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
+
+          val e2 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only(1, 3, 2) or contain only())
+          }
+          e2.failedCodeFileName.get should be(fileName)
+          e2.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e2.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
-        
-        val e2 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only (1, 3, 2) or contain only ())
-        }
-        e2.failedCodeFileName.get should be (fileName)
-        e2.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e2.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -649,12 +659,14 @@ class ListShouldContainOnlyLogicalOrSpec extends FunSpec {
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (be (List(3, 2, 1)) or contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (be(List(3, 2, 1)) or contain only())
+          }
+          e1.failedCodeFileName.get should be(fileName)
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be (fileName)
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -83,12 +83,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") {  // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should contain only ()
+          }
+          e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
+          e1.message should be (Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -158,12 +160,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          fumList should (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            fumList should (contain only ())
+          }
+          e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
+          e1.message should be (Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -320,12 +324,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          toList shouldNot contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            toList shouldNot contain only()
+          }
+          e1.failedCodeFileName.get should be("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -375,12 +381,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          toList shouldNot (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            toList shouldNot (contain only ())
+          }
+          e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
+          e1.message should be (Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -459,12 +467,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all (list1s) should contain only ()
+          }
+          e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
+          e1.message should be (Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -536,12 +546,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (list1s) should (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(list1s) should (contain only())
+          }
+          e1.failedCodeFileName.get should be("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -710,12 +722,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (toLists) shouldNot contain only ()
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(toLists) shouldNot contain only()
+          }
+          e1.failedCodeFileName.get should be("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -768,12 +782,14 @@ class ListShouldContainOnlySpec extends FunSpec {
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
-        val e1 = intercept[exceptions.NotAllowedException] {
-          all (toLists) shouldNot (contain only ())
+        if (ScalaTestVersions.BuiltForScalaVersion != "2.13") { // For 2.13, the compiler will pass in args with single argument ().
+          val e1 = intercept[exceptions.NotAllowedException] {
+            all(toLists) shouldNot (contain only())
+          }
+          e1.failedCodeFileName.get should be("ListShouldContainOnlySpec.scala")
+          e1.failedCodeLineNumber.get should be(thisLineNumber - 3)
+          e1.message should be(Some(Resources.onlyEmpty))
         }
-        e1.failedCodeFileName.get should be ("ListShouldContainOnlySpec.scala")
-        e1.failedCodeLineNumber.get should be (thisLineNumber - 3)
-        e1.message should be (Some(Resources.onlyEmpty))
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {

--- a/scalatest-test/src/test/scala/org/scalatest/RetriesSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/RetriesSpec.scala
@@ -19,7 +19,7 @@ import time.Span
 import time.SpanSugar._
 import Matchers._
 import Retries._
-import org.scalactic._
+import org.scalactic.{Resources => _, _}
 
 class RetriesSpec extends FunSpec {
 

--- a/scalatest/src/main/scala/org/scalatest/Inside.scala
+++ b/scalatest/src/main/scala/org/scalatest/Inside.scala
@@ -18,7 +18,7 @@ package org.scalatest
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.StackDepthException
 import scala.annotation.tailrec
-import org.scalactic._
+import org.scalactic.{Resources => _, _}
 
 /**
  * Trait containing the <code>inside</code> construct, which allows you to make statements about nested object graphs using pattern matching.

--- a/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
+++ b/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
@@ -160,7 +160,7 @@ trait PrivateMethodTester {
       import invocation._
 
       // If 'getMessage passed as methodName, methodNameToInvoke would be "getMessage"
-      val methodNameToInvoke = methodName.toString.substring(1)
+      val methodNameToInvoke = methodName.name
 
       def isMethodToInvoke(m: Method) = {
 


### PR DESCRIPTION
Get 3.0.x branch to build successfully with the latest Scala 2.13.3, all regular tests under jvm build now green.