### PR TITLE
Allow pendingUntilFixed to catch Throwables

### DIFF
--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -1263,7 +1263,7 @@ trait Assertions extends TripleEquals  {
    * </p>
    *
    * @param f a block of code, which if it completes abruptly, should trigger a <code>TestPendingException</code>
-   * @throws TestPendingException if the passed block of code completes abruptly with an <code>Exception</code> or <code>AssertionError</code>
+   * @throws TestPendingException if the passed block of code completes abruptly with a <code>Throwable</code>
    */
   def pendingUntilFixed(f: => Unit)(implicit pos: source.Position): Assertion with PendingStatement = {
     val isPending =
@@ -1272,8 +1272,7 @@ trait Assertions extends TripleEquals  {
         false
       }
       catch {
-        case _: Exception => true
-        case _: AssertionError => true
+        case _: Throwable => true
       }
       if (isPending)
         throw new TestPendingException

--- a/jvm/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Assertions.scala
@@ -1153,7 +1153,7 @@ trait Assertions extends TripleEquals  {
    * </p>
    *
    * @param f a block of code, which if it completes abruptly, should trigger a <code>TestPendingException</code> 
-   * @throws TestPendingException if the passed block of code completes abruptly with an <code>Exception</code> or <code>AssertionError</code>
+   * @throws TestPendingException if the passed block of code completes abruptly with a <code>Throwable</code>
    */
   def pendingUntilFixed(f: => Unit)(implicit pos: source.Position): Assertion with PendingStatement = {
     val isPending =
@@ -1162,8 +1162,7 @@ trait Assertions extends TripleEquals  {
         false
       }
       catch {
-        case _: Exception => true
-        case _: AssertionError => true
+        case _: Throwable => true
       }
       if (isPending)
         throw new TestPendingException

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSpec.scala
@@ -261,6 +261,13 @@ class SuiteSpec extends AnyFunSpec {
       it("should throw TestPendingException if the code block throws an exception") {
         intercept[TestPendingException] {
           pendingUntilFixed {
+            throw new Throwable("Testing pendingUntilFixed")
+          }
+        }
+      }
+      it("should throw TestPendingException if the code block throws a throwable") {
+        intercept[TestPendingException] {
+          pendingUntilFixed {
             assert(1 + 1 === 3)
           }
         }


### PR DESCRIPTION
Some frameworks (ZIO, for example) may result in an error that extends from `Throwable` directly instead of an `Exception` when effect is run. Test code then has to be wrapped into an extra try/catch to mark test pending.

If you think catching `Throwable` is too drastic due to catching fatal errors too, we could add extra patterns for fatal errors, or allow all subtypes of `Error` to propagate.