### PR TITLE
Add implicit conversion for Either.value

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
@@ -87,16 +87,24 @@ trait EitherValues {
   /**
    * Implicit conversion that adds a <code>value</code> method to <code>LeftProjection</code>.
    *
-   * @param either the <code>LeftProjection</code> on which to add the <code>value</code> method
+   * @param leftProj the <code>LeftProjection</code> on which to add the <code>value</code> method
    */
   implicit def convertLeftProjectionToValuable[L, R](leftProj: Either.LeftProjection[L, R])(implicit pos: source.Position): LeftValuable[L, R] = new LeftValuable(leftProj, pos)
 
   /**
    * Implicit conversion that adds a <code>value</code> method to <code>RightProjection</code>.
    *
-   * @param either the <code>RightProjection</code> on which to add the <code>value</code> method
+   * @param rightProj the <code>RightProjection</code> on which to add the <code>value</code> method
    */
   implicit def convertRightProjectionToValuable[L, R](rightProj: Either.RightProjection[L, R])(implicit pos: source.Position): RightValuable[L, R] = new RightValuable(rightProj, pos)
+
+  /**
+   * Implicit conversion that adds a <code>value</code> method to <code>Either</code>.
+   * This method is right biased and is the equivalent of calling <code>either.right.value</code>.
+   *
+   * @param either the <code>Either</code> on which to add the <code>value</code> method
+   */
+  implicit def convertEitherToValuable[L, R](either: Either[L, R])(implicit pos: source.Position): RightValuable[L, R] = new RightValuable(either.right, pos)
 
   /**
    * Wrapper class that adds a <code>value</code> method to <code>LeftProjection</code>, allowing

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -59,6 +59,23 @@ class EitherValuesSpec extends AnyFunSpec {
       caught.message.value should be (Resources.eitherRightValueNotDefined)
     }
 
+    it("should return the right value inside an either if the either is a Right") {
+      val e: Either[String, String] = Right("hi there")
+      e.value should === ("hi there")
+      e.value should startWith ("hi")
+    }
+
+    it("should throw TestFailedException if either is not a Right") {
+      val e: Either[String, String] = Left("hi there")
+      val caught =
+        the [TestFailedException] thrownBy {
+          e.value should startWith ("hi")
+        }
+      caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
+      caught.failedCodeFileName.value should be ("EitherValuesSpec.scala")
+      caught.message.value should be (Resources.eitherRightValueNotDefined)
+    }
+
     it("should allow an immediate application of parens to invoke apply on the type contained in the Left") {
       val lefty: Either[Map[String, Int], String] = Left(Map("I" -> 1, "II" -> 2))
       lefty.left.value("II") shouldBe 2
@@ -67,6 +84,11 @@ class EitherValuesSpec extends AnyFunSpec {
     it("should allow an immediate application of parens to invoke apply on the type contained in the Right") {
       val righty: Either[String, Map[String, Int]] = Right(Map("I" -> 1, "II" -> 2))
       righty.right.value("II") shouldBe 2
+    }
+
+    it("should allow an immediate application of parens to invoke apply on the type contained in the Right if the Either is a Right") {
+      val righty: Either[String, Map[String, Int]] = Right(Map("I" -> 1, "II" -> 2))
+      righty.value("II") shouldBe 2
     }
   } 
 }


### PR DESCRIPTION
* `Either.value` is right biased
* Allows users of Scala 2.13 to use `EitherValues` for `Right`s without getting deprecation warnings

Also correct param documentation for `Left` and `Right` conversions