### PR TITLE
Avoid NotSerializableException when TryValues or EitherValues raise assertion failure

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
@@ -80,7 +80,6 @@ import org.scalatest.exceptions.TestFailedException
  * either.right.value should be &gt; 9 // either.right.value throws TestFailedException
  * </pre>
  */
-@SerialVersionUID(1384255766627026242L)
 trait EitherValues extends Serializable {
 
   import scala.language.implicitConversions

--- a/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
@@ -80,7 +80,8 @@ import org.scalatest.exceptions.TestFailedException
  * either.right.value should be &gt; 9 // either.right.value throws TestFailedException
  * </pre>
  */
-trait EitherValues {
+@SerialVersionUID(1384255766627026242L)
+trait EitherValues extends Serializable {
 
   import scala.language.implicitConversions
 
@@ -109,7 +110,8 @@ trait EitherValues {
    * @param leftProj A <code>LeftProjection</code> to convert to <code>LeftValuable</code>, which provides the
    *   <code>value</code> method.
    */
-  class LeftValuable[L, R](leftProj: Either.LeftProjection[L, R], pos: source.Position) {
+  @SerialVersionUID(6456651986588292408L)
+  class LeftValuable[L, R](leftProj: Either.LeftProjection[L, R], pos: source.Position) extends Serializable {
 
     /**
      * Returns the <code>Left</code> value contained in the wrapped <code>LeftProjection</code>, if defined as a <code>Left</code>, else throws <code>TestFailedException</code> with
@@ -137,7 +139,8 @@ trait EitherValues {
    * @param rightProj A <code>RightProjection</code> to convert to <code>RightValuable</code>, which provides the
    *   <code>value</code> method.
    */
-  class RightValuable[L, R](rightProj: Either.RightProjection[L, R], pos: source.Position) {
+  @SerialVersionUID(7116575630323705558L)
+  class RightValuable[L, R](rightProj: Either.RightProjection[L, R], pos: source.Position) extends Serializable {
 
     /**
      * Returns the <code>Right</code> value contained in the wrapped <code>RightProjection</code>, if defined as a <code>Right</code>, else throws <code>TestFailedException</code> with

--- a/jvm/core/src/main/scala/org/scalatest/TryValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TryValues.scala
@@ -87,7 +87,6 @@ import org.scalatest.exceptions.TestFailedException
  * </pre>
  *
  */
-@SerialVersionUID(1122096182308845989L)
 trait TryValues extends Serializable {
 
   import scala.language.implicitConversions

--- a/jvm/core/src/main/scala/org/scalatest/TryValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TryValues.scala
@@ -87,7 +87,8 @@ import org.scalatest.exceptions.TestFailedException
  * </pre>
  *
  */
-trait TryValues {
+@SerialVersionUID(1122096182308845989L)
+trait TryValues extends Serializable {
 
   import scala.language.implicitConversions
 
@@ -109,7 +110,8 @@ trait TryValues {
    *
    * @param theTry An <code>Try</code> to convert to <code>SuccessOrFailure</code>, which provides the <code>success</code> and <code>failure</code> methods.
    */
-  class SuccessOrFailure[T](theTry: Try[T], pos: source.Position) {
+  @SerialVersionUID(7710541571360501642L)
+  class SuccessOrFailure[T](theTry: Try[T], pos: source.Position) extends Serializable {
 
     /**
      * Returns the <code>Try</code> passed to the constructor as a <code>Failure</code>, if it is a <code>Failure</code>, else throws <code>TestFailedException</code> with

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -44,6 +44,7 @@ class EitherValuesSpec extends AnyFunSpec {
       caught.message.value should be (Resources.eitherLeftValueNotDefined(e))
     }
     
+    // SKIP-SCALATESTJS-START
     it("should throw a serialized TestFailedException") {
       val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
       val e: Either[String, String] = Right("hi there")
@@ -54,6 +55,7 @@ class EitherValuesSpec extends AnyFunSpec {
 
       noException should be thrownBy objectOutputStream.writeObject(caught)
     }
+    // SKIP-SCALATESTJS-END
 
     it("should return the right value inside an either if right.value is defined") {
       val e: Either[String, String] = Right("hi there")

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest
 
+import java.io.ObjectOutputStream
+
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.SharedHelpers.thisLineNumber
@@ -42,6 +44,17 @@ class EitherValuesSpec extends AnyFunSpec {
       caught.message.value should be (Resources.eitherLeftValueNotDefined(e))
     }
     
+    it("should throw a serialized TestFailedException") {
+      val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
+      val e: Either[String, String] = Right("hi there")
+      val caught =
+        the [TestFailedException] thrownBy {
+          e.left.value should startWith ("hi")
+        }
+
+      noException should be thrownBy objectOutputStream.writeObject(caught)
+    }
+
     it("should return the right value inside an either if right.value is defined") {
       val e: Either[String, String] = Right("hi there")
       e.right.value should === ("hi there")

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
@@ -15,6 +15,8 @@
  */
 package org.scalatest
 
+import java.io.ObjectOutputStream
+
 import org.scalatest.TryValues._
 import org.scalatest.OptionValues._
 import matchers.should.Matchers._
@@ -45,6 +47,17 @@ class TryValuesSpec extends AnyFunSpec {
       caught.failedCodeLineNumber.value should equal (thisLineNumber - 2)
       caught.failedCodeFileName.value should be ("TryValuesSpec.scala")
       caught.message.value should be (Resources.tryNotAFailure(t))
+    }
+
+    it("should throw a serializable TestFailedException") {
+      val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
+      val t: Try[String] = Success("hi there")
+      val caught =
+        the [TestFailedException] thrownBy {
+          t.failure.exception should equal (new Exception)
+        }
+
+      noException should be thrownBy objectOutputStream.writeObject(caught)
     }
 
     it("should return the value inside a Try if it is a Success") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
@@ -49,6 +49,7 @@ class TryValuesSpec extends AnyFunSpec {
       caught.message.value should be (Resources.tryNotAFailure(t))
     }
 
+    // SKIP-SCALATESTJS-START
     it("should throw a serializable TestFailedException") {
       val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
       val t: Try[String] = Success("hi there")
@@ -59,6 +60,7 @@ class TryValuesSpec extends AnyFunSpec {
 
       noException should be thrownBy objectOutputStream.writeObject(caught)
     }
+    // SKIP-SCALATESTJS-END
 
     it("should return the value inside a Try if it is a Success") {
       val t: Try[String] = Success("hi there")

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AbstractPatienceConfigurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AbstractPatienceConfigurationSpec.scala
@@ -1,0 +1,29 @@
+package org.scalatest.concurrent
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.time.{Milliseconds, Span}
+
+class AbstractPatienceConfigurationSpec extends AnyFunSpec {
+
+  describe("A PatienceConfig instance") {
+
+    it("should be serialized and deserialized") {
+      val initialPatienceConfig = AbstractPatienceConfiguration.PatienceConfig(Span(466, Milliseconds))
+      val objectStream = new ByteArrayOutputStream()
+      val out = new ObjectOutputStream(objectStream)
+      out.writeObject(initialPatienceConfig)
+      val in = new ObjectInputStream(new ByteArrayInputStream(objectStream.toByteArray))
+
+      val afterSerializationPatienceConfig = in.readObject()
+
+      afterSerializationPatienceConfig mustBe initialPatienceConfig
+      out.close()
+      in.close()
+    }
+
+  }
+
+}

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AbstractPatienceConfigurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AbstractPatienceConfigurationSpec.scala
@@ -10,6 +10,7 @@ class AbstractPatienceConfigurationSpec extends AnyFunSpec {
 
   describe("A PatienceConfig instance") {
 
+    // SKIP-SCALATESTJS-START
     it("should be serialized and deserialized") {
       val initialPatienceConfig = AbstractPatienceConfiguration.PatienceConfig(Span(466, Milliseconds))
       val objectStream = new ByteArrayOutputStream()
@@ -23,6 +24,7 @@ class AbstractPatienceConfigurationSpec extends AnyFunSpec {
       out.close()
       in.close()
     }
+    // SKIP-SCALATESTJS-END
 
   }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
@@ -22,7 +22,9 @@ import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.concurrent.CanAwait
 import scala.concurrent.ExecutionContext
+// SKIP-SCALATESTJS-START
 import java.io.ObjectOutputStream
+// SKIP-SCALATESTJS-END
 import java.util.concurrent.TimeoutException
 import org.scalatest._
 import time._
@@ -179,6 +181,7 @@ class ScalaFuturesSpec extends AnyFunSpec with Matchers with OptionValues with S
         caught.failedCodeFileName.value should be ("ScalaFuturesSpec.scala")
       }
 
+      // SKIP-SCALATESTJS-START
       it("should eventually blow up with a serialized TestFailedException") {
         val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
         val caught = the [TestFailedException] thrownBy {
@@ -187,6 +190,7 @@ class ScalaFuturesSpec extends AnyFunSpec with Matchers with OptionValues with S
 
         noException should be thrownBy objectOutputStream.writeObject(caught)
       }
+      // SKIP-SCALATESTJS-END
 
       it("should provide the correct stack depth") {
         val caught1 = the [TestFailedException] thrownBy {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
@@ -19,20 +19,15 @@ import org.scalatest.SharedHelpers.thisLineNumber
 import org.scalatest.OptionValues
 import scala.concurrent.{Future => FutureOfScala}
 import scala.concurrent.Promise
-import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.CanAwait
-import scala.concurrent.Awaitable
 import scala.concurrent.ExecutionContext
-import java.util.concurrent.TimeUnit
+import java.io.ObjectOutputStream
 import java.util.concurrent.TimeoutException
 import org.scalatest._
 import time._
 import exceptions.{TestCanceledException, TestFailedException, TestPendingException}
 import util.Try
-import util.Success
-import util.Failure
-import org.scalactic.source
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -182,6 +177,15 @@ class ScalaFuturesSpec extends AnyFunSpec with Matchers with OptionValues with S
         caught.message.value should be (Resources.wasNeverReady("150 milliseconds"))
         caught.failedCodeLineNumber.value should equal (thisLineNumber - 4)
         caught.failedCodeFileName.value should be ("ScalaFuturesSpec.scala")
+      }
+
+      it("should eventually blow up with a serialized TestFailedException") {
+        val objectOutputStream: ObjectOutputStream = new ObjectOutputStream(_ => ())
+        val caught = the [TestFailedException] thrownBy {
+          neverReadyFuture.futureValue
+        }
+
+        noException should be thrownBy objectOutputStream.writeObject(caught)
       }
 
       it("should provide the correct stack depth") {

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -192,6 +192,8 @@ object GenScalaTestDotty {
     copyFiles("jvm/scalatest-test/src/test/scala/org/scalatest", "org/scalatest", targetDir,
       List(
         "AssertionsSpec.scala",
+        "TryValuesSpec.scala", 
+        "EitherValuesSpec.scala"
         // "ShouldCompileSpec.scala",
         // "ShouldNotCompileSpec.scala",
         // "ShouldNotTypeCheckSpec.scala"


### PR DESCRIPTION
Fixes scalatest/scalatest#1883