### PR TITLE
Cleaned up .jvmops

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,8 +1,4 @@
 -server 
 -Xms512M 
--Xmx4000M 
+-Xmx10G
 -Xss10M
--XX:+CMSClassUnloadingEnabled 
--XX:+UseConcMarkSweepGC 
--XX:NewRatio=8
--XX:MaxPermSize=512M


### PR DESCRIPTION
Right now if someone with JDK 14 tries to run sbt inside scalatests he will see warnings:
```
OpenJDK 64-Bit Server VM warning: Ignoring option CMSClassUnloadingEnabled; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option UseConcMarkSweepGC; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
OpenJDK 64-Bit Server VM warning: Ignoring option CMSClassUnloadingEnabled; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option UseConcMarkSweepGC; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
```

And it won't start at all if someone would like to use JDK15+ because `CMSClassUnloadingEnabled` option was remove.

I also increased `Xmx` as promised at https://github.com/scalatest/scalatest/pull/1858