### PR TITLE
Module Tests Correction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val scalatestFreeSpecTest = ScalatestBuild.scalatestFreeSpecTest
 lazy val scalatestFunSpecTest = ScalatestBuild.scalatestFunSpecTest
 lazy val scalatestFunSuiteTest = ScalatestBuild.scalatestFunSuiteTest
 lazy val scalatestPropSpecTest = ScalatestBuild.scalatestPropSpecTest
+lazy val scalatestWordSpecTest = ScalatestBuild.scalatestWordSpecTest
 lazy val scalatestJS = ScalatestBuild.scalatestJS
 lazy val scalatestNative = ScalatestBuild.scalatestNative
 lazy val scalatestDotty = ScalatestBuild.scalatestDotty

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val scalatestFreeSpecTestJS = ScalatestBuild.scalatestFreeSpecTestJS
 lazy val scalatestFunSpecTestJS = ScalatestBuild.scalatestFunSpecTestJS
 lazy val scalatestFunSuiteTestJS = ScalatestBuild.scalatestFunSuiteTestJS
 lazy val scalatestPropSpecTestJS = ScalatestBuild.scalatestPropSpecTestJS
+lazy val scalatestWordSpecTestJS = ScalatestBuild.scalatestWordSpecTestJS
 lazy val scalatestTestNative = ScalatestBuild.scalatestTestNative
 lazy val scalatestDiagramsTestNative = ScalatestBuild.scalatestDiagramsTestNative
 lazy val scalatestFeatureSpecTestNative = ScalatestBuild.scalatestFeatureSpecTestNative

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val scalatestFreeSpecTestDotty = ScalatestBuild.scalatestFreeSpecTestDotty
 lazy val scalatestFunSpecTestDotty = ScalatestBuild.scalatestFunSpecTestDotty
 lazy val scalatestFunSuiteTestDotty = ScalatestBuild.scalatestFunSuiteTestDotty
 lazy val scalatestPropSpecTestDotty = ScalatestBuild.scalatestPropSpecTestDotty
+lazy val scalatestWordSpecTestDotty = ScalatestBuild.scalatestWordSpecTestDotty
 lazy val scalatestApp = ScalatestBuild.scalatestApp
 lazy val scalatestAppJS = ScalatestBuild.scalatestAppJS
 lazy val scalatestAppNative = ScalatestBuild.scalatestAppNative

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val scalatestFreeSpecTestNative = ScalatestBuild.scalatestFreeSpecTestNativ
 lazy val scalatestFunSpecTestNative = ScalatestBuild.scalatestFunSpecTestNative
 lazy val scalatestFunSuiteTestNative = ScalatestBuild.scalatestFunSuiteTestNative
 lazy val scalatestPropSpecTestNative = ScalatestBuild.scalatestPropSpecTestNative
+lazy val scalatestWordSpecTestNative = ScalatestBuild.scalatestWordSpecTestNative
 lazy val scalatestTestDotty = ScalatestBuild.scalatestTestDotty
 lazy val scalatestDiagramsTestDotty = ScalatestBuild.scalatestDiagramsTestDotty
 lazy val scalatestFeatureSpecTestDotty = ScalatestBuild.scalatestFeatureSpecTestDotty

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureFreeSpecSpec.scala
@@ -34,7 +34,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.freespec
 
-class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -337,7 +337,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -345,6 +345,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -354,7 +355,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new freespec.FixtureAnyFreeSpec {
+      class SpecB extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -362,6 +363,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -371,7 +373,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new freespec.FixtureAnyFreeSpec {
+      class SpecC extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -379,6 +381,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -390,7 +393,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new freespec.FixtureAnyFreeSpec {
+      class SpecD extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -398,6 +401,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -411,7 +415,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new freespec.FixtureAnyFreeSpec {
+      class SpecE extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -419,6 +423,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -432,7 +437,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -440,6 +445,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -450,7 +456,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new freespec.FixtureAnyFreeSpec {
+      class SpecB extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -458,6 +464,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -465,7 +472,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new freespec.FixtureAnyFreeSpec {
+      class SpecC extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -473,6 +480,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -480,7 +488,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new freespec.FixtureAnyFreeSpec {
+      class SpecD extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -488,6 +496,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -495,7 +504,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new freespec.FixtureAnyFreeSpec {
+      class SpecE extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -505,6 +514,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -514,7 +524,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new freespec.FixtureAnyFreeSpec {
+      class SpecF extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -524,6 +534,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -533,7 +544,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new freespec.FixtureAnyFreeSpec {
+      class SpecG extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -543,6 +554,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -552,7 +564,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new freespec.FixtureAnyFreeSpec {
+      class SpecH extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -562,6 +574,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -570,7 +583,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new freespec.FixtureAnyFreeSpec {
+      class SpecI extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -580,6 +593,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -588,7 +602,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new freespec.FixtureAnyFreeSpec {
+      class SpecJ extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -598,6 +612,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -606,7 +621,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new freespec.FixtureAnyFreeSpec {
+      class SpecK extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -616,6 +631,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -627,7 +643,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -635,6 +651,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -645,7 +662,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new freespec.FixtureAnyFreeSpec {
+      class SpecB extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -653,6 +670,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -660,7 +678,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new freespec.FixtureAnyFreeSpec {
+      class SpecC extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -668,6 +686,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -675,7 +694,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new freespec.FixtureAnyFreeSpec {
+      class SpecD extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -683,6 +702,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -690,7 +710,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new freespec.FixtureAnyFreeSpec {
+      class SpecE extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -700,6 +720,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -709,7 +730,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new freespec.FixtureAnyFreeSpec {
+      class SpecF extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -719,6 +740,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -728,7 +750,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new freespec.FixtureAnyFreeSpec {
+      class SpecG extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -738,6 +760,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -747,7 +770,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new freespec.FixtureAnyFreeSpec {
+      class SpecH extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -757,6 +780,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -765,7 +789,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new freespec.FixtureAnyFreeSpec {
+      class SpecI extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -775,6 +799,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -783,7 +808,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new freespec.FixtureAnyFreeSpec {
+      class SpecJ extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -793,6 +818,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -801,7 +827,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new freespec.FixtureAnyFreeSpec {
+      class SpecK extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -811,6 +837,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -1155,7 +1182,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 */
     it("should allow both tests that take fixtures and tests that don't") {
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -1170,6 +1197,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
           "should take a fixture" in { s => takesAFixtureInvoked = true; /* ASSERTION_SUCCEED */ }
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1179,7 +1207,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with test functions whose inferred result type is not Unit") {
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -1193,6 +1221,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
           "should take a fixture" in { s => takesAFixtureInvoked = true; true; /* ASSERTION_SUCCEED */ }
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1204,7 +1233,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with ignored tests whose inferred result type is not Unit") {
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var takeNoArgsInvoked = false
@@ -1214,6 +1243,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
           "should take a fixture" ignore { s => takeAFixtureInvoked = true; 42; /* ASSERTION_SUCCEED */ }
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1292,7 +1322,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(s.theNoArgTestWasInvoked)
     }
     it("should pass the correct test name in the OneArgTest passed to withFixture") {
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1301,6 +1331,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1308,7 +1339,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the OneArgTest passed to withFixture") {
-      val a = new freespec.FixtureAnyFreeSpec {
+      class SpecA extends freespec.FixtureAnyFreeSpec {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1317,6 +1348,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1484,7 +1516,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FreeSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureFreeSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1494,7 +1526,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
           pending
         }
         registerTest("test 4") { fixture =>
-          cancel
+          cancel()
         }
         registerIgnoredTest("test 5") { fixture =>
           assert(a == 2)
@@ -1534,9 +1566,9 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
   }
@@ -1560,9 +1592,9 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
     
@@ -1595,7 +1627,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An in clause may not appear inside another in clause."))
     }
@@ -1629,7 +1661,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an in clause."))
     }
@@ -1663,7 +1695,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1697,7 +1729,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1714,7 +1746,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1722,7 +1754,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1739,7 +1771,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1747,7 +1779,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1763,7 +1795,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1786,7 +1818,7 @@ class FreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureFunSpecSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.funspec
 
 import org.scalatest._
 import SharedHelpers._
@@ -34,7 +34,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.funspec
 
-class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
+class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
 
   private val prettifier = Prettifier.default
 
@@ -276,7 +276,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
 
     "should report as ignored, and not run, tests marked ignored" in {
 
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -284,6 +284,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -293,7 +294,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new funspec.FixtureAnyFunSpec {
+      class SpecB extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -301,6 +302,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -310,7 +312,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new funspec.FixtureAnyFunSpec {
+      class SpecC extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -318,6 +320,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -329,7 +332,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new funspec.FixtureAnyFunSpec {
+      class SpecD extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -337,6 +340,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -350,7 +354,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
     "should ignore a test marked as ignored if run is invoked with that testName" in {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new funspec.FixtureAnyFunSpec {
+      class SpecE extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -358,6 +362,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -371,7 +376,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
     "should run only those tests selected by the tags to include and exclude sets" in {
 
       // Nothing is excluded
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -379,6 +384,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -389,7 +395,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new funspec.FixtureAnyFunSpec {
+      class SpecB extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -397,6 +403,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -404,7 +411,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new funspec.FixtureAnyFunSpec {
+      class SpecC extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -412,6 +419,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -419,7 +427,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new funspec.FixtureAnyFunSpec {
+      class SpecD extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -427,6 +435,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -434,7 +443,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new funspec.FixtureAnyFunSpec {
+      class SpecE extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -444,6 +453,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -453,7 +463,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new funspec.FixtureAnyFunSpec {
+      class SpecF extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -463,6 +473,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -472,7 +483,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new funspec.FixtureAnyFunSpec {
+      class SpecG extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -482,6 +493,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -491,7 +503,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new funspec.FixtureAnyFunSpec {
+      class SpecH extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -501,6 +513,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -509,7 +522,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new funspec.FixtureAnyFunSpec {
+      class SpecI extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -519,6 +532,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         it("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -527,7 +541,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new funspec.FixtureAnyFunSpec {
+      class SpecJ extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -537,6 +551,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -545,7 +560,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new funspec.FixtureAnyFunSpec {
+      class SpecK extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -555,6 +570,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -566,7 +582,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
     "should run only those registered tests selected by the tags to include and exclude sets" in {
 
       // Nothing is excluded
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -574,6 +590,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -584,7 +601,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new funspec.FixtureAnyFunSpec {
+      class SpecB extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -592,6 +609,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -599,7 +617,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new funspec.FixtureAnyFunSpec {
+      class SpecC extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -607,6 +625,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -614,7 +633,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new funspec.FixtureAnyFunSpec {
+      class SpecD extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -622,6 +641,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -629,7 +649,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new funspec.FixtureAnyFunSpec {
+      class SpecE extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -639,6 +659,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -648,7 +669,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new funspec.FixtureAnyFunSpec {
+      class SpecF extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -658,6 +679,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -667,7 +689,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new funspec.FixtureAnyFunSpec {
+      class SpecG extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -677,6 +699,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -686,7 +709,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new funspec.FixtureAnyFunSpec {
+      class SpecH extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -696,6 +719,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -704,7 +728,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new funspec.FixtureAnyFunSpec {
+      class SpecI extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -714,6 +738,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -722,7 +747,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new funspec.FixtureAnyFunSpec {
+      class SpecJ extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -732,6 +757,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -740,7 +766,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new funspec.FixtureAnyFunSpec {
+      class SpecK extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -750,6 +776,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -979,7 +1006,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
     }
 */
     "should allow both tests that take fixtures and tests that don't" in {
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -992,6 +1019,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         var takesAFixtureInvoked = false
         it("takes a fixture") { s => takesAFixtureInvoked = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1001,7 +1029,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.takesAFixtureInvoked)
     }
     "should work with test functions whose inferred result type is not Unit" in {
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -1014,6 +1042,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         var takesAFixtureInvoked = false
         it("should take a fixture") { s => takesAFixtureInvoked = true; true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1025,7 +1054,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.takesAFixtureInvoked)
     }
     "should work with ignored tests whose inferred result type is not Unit" in {
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1033,6 +1062,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         ignore("should test this") { () => theTestThisCalled = true; "hi"; /* ASSERTION_SUCCEED */ }
         ignore("should test that") { fixture => theTestThatCalled = true; 42; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1111,7 +1141,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(s.theNoArgTestWasInvoked)
     }
     "should pass the correct test name in the OneArgTest passed to withFixture" in {
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1120,6 +1150,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         }
         it("should do something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1127,7 +1158,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(a.correctTestNameWasPassed)
     }
     "should pass the correct config map in the OneArgTest passed to withFixture" in {
-      val a = new funspec.FixtureAnyFunSpec {
+      class SpecA extends funspec.FixtureAnyFunSpec {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1136,6 +1167,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         }
         it("should do something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1277,9 +1309,9 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
   }
@@ -1303,9 +1335,9 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
     
@@ -1338,7 +1370,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An it clause may not appear inside another it or they clause."))
     }
@@ -1372,7 +1404,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1406,7 +1438,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("A they clause may not appear inside another it or they clause."))
     }
@@ -1440,7 +1472,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1457,7 +1489,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FunSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureFunSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1467,7 +1499,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
           pending
         }
         registerTest("test 4") { fixture =>
-          cancel
+          cancel()
         }
         registerIgnoredTest("test 5") { fixture =>
           assert(a == 2)
@@ -1520,7 +1552,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1554,7 +1586,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1573,7 +1605,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1581,7 +1613,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1600,7 +1632,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1608,7 +1640,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1626,7 +1658,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1649,7 +1681,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureFunSuiteSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.funsuite
 
 import org.scalatest._
 import SharedHelpers._
@@ -25,7 +25,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.funsuite
 
-class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTester*/ {
+class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTester*/ {
 
   describe("A fixture.FunSuite") {
     it("should return the test names in order of registration from testNames") {
@@ -265,7 +265,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -273,6 +273,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -282,7 +283,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new funsuite.FixtureAnyFunSuite {
+      class SuiteB extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -290,6 +291,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SuiteB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -299,7 +301,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new funsuite.FixtureAnyFunSuite {
+      class SuiteC extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -307,6 +309,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SuiteC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -318,7 +321,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new funsuite.FixtureAnyFunSuite {
+      class SuiteD extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -326,6 +329,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SuiteD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -339,7 +343,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new funsuite.FixtureAnyFunSuite {
+      class SuiteE extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -347,6 +351,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SuiteE
 
       import scala.language.reflectiveCalls
 
@@ -360,7 +365,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -368,6 +373,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -378,7 +384,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new funsuite.FixtureAnyFunSuite {
+      class SuiteB extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -386,6 +392,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SuiteB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -393,7 +400,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new funsuite.FixtureAnyFunSuite {
+      class SuiteC extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -401,6 +408,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SuiteC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -408,7 +416,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new funsuite.FixtureAnyFunSuite {
+      class SuiteD extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -416,6 +424,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SuiteD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -423,7 +432,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new funsuite.FixtureAnyFunSuite {
+      class SuiteE extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -433,6 +442,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         test("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SuiteE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -442,7 +452,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new funsuite.FixtureAnyFunSuite {
+      class SuiteF extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -452,6 +462,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         test("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SuiteF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -461,7 +472,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new funsuite.FixtureAnyFunSuite {
+      class SuiteG extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -471,6 +482,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SuiteG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -480,7 +492,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new funsuite.FixtureAnyFunSuite {
+      class SuiteH extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -490,6 +502,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         test("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SuiteH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -498,7 +511,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new funsuite.FixtureAnyFunSuite {
+      class SuiteI extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -508,6 +521,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         test("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         test("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SuiteI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -516,7 +530,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new funsuite.FixtureAnyFunSuite {
+      class SuiteJ extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -526,6 +540,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         test("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SuiteJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -534,7 +549,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new funsuite.FixtureAnyFunSuite {
+      class SuiteK extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -544,6 +559,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SuiteK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -555,7 +571,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -563,6 +579,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -573,7 +590,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new funsuite.FixtureAnyFunSuite {
+      class SuiteB extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -581,6 +598,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SuiteB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -588,7 +606,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new funsuite.FixtureAnyFunSuite {
+      class SuiteC extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -596,6 +614,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SuiteC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -603,7 +622,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new funsuite.FixtureAnyFunSuite {
+      class SuiteD extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -611,6 +630,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SuiteD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -618,7 +638,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new funsuite.FixtureAnyFunSuite {
+      class SuiteE extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -628,6 +648,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SuiteE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -637,7 +658,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new funsuite.FixtureAnyFunSuite {
+      class SuiteF extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -647,6 +668,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SuiteF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -656,7 +678,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new funsuite.FixtureAnyFunSuite {
+      class SuiteG extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -666,6 +688,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SuiteG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -675,7 +698,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new funsuite.FixtureAnyFunSuite {
+      class SuiteH extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -685,6 +708,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SuiteH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -693,7 +717,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new funsuite.FixtureAnyFunSuite {
+      class SuiteI extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -703,6 +727,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SuiteI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -711,7 +736,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new funsuite.FixtureAnyFunSuite {
+      class SuiteJ extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -721,6 +746,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SuiteJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -729,7 +755,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new funsuite.FixtureAnyFunSuite {
+      class SuiteK extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -739,6 +765,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SuiteK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -882,7 +909,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
 
     it("should allow tests without fixtures to be combined with tests with fixtures") {
 
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
 
         var theTestWithFixtureWasRun = false
         var theTestWithoutFixtureWasRun = false
@@ -912,6 +939,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
           /* ASSERTION_SUCCEED */
         }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -956,7 +984,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     }
     // SKIP-SCALATESTJS,NATIVE-END
     it("should allow both tests that take fixtures and tests that don't") {
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -969,6 +997,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         var takesAFixtureInvoked = false
         test("takes a fixture") { s => takesAFixtureInvoked = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -979,7 +1008,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     }
 
     it("should work with test functions whose inferred result type is not Unit") {
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -992,6 +1021,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         var takesAFixtureInvoked = false
         test("takes a fixture") { s => takesAFixtureInvoked = true; true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -1004,7 +1034,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     }
 
     it("should work with ignored tests whose inferred result type is not Unit") {
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1012,6 +1042,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         ignore("test this") { () => theTestThisCalled = true; "hi"; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; 42; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -1091,7 +1122,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
     }
 
     it("should pass the correct test name in the OneArgTest passed to withFixture") {
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1100,6 +1131,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         }
         test("something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -1107,7 +1139,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the OneArgTest passed to withFixture") {
-      val a = new funsuite.FixtureAnyFunSuite {
+      class SuiteA extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1116,6 +1148,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         }
         test("something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SuiteA
 
       import scala.language.reflectiveCalls
 
@@ -1252,7 +1285,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
               assert(a == 2)
             }
             assert(e.message == Some("1 did not equal 2"))
-            assert(e.failedCodeFileName == Some("FunSuiteSpec.scala"))
+            assert(e.failedCodeFileName == Some("FixtureFunSuiteSpec.scala"))
             assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
           }
           registerTest("test 2") { fixture =>
@@ -1262,7 +1295,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
             pending
           }
           registerTest("test 4") { fixture =>
-            cancel
+            cancel()
           }
           registerIgnoredTest("test 5") { fixture =>
             assert(a == 2)
@@ -1313,7 +1346,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1345,7 +1378,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1365,9 +1398,9 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1388,7 +1421,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1419,7 +1452,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A test clause may not appear inside another test clause."))
     }
@@ -1451,7 +1484,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a test clause."))
     }
@@ -1466,7 +1499,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
@@ -1481,7 +1514,7 @@ class FunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTest
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec.scala
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest.fixture
+/*package org.scalatest.wordspec
 
-import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
+class AsyncPropSpecLikeSpec extends FunSpec {
 
   describe("AsyncPropSpecLike") {
 
@@ -32,37 +31,33 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             pending
           }
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           Future {
             cancel
           }
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           Future {
             cancel
           }
@@ -96,29 +91,25 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           assert(a == 1)
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(a == 2)
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           pending
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           cancel
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           cancel
         }
 
@@ -152,11 +143,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -165,7 +152,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -174,7 +161,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             assert(count == 2)
           }
@@ -202,25 +189,21 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           assert(count == 2)
         }
 
@@ -248,18 +231,14 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -292,11 +271,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -313,7 +288,7 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -356,17 +331,13 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         def sum(xs: List[Int]): Future[Int] =
           xs match {
             case Nil => Future.successful(0)
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") { fixture =>
+        property("test 1") {
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -386,25 +357,21 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             succeed
           }
@@ -435,21 +402,17 @@ class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec2.scala
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest.fixture
+/*package org.scalatest.wordspec
 
-import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
   describe("AsyncPropSpecLike") {
 
@@ -30,37 +29,33 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             pending
           }
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           Future {
             cancel
           }
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           Future {
             cancel
           }
@@ -93,29 +88,25 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           assert(a == 1)
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(a == 2)
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           pending
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           cancel
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           cancel
         }
 
@@ -148,11 +139,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -161,7 +148,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -170,7 +157,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             assert(count == 2)
           }
@@ -195,25 +182,21 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           assert(count == 2)
         }
 
@@ -240,18 +223,14 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -287,11 +266,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -308,7 +283,7 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -354,17 +329,13 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         def sum(xs: List[Int]): Future[Int] =
           xs match {
             case Nil => Future.successful(0)
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") { fixture =>
+        property("test 1") {
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -386,25 +357,21 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             succeed
           }
@@ -437,21 +404,17 @@ class AsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec.scala
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest.fixture
+/*package org.scalatest.wordspec
 
-import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec extends org.scalatest.FunSpec {
+class AsyncPropSpecSpec extends FunSpec {
 
   describe("AsyncPropSpec") {
 
@@ -32,37 +31,33 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             pending
           }
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           Future {
             cancel
           }
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           Future {
             cancel
           }
@@ -96,29 +91,25 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           assert(a == 1)
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(a == 2)
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           pending
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           cancel
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           cancel
         }
 
@@ -152,11 +143,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -165,7 +152,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -174,7 +161,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             assert(count == 2)
           }
@@ -202,25 +189,21 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           assert(count == 2)
         }
 
@@ -248,18 +231,14 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -292,11 +271,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -313,7 +288,7 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -356,17 +331,13 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         def sum(xs: List[Int]): Future[Int] =
           xs match {
             case Nil => Future.successful(0)
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") { fixture =>
+        property("test 1") {
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -386,25 +357,21 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             succeed
           }
@@ -435,21 +402,17 @@ class AsyncPropSpecSpec extends org.scalatest.FunSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec2.scala
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest.fixture
+/*package org.scalatest.wordspec
 
-import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
+class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
   describe("AsyncPropSpec") {
 
@@ -30,37 +29,33 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             pending
           }
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           Future {
             cancel
           }
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           Future {
             cancel
           }
@@ -93,29 +88,25 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         val a = 1
 
-        property("test 1") { fixture =>
+        property("test 1") {
           assert(a == 1)
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(a == 2)
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           pending
         }
 
-        property("test 4") { fixture =>
+        property("test 4") {
           cancel
         }
 
-        ignore("test 5") { fixture =>
+        ignore("test 5") {
           cancel
         }
 
@@ -148,11 +139,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -161,7 +148,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -170,7 +157,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             assert(count == 2)
           }
@@ -195,25 +182,21 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           assert(count == 2)
         }
 
@@ -240,18 +223,14 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -287,11 +266,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -308,7 +283,7 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -354,17 +329,13 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
         def sum(xs: List[Int]): Future[Int] =
           xs match {
             case Nil => Future.successful(0)
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") { fixture =>
+        property("test 1") {
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -386,25 +357,21 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           Future {
             succeed
           }
@@ -437,21 +404,17 @@ class AsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
       class ExampleSpec extends AsyncPropSpec {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        property("test 1") { fixture =>
+        property("test 1") {
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") { fixture =>
+        property("test 2") {
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") { fixture =>
+        property("test 3") {
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec.scala
@@ -13,51 +13,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest
+/*package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec extends FunSpec {
+class AsyncPropSpecLikeSpec extends org.scalatest.FunSpec {
 
-  describe("AsyncPropSpec") {
+  describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             pending
           }
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           Future {
             cancel
           }
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           Future {
             cancel
           }
@@ -87,29 +92,33 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           assert(a == 1)
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(a == 2)
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           pending
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           cancel
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           cancel
         }
 
@@ -139,11 +148,15 @@ class AsyncPropSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -152,7 +165,7 @@ class AsyncPropSpecSpec extends FunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -161,7 +174,7 @@ class AsyncPropSpecSpec extends FunSpec {
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             assert(count == 2)
           }
@@ -185,25 +198,29 @@ class AsyncPropSpecSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           assert(count == 2)
         }
 
@@ -229,16 +246,20 @@ class AsyncPropSpecSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -269,9 +290,13 @@ class AsyncPropSpecSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -288,7 +313,7 @@ class AsyncPropSpecSpec extends FunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -325,11 +350,15 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -337,7 +366,7 @@ class AsyncPropSpecSpec extends FunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") {
+        property("test 1") { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -353,25 +382,29 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             succeed
           }
@@ -398,21 +431,25 @@ class AsyncPropSpecSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec2.scala
@@ -13,49 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest
+/*package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecSpec2 extends AsyncFunSpec {
+class FixtureAsyncPropSpecLikeSpec2 extends org.scalatest.AsyncFunSpec {
 
-  describe("AsyncPropSpec") {
+  describe("AsyncPropSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             pending
           }
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           Future {
             cancel
           }
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           Future {
             cancel
           }
@@ -86,27 +91,31 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           assert(a == 1)
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(a == 2)
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           pending
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           cancel
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           cancel
         }
 
@@ -137,9 +146,13 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -148,7 +161,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -157,7 +170,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             assert(count == 2)
           }
@@ -180,23 +193,27 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           assert(count == 2)
         }
 
@@ -221,16 +238,20 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -264,9 +285,13 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -283,7 +308,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -323,11 +348,15 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -335,7 +364,7 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") {
+        property("test 1") { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -355,23 +384,27 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             succeed
           }
@@ -402,19 +435,23 @@ class AsyncPropSpecSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpec {
+      class ExampleSpec extends AsyncPropSpecLike {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec.scala
@@ -13,51 +13,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest
+/*package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec extends FunSpec {
+class FixtureAsyncPropSpecSpec extends org.scalatest.FunSpec {
 
-  describe("AsyncPropSpecLike") {
+  describe("AsyncPropSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             pending
           }
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           Future {
             cancel
           }
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           Future {
             cancel
           }
@@ -87,29 +92,33 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           assert(a == 1)
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(a == 2)
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           pending
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           cancel
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           cancel
         }
 
@@ -139,11 +148,15 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -152,7 +165,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -161,7 +174,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             assert(count == 2)
           }
@@ -185,25 +198,29 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           assert(count == 2)
         }
 
@@ -229,16 +246,20 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -269,9 +290,13 @@ class AsyncPropSpecLikeSpec extends FunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -288,7 +313,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -325,11 +350,15 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -337,7 +366,7 @@ class AsyncPropSpecLikeSpec extends FunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") {
+        property("test 1") { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -353,25 +382,29 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             succeed
           }
@@ -398,21 +431,25 @@ class AsyncPropSpecLikeSpec extends FunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec2.scala
@@ -13,49 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*package org.scalatest
+/*package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 
 import scala.util.Success
 
-class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
+class FixtureAsyncPropSpecSpec2 extends org.scalatest.AsyncFunSpec {
 
-  describe("AsyncPropSpecLike") {
+  describe("AsyncPropSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             pending
           }
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           Future {
             cancel
           }
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           Future {
             cancel
           }
@@ -86,27 +91,31 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncPropSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncPropSpec with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        property("test 1") {
+        property("test 1") { fixture =>
           assert(a == 1)
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(a == 2)
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           pending
         }
 
-        property("test 4") {
+        property("test 4") { fixture =>
           cancel
         }
 
-        ignore("test 5") {
+        ignore("test 5") { fixture =>
           cancel
         }
 
@@ -137,9 +146,13 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -148,7 +161,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -157,7 +170,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             assert(count == 2)
           }
@@ -180,23 +193,27 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           assert(count == 2)
         }
 
@@ -221,16 +238,20 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -264,9 +285,13 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -283,7 +308,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -323,11 +348,15 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -335,7 +364,7 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        property("test 1") {
+        property("test 1") { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -355,23 +384,27 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           Future {
             succeed
           }
@@ -402,19 +435,23 @@ class AsyncPropSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncPropSpecLike {
+      class ExampleSpec extends AsyncPropSpec {
 
-        property("test 1") {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        property("test 1") { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        property("test 2") {
+        property("test 2") { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        property("test 3") {
+        property("test 3") { fixture =>
           succeed
         }
 

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixturePropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixturePropSpecSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.propspec
 
 import org.scalatest._
 import SharedHelpers._
@@ -25,7 +25,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.propspec
 
-class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   describe("A fixture.PropSpec") {
     it("should return the test names in order of registration from testNames") {
@@ -265,7 +265,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -273,6 +273,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -282,7 +283,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new propspec.FixtureAnyPropSpec {
+      class SpecB extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -290,6 +291,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -299,7 +301,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new propspec.FixtureAnyPropSpec {
+      class SpecC extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -307,6 +309,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -318,7 +321,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new propspec.FixtureAnyPropSpec {
+      class SpecD extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -326,6 +329,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -339,7 +343,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new propspec.FixtureAnyPropSpec {
+      class SpecE extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -347,6 +351,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test this") { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -360,7 +365,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -368,6 +373,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -378,7 +384,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new propspec.FixtureAnyPropSpec {
+      class SpecB extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -386,6 +392,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -393,7 +400,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new propspec.FixtureAnyPropSpec {
+      class SpecC extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -401,6 +408,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -408,7 +416,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new propspec.FixtureAnyPropSpec {
+      class SpecD extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -416,6 +424,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -423,7 +432,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new propspec.FixtureAnyPropSpec {
+      class SpecE extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -433,6 +442,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         property("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -442,7 +452,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new propspec.FixtureAnyPropSpec {
+      class SpecF extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -452,6 +462,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         property("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -461,7 +472,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new propspec.FixtureAnyPropSpec {
+      class SpecG extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -471,6 +482,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -480,7 +492,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new propspec.FixtureAnyPropSpec {
+      class SpecH extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -490,6 +502,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         property("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -498,7 +511,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new propspec.FixtureAnyPropSpec {
+      class SpecI extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -508,6 +521,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         property("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         property("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -516,7 +530,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new propspec.FixtureAnyPropSpec {
+      class SpecJ extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -526,6 +540,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         property("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -534,7 +549,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new propspec.FixtureAnyPropSpec {
+      class SpecK extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -544,6 +559,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -555,7 +571,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -563,6 +579,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -573,7 +590,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new propspec.FixtureAnyPropSpec {
+      class SpecB extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -581,6 +598,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -588,7 +606,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new propspec.FixtureAnyPropSpec {
+      class SpecC extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -596,6 +614,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -603,7 +622,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new propspec.FixtureAnyPropSpec {
+      class SpecD extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -611,6 +630,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -618,7 +638,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new propspec.FixtureAnyPropSpec {
+      class SpecE extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -628,6 +648,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -637,7 +658,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new propspec.FixtureAnyPropSpec {
+      class SpecF extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -647,6 +668,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -656,7 +678,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new propspec.FixtureAnyPropSpec {
+      class SpecG extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -666,6 +688,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -675,7 +698,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new propspec.FixtureAnyPropSpec {
+      class SpecH extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -685,6 +708,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -693,7 +717,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new propspec.FixtureAnyPropSpec {
+      class SpecI extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -703,6 +727,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -711,7 +736,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new propspec.FixtureAnyPropSpec {
+      class SpecJ extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -721,6 +746,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -729,7 +755,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new propspec.FixtureAnyPropSpec {
+      class SpecK extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -739,6 +765,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -882,7 +909,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
 
     it("should allow tests without fixtures to be combined with tests with fixtures") {
 
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
 
         var theTestWithFixtureWasRun = false
         var theTestWithoutFixtureWasRun = false
@@ -912,6 +939,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
           /* ASSERTION_SUCCEED */
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -956,7 +984,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
     // SKIP-SCALATESTJS,NATIVE-END
     it("should allow both tests that take fixtures and tests that don't") {
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -969,6 +997,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         var takesAFixtureInvoked = false
         property("takes a fixture") { s => takesAFixtureInvoked = true;  /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -979,7 +1008,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should work with test functions whose inferred result type is not Unit") {
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -992,6 +1021,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         var takesAFixtureInvoked = false
         property("takes a fixture") { s => takesAFixtureInvoked = true; true;  /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1004,7 +1034,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should work with ignored tests whose inferred result type is not Unit") {
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1012,6 +1042,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore("test this") { () => theTestThisCalled = true; "hi";  /* ASSERTION_SUCCEED */ }
         ignore("test that") { fixture => theTestThatCalled = true; 42;  /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1091,7 +1122,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should pass the correct test name in the OneArgTest passed to withFixture") {
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1100,6 +1131,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         property("something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1107,7 +1139,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the OneArgTest passed to withFixture") {
-      val a = new propspec.FixtureAnyPropSpec {
+      class SpecA extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1116,6 +1148,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         property("something") { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1250,7 +1283,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("PropSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixturePropSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1260,7 +1293,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
           pending
         }
         registerTest("test 4") { fixture =>
-          cancel
+          cancel()
         }
         registerIgnoredTest("test 5") { fixture =>
           assert(a == 2)
@@ -1298,9 +1331,9 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1321,7 +1354,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1352,7 +1385,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A property clause may not appear inside another property clause."))
     }
@@ -1384,7 +1417,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a property clause."))
     }
@@ -1416,7 +1449,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1448,7 +1481,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1463,7 +1496,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("PropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
@@ -1478,7 +1511,7 @@ class PropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("PropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixturePropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
@@ -13,59 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest._
-import SharedHelpers.EventRecordingReporter
+import org.scalatest.SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
-import org.scalatest
-import org.scalatest.wordspec
+import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.wordspec.AsyncWordSpecLike
 
-class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
+class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
-
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
 
         val a = 1
 
-        "test 1" in { fixture =>
+        "test 1" in {
           Future {
             assert(a == 1)
           }
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           Future {
             assert(a == 2)
           }
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           Future {
             pending
           }
         }
 
-        "test 4" in { fixture =>
+        "test 4" in {
           Future {
-            cancel
+            cancel()
           }
         }
 
-        "test 5" ignore { fixture =>
+        "test 5" ignore {
           Future {
-            cancel
+            cancel()
           }
         }
 
@@ -94,32 +90,28 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
-
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
 
         val a = 1
 
-        "test 1" in { fixture =>
+        "test 1" in {
           assert(a == 1)
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           assert(a == 2)
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           pending
         }
 
-        "test 4" in { fixture =>
-          cancel
+        "test 4" in {
+          cancel()
         }
 
-        "test 5" ignore { fixture =>
-          cancel
+        "test 5" ignore {
+          cancel()
         }
 
         override def newInstance = new ExampleSpec
@@ -149,13 +141,9 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -164,7 +152,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
           }
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -173,7 +161,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
           }
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           Future {
             assert(count == 2)
           }
@@ -196,27 +184,23 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           assert(count == 2)
         }
 
@@ -241,20 +225,16 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -288,13 +268,9 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -311,7 +287,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
           }
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -351,15 +327,11 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
-
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -367,7 +339,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        "test 1" in { fixture =>
+        "test 1" in {
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -387,27 +359,23 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           Future {
             succeed
           }
@@ -418,6 +386,9 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
+      // SKIP-SCALATESTJS,NATIVE-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS,NATIVE-END
 
       val promise = Promise[EventRecordingReporter]
       status whenCompleted { _ => promise.success(rep) }
@@ -435,23 +406,19 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpecLike {
 
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
-
-        "test 1" in { fixture =>
+        "test 1" in {
           SleepHelper.sleep(60)
           succeed
         }
 
-        "test 2" in { fixture =>
+        "test 2" in {
           SleepHelper.sleep(30)
           succeed
         }
 
-        "test 3" in { fixture =>
+        "test 3" in {
           succeed
         }
 
@@ -460,6 +427,9 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
+      // SKIP-SCALATESTJS,NATIVE-START
+      status.waitUntilCompleted()
+      // SKIP-SCALATESTJS,NATIVE-END
 
       val promise = Promise[EventRecordingReporter]
       status whenCompleted { _ => promise.success(rep) }
@@ -476,10 +446,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
         info(
           "hi there"
         )
@@ -499,16 +466,14 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
           info(
             "hi there"
           )
 
-          "test 1" in { fixture => succeed }
+          "test 1" in { succeed }
         }
       }
       val suite = new MySuite
@@ -526,12 +491,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             info("hi there")
             succeed
           }
@@ -558,12 +521,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             Future {
               info("hi there")
               succeed
@@ -592,10 +553,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
         note(
           "hi there"
         )
@@ -615,16 +573,14 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
           note(
             "hi there"
           )
 
-          "test 1" in { fixture => succeed }
+          "test 1" in { succeed }
         }
       }
       val suite = new MySuite
@@ -642,12 +598,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             note("hi there")
             succeed
           }
@@ -667,12 +621,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             Future {
               note("hi there")
               succeed
@@ -694,10 +646,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
         alert(
           "hi there"
         )
@@ -717,16 +666,14 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
           alert(
             "hi there"
           )
 
-          "test 1" in { fixture => succeed }
+          "test 1" in { succeed }
         }
       }
       val suite = new MySuite
@@ -744,12 +691,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             alert("hi there")
             succeed
           }
@@ -769,12 +714,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             Future {
               alert("hi there")
               succeed
@@ -796,10 +739,7 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
         markup(
           "hi there"
         )
@@ -819,16 +759,14 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
           markup(
             "hi there"
           )
 
-          "test 1" in { fixture => succeed }
+          "test 1" in { succeed }
         }
       }
       val suite = new MySuite
@@ -846,12 +784,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             markup("hi there")
             succeed
           }
@@ -878,12 +814,10 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome =
-          test("testing")
+      class MySuite extends AsyncWordSpecLike  {
+
         "test feature" should {
-          "test 1" in { fixture =>
+          "test 1" in {
             Future {
               markup("hi there")
               succeed
@@ -912,28 +846,24 @@ class AsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends wordspec.FixtureAsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
         // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
-
-        type FixtureParam = String
-        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
-
         val a = 1
         "feature 1" should {
-          "test A" in { fixture =>
+          "test A" in {
             Future { assert(a == 1) }
           }
         }
         "feature 2" should {
-          "test B" in { fixture =>
+          "test B" in {
             Future { assert(a == 1) }
           }
         }
         "feature 3" should {
-          "test C" in { fixture =>
+          "test C" in {
             Future { assert(a == 1) }
           }
         }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
@@ -13,28 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
-import SharedHelpers.{EventRecordingReporter, thisLineNumber}
+import org.scalatest._
+import org.scalatest.SharedHelpers.{EventRecordingReporter, thisLineNumber}
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 import org.scalatest.events.{InfoProvided, MarkupProvided}
-import org.scalatest.exceptions.{DuplicateTestNameException, NotAllowedException}
+import org.scalatest.exceptions.{NotAllowedException, DuplicateTestNameException}
 import org.scalactic.Prettifier
 
 import scala.util.Success
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.wordspec.{ AsyncWordSpec, AsyncWordSpecLike }
+import org.scalatest.wordspec.AsyncWordSpec
 
-class AsyncWordSpecLikeSpec extends AnyFunSpec {
+class AsyncWordSpecSpec extends AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
-  describe("AsyncWordSpecLike") {
+  describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -94,7 +95,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -179,7 +180,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -225,12 +226,12 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
         "test 1" in {
-          SleepHelper.sleep(30)
+          SleepHelper.sleep(3000)
           assert(count == 0)
           count = 1
           succeed
@@ -238,7 +239,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
         "test 2" in {
           assert(count == 1)
-          SleepHelper.sleep(50)
+          SleepHelper.sleep(5000)
           count = 2
           succeed
         }
@@ -246,7 +247,6 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
         "test 3" in {
           assert(count == 2)
         }
-
       }
 
       val rep = new EventRecordingReporter
@@ -269,7 +269,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         "test 1" in {
           Future {
@@ -309,7 +309,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         "test 1" in {
           val promise = Promise[Assertion]
@@ -365,7 +365,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -393,7 +393,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -438,7 +438,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends AsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -476,7 +476,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
         info(
           "hi there"
         )
@@ -495,7 +495,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -521,7 +521,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -552,7 +552,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -585,7 +585,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
         note(
           "hi there"
         )
@@ -604,7 +604,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -630,7 +630,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -654,7 +654,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -680,7 +680,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
         alert(
           "hi there"
         )
@@ -699,7 +699,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -725,7 +725,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -749,7 +749,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -775,7 +775,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
         markup(
           "hi there"
         )
@@ -794,7 +794,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -820,7 +820,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -851,7 +851,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends AsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
@@ -884,7 +884,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" when {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -893,7 +893,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -905,7 +905,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" when {}
         it when {
           "test 1" in { succeed }
@@ -915,7 +915,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -927,7 +927,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" should {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -936,7 +936,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -948,7 +948,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" should {}
         it should {
           "test 1" in { succeed }
@@ -958,7 +958,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -970,7 +970,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" must {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -979,7 +979,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -991,7 +991,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" must {}
         it must {
           "test 1" in { succeed }
@@ -1001,7 +1001,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1013,7 +1013,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" that {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1022,7 +1022,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1034,7 +1034,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" which {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1043,7 +1043,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1055,7 +1055,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" can {
           "test 1" in { succeed }
           "test 1" in { succeed }
@@ -1064,7 +1064,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1076,7 +1076,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         "a feature" can {}
         it can {
           "test 1" in { succeed }
@@ -1086,7 +1086,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1098,7 +1098,7 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends AsyncWordSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
-import SharedHelpers.EventRecordingReporter
+import org.scalatest._
+import org.scalatest.SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 import org.scalatest.events.{InfoProvided, MarkupProvided}

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest._
 import SharedHelpers.{EventRecordingReporter, thisLineNumber}
@@ -27,7 +27,7 @@ import scala.util.Success
 import org.scalatest
 import org.scalatest.wordspec
 
-class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
+class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -959,7 +959,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -983,7 +983,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1006,7 +1006,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1030,7 +1030,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1053,7 +1053,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1077,7 +1077,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1100,7 +1100,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1123,7 +1123,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1146,7 +1146,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1170,7 +1170,7 @@ class AsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("AsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
@@ -65,13 +65,13 @@ class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
 
         "test 4" in { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
         "test 5" ignore { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
@@ -122,11 +122,11 @@ class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
         }
 
         "test 4" in { fixture =>
-          cancel
+          cancel()
         }
 
         "test 5" ignore { fixture =>
-          cancel
+          cancel()
         }
 
         override def newInstance = new ExampleSpec

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
@@ -59,13 +59,13 @@ class FixtureAsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
         "test 4" in { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
         "test 5" ignore { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
@@ -115,11 +115,11 @@ class FixtureAsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         }
 
         "test 4" in { fixture =>
-          cancel
+          cancel()
         }
 
         "test 5" ignore { fixture =>
-          cancel
+          cancel()
         }
 
         override def newInstance = new ExampleSpec

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest._
 import SharedHelpers.EventRecordingReporter
@@ -25,13 +25,13 @@ import scala.util.Success
 import org.scalatest
 import org.scalatest.wordspec
 
-class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
+class FixtureAsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
-  describe("AsyncWordSpec") {
+  describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -94,7 +94,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike with ParallelTestExecution {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -149,7 +149,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -196,7 +196,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -241,7 +241,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -288,7 +288,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -351,7 +351,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         // Note we get a StackOverflowError with the following execution
         // context.
@@ -387,7 +387,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -435,7 +435,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -476,7 +476,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -499,7 +499,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -526,7 +526,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -558,7 +558,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -592,7 +592,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -615,7 +615,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -642,7 +642,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -667,7 +667,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -694,7 +694,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -717,7 +717,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -744,7 +744,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -769,7 +769,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -796,7 +796,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -819,7 +819,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -846,7 +846,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -878,7 +878,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpecLike  {
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
           test("testing")
@@ -912,7 +912,7 @@ class AsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
@@ -65,13 +65,13 @@ class FixtureAsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
 
         "test 4" in { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
         "test 5" ignore { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
@@ -122,11 +122,11 @@ class FixtureAsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
 
         "test 4" in { fixture =>
-          cancel
+          cancel()
         }
 
         "test 5" ignore { fixture =>
-          cancel
+          cancel()
         }
 
         override def newInstance = new ExampleSpec

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.{EventRecordingReporter, thisLineNumber}
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import org.scalatest.concurrent.SleepHelper
 import org.scalatest.events.{InfoProvided, MarkupProvided}
-import org.scalatest.exceptions.{NotAllowedException, DuplicateTestNameException}
+import org.scalatest.exceptions.{DuplicateTestNameException, NotAllowedException}
 import org.scalactic.Prettifier
 
 import scala.util.Success
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest
+import org.scalatest.wordspec
 
-class AsyncWordSpecSpec extends AnyFunSpec {
+class FixtureAsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -34,39 +35,43 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        "test 1" in {
+        "test 1" in { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             pending
           }
         }
 
-        "test 4" in {
+        "test 4" in { fixture =>
           Future {
-            cancel()
+            cancel
           }
         }
 
-        "test 5" ignore {
+        "test 5" ignore { fixture =>
           Future {
-            cancel()
+            cancel
           }
         }
 
@@ -94,30 +99,34 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpec with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
         val a = 1
 
-        "test 1" in {
+        "test 1" in { fixture =>
           assert(a == 1)
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           assert(a == 2)
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           pending
         }
 
-        "test 4" in {
-          cancel()
+        "test 4" in { fixture =>
+          cancel
         }
 
-        "test 5" ignore {
-          cancel()
+        "test 5" ignore { fixture =>
+          cancel
         }
 
         override def newInstance = new ExampleSpec
@@ -142,48 +151,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       assert(rep.testIgnoredEventsReceived(0).testName == "test 5")
     }
 
-    it("can be used with is for pending tests that don't return a Future") {
-
-      class ExampleSpec extends AsyncWordSpec {
-
-        //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
-
-        val a = 1
-
-        "test 1" is {
-          pending
-        }
-
-        "test 2" ignore {
-          pending
-        }
-      }
-
-      val rep = new EventRecordingReporter
-      val spec = new ExampleSpec
-      val status = spec.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS,NATIVE-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS,NATIVE-END
-      assert(rep.testStartingEventsReceived.length == 1)
-      assert(rep.testSucceededEventsReceived.length == 0)
-      assert(rep.testFailedEventsReceived.length == 0)
-      assert(rep.testPendingEventsReceived.length == 1)
-      assert(rep.testPendingEventsReceived(0).testName == "test 1")
-      assert(rep.testCanceledEventsReceived.length == 0)
-      assert(rep.testIgnoredEventsReceived.length == 1)
-      assert(rep.testIgnoredEventsReceived(0).testName == "test 2")
-    }
-
     it("should run tests that return Future in serial by default") {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -192,7 +172,7 @@ class AsyncWordSpecSpec extends AnyFunSpec {
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -201,7 +181,7 @@ class AsyncWordSpecSpec extends AnyFunSpec {
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             assert(count == 2)
           }
@@ -225,27 +205,32 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        "test 1" in {
-          SleepHelper.sleep(3000)
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
+          SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           succeed
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           assert(count == 1)
-          SleepHelper.sleep(5000)
+          SleepHelper.sleep(50)
           count = 2
           succeed
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           assert(count == 2)
         }
+
       }
 
       val rep = new EventRecordingReporter
@@ -268,16 +253,20 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -308,9 +297,13 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -327,7 +320,7 @@ class AsyncWordSpecSpec extends AnyFunSpec {
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -364,11 +357,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -376,7 +373,7 @@ class AsyncWordSpecSpec extends AnyFunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        "test 1" in {
+        "test 1" in { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -392,25 +389,29 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             succeed
           }
@@ -437,21 +438,25 @@ class AsyncWordSpecSpec extends AnyFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpec {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           succeed
         }
 
@@ -475,7 +480,13 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         info(
           "hi there"
         )
@@ -494,16 +505,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           info(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -520,12 +534,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             info("hi there")
             succeed
           }
@@ -551,12 +568,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               info("hi there")
               succeed
@@ -584,7 +604,13 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         note(
           "hi there"
         )
@@ -603,16 +629,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           note(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -629,12 +658,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             note("hi there")
             succeed
           }
@@ -653,12 +685,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               note("hi there")
               succeed
@@ -679,7 +714,13 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         alert(
           "hi there"
         )
@@ -698,16 +739,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           alert(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -724,12 +768,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             alert("hi there")
             succeed
           }
@@ -748,12 +795,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               alert("hi there")
               succeed
@@ -774,7 +824,13 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+
+        //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         markup(
           "hi there"
         )
@@ -793,16 +849,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           markup(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -819,12 +878,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             markup("hi there")
             succeed
           }
@@ -850,12 +912,15 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpec  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
 
         //SCALATESTJS-ONLY implicit override def executionContext = org.scalatest.concurrent.TestExecutionContext.runNow
 
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               markup("hi there")
               succeed
@@ -883,16 +948,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside when") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -904,17 +971,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand when") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" when {}
         it when {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -926,16 +995,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside should") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -947,17 +1018,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand should") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" should {}
         it should {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -969,16 +1042,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside must") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -990,17 +1065,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand must") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" must {}
         it must {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1012,16 +1089,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside that") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" that {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1033,16 +1112,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside which") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" which {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1054,16 +1135,18 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside can") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
-            new TestSpec
-          }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+        new TestSpec
+      }
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1075,17 +1158,19 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should throw NotAllowedException wrapping a DuplicateTestNameException when duplicate test name is detected inside shorthand can") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
         "a feature" can {}
         it can {
-          "test 1" in { succeed }
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val e = intercept[NotAllowedException] {
-            new TestSpec
-          }
-      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+        new TestSpec
+      }
+      assert("FixtureAsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1097,24 +1182,28 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpec {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
         // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
         val a = 1
         "feature 1" should {
-          "test A" in {
+          "test A" in { fixture =>
             Future { assert(a == 1) }
           }
         }
         "feature 2" should {
-          "test B" in {
+          "test B" in { fixture =>
             Future { assert(a == 1) }
           }
         }
         "feature 3" should {
-          "test C" in {
+          "test C" in { fixture =>
             Future { assert(a == 1) }
           }
         }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
@@ -13,54 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
+import org.scalatest._
 import SharedHelpers.EventRecordingReporter
 import scala.concurrent.{ExecutionContext, Promise, Future}
 import org.scalatest.concurrent.SleepHelper
 import org.scalatest.events.{InfoProvided, MarkupProvided}
 
 import scala.util.Success
-import org.scalatest.funspec.AsyncFunSpec
-import org.scalatest.wordspec.AsyncWordSpecLike
+import org.scalatest
+import org.scalatest.wordspec
 
-class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
+class FixtureAsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
-  describe("AsyncWordSpecLike") {
+  describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        "test 1" in {
+        "test 1" in { fixture =>
           Future {
             assert(a == 1)
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             assert(a == 2)
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             pending
           }
         }
 
-        "test 4" in {
+        "test 4" in { fixture =>
           Future {
-            cancel()
+            cancel
           }
         }
 
-        "test 5" ignore {
+        "test 5" ignore { fixture =>
           Future {
-            cancel()
+            cancel
           }
         }
 
@@ -89,28 +94,32 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("can be used for tests that did not return Future under parallel async test execution") {
 
-      class ExampleSpec extends AsyncWordSpecLike with ParallelTestExecution {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec with ParallelTestExecution {
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         val a = 1
 
-        "test 1" in {
+        "test 1" in { fixture =>
           assert(a == 1)
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           assert(a == 2)
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           pending
         }
 
-        "test 4" in {
-          cancel()
+        "test 4" in { fixture =>
+          cancel
         }
 
-        "test 5" ignore {
-          cancel()
+        "test 5" ignore { fixture =>
+          cancel
         }
 
         override def newInstance = new ExampleSpec
@@ -140,9 +149,13 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             SleepHelper.sleep(30)
             assert(count == 0)
@@ -151,7 +164,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             assert(count == 1)
             SleepHelper.sleep(50)
@@ -160,7 +173,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             assert(count == 2)
           }
@@ -183,23 +196,27 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
       @volatile var count = 0
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           SleepHelper.sleep(30)
           assert(count == 0)
           count = 1
           Succeeded
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           assert(count == 1)
           SleepHelper.sleep(50)
           count = 2
           Succeeded
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           assert(count == 2)
         }
 
@@ -224,16 +241,20 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             test1Thread = Some(Thread.currentThread)
             succeed
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             test2Thread = Some(Thread.currentThread)
             succeed
@@ -267,9 +288,13 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       @volatile var test2Thread: Option[Thread] = None
       var onCompleteThread: Option[Thread] = None
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -286,7 +311,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           val promise = Promise[Assertion]
           val timer = new java.util.Timer
           timer.schedule(
@@ -326,11 +351,15 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should not run out of stack space with nested futures when using SerialExecutionContext") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
         // Note we get a StackOverflowError with the following execution
         // context.
         // override implicit def executionContext: ExecutionContext = new ExecutionContext { def execute(runnable: Runnable) = runnable.run; def reportFailure(cause: Throwable) = () }
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
 
         def sum(xs: List[Int]): Future[Int] =
           xs match {
@@ -338,7 +367,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
             case x :: xs => Future(x).flatMap(xx => sum(xs).map(xxx => xx + xxx))
           }
 
-        "test 1" in {
+        "test 1" in { fixture =>
           val fut: Future[Int] = sum((1 to 50000).toList)
           fut.map(total => assert(total == 1250025000))
         }
@@ -358,23 +387,27 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that returns Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           Future {
             SleepHelper.sleep(60)
             succeed
           }
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           Future {
             SleepHelper.sleep(30)
             succeed
           }
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           Future {
             succeed
           }
@@ -385,9 +418,6 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS,NATIVE-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS,NATIVE-END
 
       val promise = Promise[EventRecordingReporter]
       status whenCompleted { _ => promise.success(rep) }
@@ -405,19 +435,23 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
     it("should run tests that does not return Future and report their result in serial") {
 
-      class ExampleSpec extends AsyncWordSpecLike {
+      class ExampleSpec extends wordspec.FixtureAsyncWordSpec {
 
-        "test 1" in {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
+
+        "test 1" in { fixture =>
           SleepHelper.sleep(60)
           succeed
         }
 
-        "test 2" in {
+        "test 2" in { fixture =>
           SleepHelper.sleep(30)
           succeed
         }
 
-        "test 3" in {
+        "test 3" in { fixture =>
           succeed
         }
 
@@ -426,9 +460,6 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
       val rep = new EventRecordingReporter
       val suite = new ExampleSpec
       val status = suite.run(None, Args(reporter = rep))
-      // SKIP-SCALATESTJS,NATIVE-START
-      status.waitUntilCompleted()
-      // SKIP-SCALATESTJS,NATIVE-END
 
       val promise = Promise[EventRecordingReporter]
       status whenCompleted { _ => promise.success(rep) }
@@ -445,7 +476,10 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         info(
           "hi there"
         )
@@ -465,14 +499,16 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           info(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -490,10 +526,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             info("hi there")
             succeed
           }
@@ -520,10 +558,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an InfoProvided event for an info in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               info("hi there")
               succeed
@@ -552,7 +592,10 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         note(
           "hi there"
         )
@@ -572,14 +615,16 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           note(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -597,10 +642,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             note("hi there")
             succeed
           }
@@ -620,10 +667,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a NoteProvided event for a note in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               note("hi there")
               succeed
@@ -645,7 +694,10 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         alert(
           "hi there"
         )
@@ -665,14 +717,16 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           alert(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -690,10 +744,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             alert("hi there")
             succeed
           }
@@ -713,10 +769,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send an AlertProvided event for an alert in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               alert("hi there")
               succeed
@@ -738,7 +796,10 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in main spec body") {
-      class MySuite extends AsyncWordSpecLike  {
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         markup(
           "hi there"
         )
@@ -758,14 +819,16 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in scope body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
           markup(
             "hi there"
           )
 
-          "test 1" in { succeed }
+          "test 1" in { fixture => succeed }
         }
       }
       val suite = new MySuite
@@ -783,10 +846,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             markup("hi there")
             succeed
           }
@@ -813,10 +878,12 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should send a MarkupProvided event for a markup in Future returned by test body") {
-      class MySuite extends AsyncWordSpecLike  {
-
+      class MySuite extends wordspec.FixtureAsyncWordSpec  {
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome =
+          test("testing")
         "test feature" should {
-          "test 1" in {
+          "test 1" in { fixture =>
             Future {
               markup("hi there")
               succeed
@@ -845,24 +912,28 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      class TestSpec extends AsyncWordSpecLike {
+      class TestSpec extends wordspec.FixtureAsyncWordSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
         // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
         val a = 1
         "feature 1" should {
-          "test A" in {
+          "test A" in { fixture =>
             Future { assert(a == 1) }
           }
         }
         "feature 2" should {
-          "test B" in {
+          "test B" in { fixture =>
             Future { assert(a == 1) }
           }
         }
         "feature 3" should {
-          "test C" in {
+          "test C" in { fixture =>
             Future { assert(a == 1) }
           }
         }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
@@ -59,13 +59,13 @@ class FixtureAsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
         "test 4" in { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
         "test 5" ignore { fixture =>
           Future {
-            cancel
+            cancel()
           }
         }
 
@@ -115,11 +115,11 @@ class FixtureAsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         }
 
         "test 4" in { fixture =>
-          cancel
+          cancel()
         }
 
         "test 5" ignore { fixture =>
-          cancel
+          cancel()
         }
 
         override def newInstance = new ExampleSpec

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecImportedMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecImportedMatchersSpec.scala
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest.StringFixture
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.FixtureAnyWordSpec
 
-class WordSpecMixedInMatchersSpec extends FixtureAnyWordSpec with Matchers with StringFixture {
+/*
+This tests that matchers works with WordSpec when matchers are imported,
+something that broke in 2.1.RC1.
+*/
+class FixtureWordSpecImportedMatchersSpec extends FixtureAnyWordSpec with StringFixture {
   "This spec" should {
     "work OK" in { _ =>
       "hello" should startWith ("he")
@@ -29,7 +33,7 @@ class WordSpecMixedInMatchersSpec extends FixtureAnyWordSpec with Matchers with 
       "hello" should endWith regex (".*o")
       "hello" should include regex ("l*")
     }
-    "still work OK" in { _ => 
+    "still work OK" in { _ =>
       "dude" should not startWith ("he")
       "dude" should not endWith ("lo")
       "dude" should not include ("el")

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecMixedInMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecMixedInMatchersSpec.scala
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest.StringFixture
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.FixtureAnyWordSpec
 
-/*
-This tests that matchers works with WordSpec when matchers are imported,
-something that broke in 2.1.RC1.
-*/
-class WordSpecImportedMatchersSpec extends FixtureAnyWordSpec with StringFixture {
+class FixtureWordSpecMixedInMatchersSpec extends FixtureAnyWordSpec with Matchers with StringFixture {
   "This spec" should {
     "work OK" in { _ =>
       "hello" should startWith ("he")
@@ -33,7 +29,7 @@ class WordSpecImportedMatchersSpec extends FixtureAnyWordSpec with StringFixture
       "hello" should endWith regex (".*o")
       "hello" should include regex ("l*")
     }
-    "still work OK" in { _ =>
+    "still work OK" in { _ => 
       "dude" should not startWith ("he")
       "dude" should not endWith ("lo")
       "dude" should not include ("el")

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.wordspec
 
 import org.scalatest._
 import SharedHelpers._
@@ -36,7 +36,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.wordspec
 
-class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FixtureWordSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -339,7 +339,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -347,6 +347,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -356,7 +357,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new wordspec.FixtureAnyWordSpec {
+      class SpecB extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -364,6 +365,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -373,7 +375,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new wordspec.FixtureAnyWordSpec {
+      class SpecC extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -381,6 +383,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -392,7 +395,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new wordspec.FixtureAnyWordSpec {
+      class SpecD extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -400,6 +403,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -413,7 +417,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new wordspec.FixtureAnyWordSpec {
+      class SpecE extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -421,6 +425,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -434,7 +439,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -442,6 +447,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -452,7 +458,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new wordspec.FixtureAnyWordSpec {
+      class SpecB extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -460,6 +466,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -467,7 +474,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new wordspec.FixtureAnyWordSpec {
+      class SpecC extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -475,6 +482,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -482,7 +490,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new wordspec.FixtureAnyWordSpec {
+      class SpecD extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -490,6 +498,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test this" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -497,7 +506,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new wordspec.FixtureAnyWordSpec {
+      class SpecE extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -507,6 +516,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -516,7 +526,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new wordspec.FixtureAnyWordSpec {
+      class SpecF extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -526,6 +536,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -535,7 +546,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new wordspec.FixtureAnyWordSpec {
+      class SpecG extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -545,6 +556,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -554,7 +566,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new wordspec.FixtureAnyWordSpec {
+      class SpecH extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -564,6 +576,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -572,7 +585,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new wordspec.FixtureAnyWordSpec {
+      class SpecI extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -582,6 +595,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -590,7 +604,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new wordspec.FixtureAnyWordSpec {
+      class SpecJ extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -600,6 +614,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -608,7 +623,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new wordspec.FixtureAnyWordSpec {
+      class SpecK extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -618,6 +633,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -629,7 +645,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -637,6 +653,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -647,7 +664,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new wordspec.FixtureAnyWordSpec {
+      class SpecB extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -655,6 +672,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -662,7 +680,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new wordspec.FixtureAnyWordSpec {
+      class SpecC extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -670,6 +688,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -677,7 +696,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new wordspec.FixtureAnyWordSpec {
+      class SpecD extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -685,6 +704,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -692,7 +712,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new wordspec.FixtureAnyWordSpec {
+      class SpecE extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -702,6 +722,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -711,7 +732,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new wordspec.FixtureAnyWordSpec {
+      class SpecF extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -721,6 +742,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -730,7 +752,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new wordspec.FixtureAnyWordSpec {
+      class SpecG extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -740,6 +762,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -749,7 +772,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new wordspec.FixtureAnyWordSpec {
+      class SpecH extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -759,6 +782,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -767,7 +791,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new wordspec.FixtureAnyWordSpec {
+      class SpecI extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -777,6 +801,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -785,7 +810,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new wordspec.FixtureAnyWordSpec {
+      class SpecJ extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -795,6 +820,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -803,7 +829,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new wordspec.FixtureAnyWordSpec {
+      class SpecK extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -813,6 +839,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -1070,13 +1097,12 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 */
     it("should allow both tests that take fixtures and tests that don't") {
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
           test("Hello, world!")
         }
-
         var takesNoArgsInvoked = false
         var takesAFixtureInvoked = false
 
@@ -1086,6 +1112,9 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
       }
 
+      val a = new SpecA
+
+        
       import scala.language.reflectiveCalls
 
       a.run(None, Args(SilentReporter))
@@ -1094,13 +1123,12 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with test functions whose inferred result type is not Unit") {
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
           test("Hello, world!")
         }
-
         var takesNoArgsInvoked = false
         var takesAFixtureInvoked = false
         "A WordSpec" should {
@@ -1108,6 +1136,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           "take a fixture" in { s => takesAFixtureInvoked = true; true; /* ASSERTION_SUCCEED */ }
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1119,7 +1148,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with ignored tests whose inferred result type is not Unit") {
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var takeNoArgsInvoked = false
@@ -1129,6 +1158,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           "take a fixture" ignore { s => takeAFixtureInvoked = true; 42; /* ASSERTION_SUCCEED */ }
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1207,7 +1237,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(s.theNoArgTestWasInvoked)
     }
     it("should pass the correct test name in the OneArgTest passed to withFixture") {
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1216,6 +1246,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1223,7 +1254,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the OneArgTest passed to withFixture") {
-      val a = new wordspec.FixtureAnyWordSpec {
+      class SpecA extends wordspec.FixtureAnyWordSpec {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1232,6 +1263,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -1530,9 +1562,9 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       class TestSpec extends wordspec.FixtureAnyWordSpec with StringFixture {
         "a feature" should {
           "succeeded here" in { fixture => /* ASSERTION_SUCCEED */ }
-          "failed here" in { fixture =>  fail }
+          "failed here" in { fixture =>  fail() }
           "pending here" in { fixture =>  pending }
-          "cancel here" in { fixture =>  cancel }
+          "cancel here" in { fixture =>  cancel() }
           "ignore here" ignore { fixture => /* ASSERTION_SUCCEED */ }
         }
       }
@@ -1598,7 +1630,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
               assert(a == 2)
             }
             assert(e.message == Some("1 did not equal 2"))
-            assert(e.failedCodeFileName == Some("WordSpecSpec.scala"))
+            assert(e.failedCodeFileName == Some("FixtureWordSpecSpec.scala"))
             assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
           }
           registerTest("test 2") { fixture =>
@@ -1608,7 +1640,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             pending
           }
           registerTest("test 4") { fixture =>
-            cancel
+            cancel()
           }
           registerIgnoredTest("test 5") { fixture =>
             assert(a == 2)
@@ -1661,7 +1693,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1695,7 +1727,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1717,9 +1749,9 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "WordSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureWordSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "WordSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureWordSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
   }
@@ -1740,7 +1772,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "WordSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureWordSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 9)
     }
     
@@ -1773,7 +1805,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An in clause may not appear inside another in clause."))
     }
@@ -1807,7 +1839,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an in clause."))
     }
@@ -1879,7 +1911,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1895,7 +1927,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1911,7 +1943,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1927,7 +1959,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1951,7 +1983,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1975,7 +2007,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -1999,7 +2031,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2023,7 +2055,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
       }
@@ -2047,7 +2079,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2068,7 +2100,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2089,7 +2121,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2110,7 +2142,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2128,7 +2160,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2146,7 +2178,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2164,7 +2196,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2182,7 +2214,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2204,7 +2236,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2226,7 +2258,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2248,7 +2280,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2270,7 +2302,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "An it clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
       }
@@ -2304,7 +2336,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "An it clause must only appear after a top level subject clause.")
         }
@@ -2336,7 +2368,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "An it clause must only appear after a top level subject clause.")
         }
@@ -2368,7 +2400,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "An it clause must only appear after a top level subject clause.")
         }
@@ -2400,7 +2432,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "An it clause must only appear after a top level subject clause.")
         }
@@ -2472,7 +2504,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2488,7 +2520,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2504,7 +2536,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2520,7 +2552,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2544,7 +2576,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2568,7 +2600,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2592,7 +2624,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
         
@@ -2616,7 +2648,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 9))
         }
       }
@@ -2640,7 +2672,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2661,7 +2693,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2682,7 +2714,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2703,7 +2735,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2721,7 +2753,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2739,7 +2771,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2757,7 +2789,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2775,7 +2807,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2797,7 +2829,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2819,7 +2851,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2841,7 +2873,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
         
@@ -2863,7 +2895,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
             new TestSpec
           }
           assert(e.getMessage === "A they clause must only appear after a top level subject clause.")
-          assert(e.failedCodeFileName === Some("WordSpecSpec.scala"))
+          assert(e.failedCodeFileName === Some("FixtureWordSpecSpec.scala"))
           assert(e.failedCodeLineNumber === Some(thisLineNumber - 10))
         }
       }
@@ -2897,7 +2929,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "A they clause must only appear after a top level subject clause.")
         }
@@ -2929,7 +2961,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "A they clause must only appear after a top level subject clause.")
         }
@@ -2961,7 +2993,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "A they clause must only appear after a top level subject clause.")
         }
@@ -2993,7 +3025,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           assert(testFailedEvents.size === 1)
           assert(testFailedEvents(0).throwable.get.getClass() === classOf[exceptions.NotAllowedException])
           val trce = testFailedEvents(0).throwable.get.asInstanceOf[exceptions.NotAllowedException]
-          assert("WordSpecSpec.scala" === trce.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" === trce.failedCodeFileName.get)
           assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
           assert(trce.getMessage === "A they clause must only appear after a top level subject clause.")
         }
@@ -3010,7 +3042,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3018,7 +3050,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3035,7 +3067,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3043,7 +3075,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3060,7 +3092,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3068,7 +3100,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3085,7 +3117,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3093,7 +3125,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3110,7 +3142,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3118,7 +3150,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3135,7 +3167,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3143,7 +3175,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestFailedException])
           val cause = causeThrowable.asInstanceOf[TestFailedException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3160,7 +3192,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3168,7 +3200,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3185,7 +3217,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3193,7 +3225,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3210,7 +3242,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3218,7 +3250,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3235,7 +3267,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3243,7 +3275,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3260,7 +3292,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3268,7 +3300,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3285,7 +3317,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause))
 
@@ -3293,7 +3325,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val causeThrowable = e.cause.get
           assert(causeThrowable.isInstanceOf[TestCanceledException])
           val cause = causeThrowable.asInstanceOf[TestCanceledException]
-          assert("WordSpecSpec.scala" == cause.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == cause.failedCodeFileName.get)
           assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
           assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
         }
@@ -3311,7 +3343,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -3335,7 +3367,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -3359,7 +3391,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -3383,7 +3415,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -3407,7 +3439,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -3431,7 +3463,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
           val e = intercept[NotAllowedException] {
             new TestSpec
           }
-          assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+          assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
           assert(e.failedCodeLineNumber.get == thisLineNumber - 3)
           assert(e.cause.isDefined)
           val causeThrowable = e.cause.get
@@ -4229,7 +4261,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4253,7 +4285,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4276,7 +4308,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4300,7 +4332,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4323,7 +4355,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4347,7 +4379,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4370,7 +4402,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4393,7 +4425,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
             new TestSpec
           }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4416,7 +4448,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -4440,7 +4472,7 @@ class WordSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecImportedMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecImportedMatchersSpec.scala
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
-class WordSpecMixedInMatchersSpec extends AnyWordSpec with Matchers {
+
+/*
+This tests that matchers works with WordSpec when matchers are imported,
+something that broke in 2.1.RC1.
+*/
+class WordSpecImportedMatchersSpec extends AnyWordSpec {
   "This spec" should {
     "work OK" in {
       "hello" should startWith ("he")

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecMixedInMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecMixedInMatchersSpec.scala
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-/*
-This tests that matchers works with WordSpec when matchers are imported,
-something that broke in 2.1.RC1.
-*/
-class WordSpecImportedMatchersSpec extends AnyWordSpec {
+class WordSpecMixedInMatchersSpec extends AnyWordSpec with Matchers {
   "This spec" should {
     "work OK" in {
       "hello" should startWith ("he")

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest
+package org.scalatest.wordspec
 
 // elements
-import SharedHelpers._
+import org.scalatest._
+import org.scalatest.SharedHelpers._
 import org.scalatest.events._
 import org.scalactic.Prettifier
 import java.awt.AWTError

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
@@ -41,7 +41,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
   describe("A WordSpec") {
 
     it("should invoke withFixture from runTest") {
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var withFixtureWasInvoked = false
         var testWasInvoked = false
         override def withFixture(test: NoArgTest): Outcome = {
@@ -53,6 +53,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
           /* ASSERTION_SUCCEED */
         }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -61,7 +62,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(a.testWasInvoked)
     }
     it("should pass the correct test name in the NoArgTest passed to withFixture") {
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var correctTestNameWasPassed = false
         override def withFixture(test: NoArgTest): Outcome = {
           correctTestNameWasPassed = test.name == "do something"
@@ -69,6 +70,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         }
         "do something" in {/* ASSERTION_SUCCEED */}
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -76,7 +78,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the NoArgTest passed to withFixture") {
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var correctConfigMapWasPassed = false
         override def withFixture(test: NoArgTest): Outcome = {
           correctConfigMapWasPassed = (test.configMap == ConfigMap("hi" -> 7))
@@ -84,6 +86,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         }
         "do something" in {/* ASSERTION_SUCCEED */}
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -649,12 +652,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" in { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -664,12 +668,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new AnyWordSpec {
+      class SpecB extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" ignore { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -679,12 +684,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new AnyWordSpec {
+      class SpecC extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" in { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -696,12 +702,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new AnyWordSpec {
+      class SpecD extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" ignore { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" ignore { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -715,12 +722,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new AnyWordSpec {
+      class SpecE extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" ignore { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -734,12 +742,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" taggedAs(mytags.SlowAsMolasses) in { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -750,12 +759,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new AnyWordSpec {
+      class SpecB extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" taggedAs(mytags.SlowAsMolasses) in { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -763,12 +773,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new AnyWordSpec {
+      class SpecC extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" taggedAs(mytags.SlowAsMolasses) in { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -776,12 +787,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new AnyWordSpec {
+      class SpecD extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         "test this" taggedAs(mytags.SlowAsMolasses) ignore { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -789,7 +801,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new AnyWordSpec {
+      class SpecE extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -797,6 +809,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -806,7 +819,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new AnyWordSpec {
+      class SpecF extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -814,6 +827,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -823,7 +837,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new AnyWordSpec {
+      class SpecG extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -831,6 +845,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -840,7 +855,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new AnyWordSpec {
+      class SpecH extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -848,6 +863,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -856,7 +872,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, mytags.SlowAsMolasses excluded
-      val i = new AnyWordSpec {
+      class SpecI extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -864,6 +880,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) in { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -872,7 +889,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, mytags.SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new AnyWordSpec {
+      class SpecJ extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -880,6 +897,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" in { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -888,7 +906,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new AnyWordSpec {
+      class SpecK extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -896,6 +914,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         "test that" taggedAs(mytags.SlowAsMolasses) ignore { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         "test the other" ignore { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -907,12 +926,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new AnyWordSpec {
+      class SpecA extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -923,12 +943,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new AnyWordSpec {
+      class SpecB extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that") { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -936,12 +957,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new AnyWordSpec {
+      class SpecC extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         registerTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -949,12 +971,13 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new AnyWordSpec {
+      class SpecD extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         registerIgnoredTest("test this", mytags.SlowAsMolasses) { theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -962,7 +985,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new AnyWordSpec {
+      class SpecE extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -970,6 +993,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -979,7 +1003,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new AnyWordSpec {
+      class SpecF extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -987,6 +1011,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -996,7 +1021,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new AnyWordSpec {
+      class SpecG extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -1004,6 +1029,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -1013,7 +1039,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new AnyWordSpec {
+      class SpecH extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -1021,6 +1047,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -1029,7 +1056,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, mytags.SlowAsMolasses excluded
-      val i = new AnyWordSpec {
+      class SpecI extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -1037,6 +1064,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -1045,7 +1073,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, mytags.SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new AnyWordSpec {
+      class SpecJ extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -1053,6 +1081,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -1061,7 +1090,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new AnyWordSpec {
+      class SpecK extends AnyWordSpec {
         var theTestThisCalled = false
         var theTestThatCalled = false
         var theTestTheOtherCalled = false
@@ -1069,6 +1098,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
         registerIgnoredTest("test that", mytags.SlowAsMolasses) { theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("test the other") { theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -1333,9 +1363,9 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       class TestSpec extends AnyWordSpec {
         "a feature" should {
           "succeeded here" in {/* ASSERTION_SUCCEED */}
-          "failed here" in { fail }
+          "failed here" in { fail() }
           "pending here" in { pending }
-          "cancel here" in { cancel }
+          "cancel here" in { cancel() }
           "ignore here" ignore {/* ASSERTION_SUCCEED */}
         }
       }
@@ -1409,7 +1439,7 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
             pending
           }
           registerTest("test 4") {
-            cancel
+            cancel()
           }
           registerIgnoredTest("test 5") {
             assert(a == 2)

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -391,7 +391,8 @@ trait DottyBuild { this: BuildCommons =>
       scalatestFreeSpecTestDotty, 
       scalatestFunSpecTestDotty, 
       scalatestFunSuiteTestDotty, 
-      scalatestPropSpecTestDotty
+      scalatestPropSpecTestDotty, 
+      scalatestWordSpecTestDotty
     )
 
   lazy val scalatestDiagramsTestDotty = project.in(file("dotty/diagrams-test"))
@@ -470,5 +471,16 @@ trait DottyBuild { this: BuildCommons =>
         GenScalaTestDotty.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")                
+
+  lazy val scalatestWordSpecTestDotty = project.in(file("dotty/wordspec-test"))
+    .settings(sharedSettings: _*)
+    .settings(dottySettings: _*)
+    .settings(sharedTestSettingsDotty)
+    .settings(
+      projectTitle := "ScalaTest WordSpec Test",
+      sourceGenerators in Test += Def.task {
+        GenScalaTestDotty.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+      }.taskValue,
+    ).dependsOn(commonTestDotty % "test")
 
 }

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -490,7 +490,9 @@ object GenScalaTestDotty {
           "FixtureAsyncWordSpecLikeSpec.scala", // skipped because does not compile yet
           "FixtureAsyncWordSpecSpec.scala", // skipped because does not compile yet
           "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-          "WordSpecSpec.scala" // skipped because does not compile yet
+          "WordSpecSpec.scala", // skipped because does not compile yet
+          "FixtureWordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
+          "FixtureWordSpecSpec.scala" // skipped because does not compile yet
         )
       )    
 }

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -197,8 +197,6 @@ object GenScalaTestDotty {
         "AnyValMatchersSpec.scala",  // skipped because does not compile yet
         "AppendedCluesSpec.scala", // skipped because does not compile yet 
         "ArgsSpec.scala",  // skipped because does not compile yet
-        "AsyncWordSpecLikeSpec.scala", // skipped because does not compile yet 
-        "AsyncWordSpecSpec.scala", // skipped because does not compile yet 
         "BeforeAndAfterAllConfigMapSpec.scala", // skipped because does not compile yet 
         "BeforeAndAfterAllProp.scala", // skipped because does not compile yet 
         "BeforeAndAfterAllSpec.scala", // skipped because does not compile yet 
@@ -349,8 +347,6 @@ object GenScalaTestDotty {
         "TestDataProp.scala", // skipped because does not compile yet 
         "TestNameProp.scala", // skipped because does not compile yet 
         "TypeCheckedAssertionsSpec.scala", // skipped because does not compile yet 
-        "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet 
-        "WordSpecSpec.scala" // skipped because does not compile yet 
       )
     ) ++ 
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/expectations", "org/scalatest/expectations", targetDir, 
@@ -484,5 +480,17 @@ object GenScalaTestDotty {
     def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, 
         List("PropSpecSpec.scala")
-      )  
+      )
+
+    def genWordSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
+      copyDir("jvm/wordspec-test/src/test/scala/org/scalatest/wordspec", "org/scalatest/wordspec", targetDir, 
+        List(
+          "AsyncWordSpecLikeSpec.scala", // skipped because does not compile yet
+          "AsyncWordSpecSpec.scala", // skipped because does not compile yet
+          "FixtureAsyncWordSpecLikeSpec.scala", // skipped because does not compile yet
+          "FixtureAsyncWordSpecSpec.scala", // skipped because does not compile yet
+          "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
+          "WordSpecSpec.scala" // skipped because does not compile yet
+        )
+      )    
 }

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -482,7 +482,10 @@ object GenScalaTestDotty {
 
     def genFunSuiteTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, 
-        List("FunSuiteSpec.scala")
+        List(
+          "FunSuiteSpec.scala", 
+          "FixtureFunSuiteSpec.scala"
+        )
       )
 
     def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -467,7 +467,11 @@ object GenScalaTestDotty {
       )    
 
     def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-      copyDir("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, List.empty)
+      copyDir("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, 
+        List(
+          "FixtureFreeSpecSpec.scala"
+        )
+      )
 
     def genFunSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, List.empty)    

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -490,7 +490,10 @@ object GenScalaTestDotty {
 
     def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, 
-        List("PropSpecSpec.scala")
+        List(
+          "PropSpecSpec.scala", 
+          "FixturePropSpecSpec.scala"
+        )
       )
 
     def genWordSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -469,12 +469,16 @@ object GenScalaTestDotty {
     def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, 
         List(
-          "FixtureFreeSpecSpec.scala"
+          "FixtureFreeSpecSpec.scala" // skipped because tests failed
         )
       )
 
     def genFunSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-      copyDir("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, List.empty)    
+      copyDir("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, 
+        List(
+          "FixtureFunSpecSpec.scala" // skipped because tests failed
+        )
+      )    
 
     def genFunSuiteTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
       copyDir("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, 

--- a/project/GenScalaTestJS.scala
+++ b/project/GenScalaTestJS.scala
@@ -387,4 +387,7 @@ object GenScalaTestJS {
   def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, List.empty)
 
+  def genWordSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
+    copyDir("jvm/wordspec-test/src/test/scala/org/scalatest/wordspec", "org/scalatest/wordspec", targetDir, List.empty)  
+
 }

--- a/project/GenScalaTestNative.scala
+++ b/project/GenScalaTestNative.scala
@@ -656,6 +656,9 @@ object GenScalaTestNative {
     copyDir("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, List.empty)  
 
   def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
-    copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, List.empty)  
+    copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, List.empty)
+
+  def genWordSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] =
+    copyDir("jvm/wordspec-test/src/test/scala/org/scalatest/wordspec", "org/scalatest/wordspec", targetDir, List.empty)    
 
 }

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -237,6 +237,7 @@ trait JsBuild { this: BuildCommons =>
       "-m", "org.scalatest.funspec",
       "-m", "org.scalatest.funsuite",
       "-m", "org.scalatest.propspec",
+      "-m", "org.scalatest.wordspec",
       "-oDIF"))  
 
   lazy val commonTestJS = project.in(file("js/common-test"))
@@ -336,7 +337,8 @@ trait JsBuild { this: BuildCommons =>
        scalatestFreeSpecTestJS, 
        scalatestFunSpecTestJS, 
        scalatestFunSuiteTestJS, 
-       scalatestPropSpecTestJS
+       scalatestPropSpecTestJS, 
+       scalatestWordSpecTestJS
      )
 
   lazy val scalatestDiagramsTestJS = project.in(file("js/diagrams-test"))
@@ -421,7 +423,19 @@ trait JsBuild { this: BuildCommons =>
           GenScalaTestJS.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
         }.taskValue
       }
-    ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)       
+    ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
+
+  lazy val scalatestWordSpecTestJS = project.in(file("js/wordspec-test"))
+    .settings(sharedSettings: _*)
+    .settings(sharedTestSettingsJS: _*)
+    .settings(
+      projectTitle := "ScalaTest WordSpec Test",
+      sourceGenerators in Test += {
+        Def.task {
+          GenScalaTestJS.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        }.taskValue
+      }
+    ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)         
 
   val scalatestJSDocTaskSetting =
     doc in Compile := docTask((doc in Compile).value,

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -752,7 +752,8 @@ trait NativeBuild { this: BuildCommons =>
        scalatestFreeSpecTestNative, 
        scalatestFunSpecTestNative, 
        scalatestFunSuiteTestNative, 
-       scalatestPropSpecTestNative
+       scalatestPropSpecTestNative, 
+       scalatestWordSpecTestNative
     )*/
 
   lazy val scalatestDiagramsTestNative = project.in(file("native/diagrams-test"))
@@ -840,6 +841,18 @@ trait NativeBuild { this: BuildCommons =>
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
+
+  lazy val scalatestWordSpecTestNative = project.in(file("native/wordspec-test"))
+    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedTestSettingsNative: _*)
+    .settings(
+      projectTitle := "ScalaTest WordSpec Test",
+      sourceGenerators in Test += {
+        Def.task {
+          GenScalaTestNative.genWordSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+        }.taskValue
+      }
+    ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)  
 
   lazy val scalatestModulesNative = project.in(file("modules/native/modules-aggregation"))
     .settings(sharedSettings ++ sharedNativeSettings)

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -224,6 +224,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       "-m", "org.scalatest.funspec",
       "-m", "org.scalatest.funsuite",
       "-m", "org.scalatest.propspec",
+      "-m", "org.scalatest.wordspec",
       "-oDIF",
       "-W", "120", "60",
       "-h", "target/html",
@@ -364,7 +365,8 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
        scalatestFreeSpecTest, 
        scalatestFunSpecTest, 
        scalatestFunSuiteTest, 
-       scalatestPropSpecTest
+       scalatestPropSpecTest, 
+       scalatestWordSpecTest
      )
 
   lazy val scalatestDiagramsTest = project.in(file("jvm/diagrams-test"))
@@ -414,7 +416,14 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedTestSettings: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec Test"
-    ).dependsOn(commonTest % "test")          
+    ).dependsOn(commonTest % "test")
+
+  lazy val scalatestWordSpecTest = project.in(file("jvm/wordspec-test"))
+    .settings(sharedSettings: _*)
+    .settings(sharedTestSettings: _*)
+    .settings(
+      projectTitle := "ScalaTest WordSpec Test"
+    ).dependsOn(commonTest % "test")            
 
   lazy val scalatestApp = project.in(file("scalatest-app"))
     .enablePlugins(SbtOsgi)


### PR DESCRIPTION
Another round of moving style trait tests to their related test module, though some skipped currently in Dotty due to failing tests, I notice those failed tests are registerTest related to source location, once we fix one I think we can include all of them together.