### PR TITLE
Fixed building scalatests on scala-native-2.13

### DIFF
--- a/project/GenScalaTestNative.scala
+++ b/project/GenScalaTestNative.scala
@@ -116,10 +116,16 @@ object GenScalaTestNative {
   val genScalaPackages: Map[String, List[String]] =
     Map(
       "org/scalatest" -> (List(
+        "Doc.scala",
+        "DocSpec.scala",
+        "DocSpecLike.scala",
         "DispatchReporter.scala",
         "ConfigMapWrapperSuite.scala",    // skipped because depends on java reflection.
         "JavaClassesWrappers.scala",
         "Shell.scala",
+        "StreamlinedXml.scala",
+        "StreamlinedXmlEquality.scala",
+        "StreamlinedXmlNormMethods.scala",
         "SuiteRerunner.scala",
         "SuiteRerunner.scala",
         "run.scala"

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -16,18 +16,6 @@ trait NativeBuild { this: BuildCommons =>
 
   val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0-M2")
 
-  lazy val nativeCrossBuildLibraryDependencies = Def.setting {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      // if scala 2.11+ is used, add dependency on scala-xml module
-      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        Seq(
-          "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
-        )
-      case _ =>
-        Seq.empty
-    }
-  }
-
   private lazy val sharedNativeSettings = Seq(
     // This hack calls class directory as "resource" that forces to add all NIRs that was generated
     // by scala-native for classes that has `EnableReflectiveInstantiation` annotation
@@ -166,7 +154,6 @@ trait NativeBuild { this: BuildCommons =>
         name := "scalatest-app",
         organization := "org.scalatest",
         moduleName := "scalatest-app",
-        libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
         libraryDependencies += "org.scala-native" %%% "test-interface" % scalaNativeVersion,
         // include the scalactic classes and resources in the jar
         mappings in (Compile, packageBin) ++= mappings.in(scalacticNative, Compile, packageBin).value,
@@ -714,7 +701,6 @@ trait NativeBuild { this: BuildCommons =>
   def sharedTestSettingsNative: Seq[Setting[_]] =
     Seq(
       organization := "org.scalatest",
-      libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
       // libraryDependencies += "io.circe" %%% "circe-parser" % "0.7.1" % "test",
       fork in test := false,
       nativeLinkStubs in Test := true,


### PR DESCRIPTION
This commit fixed a future issue with scala-native that can be discovered inside current scala-native master because it supports scala-2.13 :)