### PR TITLE
.jvmopts: Increase max heap size to 11 GB

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,6 @@
 -server 
 -Xms512M 
--Xmx4000M 
+-Xmx11G
 -Xss10M
 -XX:+CMSClassUnloadingEnabled 
 -XX:+UseConcMarkSweepGC 


### PR DESCRIPTION
The previous default of 4 GB lead to the JVM getting stuck in garbage
collection seemingly forever.