### PR TITLE
NonEmptyArraySpec Test Fix

### DIFF
--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
@@ -145,7 +145,7 @@ class NonEmptyArraySpec extends UnitSpec {
     the [IndexOutOfBoundsException] thrownBy { // In ScalaJs, this throws scala.scalajs.runtime.UndefinedBehaviorError
       val arr5 = NonEmptyArray(1, 2, 3)        // TODO, might be nice to check for that exception on ScalaJS instead of just skipping the check
       arr5(3)
-    } should have message "3"
+    } should (have message "3" or have message "Index 3 out of bounds for length 3")  // message 3 is in jdk8 and older, the new message is used by newer version of jdk.
     // SKIP-SCALATESTJS,NATIVE-END
   }
   it should "have a length method" in {


### PR DESCRIPTION
Fixed failing test in NonEmptyArraySpec under newer JDK (11), which underlying JDK classes now giving a different error message.