### PR TITLE
Retrying's Scheduler Shutdown

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
@@ -56,11 +56,12 @@ trait Retrying[T] {
   */
 object Retrying {
 
-  private lazy val scheduler: ScheduledExecutorService = {
+  private def createScheduler(): ScheduledExecutorService = {
     val threadFactory = new ThreadFactory {
       val inner = Executors.defaultThreadFactory()
       def newThread(runnable: Runnable) = {
         val thread = inner.newThread(runnable)
+        thread.setName("ScalaTest-retrying")
         thread.setDaemon(true)
         thread
       }
@@ -111,7 +112,10 @@ object Retrying {
                     }
                   }
 
+                val scheduler = createScheduler()
                 scheduler.schedule(task, chillTime, TimeUnit.MILLISECONDS)
+                scheduler.shutdown()
+
                 promise.future
               }
               else { // Timed out so return a failed Future


### PR DESCRIPTION
Rewritten Retrying.scala to do away with lazy val scheduler in object Retrying which is not shutdown, replaced with approach where new instance of scheduler is created every time and .shutdown() is called right after the intended task is scheduled with it, this way the scheduler will shutdown after the scheduled task completes its execution.