### PR TITLE
Release 3.2.6

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1038,6 +1038,10 @@ object Runner {
   // use different numbers. So this is a "global" count in Runner.
   private val atomicThreadCounter = new AtomicInteger
 
+  private[scalatest] def loadJUnitWrapperClass(loader: ClassLoader) = loader.loadClass("org.scalatestplus.junit.JUnitWrapperSuite")
+
+  private[scalatest] def loadTestNGWrapperClass(loader: ClassLoader) = loader.loadClass("org.scalatestplus.testng.TestNGWrapperSuite")
+
   private[scalatest] def doRunRunRunDaDoRunRun(
     dispatch: DispatchReporter,
     suitesList: List[SuiteParam],
@@ -1204,8 +1208,7 @@ object Runner {
             if (junitsList.isEmpty)
               List.empty
             else {
-              // TODO: should change the class name to org.scalatestplus.junit.JUnitWrapperSuite after we move junit out.
-              val junitWrapperClass = loader.loadClass("org.scalatest.junit.JUnitWrapperSuite")
+              val junitWrapperClass = loadJUnitWrapperClass(loader)
               val junitWrapperClassConstructor = junitWrapperClass.getDeclaredConstructor(classOf[String], classOf[ClassLoader])
               for (junitClassName <- junitsList)
                 yield SuiteConfig(junitWrapperClassConstructor.newInstance(junitClassName, loader).asInstanceOf[Suite], emptyDynaTags, false, true) // JUnit suite should exclude nested suites
@@ -1213,8 +1216,7 @@ object Runner {
 
           val testNGWrapperSuiteList: List[SuiteConfig] =
             if (!testNGList.isEmpty) {
-              // TODO: should change the class name to org.scalatestplus.testng.TestNGWrapperSuite after we move junit out.
-              val testngWrapperClass = loader.loadClass("org.scalatest.testng.TestNGWrapperSuite")
+              val testngWrapperClass = loadTestNGWrapperClass(loader)
               val testngWrapperClassConstructor = testngWrapperClass.getDeclaredConstructor(classOf[List[String]])
               List(SuiteConfig(testngWrapperClassConstructor.newInstance(testNGList).asInstanceOf[Suite], emptyDynaTags, false, true)) // TestNG suite should exclude nested suites
             }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunnerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunnerSpec.scala
@@ -87,4 +87,14 @@ class RunnerSpec extends AnyFunSpec with PrivateMethodTester {
     assert(1 === events.filter(_.isInstanceOf[AlertProvided]).size)
   }
 
+  it("should load JUnit wrapper suite class correctly") {
+    val clazz = Runner.loadJUnitWrapperClass(Runner.getClass().getClassLoader())
+    assert(clazz.getName == "org.scalatestplus.junit.JUnitWrapperSuite")
+  }
+
+  it("should load TestNG wrapper suite class correctly") {
+    val clazz = Runner.loadTestNGWrapperClass(Runner.getClass().getClassLoader())
+    assert(clazz.getName == "org.scalatestplus.testng.TestNGWrapperSuite")
+  }
+
 }

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -10,9 +10,9 @@ trait BuildCommons {
     scalaVersion := crossScalaVersions.value.head,
   )
 
-  val releaseVersion = "3.2.5"
+  val releaseVersion = "3.2.6"
 
-  val previousReleaseVersion = "3.2.3"
+  val previousReleaseVersion = "3.2.5"
 
   val plusJUnitVersion = "3.2.4.0"
   val plusTestNGVersion = "3.2.4.0"

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -14,8 +14,8 @@ trait BuildCommons {
 
   val previousReleaseVersion = "3.2.5"
 
-  val plusJUnitVersion = "3.2.4.0"
-  val plusTestNGVersion = "3.2.4.0"
+  val plusJUnitVersion = "3.2.5.0"
+  val plusTestNGVersion = "3.2.5.0"
   val flexmarkVersion = "0.36.8"
 
   def rootProject: Project

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -145,7 +145,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 3 =>
         Seq(("org.scala-lang.modules" %% "scala-xml" % "2.0.0-M5"))
       case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 2 && scalaMajor >= 11 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "1.2.0"))
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
       case other =>
         Seq.empty
     }

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -142,8 +142,10 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   def scalaXmlDependency(theScalaVersion: String): Seq[ModuleID] =
     CrossVersion.partialVersion(theScalaVersion) match {
-      case Some((scalaEpoch, scalaMajor)) if scalaEpoch != 2 || scalaMajor >= 11 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "1.2.0").withDottyCompat(theScalaVersion))
+      case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 3 =>
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.0.0-M5"))
+      case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 2 && scalaMajor >= 11 =>
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "1.2.0"))
       case other =>
         Seq.empty
     }


### PR DESCRIPTION
- Fixed class loading problem for JUnit and TestNG wrapper class in Runner as reported in https://github.com/scalatest/scalatest/issues/1971 .
- Changed to use scala-xml 2.0.0-M5 for Scala 3 build.
- Changed to use scala-xml 1.3.0 for Scala 2 build.