### PR TITLE
RoseTree Test Refactoring First Step

### DIFF
--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2824,16 +2824,17 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val xs = List.empty[Int]
         lstGen.shrink(xs, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) shouldBe empty
       }
-      // TODO: Fix this test
-      ignore("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a List of size 1") {
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a List of size 1") {
         val lstGen = implicitly[Generator[List[Int]]]
         val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
         val expectedLists = List(List.empty[Int]) ++ canonicalLists
         val nonCanonical = List(99)
-        lstGen.shrink(nonCanonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+        // pass in nonCanonical as only edge case so the generator will generate rose tree with the specified value.
+        lstGen.next(SizeParam(1, 0, 1), List(nonCanonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
         val canonical = List(3)
         // Ensure 3 (an Int canonical value) does not show up twice in the output
-        lstGen.shrink(canonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+        // pass in canonical as only edge case so the generator will generate rose tree with the specified value.
+        lstGen.next(SizeParam(1, 0, 1), List(canonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[List[Int]]]
@@ -3065,16 +3066,17 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val xs = Vector.empty[Int]
         lstGen.shrink(xs, Randomizer.default)._1.shrinks(Randomizer.default)._1 shouldBe empty
       }
-      // TODO: Fix this test
-      ignore("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a Vector of size 1") {
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a Vector of size 1") {
         val lstGen = implicitly[Generator[Vector[Int]]]
         val canonicalLists = Vector(0, 1, -1, 2, -2, 3, -3).map(i => Vector(i))
         val expectedLists = Vector(Vector.empty[Int]) ++ canonicalLists
         val nonCanonical = Vector(99)
-        lstGen.shrink(nonCanonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
+        // We control the intended generated rosetree value by passing the intended value as the only edge case.
+        lstGen.next(SizeParam(1, 0, 1), List(nonCanonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
         val canonical = Vector(3)
         // Ensure 3 (an Int canonical value) does not show up twice in the output
-        lstGen.shrink(canonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
+        // We control the intended generated rosetree value by passing the intended value as the only edge case.
+        lstGen.next(SizeParam(1, 0, 1), List(canonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a Vector of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[Vector[Int]]]
@@ -3183,16 +3185,17 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val xs = Set.empty[Int]
         lstGen.shrink(xs, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toSet shouldBe empty
       }
-      // TOOD: Fix this test
-      ignore("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a Set of size 1") {
+      it("should return an Iterator of the canonicals excluding the given values to shrink when asked to shrink a Set of size 1") {
         val lstGen = implicitly[Generator[Set[Int]]]
         val canonicalLists = Vector(0, 1, -1, 2, -2, 3, -3).map(i => Set(i))
         val expectedLists = Vector(Set.empty[Int]) ++ canonicalLists
         val nonCanonical = Set(99)
-        lstGen.shrink(nonCanonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
+        // We control the intended generated rosetree value by passing the intended value as the only edge case.
+        lstGen.next(SizeParam(1, 0, 1), List(nonCanonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
         val canonical = Set(3)
         // Ensure 3 (an Int canonical value) does not show up twice in the output
-        lstGen.shrink(canonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
+        // We control the intended generated rosetree value by passing the intended value as the only edge case.
+        lstGen.next(SizeParam(1, 0, 1), List(canonical), Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value).toVector should contain theSameElementsAs expectedLists
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a Set of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[Set[Int]]]

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2754,7 +2754,8 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       val (intCanonicalsIt, _) = intGenerator.canonicals(Randomizer.default)
       val intCanonicals = intCanonicalsIt.toList
       forAll { (xs: F[Int]) =>
-        val (shrinkRoseTree, _) = generator.shrink(xs, Randomizer.default)
+        // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
+        val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)
         val shrinks: List[F[Int]] = shrinkRoseTree.shrinks(Randomizer.default)._1.map(_.value).reverse
         if (xs.isEmpty)
           shrinks shouldBe empty
@@ -2815,8 +2816,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val xss = List(List(100, 200, 300, 400, 300))
         lstGen.shrink(xss, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should not contain xss
       }
-      // TODO: Fix this test
-      ignore("should shrink Lists using strategery") {
+      it("should shrink Lists using strategery") {
         shrinkByStrategery[List](List)
       }
       it("should return an empty Iterator when asked to shrink a List of size 0") {
@@ -3056,8 +3056,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           v.length shouldBe 5
         }
       }
-      // TODO: Fix this test
-      ignore("should shrink Vectors using strategery") {
+      it("should shrink Vectors using strategery") {
         shrinkByStrategery[Vector](Vector)
       }
 
@@ -3176,8 +3175,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
       }
 
-      // TODO:
-      ignore("should shrink Sets using strategery") {
+      it("should shrink Sets using strategery") {
         shrinkByStrategery[Set](Set)
       }
       it("should return an empty Iterator when asked to shrink a Set of size 0") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -97,11 +97,17 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         val lstGen = lists[Int].havingLengthsBetween(0, 88)
         val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
         val expectedLists = List(List.empty[Int]) ++ canonicalLists
-        val nonCanonical = List(99)
-        lstGen.shrink(nonCanonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
-        val canonical = List(3)
+        
+        val singleElementLstGen = lists[Int].havingLength(1)
+
+        // pass in List(99) as only edge case so the generator will generate rose tree with the specified value.
+        val (rtNonCanonical, _, _) = singleElementLstGen.next(SizeParam(1, 1, 1), List(List(99)), Randomizer.default)
+        rtNonCanonical.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+        
+        // pass in List(3) as only edge case so the generator will generate rose tree with the specified value.
+        val (rtCanonical, _, _) = singleElementLstGen.next(SizeParam(1, 1, 1), List(List(3)), Randomizer.default)
         // Ensure 3 (an Int canonical value) does not show up twice in the output
-        lstGen.shrink(canonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+        rtCanonical.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
         import CommonGenerators.lists
@@ -229,11 +235,16 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         val lstGen = lists[Int].havingLengthsBetween(5, 88)
         val canonicalLists = List(0, 1, -1, 2, -2, 3, -3).map(i => List(i))
         val expectedLists = List(List.empty[Int]) ++ canonicalLists
-        val nonCanonical = List(99)
-        lstGen.shrink(nonCanonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
-        val canonical = List(3)
-        // Ensure 3 (an Int canonical value) does not show up twice in the output
-        lstGen.shrink(canonical, Randomizer.default)._1.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+
+        val singleElementLstGen = lists[Int].havingLength(1)
+        
+        // pass in List(99) as only edge case so the generator will generate rose tree with the specified value.
+        val (rtNonCanonical, _, _) = singleElementLstGen.next(SizeParam(1, 1, 1), List(List(99)), Randomizer.default)
+        rtNonCanonical.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
+        
+        // pass in List(3) as only edge case so the generator will generate rose tree with the specified value.
+        val (rtCanonical, _, _) = singleElementLstGen.next(SizeParam(1, 1, 1), List(List(3)), Randomizer.default)
+        rtCanonical.shrinks(Randomizer.default)._1.map(_.value) should contain theSameElementsAs expectedLists
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
         import CommonGenerators.lists

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -54,7 +54,8 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         val intCanonicals = intCanonicalsIt.toList
         forAll (lists[Int].havingLengthsBetween(0, 78)) { (xs: List[Int]) =>
           val generator = lists[Int]
-          val (shrinkRt, _) = generator.shrink(xs, Randomizer.default)
+          // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
+          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(xs), Randomizer.default) //generator.shrink(xs, Randomizer.default)
           val shrinks: List[List[Int]] = shrinkRt.shrinks(Randomizer.default)._1.map(_.value).reverse
           if (xs.isEmpty)
             shrinks shouldBe empty
@@ -192,8 +193,9 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         val intCanonicals = intCanonicalsIt.toList
         forAll (lists[Int].havingLengthsBetween(5, 78)) { (xs: List[Int]) =>
           val generator = lists[Int]
-          val (shrinkIt, _) = generator.shrink(xs, Randomizer.default)
-          val shrinks: List[List[Int]] = shrinkIt.shrinks(Randomizer.default)._1.map(_.value).reverse
+          // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
+          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(xs), Randomizer.default)
+          val shrinks: List[List[Int]] = shrinkRt.shrinks(Randomizer.default)._1.map(_.value).reverse
           if (xs.isEmpty)
             shrinks shouldBe empty
           else {


### PR DESCRIPTION
First step in refactoring tests to do away with Generator.shrink call, fixed failing tests in HavingLengthsBetweenSpec.scala.