### PR TITLE
Assertions' assertResult, shouldBe and mustBe matchers with scala.CanEqual

### DIFF
--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -949,7 +949,7 @@ trait Assertions extends TripleEquals  {
    * @param actual the actual value, which should equal the passed <code>expected</code> value
    * @throws TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
    */
-  def assertResult(expected: Any, clue: Any)(actual: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion = {
+  def assertResult[L, R](expected: L, clue: Any)(actual: R)(implicit prettifier: Prettifier, pos: source.Position, caneq: scala.CanEqual[L, R]): Assertion = {
     if (!areEqualComparingArraysStructurally(actual, expected)) {
       val (act, exp) = Suite.getObjectsForFailureMessage(actual, expected)
       val s = FailureMessages.expectedButGot(prettifier, exp, act)
@@ -970,7 +970,7 @@ trait Assertions extends TripleEquals  {
    * @param actual the actual value, which should equal the passed <code>expected</code> value
    * @throws TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
    */
-  def assertResult(expected: Any)(actual: Any)(implicit prettifier: Prettifier, pos: source.Position): Assertion = {
+  def assertResult[L, R](expected: L)(actual: R)(implicit prettifier: Prettifier, pos: source.Position, caneq: scala.CanEqual[L, R]): Assertion = {
     if (!areEqualComparingArraysStructurally(actual, expected)) {
       val (act, exp) = Suite.getObjectsForFailureMessage(actual, expected)
       val s = FailureMessages.expectedButGot(prettifier, exp, act)

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/AssertionsCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/AssertionsCanEqualSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.scalatest
+
+ import org.scalatest.funspec._
+
+ class AssertionsCanEqualSpec extends AnyFunSpec {
+
+   describe("assertResult without clue") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         assertResult(x)(y)
+         """  
+       )
+     }
+
+     it("should now allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         assertResult(x)(y)
+         """  
+       )
+     }
+
+   }
+
+   describe("org.scalatest.Assertions.assertResult without clue") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         org.scalatest.Assertions.assertResult(x)(y)
+         """  
+       )
+     }
+
+     it("should now allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         org.scalatest.Assertions.assertResult(x)(y)
+         """  
+       )
+     }
+
+   }
+
+   describe("assertResult with clue") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         assertResult(x, "test clue")(y)
+         """  
+       )
+     }
+
+     it("should now allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         assertResult(x, "test clue")(y)
+         """  
+       )
+     }
+
+   }
+
+   describe("org.scalatest.Assertions.assertResult with clue") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         org.scalatest.Assertions.assertResult(x, "test clue")(y)
+         """  
+       )
+     }
+
+     it("should now allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         org.scalatest.Assertions.assertResult(x, "test clue")(y)
+         """  
+       )
+     }
+
+   }
+
+ }

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
@@ -50,4 +50,33 @@
 
    }
 
+   describe("mustBe matcher for inspector shortand syntax") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         all(List(x)) mustBe y
+         """  
+       )
+     }
+
+     it("should not allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         all(List(x)) mustBe y
+         """  
+       )
+     }
+
+   }
+
  }

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.scalatest.matchers.must
+
+ import org.scalatest.funspec._
+ import org.scalatest.matchers.must._
+
+ class MustBeCanEqualSpec extends AnyFunSpec with Matchers {
+
+   describe("mustBe matcher syntax") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         x mustBe y
+         """  
+       )
+     }
+
+     it("should not allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         x mustBe y
+         """  
+       )
+     }
+
+   }
+
+ }

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.scalatest.matchers.should
+
+ import org.scalatest.funspec._
+ import org.scalatest.matchers.should._
+
+ class ShouldBeCanEqualSpec extends AnyFunSpec with Matchers {
+
+   describe("shouldBe matcher syntax") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         x shouldBe y
+         """  
+       )
+     }
+
+     it("should not allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         x shouldBe y
+         """  
+       )
+     }
+
+   }
+
+ }

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
@@ -50,4 +50,33 @@
 
    }
 
+   describe("shouldBe matcher for inspector shortand syntax") {
+
+     it("should allow 2 unrelated types when strictEquality is not enabled") {
+       assertCompiles(
+         """
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         all(List(x)) shouldBe y
+         """  
+       )
+     }
+
+     it("should not allow 2 unrelated types when strictEquality is enabled") {
+       assertDoesNotCompile(
+         """
+         import scala.language.strictEquality
+         case class Apple(size: Int)
+         case class Orange(size: Int)
+         val x = Apple(42)
+         val y = Orange(42)
+         all(List(x)) shouldBe y
+         """  
+       )
+     }
+
+   }
+
  }

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
@@ -982,7 +982,7 @@ class NonEmptyArraySpec extends UnitSpec {
   }
   it should "have a reverseIterator method" in {
     NonEmptyArray(3).reverseIterator.toStream shouldBe Stream(3)
-    NonEmptyArray(1, 2, 3).reverseIterator.toArray shouldBe Stream(3, 2, 1)
+    NonEmptyArray(1, 2, 3).reverseIterator.toStream shouldBe Stream(3, 2, 1)
   }
   it should "have a reverseMap method" in {
     NonEmptyArray(3).reverseMap(_ + 1) shouldBe NonEmptyArray(4)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -6541,11 +6541,12 @@ class AssertionsSpec extends AnyFunSpec {
         assertResult("hi") { n1 }
       }
       val a1 = Array(1, 2, 3)
+      val aNull: Array[Int] = null
       intercept[TestFailedException] {
-        assertResult(n1) { a1 }
+        assertResult(aNull) { a1 }
       }
       intercept[TestFailedException] {
-        assertResult(a1) { n1 }
+        assertResult(a1) { aNull }
       }
       val a = "hi"
       val e1 = intercept[TestFailedException] {
@@ -6608,11 +6609,12 @@ class AssertionsSpec extends AnyFunSpec {
         assertResult("hi", "a clue") { n1 }
       }
       val a1 = Array(1, 2, 3)
+      val aNull: Array[Int] = null
       intercept[TestFailedException] {
-        assertResult(n1, "a clue") { a1 }
+        assertResult(aNull, "a clue") { a1 }
       }
       intercept[TestFailedException] {
-        assertResult(a1, "a clue") { n1 }
+        assertResult(a1, "a clue") { aNull }
       }
       val a = "hi"
       val e1 = intercept[TestFailedException] {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
@@ -6426,11 +6426,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assertResult("hi") { n1 }
       }
       val a1 = Array(1, 2, 3)
+      val aNull: Array[Int] = null
       intercept[TestFailedException] {
-        org.scalatest.Assertions.assertResult(n1) { a1 }
+        org.scalatest.Assertions.assertResult(aNull) { a1 }
       }
       intercept[TestFailedException] {
-        org.scalatest.Assertions.assertResult(a1) { n1 }
+        org.scalatest.Assertions.assertResult(a1) { aNull }
       }
       val a = "hi"
       val e1 = intercept[TestFailedException] {
@@ -6493,11 +6494,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assertResult("hi", "a clue") { n1 }
       }
       val a1 = Array(1, 2, 3)
+      val aNull: Array[Int] = null
       intercept[TestFailedException] {
-        org.scalatest.Assertions.assertResult(n1, "a clue") { a1 }
+        org.scalatest.Assertions.assertResult(aNull, "a clue") { a1 }
       }
       intercept[TestFailedException] {
-        org.scalatest.Assertions.assertResult(a1, "a clue") { n1 }
+        org.scalatest.Assertions.assertResult(a1, "a clue") { aNull }
       }
       val a = "hi"
       val e1 = intercept[TestFailedException] {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -68,6 +68,8 @@ class InspectorsSpec extends AnyFunSpec with Inspectors with TableDrivenProperty
       }
     }
     
+    // This does not compile anymore in dotty after CanEqual is added to shouldBe, as the forAll returns Unit trying to compare to Succeeded.
+    // SKIP-DOTTY-START
     ignore("should, when passed a Fact, convert that Fact to an Assertion") { // Unignore after we uncomment the expectation implicits in RegistrationPolicy
       import expectations.Expectations._
 
@@ -79,6 +81,7 @@ class InspectorsSpec extends AnyFunSpec with Inspectors with TableDrivenProperty
       tfe.failedCodeFileName should be (Some("InspectorsSpec.scala"))
       tfe.failedCodeLineNumber should be (Some( thisLineNumber - 3))
     }
+    // SKIP-DOTTY-END
     
     it("should throw TestFailedException with correct stack depth and message when at least one element failed") {
       forAll(examples) { colFun => 

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -7011,7 +7011,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     // SKIP-DOTTY-START 
     def shouldBe(right: Any): Assertion = {
     // SKIP-DOTTY-END
-    //DOTTY-ONLY extension [T](leftSideValue: T)(using pos: source.Position, prettifier: Prettifier) def shouldBe(right: Any): Assertion = {
+    //DOTTY-ONLY extension [T, R](leftSideValue: T)(using pos: source.Position, prettifier: Prettifier) def shouldBe(right: R)(implicit caneq: scala.CanEqual[T, R]): Assertion = {
       if (!areEqualComparingArraysStructurally(leftSideValue, right)) {
         val (leftee, rightee) = Suite.getObjectsForFailureMessage(leftSideValue, right)
         val localPrettifier = prettifier // Grabbing a local copy so we don't attempt to serialize AnyShouldWrapper (since first param to indicateFailure is a by-name)

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -5533,7 +5533,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *          ^
      * </pre>
      */
+    // SKIP-DOTTY-START 
     def shouldBe(right: Any): Assertion = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def shouldBe[R](right: R)(implicit caneq: scala.CanEqual[T, R]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (e != right) {
           val (eee, rightee) = Suite.getObjectsForFailureMessage(e, right)

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -523,6 +523,8 @@ object GenScalaTestDotty {
       )
     ) ++ 
     copyDirJS("dotty/scalatest-test/src/test/scala/org/scalatest", "org/scalatest", targetDir, List.empty) ++
+    copyDirJS("dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should", "org/scalatest/matchers/should", targetDir, List.empty) ++
+    copyDirJS("dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must", "org/scalatest/matchers/must", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/expectations", "org/scalatest/expectations", targetDir, List.empty) ++ 
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/concurrent", "org/scalatest/concurrent", targetDir, 
       List(

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -522,6 +522,7 @@ object GenScalaTestDotty {
         "SeveredStackTracesFailureSpec.scala" // skipped because stack trace isn't really helpful after linked in different js env like node.
       )
     ) ++ 
+    copyDirJS("dotty/scalatest-test/src/test/scala/org/scalatest", "org/scalatest", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/expectations", "org/scalatest/expectations", targetDir, List.empty) ++ 
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/concurrent", "org/scalatest/concurrent", targetDir, 
       List(


### PR DESCRIPTION
- Enhanced Assertions' assertResult for dotty to use scala.CanEqual.
- Enhanced shouldBe and mustBe matcher for dotty to use scala.CanEqual.
- Enhanced shouldBe and mustBe of inspector shorthand matcher for dotty to use scala.CanEqual.