### PR TITLE
Fix `shouldNot typeCheck` syntax for Scala 3

### DIFF
--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
@@ -21,6 +21,7 @@ import org.scalatest.exceptions.{TestFailedException, StackDepthException}
 import org.scalatest.verbs.{CompileWord, TypeCheckWord}
 
 import scala.quoted._
+import scala.compiletime.testing.{Error, ErrorKind}
 
 object CompileMacro {
 
@@ -70,44 +71,55 @@ object CompileMacro {
     }
   }
 
-  // check that a code snippet does not compile
-  def assertNotTypeCheckImpl(self: Expr[_], typeChecked: Expr[Boolean], typeCheckWord: Expr[TypeCheckWord], pos: Expr[source.Position])(shouldOrMust: String)(using Quotes): Expr[Assertion] = {
+  given FromExpr[ErrorKind] with {
+    def unapply(expr: Expr[ErrorKind])(using Quotes) = expr match {
+      case '{ ErrorKind.Parser } => Some(ErrorKind.Parser)
+      case '{ ErrorKind.Typer }  => Some(ErrorKind.Typer)
+      case _ => None
+    }
+  }
+
+  given FromExpr[Error] with {
+    def unapply(expr: Expr[Error])(using Quotes) = expr match {
+      case '{ Error(${Expr(msg)}, ${Expr(line)}, ${Expr(col)}, ${Expr(kind)}) } => Some(Error(msg, line, col, kind))
+      case _ => None
+    }
+  }
+
+  // check that a code snippet does not type check
+  def assertNotTypeCheckImpl(self: Expr[_], typeChecked: Expr[List[Error]], typeCheckWord: Expr[TypeCheckWord], pos: Expr[source.Position])(shouldOrMust: String)(using Quotes): Expr[Assertion] = {
     import quotes.reflect._
 
-    // parse and type check a code snippet, generate code to throw TestFailedException if both parse and type check succeeded
-    def checkNotTypeCheck(code: String): Expr[Assertion] =
-      if (!typeChecked.valueOrError) '{ Succeeded }
-      else '{
-        val messageExpr = Resources.expectedTypeErrorButGotNone(${ Expr(code) })
-        throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
+    // parse and type check a code snippet
+    // generate code to throw TestFailedException if there is a parse error or type checking succeeds
+    def checkNotTypeCheck(code: String): Expr[Assertion] = {
+      // For some reason `typeChecked.valueOrError` is failing here, so instead we grab
+      // the varargs argument to List.apply and use that to extract the list of errors
+      val errors = typeChecked.asTerm.underlyingArgument match {
+        case Apply(TypeApply(Select(Ident("List"), "apply"), _), List(seq)) =>
+          seq.asExprOf[Seq[Error]].valueOrError.toList
       }
 
-    val methodName = shouldOrMust + "Not"
+      errors match {
+        case Error(_, _, _, ErrorKind.Typer) :: _ => '{ Succeeded }
+        case Error(msg, _, _, ErrorKind.Parser) :: _ => '{
+          val messageExpr = Resources.expectedTypeErrorButGotParseError(${ Expr(msg) }, ${ Expr(code) })
+          throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
+        }
+        case Nil => '{
+          val messageExpr = Resources.expectedTypeErrorButGotNone(${ Expr(code) })
+          throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, $pos)
+        }
+      }
+    }
 
     self.asTerm.underlyingArgument match {
-      case Apply(
-             Apply(
-               Select(_, shouldOrMustTerconvertToStringShouldOrMustWrapperTermName),
-               List(
-                 Literal(code)
-               )
-             ),
-             _
-           ) if shouldOrMustTerconvertToStringShouldOrMustWrapperTermName ==  "convertToString" + shouldOrMust.capitalize + "Wrapper" =>
-        // LHS is a normal string literal, call checkNotTypeCheck with the extracted code string to generate code
+
+      case Literal(StringConstant(code)) =>
         checkNotTypeCheck(code.toString)
 
-      case Apply(
-             Apply(
-               Ident(shouldOrMustTerconvertToStringShouldOrMustWrapperTermName),
-               List(
-                 Literal(StringConstant(code))
-               )
-             ),
-             _
-           ) if shouldOrMustTerconvertToStringShouldOrMustWrapperTermName ==  "convertToString" + shouldOrMust.capitalize + "Wrapper" =>
-        // LHS is a normal string literal, call checkNotTypeCheck with the extracted code string to generate code
-        checkNotTypeCheck(code.toString)
+      case Apply(Select(_, "stripMargin"), List(Literal(StringConstant(code)))) =>
+        checkNotTypeCheck(code.toString.stripMargin)
 
       case _ =>
         report.throwError("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")

--- a/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
+++ b/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
@@ -20,6 +20,7 @@ import org.scalatest.Assertion
 import org.scalatest.verbs.{CompileWord, TypeCheckWord}
 
 import scala.quoted._
+import scala.compiletime.testing.Error
 
 object CompileMacro {
 
@@ -32,7 +33,7 @@ object CompileMacro {
     org.scalatest.matchers.CompileMacro.assertNotCompileImpl(code, typeChecked, compileWord, pos)("must")  
 
   // used by mustNot typeCheck syntax, delegate to assertNotTypeCheckImpl to generate code
-  def mustNotTypeCheckImpl(code: Expr[String], typeChecked: Expr[Boolean], typeCheckWord: Expr[TypeCheckWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
+  def mustNotTypeCheckImpl(code: Expr[String], typeChecked: Expr[List[Error]], typeCheckWord: Expr[TypeCheckWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
     org.scalatest.matchers.CompileMacro.assertNotTypeCheckImpl(code, typeChecked, typeCheckWord, pos)("must")
 
 }

--- a/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
+++ b/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
@@ -20,6 +20,7 @@ import org.scalatest.Assertion
 import org.scalatest.verbs.{CompileWord, TypeCheckWord}
 
 import scala.quoted._
+import scala.compiletime.testing.Error
 
 object CompileMacro {
 
@@ -32,7 +33,7 @@ object CompileMacro {
     org.scalatest.matchers.CompileMacro.assertNotCompileImpl(code, typeChecked, compileWord, pos)("should")
 
   // used by shouldNot typeCheck syntax, delegate to assertNotTypeCheckImpl to generate code
-  def shouldNotTypeCheckImpl(code: Expr[String], typeChecked: Expr[Boolean], typeCheckWord: Expr[TypeCheckWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
+  def shouldNotTypeCheckImpl(code: Expr[String], typeChecked: Expr[List[Error]], typeCheckWord: Expr[TypeCheckWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
     org.scalatest.matchers.CompileMacro.assertNotTypeCheckImpl(code, typeChecked, typeCheckWord, pos)("should")  
   
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
@@ -42,7 +42,6 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
 
-      // SKIP-DOTTY-START
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           "println(\"test)" shouldNot typeCheck
@@ -53,7 +52,6 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
 
       it("should do nothing when used with 'val i: Int = null") {
         "val i: Int = null" shouldNot typeCheck
@@ -91,7 +89,6 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
 
-      // SKIP-DOTTY-START
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           """println("test)""" shouldNot typeCheck
@@ -102,7 +99,6 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
 
       it("should do nothing when used with 'val i: Int = null") {
         """val i: Int = null""" shouldNot typeCheck
@@ -125,7 +121,6 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
       }
     }
 
-    // SKIP-DOTTY-START
     describe("when work with triple quotes string literal with stripMargin") {
 
       it("should do nothing when type check failed") {
@@ -182,6 +177,5 @@ class ShouldNotTypeCheckSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
     }
-    // SKIP-DOTTY-END
   }
 }

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -7780,7 +7780,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     //DOTTY-ONLY extension (leftSideString: String)(using pos: source.Position, prettifier: Prettifier) def shouldNot(fullyMatchWord: FullyMatchWord): ResultOfFullyMatchWordForString =
       new ResultOfFullyMatchWordForString(leftSideString, false, prettifier, pos)
 
-    //DOTTY-ONLY import scala.compiletime.testing.typeChecks  
+    //DOTTY-ONLY import scala.compiletime.testing.{typeChecks,typeCheckErrors}
 
     /**
      * This method enables syntax such as the following:
@@ -7819,7 +7819,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     // SKIP-DOTTY-START
     def shouldNot(typeCheckWord: TypeCheckWord)(implicit pos: source.Position): Assertion = macro CompileMacro.shouldNotTypeCheckImpl
     // SKIP-DOTTY-END
-    //DOTTY-ONLY extension (inline leftSideString: String)(using pos: source.Position, prettifier: Prettifier) transparent inline def shouldNot(typeCheckWord: TypeCheckWord): Assertion = ${ org.scalatest.matchers.should.CompileMacro.shouldNotTypeCheckImpl('{leftSideString}, '{typeChecks(leftSideString)}, '{typeCheckWord})('{pos}) }
+    //DOTTY-ONLY extension (inline leftSideString: String)(using pos: source.Position, prettifier: Prettifier) transparent inline def shouldNot(typeCheckWord: TypeCheckWord): Assertion = ${ org.scalatest.matchers.should.CompileMacro.shouldNotTypeCheckImpl('{leftSideString}, '{typeCheckErrors(leftSideString)}, '{typeCheckWord})('{pos}) }
   // SKIP-DOTTY-START
   }
   // SKIP-DOTTY-END

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -397,7 +397,6 @@ object GenScalaTestDotty {
         "SeveredStackTracesFailureSpec.scala", // skipped because tests failed 
         "SeveredStackTracesSpec.scala", // skipped because tests failed 
         "ShellSuite.scala", // skipped because does not compile yet 
-        "ShouldNotTypeCheckSpec.scala", // skipped because tests failed  
       )
     ) ++ 
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/expectations", "org/scalatest/expectations", targetDir, List.empty) ++


### PR DESCRIPTION
Fixes #2007 