### PR TITLE
Release 3.2.8

### DIFF
--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -16,12 +16,12 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.7"
+  val releaseVersion = "3.2.8"
 
-  val previousReleaseVersion = "3.2.6"
+  val previousReleaseVersion = "3.2.7"
 
-  val plusJUnitVersion = "3.2.7.0"
-  val plusTestNGVersion = "3.2.7.0"
+  val plusJUnitVersion = "3.2.8.0"
+  val plusTestNGVersion = "3.2.8.0"
   val flexmarkVersion = "0.36.8"
 
   def rootProject: Project

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -14,7 +14,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.27/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.0.0-RC2")
+  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.0.0-RC3")
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     scalacOptions ++= List("-language:implicitConversions", "-noindent", "-Xprint-suspension")


### PR DESCRIPTION
Adjusted for 3.2.8 release, use scala 3.0.0-RC3.