### PR TITLE
[3.2] Include Native Tests

### DIFF
--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -750,7 +750,7 @@ trait NativeBuild { this: BuildCommons =>
         }*/
     ).dependsOn(scalatestNative % "test", commonTestNative % "test")
      .enablePlugins(ScalaNativePlugin)
-     /*.aggregate(
+     .aggregate(
        scalatestDiagramsTestNative, 
        scalatestFeatureSpecTestNative, 
        scalatestFlatSpecTestNative, 
@@ -759,7 +759,7 @@ trait NativeBuild { this: BuildCommons =>
        scalatestFunSuiteTestNative, 
        scalatestPropSpecTestNative, 
        scalatestWordSpecTestNative
-    )*/
+    )
 
   lazy val scalatestDiagramsTestNative = project.in(file("native/diagrams-test"))
     .settings(sharedSettings ++ sharedNativeSettings)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -675,6 +675,10 @@ trait NativeBuild { this: BuildCommons =>
       "-m", "org.scalatest.featurespec",
       "-m", "org.scalatest.flatspec",
       "-m", "org.scalatest.freespec",
+      "-m", "org.scalatest.funspec",
+      "-m", "org.scalatest.funsuite",
+      "-m", "org.scalatest.propspec",
+      "-m", "org.scalatest.wordspec",
       "-oDIF"))
 
   lazy val commonTestNative = project.in(file("native/common-test"))


### PR DESCRIPTION
Notice this when I am enabling pure style traits in 3.3, this enables sub project tests in native build, we disabled them because back then we were building with 4GB of heap size, but now with 9GB heap size (added for dotty build), we now have enough memory to build them.