### PR TITLE
[3.3] Safe/Pure Style Traits

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
@@ -343,22 +343,23 @@ abstract class UnitInspectorAsserting {
  * Abstract class that in the future will hold an intermediate priority <code>InspectorAsserting</code> implicit, which will enable inspector expressions
  * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
  */
-/*abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
+abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
 
   private[scalatest] implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
     new InspectorAssertingImpl[Expectation] {
       type Result = Expectation
       def indicateSuccess(message: => String): Expectation = Fact.Yes(message)(prettifier)
-      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position): Expectation = Fact.No(message)(prettifier)
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: org.scalactic.source.Position): Expectation = Fact.No(message)(prettifier)
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Expectation = Fact.No(message)(prettifier)
     }
   }
-}*/
+}
 
 /**
  * Companion object to <code>InspectorAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
  * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
  */
-object InspectorAsserting extends UnitInspectorAsserting /*ExpectationInspectorAsserting*/ {
+object InspectorAsserting extends ExpectationInspectorAsserting {
 
   /**
    * Provides an implicit <code>InspectorAsserting</code> instance for type <code>Assertion</code>,

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala
@@ -46,7 +46,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.funspec.AnyFunSpec
 
-class FeatureSpecSpec extends AnyFunSpec {
+class AnyFeatureSpecSpec extends AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -1105,7 +1105,7 @@ class FeatureSpecSpec extends AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FeatureSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("AnyFeatureSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") {
@@ -1156,9 +1156,9 @@ class FeatureSpecSpec extends AnyFunSpec {
         val s1 = new TestSpec
         s1.run(None, Args(rep))
         assert(rep.testFailedEventsReceived.size === 2)
-        assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FeatureSpecSpec.scala")
+        assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFeatureSpecSpec.scala")
         assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-        assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FeatureSpecSpec.scala")
+        assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFeatureSpecSpec.scala")
         assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
       }
       
@@ -1178,7 +1178,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val caught = intercept[NotAllowedException] {
           new TestSpec
         }
-        assert(caught.failedCodeFileName.get === "FeatureSpecSpec.scala")
+        assert(caught.failedCodeFileName.get === "AnyFeatureSpecSpec.scala")
         assert(caught.failedCodeLineNumber.get === thisLineNumber - 12)
       }
       // SKIP-DOTTY-END
@@ -1213,7 +1213,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FeatureSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("A scenario clause may not appear inside another scenario clause."))
       }
@@ -1246,7 +1246,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FeatureSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("An ignore clause may not appear inside a scenario clause."))
       }
@@ -1279,7 +1279,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FeatureSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1312,7 +1312,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FeatureSpecSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1329,7 +1329,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val e = intercept[NotAllowedException] {
           new TestSpec
         }
-        assert("FeatureSpecSpec.scala" == e.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == e.failedCodeFileName.get)
         assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
         assert(e.message == Some(FailureMessages.assertionShouldBePutInsideScenarioClauseNotFeatureClause))
 
@@ -1337,7 +1337,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val causeThrowable = e.cause.get
         assert(causeThrowable.isInstanceOf[TestFailedException])
         val cause = causeThrowable.asInstanceOf[TestFailedException]
-        assert("FeatureSpecSpec.scala" == cause.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == cause.failedCodeFileName.get)
         assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
         assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
       }
@@ -1352,7 +1352,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val e = intercept[NotAllowedException] {
           new TestSpec
         }
-        assert("FeatureSpecSpec.scala" == e.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == e.failedCodeFileName.get)
         assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
         assert(e.message == Some(FailureMessages.assertionShouldBePutInsideScenarioClauseNotFeatureClause))
 
@@ -1360,7 +1360,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val causeThrowable = e.cause.get
         assert(causeThrowable.isInstanceOf[TestCanceledException])
         val cause = causeThrowable.asInstanceOf[TestCanceledException]
-        assert("FeatureSpecSpec.scala" == cause.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == cause.failedCodeFileName.get)
         assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
         assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
       }
@@ -1376,7 +1376,7 @@ class FeatureSpecSpec extends AnyFunSpec {
         val e = intercept[NotAllowedException] {
           new TestSpec
         }
-        assert("FeatureSpecSpec.scala" == e.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == e.failedCodeFileName.get)
         assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
         assert(e.cause.isDefined)
         val causeThrowable = e.cause.get
@@ -1391,14 +1391,14 @@ class FeatureSpecSpec extends AnyFunSpec {
       it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
         class TestSpec extends AnyFeatureSpec {
           Feature("a feature") {
-            Scenario("test 1") {}
-            Scenario("test 1") {}
+            Scenario("test 1") {/* ASSERTION_SUCCEED */}
+            Scenario("test 1") {/* ASSERTION_SUCCEED */}
           }
         }
         val e = intercept[NotAllowedException] {
           new TestSpec
         }
-        assert("FeatureSpecSpec.scala" == e.failedCodeFileName.get)
+        assert("AnyFeatureSpecSpec.scala" == e.failedCodeFileName.get)
         assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
         assert(e.cause.isDefined)
         val causeThrowable = e.cause.get
@@ -1524,9 +1524,9 @@ class FeatureSpecSpec extends AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FeatureSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFeatureSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FeatureSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFeatureSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
     

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala
@@ -1627,8 +1627,8 @@ class FixtureAnyFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("a string") }
         Feature("a feature") {
-          Scenario("test 1") { fixture => }
-          Scenario("test 1") { fixture => }
+          Scenario("test 1") { fixture => /* ASSERTION_SUCCEED */}
+          Scenario("test 1") { fixture => /* ASSERTION_SUCCEED */}
         }
       }
       val e = intercept[NotAllowedException] {

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala
@@ -39,7 +39,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import Matchers._
 
-class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
+class AnyFlatSpecSpec extends AnyFunSpec with GivenWhenThen {
 
   describe("A FlatSpec") {
 
@@ -1358,7 +1358,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
         assertResult(1)(testFailedEvents.size)
         assertResult(classOf[TestRegistrationClosedException])(testFailedEvents(0).throwable.get.getClass())
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assertResult("FlatSpecSpec.scala")(trce.failedCodeFileName.get)
+        assertResult("AnyFlatSpecSpec.scala")(trce.failedCodeFileName.get)
         assertResult(thisLineNumber - 23)(trce.failedCodeLineNumber.get)
     }
 
@@ -1370,7 +1370,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FlatSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("AnyFlatSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") {
@@ -1416,9 +1416,9 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 10)
     }
   }
@@ -1439,9 +1439,9 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 12)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 10)
     }
     
@@ -1474,7 +1474,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFlatSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 23)
       assert(trce.message == Some("An in clause may not appear inside another in or is clause."))
     }
@@ -1506,7 +1506,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFlatSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside an in or an is clause."))
     }
@@ -1538,7 +1538,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFlatSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1570,7 +1570,7 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFlatSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1579,13 +1579,13 @@ class FlatSpecSpec extends AnyFunSpec with GivenWhenThen {
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
       class TestSpec extends AnyFlatSpec {
         behavior of "a feature"
-        it should "test 1" in {}
-        it should "test 1" in {}
+        it should "test 1" in {/* ASSERTION_SUCCEED */}
+        it should "test 1" in {/* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FlatSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFlatSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
@@ -556,7 +556,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
 
     it("should report as ignored, and not run, tests marked ignored") {
 
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -564,6 +564,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it can "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it can "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -573,7 +574,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThisCalled)
       assert(a.theTestThatCalled)
 
-      val b = new flatspec.FixtureAnyFlatSpec {
+      class SpecB extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -581,6 +582,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore must "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it must "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
 
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB))
@@ -590,7 +592,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThisCalled)
       assert(b.theTestThatCalled)
 
-      val c = new flatspec.FixtureAnyFlatSpec {
+      class SpecC extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -598,6 +600,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it can "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore can "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
 
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repC))
@@ -609,7 +612,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
 
       // The order I want is order of appearance in the file.
       // Will try and implement that tomorrow. Subtypes will be able to change the order.
-      val d = new flatspec.FixtureAnyFlatSpec {
+      class SpecD extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -617,6 +620,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore should "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         ignore should "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
 
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD))
@@ -630,7 +634,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should ignore a test marked as ignored if run is invoked with that testName") {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
-      val e = new flatspec.FixtureAnyFlatSpec {
+      class SpecE extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -638,6 +642,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore must "test this" in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it must "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
 
       import scala.language.reflectiveCalls
 
@@ -651,7 +656,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -659,6 +664,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -669,7 +675,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new flatspec.FixtureAnyFlatSpec {
+      class SpecB extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -677,6 +683,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test that" in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -684,7 +691,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new flatspec.FixtureAnyFlatSpec {
+      class SpecC extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -692,6 +699,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -699,7 +707,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new flatspec.FixtureAnyFlatSpec {
+      class SpecD extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -707,6 +715,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore should "test this" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -714,7 +723,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new flatspec.FixtureAnyFlatSpec {
+      class SpecE extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -724,6 +733,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -733,7 +743,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new flatspec.FixtureAnyFlatSpec {
+      class SpecF extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -743,6 +753,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -752,7 +763,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new flatspec.FixtureAnyFlatSpec {
+      class SpecG extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -762,6 +773,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
                 ConfigMap.empty, None, new Tracker, Set.empty))
@@ -771,7 +783,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new flatspec.FixtureAnyFlatSpec {
+      class SpecH extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -781,6 +793,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -789,7 +802,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new flatspec.FixtureAnyFlatSpec {
+      class SpecI extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -799,6 +812,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         it should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -807,7 +821,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new flatspec.FixtureAnyFlatSpec {
+      class SpecJ extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -817,6 +831,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         it should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -825,7 +840,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new flatspec.FixtureAnyFlatSpec {
+      class SpecK extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -835,6 +850,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore should "test that" taggedAs(mytags.SlowAsMolasses) in { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         ignore should "test the other" in { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -846,7 +862,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     it("should run only those registered tests selected by the tags to include and exclude sets") {
 
       // Nothing is excluded
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -854,6 +870,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val a = new SpecA
 
       import scala.language.reflectiveCalls
 
@@ -864,7 +881,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.theTestThatCalled)
 
       // SlowAsMolasses is included, one test should be excluded
-      val b = new flatspec.FixtureAnyFlatSpec {
+      class SpecB extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -872,6 +889,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test that") { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val b = new SpecB
       val repB = new TestIgnoredTrackingReporter
       b.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repB.testIgnoredReceived)
@@ -879,7 +897,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!b.theTestThatCalled)
 
       // SlowAsMolasses is included, and both tests should be included
-      val c = new flatspec.FixtureAnyFlatSpec {
+      class SpecC extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -887,6 +905,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val c = new SpecC
       val repC = new TestIgnoredTrackingReporter
       c.run(None, Args(repB, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set()), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repC.testIgnoredReceived)
@@ -894,7 +913,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(c.theTestThatCalled)
 
       // SlowAsMolasses is included. both tests should be included but one ignored
-      val d = new flatspec.FixtureAnyFlatSpec {
+      class SpecD extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -902,6 +921,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("should test this", mytags.SlowAsMolasses) { fixture => theTestThisCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val d = new SpecD
       val repD = new TestIgnoredTrackingReporter
       d.run(None, Args(repD, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repD.testIgnoredReceived)
@@ -909,7 +929,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(d.theTestThatCalled)
 
       // SlowAsMolasses included, FastAsLight excluded
-      val e = new flatspec.FixtureAnyFlatSpec {
+      class SpecE extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -919,6 +939,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val e = new SpecE
       val repE = new TestIgnoredTrackingReporter
       e.run(None, Args(repE, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -928,7 +949,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!e.theTestTheOtherCalled)
 
       // An Ignored test that was both included and excluded should not generate a TestIgnored event
-      val f = new flatspec.FixtureAnyFlatSpec {
+      class SpecF extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -938,6 +959,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val f = new SpecF
       val repF = new TestIgnoredTrackingReporter
       f.run(None, Args(repF, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -947,7 +969,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!f.theTestTheOtherCalled)
 
       // An Ignored test that was not included should not generate a TestIgnored event
-      val g = new flatspec.FixtureAnyFlatSpec {
+      class SpecG extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -957,6 +979,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val g = new SpecG
       val repG = new TestIgnoredTrackingReporter
       g.run(None, Args(repG, Stopper.default, Filter(Some(Set("org.scalatest.SlowAsMolasses")), Set("org.scalatest.FastAsLight")),
         ConfigMap.empty, None, new Tracker, Set.empty))
@@ -966,7 +989,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(!g.theTestTheOtherCalled)
 
       // No tagsToInclude set, FastAsLight excluded
-      val h = new flatspec.FixtureAnyFlatSpec {
+      class SpecH extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -976,6 +999,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val h = new SpecH
       val repH = new TestIgnoredTrackingReporter
       h.run(None, Args(repH, Stopper.default, Filter(None, Set("org.scalatest.FastAsLight")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repH.testIgnoredReceived)
@@ -984,7 +1008,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(h.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded
-      val i = new flatspec.FixtureAnyFlatSpec {
+      class SpecI extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -994,6 +1018,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val i = new SpecI
       val repI = new TestIgnoredTrackingReporter
       i.run(None, Args(repI, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -1002,7 +1027,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(i.theTestTheOtherCalled)
 
       // No tagsToInclude set, SlowAsMolasses excluded, TestIgnored should not be received on excluded ones
-      val j = new flatspec.FixtureAnyFlatSpec {
+      class SpecJ extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1012,6 +1037,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val j = new SpecJ
       val repJ = new TestIgnoredTrackingReporter
       j.run(None, Args(repJ, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(!repI.testIgnoredReceived)
@@ -1020,7 +1046,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(j.theTestTheOtherCalled)
 
       // Same as previous, except Ignore specifically mentioned in excludes set
-      val k = new flatspec.FixtureAnyFlatSpec {
+      class SpecK extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1030,6 +1056,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         registerIgnoredTest("should test that", mytags.SlowAsMolasses) { fixture => theTestThatCalled = true; /* ASSERTION_SUCCEED */ }
         registerIgnoredTest("should test the other") { fixture => theTestTheOtherCalled = true; /* ASSERTION_SUCCEED */ }
       }
+      val k = new SpecK
       val repK = new TestIgnoredTrackingReporter
       k.run(None, Args(repK, Stopper.default, Filter(None, Set("org.scalatest.SlowAsMolasses", "org.scalatest.Ignore")), ConfigMap.empty, None, new Tracker, Set.empty))
       assert(repK.testIgnoredReceived)
@@ -1260,7 +1287,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 */
     it("should allow both tests that take fixtures and tests that don't") {
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -1273,8 +1300,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         var takesAFixtureInvoked = false
         it should "take a fixture" in { s => takesAFixtureInvoked = true; /* ASSERTION_SUCCEED */ }
       }
-
-      import scala.language.reflectiveCalls
+      val a = new SpecA
 
       a.run(None, Args(SilentReporter))
       assert(a.testNames.size === 2, a.testNames)
@@ -1282,7 +1308,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with test functions whose inferred result type is not Unit") {
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
 
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = {
@@ -1295,8 +1321,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         var takesAFixtureInvoked = false
         it should "take a fixture" in { s => takesAFixtureInvoked = true; true; /* ASSERTION_SUCCEED */ }
       }
-
-      import scala.language.reflectiveCalls
+      val a = new SpecA
 
       assert(!a.takesNoArgsInvoked)
       assert(!a.takesAFixtureInvoked)
@@ -1306,7 +1331,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(a.takesAFixtureInvoked)
     }
     it("should work with ignored tests whose inferred result type is not Unit") {
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         var theTestThisCalled = false
@@ -1314,8 +1339,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         ignore should "test this" in { () => theTestThisCalled = true; "hi"; /* ASSERTION_SUCCEED */ }
         ignore should "test that" in { fixture => theTestThatCalled = true; 42; /* ASSERTION_SUCCEED */ }
       }
-
-      import scala.language.reflectiveCalls
+      val a = new SpecA
 
       assert(!a.theTestThisCalled)
       assert(!a.theTestThatCalled)
@@ -1392,7 +1416,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(s.theNoArgTestWasInvoked)
     }
     it("should pass the correct test name in the OneArgTest passed to withFixture") {
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         var correctTestNameWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1401,14 +1425,12 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         it should "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
-
-      import scala.language.reflectiveCalls
-
+      val a = new SpecA
       a.run(None, Args(SilentReporter))
       assert(a.correctTestNameWasPassed)
     }
     it("should pass the correct config map in the OneArgTest passed to withFixture") {
-      val a = new flatspec.FixtureAnyFlatSpec {
+      class SpecA extends flatspec.FixtureAnyFlatSpec {
         type FixtureParam = String
         var correctConfigMapWasPassed = false
         def withFixture(test: OneArgTest): Outcome = {
@@ -1417,9 +1439,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         }
         it should "do something" in { fixture => /* ASSERTION_SUCCEED */ }
       }
-
-      import scala.language.reflectiveCalls
-
+      val a = new SpecA
       a.run(None, Args(SilentReporter, Stopper.default, Filter(), ConfigMap("hi" -> 7), None, new Tracker(), Set.empty))
       assert(a.correctConfigMapWasPassed)
     }
@@ -1727,7 +1747,7 @@ class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
           pending
         }
         registerTest("test 4") { fixture =>
-          cancel
+          cancel()
         }
         registerIgnoredTest("test 5") { fixture =>
           assert(a == 2)

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.flatspec
 
 import org.scalatest._
 import SharedHelpers._
@@ -26,9 +26,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.flatspec
 
-object SlowTest extends Tag("SlowTest")
-
-class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FitxureAnyFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   describe("A fixture.FlatSpec ") {
     it("A fixture.Spec should return the test names in order of registration from testNames") {
@@ -1719,7 +1717,7 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FlatSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureAnyFlatSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1767,9 +1765,9 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1792,9 +1790,9 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 12)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FlatSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFlatSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
     
@@ -1826,7 +1824,7 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFlatSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An in clause may not appear inside another in or is clause."))
     }
@@ -1859,7 +1857,7 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFlatSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside an in or an is clause."))
     }
@@ -1892,7 +1890,7 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFlatSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1925,7 +1923,7 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FlatSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFlatSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1935,13 +1933,13 @@ class FlatSpecSpec extends scalatest.funspec.AnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         behavior of "a feature"
-        it should "test 1" in { fixture => }
-        it should "test 1" in { fixture => }
+        it should "test 1" in { fixture => /* ASSERTION_SUCCEED */}
+        it should "test 1" in { fixture => /* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FlatSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFlatSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecImportedMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecImportedMatchersSpec.scala
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.flatspec
 
 import org.scalatest.StringFixture
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.flatspec.FixtureAnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
-class FlatSpecMixedInMatchersSpec extends FixtureAnyFlatSpec with Matchers with StringFixture {
+/*
+This tests that matchers works with FlatSpec when matchers are imported,
+something that broke in 2.1.RC1.
+*/
+class FixtureFlatSpecImportedMatchersSpec extends FixtureAnyFlatSpec with StringFixture {
   "This spec" should "work OK" in { _ =>
     "hello" should startWith ("he")
     "hello" should endWith ("lo")

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecMixedInMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecMixedInMatchersSpec.scala
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest.flatspec
 
 import org.scalatest.StringFixture
-import org.scalatest.matchers.should.Matchers._
 import org.scalatest.flatspec.FixtureAnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-/*
-This tests that matchers works with FlatSpec when matchers are imported,
-something that broke in 2.1.RC1.
-*/
-class FlatSpecImportedMatchersSpec extends FixtureAnyFlatSpec with StringFixture {
+class FixtureFlatSpecMixedInMatchersSpec extends FixtureAnyFlatSpec with Matchers with StringFixture {
   "This spec" should "work OK" in { _ =>
     "hello" should startWith ("he")
     "hello" should endWith ("lo")

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/SlowTest.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/SlowTest.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2001-2021 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.flatspec
+
+import org.scalatest.Tag
+
+object SlowTest extends Tag("SlowTest")

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala
@@ -46,7 +46,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.funspec.AnyFunSpec
 
-class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
+class AnyFreeSpecSpec extends AnyFunSpec with GivenWhenThen {
 
   private val prettifier = Prettifier.default
 
@@ -1199,7 +1199,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FreeSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("AnyFreeSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") {
@@ -1247,9 +1247,9 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 11)
     }
   }
@@ -1271,9 +1271,9 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 11)
     }
     
@@ -1305,7 +1305,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("An in clause may not appear inside another in clause."))
     }
@@ -1338,7 +1338,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an in clause."))
     }
@@ -1373,7 +1373,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1406,7 +1406,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FreeSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1422,7 +1422,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1430,7 +1430,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1445,7 +1445,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1453,7 +1453,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1467,7 +1467,7 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1481,14 +1481,14 @@ class FreeSpecSpec extends AnyFunSpec with GivenWhenThen {
     it("should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope") {
       class TestSpec extends AnyFreeSpec {
         "a feature" - {
-          "test 1" in {}
-          "test 1" in {}
+          "test 1" in {/* ASSERTION_SUCCEED */}
+          "test 1" in {/* ASSERTION_SUCCEED */}
         }
       }
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala
@@ -34,7 +34,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.freespec
 
-class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FixtureAnyFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   private val prettifier = Prettifier.default
 
@@ -1516,7 +1516,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FixtureFreeSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureAnyFreeSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1566,9 +1566,9 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
   }
@@ -1592,9 +1592,9 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFreeSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFreeSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
     
@@ -1627,7 +1627,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An in clause may not appear inside another in clause."))
     }
@@ -1661,7 +1661,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an in clause."))
     }
@@ -1695,7 +1695,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1729,7 +1729,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFreeSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1746,7 +1746,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1754,7 +1754,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FixtureFreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1771,7 +1771,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideInClauseNotDashClause))
 
@@ -1779,7 +1779,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FixtureFreeSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1795,7 +1795,7 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1811,14 +1811,14 @@ class FixtureFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
         "a feature" - {
-          "test 1" in { fixture => }
-          "test 1" in { fixture => }
+          "test 1" in { fixture => /* ASSERTION_SUCCEED */}
+          "test 1" in { fixture => /* ASSERTION_SUCCEED */}
         }
       }
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFreeSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFreeSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala
@@ -45,7 +45,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.funspec.AnyFunSpec
 
-class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
+class AnyFunSpecSpec extends AnyFreeSpec with GivenWhenThen {
 
   private val prettifier = Prettifier.default
 
@@ -1066,9 +1066,9 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 11)
     }
   }
@@ -1090,9 +1090,9 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size == 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "FunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get == "AnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get == thisLineNumber - 11)
     }
     
@@ -1126,7 +1126,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("An it clause may not appear inside another it or they clause."))
     }
@@ -1159,7 +1159,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1192,7 +1192,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("A they clause may not appear inside another it or they clause."))
     }
@@ -1225,7 +1225,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1238,7 +1238,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FunSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("AnyFunSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") {
@@ -1300,7 +1300,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1333,7 +1333,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       assert(testFailedEvents.size == 1)
       assert(testFailedEvents(0).throwable.get.getClass() == classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSpecSpec.scala" == trce.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get == thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1349,7 +1349,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1357,7 +1357,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1372,7 +1372,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1380,7 +1380,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1395,7 +1395,7 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1410,14 +1410,14 @@ class FunSpecSpec extends AnyFreeSpec with GivenWhenThen {
     "should generate NotAllowedException wrapping a DuplicateTestNameException is thrown inside scope" in {
       class TestSpec extends AnyFunSpec {
         describe("a feature") {
-          it("test 1") {}
-          it("test 1") {}
+          it("test 1") {/* ASSERTION_SUCCEED */}
+          it("test 1") {/* ASSERTION_SUCCEED */}
         }
       }
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala
@@ -33,7 +33,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class FunSpecSuite extends AnyFunSuite {
+class AnyFunSpecSuite extends AnyFunSuite {
 
   test("three plain-old specifiers should be invoked in order") {
     class MySpec extends AnyFunSpec with Matchers {

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala
@@ -34,7 +34,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.funspec
 
-class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
+class FixtureAnyFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
 
   private val prettifier = Prettifier.default
 
@@ -1309,9 +1309,9 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
   }
@@ -1335,9 +1335,9 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 13)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
     }
     
@@ -1370,7 +1370,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An it clause may not appear inside another it or they clause."))
     }
@@ -1404,7 +1404,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1438,7 +1438,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("A they clause may not appear inside another it or they clause."))
     }
@@ -1472,7 +1472,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("An ignore clause may not appear inside an it or a they clause."))
     }
@@ -1489,7 +1489,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FixtureFunSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureAnyFunSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1552,7 +1552,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1586,7 +1586,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 24)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1605,7 +1605,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1613,7 +1613,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestFailedException])
       val cause = causeThrowable.asInstanceOf[TestFailedException]
-      assert("FixtureFunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1632,7 +1632,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.message == Some(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotDescribeClause))
 
@@ -1640,7 +1640,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val causeThrowable = e.cause.get
       assert(causeThrowable.isInstanceOf[TestCanceledException])
       val cause = causeThrowable.asInstanceOf[TestCanceledException]
-      assert("FixtureFunSpecSpec.scala" == cause.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == cause.failedCodeFileName.get)
       assert(cause.failedCodeLineNumber.get == thisLineNumber - 15)
       assert(cause.message == Some(FailureMessages.didNotEqual(prettifier, 1, 2)))
     }
@@ -1658,7 +1658,7 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 8)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get
@@ -1674,14 +1674,14 @@ class FixtureFunSpecSpec extends scalatest.freespec.AnyFreeSpec {
         type FixtureParam = String
         override def withFixture(test: OneArgTest): Outcome = test("test")
         describe("a feature") {
-          it("test 1") { fixture => }
-          it("test 1") { fixture => }
+          it("test 1") { fixture => /* ASSERTION_SUCCEED */}
+          it("test 1") { fixture => /* ASSERTION_SUCCEED */}
         }
       }
       val e = intercept[NotAllowedException] {
         new TestSpec
       }
-      assert("FixtureFunSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 7)
       assert(e.cause.isDefined)
       val causeThrowable = e.cause.get

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.funsuite.AnyFunSuite
 
-class FunSuiteSpec extends AnyFunSpec {
+class AnyFunSuiteSpec extends AnyFunSpec {
 
   describe("A FunSuite") {
 
@@ -1308,7 +1308,7 @@ class FunSuiteSpec extends AnyFunSpec {
               assert(a == 2)
             }
             assert(e.message == Some("1 did not equal 2"))
-            assert(e.failedCodeFileName == Some("FunSuiteSpec.scala"))
+            assert(e.failedCodeFileName == Some("AnyFunSuiteSpec.scala"))
             assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
           }
           registerTest("test 2") {
@@ -1368,7 +1368,7 @@ class FunSuiteSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1399,7 +1399,7 @@ class FunSuiteSpec extends AnyFunSpec {
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("AnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1418,9 +1418,9 @@ class FunSuiteSpec extends AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1436,7 +1436,7 @@ class FunSuiteSpec extends AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1466,7 +1466,7 @@ class FunSuiteSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A test clause may not appear inside another test clause."))
     }
@@ -1497,33 +1497,33 @@ class FunSuiteSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a test clause."))
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
       class TestSpec extends AnyFunSuite {
-        test("test 1") {}
-        test("test 1") {}
+        test("test 1") {/* ASSERTION_SUCCEED */}
+        test("test 1") {/* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected using ignore") {
       class TestSpec extends AnyFunSuite {
-        test("test 1") {}
-        ignore("test 1") {}
+        test("test 1") {/* ASSERTION_SUCCEED */}
+        ignore("test 1") {/* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.funsuite
 
-class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTester*/ {
+class FixtureAnyFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMethodTester*/ {
 
   describe("A fixture.FunSuite") {
     it("should return the test names in order of registration from testNames") {
@@ -1285,7 +1285,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
               assert(a == 2)
             }
             assert(e.message == Some("1 did not equal 2"))
-            assert(e.failedCodeFileName == Some("FixtureFunSuiteSpec.scala"))
+            assert(e.failedCodeFileName == Some("FixtureAnyFunSuiteSpec.scala"))
             assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
           }
           registerTest("test 2") { fixture =>
@@ -1346,7 +1346,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureAnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1378,7 +1378,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
         assert(testFailedEvents.size === 1)
         assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
         val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-        assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+        assert("FixtureAnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
         assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
         assert(trce.message == Some("Test cannot be nested inside another test."))
       }
@@ -1398,9 +1398,9 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1421,7 +1421,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureFunSuiteSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyFunSuiteSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1452,7 +1452,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A test clause may not appear inside another test clause."))
     }
@@ -1484,7 +1484,7 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixtureFunSuiteSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyFunSuiteSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a test clause."))
     }
@@ -1493,13 +1493,13 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       class TestSpec extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
-        test("test 1") { fixture => }
-        test("test 1") { fixture => }
+        test("test 1") { fixture => /* ASSERTION_SUCCEED */ }
+        test("test 1") { fixture => /* ASSERTION_SUCCEED */ }
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FixtureFunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
@@ -1508,13 +1508,13 @@ class FixtureFunSuiteSpec extends scalatest.funspec.AnyFunSpec /*with PrivateMet
       class TestSpec extends funsuite.FixtureAnyFunSuite {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
-        test("test 1") { fixture => }
-        ignore("test 1") { fixture => }
+        test("test 1") { fixture => /* ASSERTION_SUCCEED */ }
+        ignore("test 1") { fixture => /* ASSERTION_SUCCEED */ }
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FixtureFunSuiteSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyFunSuiteSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.propspec.AnyPropSpec
 
-class PropSpecSpec extends AnyFunSpec {
+class AnyPropSpecSpec extends AnyFunSpec {
 
   describe("A PropSpec") {
 
@@ -1047,7 +1047,7 @@ class PropSpecSpec extends AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("PropSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("AnyPropSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") {
@@ -1093,9 +1093,9 @@ class PropSpecSpec extends AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1112,7 +1112,7 @@ class PropSpecSpec extends AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "PropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "AnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1142,7 +1142,7 @@ class PropSpecSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A property clause may not appear inside another property clause."))
     }
@@ -1173,7 +1173,7 @@ class PropSpecSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a property clause."))
     }
@@ -1204,7 +1204,7 @@ class PropSpecSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1235,33 +1235,33 @@ class PropSpecSpec extends AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("PropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected") {
       class TestSpec extends AnyPropSpec {
-        property("test 1") {}
-        property("test 1") {}
+        property("test 1") {/* ASSERTION_SUCCEED */}
+        property("test 1") {/* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("PropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
 
     it("should generate a DuplicateTestNameException when duplicate test name is detected using ignore") {
       class TestSpec extends AnyPropSpec {
-        property("test 1") {}
-        ignore("test 1") {}
+        property("test 1") {/* ASSERTION_SUCCEED */}
+        ignore("test 1") {/* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("PropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("AnyPropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.exceptions.TestRegistrationClosedException
 import org.scalatest
 import org.scalatest.propspec
 
-class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
+class FixtureAnyPropSpecSpec extends scalatest.funspec.AnyFunSpec {
 
   describe("A fixture.PropSpec") {
     it("should return the test names in order of registration from testNames") {
@@ -1283,7 +1283,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
             assert(a == 2)
           }
           assert(e.message == Some("1 did not equal 2"))
-          assert(e.failedCodeFileName == Some("FixturePropSpecSpec.scala"))
+          assert(e.failedCodeFileName == Some("FixtureAnyPropSpecSpec.scala"))
           assert(e.failedCodeLineNumber == Some(thisLineNumber - 4))
         }
         registerTest("test 2") { fixture =>
@@ -1331,9 +1331,9 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 2)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 11)
-      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(1).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 10)
     }
   }
@@ -1354,7 +1354,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       val s1 = new TestSpec
       s1.run(None, Args(rep))
       assert(rep.testFailedEventsReceived.size === 1)
-      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixturePropSpecSpec.scala")
+      assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeFileName.get === "FixtureAnyPropSpecSpec.scala")
       assert(rep.testFailedEventsReceived(0).throwable.get.asInstanceOf[TestFailedException].failedCodeLineNumber.get === thisLineNumber - 8)
     }
     
@@ -1385,7 +1385,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("A property clause may not appear inside another property clause."))
     }
@@ -1417,7 +1417,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("An ignore clause may not appear inside a property clause."))
     }
@@ -1449,7 +1449,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1481,7 +1481,7 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(testFailedEvents.size === 1)
       assert(testFailedEvents(0).throwable.get.getClass() === classOf[TestRegistrationClosedException])
       val trce = testFailedEvents(0).throwable.get.asInstanceOf[TestRegistrationClosedException]
-      assert("FixturePropSpecSpec.scala" === trce.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" === trce.failedCodeFileName.get)
       assert(trce.failedCodeLineNumber.get === thisLineNumber - 23)
       assert(trce.message == Some("Test cannot be nested inside another test."))
     }
@@ -1490,13 +1490,13 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       class TestSpec extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
-        property("test 1") { fixture => }
-        property("test 1") { fixture => }
+        property("test 1") { fixture => /* ASSERTION_SUCCEED */}
+        property("test 1") { fixture => /* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FixturePropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }
@@ -1505,13 +1505,13 @@ class FixturePropSpecSpec extends scalatest.funspec.AnyFunSpec {
       class TestSpec extends propspec.FixtureAnyPropSpec {
         type FixtureParam = String
         def withFixture(test: OneArgTest): Outcome = { test("hi") }
-        property("test 1") { fixture => }
-        ignore("test 1") { fixture => }
+        property("test 1") { fixture => /* ASSERTION_SUCCEED */}
+        ignore("test 1") { fixture => /* ASSERTION_SUCCEED */}
       }
       val e = intercept[DuplicateTestNameException] {
         new TestSpec
       }
-      assert("FixturePropSpecSpec.scala" == e.failedCodeFileName.get)
+      assert("FixtureAnyPropSpecSpec.scala" == e.failedCodeFileName.get)
       assert(e.failedCodeLineNumber.get == thisLineNumber - 6)
       assert(!e.cause.isDefined)
     }

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -814,7 +814,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FeatureSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFeatureSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFeatureSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeFeatureSpecSpec.scala" && 
+          f.getName != "SafeFeatureSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -836,7 +840,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FlatSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFlatSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFlatSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeFlatSpecSpec.scala" && 
+          f.getName != "SafeFlatSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -858,7 +866,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FreeSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFreeSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFreeSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeFreeSpecSpec.scala" && 
+          f.getName != "SafeFreeSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -880,7 +892,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FunSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFunSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFunSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeFunSpecSpec.scala" && 
+          f.getName != "SafeFunSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -902,7 +918,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FunSuite Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFunSuiteTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFunSuiteTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeFunSuiteSpec.scala" && 
+          f.getName != "SafeFunSuiteSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -924,7 +944,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest PropSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafePropSpecSpec.scala" && 
+          f.getName != "SafePropSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 
@@ -946,7 +970,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest WordSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, false).filter { f =>
+          f.getName != "FixtureSafeWordSpecSpec.scala" && 
+          f.getName != "SafeWordSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -244,7 +244,8 @@ trait DottyBuild { this: BuildCommons =>
         ScalaTestGenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
         ScalaTestGenResourcesJSVM.genFailureMessages((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)  ++
         GenGen.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest" / "prop", version.value, scalaVersion.value) ++
-        GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)
+        GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genCore((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value, true)
       }.taskValue,
       javaSourceManaged := target.value / "java",
       managedSourceDirectories in Compile += javaSourceManaged.value,
@@ -829,7 +830,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FeatureSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFeatureSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFeatureSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeFeatureSpecSpec.scala" && 
+          f.getName != "SafeFeatureSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
 
@@ -855,7 +860,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FlatSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFlatSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFlatSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeFlatSpecSpec.scala" && 
+          f.getName != "SafeFlatSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
 
@@ -881,7 +890,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FreeSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFreeSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFreeSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeFreeSpecSpec.scala" && 
+          f.getName != "SafeFreeSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
 
@@ -907,7 +920,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FunSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFunSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFunSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeFunSpecSpec.scala" && 
+          f.getName != "SafeFunSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
 
@@ -933,7 +950,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest FunSuite Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genFunSuiteTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genFunSuiteTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeFunSuiteSpec.scala" && 
+          f.getName != "SafeFunSuiteSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
 
@@ -959,7 +980,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest PropSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genPropSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genPropSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafePropSpecSpec.scala" && 
+          f.getName != "SafePropSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)             
 
@@ -985,7 +1010,11 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "ScalaTest WordSpec Test",
       sourceGenerators in Test += Def.task {
-        GenScalaTestDotty.genWordSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value)
+        GenScalaTestDotty.genWordSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+        GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true).filter { f =>
+          f.getName != "FixtureSafeWordSpecSpec.scala" && 
+          f.getName != "SafeWordSpecSpec.scala"
+        }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin) 
 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -817,8 +817,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFeatureSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeFeatureSpecSpec.scala" && 
-          f.getName != "SafeFeatureSpecSpec.scala"
+          f.getName != "FixtureFeatureSpecSpec.scala" && 
+          f.getName != "FeatureSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -832,8 +832,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFeatureSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeFeatureSpecSpec.scala" && 
-          f.getName != "SafeFeatureSpecSpec.scala"
+          f.getName != "FixtureFeatureSpecSpec.scala" && 
+          f.getName != "FeatureSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
@@ -847,8 +847,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFlatSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeFlatSpecSpec.scala" && 
-          f.getName != "SafeFlatSpecSpec.scala"
+          f.getName != "FixtureFlatSpecSpec.scala" && 
+          f.getName != "FlatSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -862,8 +862,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFlatSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeFlatSpecSpec.scala" && 
-          f.getName != "SafeFlatSpecSpec.scala"
+          f.getName != "FixtureFlatSpecSpec.scala" && 
+          f.getName != "FlatSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
@@ -877,8 +877,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFreeSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeFreeSpecSpec.scala" && 
-          f.getName != "SafeFreeSpecSpec.scala"
+          f.getName != "FixtureFreeSpecSpec.scala" && 
+          f.getName != "FreeSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -892,8 +892,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFreeSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeFreeSpecSpec.scala" && 
-          f.getName != "SafeFreeSpecSpec.scala"
+          f.getName != "FixtureFreeSpecSpec.scala" && 
+          f.getName != "FreeSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
@@ -907,8 +907,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFunSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeFunSpecSpec.scala" && 
-          f.getName != "SafeFunSpecSpec.scala"
+          f.getName != "FixtureFunSpecSpec.scala" && 
+          f.getName != "FunSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -922,8 +922,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFunSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeFunSpecSpec.scala" && 
-          f.getName != "SafeFunSpecSpec.scala"
+          f.getName != "FixtureFunSpecSpec.scala" && 
+          f.getName != "FunSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
@@ -937,8 +937,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFunSuiteTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeFunSuiteSpec.scala" && 
-          f.getName != "SafeFunSuiteSpec.scala"
+          f.getName != "FixtureFunSuiteSpec.scala" && 
+          f.getName != "FunSuiteSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -952,8 +952,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genFunSuiteTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeFunSuiteSpec.scala" && 
-          f.getName != "SafeFunSuiteSpec.scala"
+          f.getName != "FixtureFunSuiteSpec.scala" && 
+          f.getName != "FunSuiteSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)
@@ -967,8 +967,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafePropSpecSpec.scala" && 
-          f.getName != "SafePropSpecSpec.scala"
+          f.getName != "FixturePropSpecSpec.scala" && 
+          f.getName != "PropSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -982,8 +982,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genPropSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafePropSpecSpec.scala" && 
-          f.getName != "SafePropSpecSpec.scala"
+          f.getName != "FixturePropSpecSpec.scala" && 
+          f.getName != "PropSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin)             
@@ -997,8 +997,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, false).filter { f =>
-          f.getName != "FixtureSafeWordSpecSpec.scala" && 
-          f.getName != "SafeWordSpecSpec.scala"
+          f.getName != "FixtureWordSpecSpec.scala" && 
+          f.getName != "WordSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDotty % "test")
@@ -1012,8 +1012,8 @@ trait DottyBuild { this: BuildCommons =>
       sourceGenerators in Test += Def.task {
         GenScalaTestDotty.genWordSpecTestJS((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
         GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true).filter { f =>
-          f.getName != "FixtureSafeWordSpecSpec.scala" && 
-          f.getName != "SafeWordSpecSpec.scala"
+          f.getName != "FixtureWordSpecSpec.scala" && 
+          f.getName != "WordSpecSpec.scala"
         }
       }.taskValue,
     ).dependsOn(commonTestDottyJS % "test").enablePlugins(ScalaJSPlugin) 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -165,7 +165,8 @@ trait DottyBuild { this: BuildCommons =>
           ScalaTestGenResourcesJVM.genResources((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++
           ScalaTestGenResourcesJVM.genFailureMessages((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)  ++
           GenGen.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest" / "prop", version.value, scalaVersion.value) ++
-          GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)
+          GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genCore((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value, false)
         }.taskValue,
       javaSourceManaged := target.value / "java",
       managedSourceDirectories in Compile += javaSourceManaged.value,

--- a/project/GenModulesDotty.scala
+++ b/project/GenModulesDotty.scala
@@ -54,15 +54,15 @@ object GenModulesDotty {
   /** (targetDir, version, scalaVersion) => generated files */
   type GenFn = (File, String, String) => Seq[File]
 
-  def genModuleFiles(moduleName: String, targetDir: File, version: String, scalaVersion: String): Seq[File] = 
+  def genModuleFiles(moduleName: String, targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = 
     moduleName match {
-      case "featurespec" => GenSafeStyles.genFeatureSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "flatspec" => GenSafeStyles.genFlatSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "freespec" => GenSafeStyles.genFreeSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "funsuite" => GenSafeStyles.genFunSuite(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "funspec" => GenSafeStyles.genFunSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "propspec" => GenSafeStyles.genPropSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
-      case "wordspec" => GenSafeStyles.genWordSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "featurespec" => GenSafeStyles.genFeatureSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "flatspec" => GenSafeStyles.genFlatSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "freespec" => GenSafeStyles.genFreeSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "funsuite" => GenSafeStyles.genFunSuite(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "funspec" => GenSafeStyles.genFunSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "propspec" => GenSafeStyles.genPropSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
+      case "wordspec" => GenSafeStyles.genWordSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, scalaJS)
       case _ => Seq.empty[File]
     }
   
@@ -71,7 +71,7 @@ object GenModulesDotty {
       .filter { case (packagePath, _) => packagePaths.contains(packagePath) }
       .flatMap { case (packagePath, skipList) =>
         GenScalaTestDotty.copyDir(s"jvm/$moduleDirName/src/main/scala/" + packagePath, packagePath, targetDir, skipList) ++ 
-        genModuleFiles(moduleDirName, targetDir, version, scalaVersion)
+        genModuleFiles(moduleDirName, targetDir, version, scalaVersion, false)
       }.toList
   }
   
@@ -100,7 +100,8 @@ object GenModulesDotty {
     GenScalaTestDotty.genScalaPackagesJS
       .filter { case (packagePath, _) => packagePaths.contains(packagePath) }
       .flatMap { case (packagePath, skipList) =>
-        GenScalaTestDotty.copyDirJS(s"jvm/$moduleDirName/src/main/scala/" + packagePath, packagePath, targetDir, skipList)
+        GenScalaTestDotty.copyDirJS(s"jvm/$moduleDirName/src/main/scala/" + packagePath, packagePath, targetDir, skipList) ++ 
+        genModuleFiles(moduleDirName, targetDir, version, scalaVersion, true)
       }.toList
   }
   

--- a/project/GenModulesDotty.scala
+++ b/project/GenModulesDotty.scala
@@ -53,12 +53,25 @@ object GenModulesDotty {
   
   /** (targetDir, version, scalaVersion) => generated files */
   type GenFn = (File, String, String) => Seq[File]
+
+  def genModuleFiles(moduleName: String, targetDir: File, version: String, scalaVersion: String): Seq[File] = 
+    moduleName match {
+      case "featurespec" => GenSafeStyles.genFeatureSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "flatspec" => GenSafeStyles.genFlatSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "freespec" => GenSafeStyles.genFreeSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "funsuite" => GenSafeStyles.genFunSuite(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "funspec" => GenSafeStyles.genFunSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "propspec" => GenSafeStyles.genPropSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case "wordspec" => GenSafeStyles.genWordSpec(new File(targetDir.getAbsolutePath + "/org/scalatest/" + moduleName), version, scalaVersion, false)
+      case _ => Seq.empty[File]
+    }
   
   def apply(moduleDirName: String, packagePaths: Seq[String]): GenFn = (targetDir, version, scalaVersion) => {
     GenScalaTestDotty.genScalaPackages
       .filter { case (packagePath, _) => packagePaths.contains(packagePath) }
       .flatMap { case (packagePath, skipList) =>
-        GenScalaTestDotty.copyDir(s"jvm/$moduleDirName/src/main/scala/" + packagePath, packagePath, targetDir, skipList)
+        GenScalaTestDotty.copyDir(s"jvm/$moduleDirName/src/main/scala/" + packagePath, packagePath, targetDir, skipList) ++ 
+        genModuleFiles(moduleDirName, targetDir, version, scalaVersion)
       }.toList
   }
   

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -172,12 +172,11 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
+      
       translateFile(targetDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
 
-      translateFile(fixtureDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
       translateFile(fixtureDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(fixtureDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(fixtureDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec"))
@@ -209,6 +208,15 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
       translateFile(targetDir, "FixtureSafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
+    )
+  }
+
+  def genFlatSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureSafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -88,23 +88,7 @@ object GenSafeStyles {
 
       /*
 
-      translateFile(targetDir, "SafeFunSpecLike.scala", "scalatest/src/main/scala/org/scalatest/FunSpecLike.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
-      translateFile(targetDir, "SafeFunSpec.scala", "scalatest/src/main/scala/org/scalatest/FunSpec.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
-
-      translateFile(targetDir, "SafePropSpecLike.scala", "scalatest/src/main/scala/org/scalatest/PropSpecLike.scala", scalaVersion, scalaJS, translateLine("PropSpec")),
-      translateFile(targetDir, "SafePropSpec.scala", "scalatest/src/main/scala/org/scalatest/PropSpec.scala", scalaVersion, scalaJS, translateLine("PropSpec")),
-
-      translateFile(targetDir, "SafeWordSpecLike.scala", "scalatest/src/main/scala/org/scalatest/WordSpecLike.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
-      translateFile(targetDir, "SafeWordSpec.scala", "scalatest/src/main/scala/org/scalatest/WordSpec.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
-
-      translateFile(safeFixtureDir, "SafeFunSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
-      translateFile(safeFixtureDir, "SafeFunSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSpec.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
-
-      translateFile(safeFixtureDir, "SafePropSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala", scalaVersion, scalaJS, translateLine("PropSpec")),
-      translateFile(safeFixtureDir, "SafePropSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/PropSpec.scala", scalaVersion, scalaJS, translateLine("PropSpec")),
-
-      translateFile(safeFixtureDir, "SafeWordSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
-      translateFile(safeFixtureDir, "SafeWordSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/WordSpec.scala", scalaVersion, scalaJS, translateLine("WordSpec"))*/
+      */
     )
   }
 
@@ -149,6 +133,39 @@ object GenSafeStyles {
       translateFile(targetDir, "SafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
       translateFile(targetDir, "FixtureSafeFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
       translateFile(targetDir, "FixtureSafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+    )
+  }
+
+  def genFunSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "SafeFunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureSafeFunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureSafeFunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+    )
+  }
+
+  def genPropSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafePropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "SafePropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "FixtureSafePropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "FixtureSafePropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+    )
+  }
+
+  def genWordSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeWordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "SafeWordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureSafeWordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureSafeWordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec"))
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -165,16 +165,6 @@ object GenSafeStyles {
     )
   }
 
-  def genTestImpl(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
-    targetDir.mkdirs()
-
-    val fixtureDir = new File(targetDir, "fixture")
-    fixtureDir.mkdirs()
-
-    Seq(
-    )
-  }
-
   def genFunSuiteTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
     targetDir.mkdirs()
 
@@ -237,9 +227,5 @@ object GenSafeStyles {
       translateFile(targetDir, "SafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec")),
       translateFile(targetDir, "FixtureSafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec"))
     )
-  }
-
-  def genTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
-    genTestImpl(targetDir, version, scalaVersion, false)
   }
 }

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -172,11 +172,7 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      
-      translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
-
-      translateFile(fixtureDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(fixtureDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec"))
     )
   }
@@ -224,6 +220,15 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
       translateFile(targetDir, "FixtureSafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
+    )
+  }
+
+  def genPropSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
+      translateFile(targetDir, "FixtureSafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -172,8 +172,6 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
-      translateFile(fixtureDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec"))
     )
   }
 
@@ -229,6 +227,15 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
       translateFile(targetDir, "FixtureSafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
+    )
+  }
+
+  def genWordSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureSafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec"))
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -24,6 +24,7 @@ object GenSafeStyles {
 
   def translateLine(traitName: String)(line: String): String =
     line.replaceAllLiterally("with TestRegistration", "with SafeTestRegistration")
+        .replaceAllLiterally("with org.scalatest.FixtureTestRegistration", "with org.scalatest.FixtureSafeTestRegistration")
         .replaceAllLiterally("Any /* Assertion */", "Assertion")
         .replaceAllLiterally(traitName, "Safe" + traitName)
         .replaceAllLiterally("Resources.concurrentSafe" + traitName + "Mod", "Resources.concurrent" + traitName + "Mod")
@@ -78,26 +79,14 @@ object GenSafeStyles {
     outputFile
   }
 
-  def genMainImpl(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+  def genCore(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
     targetDir.mkdirs()
 
-    val safeFixtureDir = new File(targetDir, "fixture")
-    safeFixtureDir.mkdirs()
-
     Seq(
-      translateFile(targetDir, "SafeTestRegistration.scala", "scalatest/src/main/scala/org/scalatest/TestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
+      translateFile(targetDir, "SafeTestRegistration.scala", "jvm/core/src/main/scala/org/scalatest/TestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
+      translateFile(targetDir, "FixtureSafeTestRegistration.scala", "jvm/core/src/main/scala/org/scalatest/FixtureTestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
 
-      translateFile(targetDir, "SafeFunSuiteLike.scala", "scalatest/src/main/scala/org/scalatest/FunSuiteLike.scala", scalaVersion, scalaJS, translateLine("FunSuite")),
-      translateFile(targetDir, "SafeFunSuite.scala", "scalatest/src/main/scala/org/scalatest/FunSuite.scala", scalaVersion, scalaJS, translateLine("FunSuite")),
-
-      translateFile(targetDir, "SafeFeatureSpecLike.scala", "scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("FeatureSpec")),
-      translateFile(targetDir, "SafeFeatureSpec.scala", "scalatest/src/main/scala/org/scalatest/FeatureSpec.scala", scalaVersion, scalaJS, translateLine("FeatureSpec")),
-
-      translateFile(targetDir, "SafeFlatSpecLike.scala", "scalatest/src/main/scala/org/scalatest/FlatSpecLike.scala", scalaVersion, scalaJS, translateLine("FlatSpec")),
-      translateFile(targetDir, "SafeFlatSpec.scala", "scalatest/src/main/scala/org/scalatest/FlatSpec.scala", scalaVersion, scalaJS, translateLine("FlatSpec")),
-
-      translateFile(targetDir, "SafeFreeSpecLike.scala", "scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala", scalaVersion, scalaJS, translateLine("FreeSpec")),
-      translateFile(targetDir, "SafeFreeSpec.scala", "scalatest/src/main/scala/org/scalatest/FreeSpec.scala", scalaVersion, scalaJS, translateLine("FreeSpec")),
+      /*
 
       translateFile(targetDir, "SafeFunSpecLike.scala", "scalatest/src/main/scala/org/scalatest/FunSpecLike.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
       translateFile(targetDir, "SafeFunSpec.scala", "scalatest/src/main/scala/org/scalatest/FunSpec.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
@@ -108,20 +97,6 @@ object GenSafeStyles {
       translateFile(targetDir, "SafeWordSpecLike.scala", "scalatest/src/main/scala/org/scalatest/WordSpecLike.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
       translateFile(targetDir, "SafeWordSpec.scala", "scalatest/src/main/scala/org/scalatest/WordSpec.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
 
-      translateFile(safeFixtureDir, "SafeTestRegistration.scala", "scalatest/src/main/scala/org/scalatest/fixture/TestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
-
-      translateFile(safeFixtureDir, "SafeFunSuiteLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala", scalaVersion, scalaJS, translateLine("FunSuite")),
-      translateFile(safeFixtureDir, "SafeFunSuite.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSuite.scala", scalaVersion, scalaJS, translateLine("FunSuite")),
-
-      translateFile(safeFixtureDir, "SafeFeatureSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("FeatureSpec")),
-      translateFile(safeFixtureDir, "SafeFeatureSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/FeatureSpec.scala", scalaVersion, scalaJS, translateLine("FeatureSpec")),
-
-      translateFile(safeFixtureDir, "SafeFlatSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala", scalaVersion, scalaJS, translateLine("FlatSpec")),
-      translateFile(safeFixtureDir, "SafeFlatSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/FlatSpec.scala", scalaVersion, scalaJS, translateLine("FlatSpec")),
-
-      translateFile(safeFixtureDir, "SafeFreeSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala", scalaVersion, scalaJS, translateLine("FreeSpec")),
-      translateFile(safeFixtureDir, "SafeFreeSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/FreeSpec.scala", scalaVersion, scalaJS, translateLine("FreeSpec")),
-
       translateFile(safeFixtureDir, "SafeFunSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
       translateFile(safeFixtureDir, "SafeFunSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/FunSpec.scala", scalaVersion, scalaJS, translateLine("FunSpec")),
 
@@ -129,17 +104,61 @@ object GenSafeStyles {
       translateFile(safeFixtureDir, "SafePropSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/PropSpec.scala", scalaVersion, scalaJS, translateLine("PropSpec")),
 
       translateFile(safeFixtureDir, "SafeWordSpecLike.scala", "scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala", scalaVersion, scalaJS, translateLine("WordSpec")),
-      translateFile(safeFixtureDir, "SafeWordSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/WordSpec.scala", scalaVersion, scalaJS, translateLine("WordSpec"))
+      translateFile(safeFixtureDir, "SafeWordSpec.scala", "scalatest/src/main/scala/org/scalatest/fixture/WordSpec.scala", scalaVersion, scalaJS, translateLine("WordSpec"))*/
     )
   }
 
-  def genMain(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
+  def genFunSuite(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "SafeFunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureSafeFunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureSafeFunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+    )
+  }
+
+  def genFeatureSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "SafeFeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureSafeFeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureSafeFeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+    )
+  }
+
+  def genFlatSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "SafeFlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureSafeFlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureSafeFlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+    )
+  }
+
+  def genFreeSpec(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "SafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureSafeFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureSafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+    )
+  }
+
+  /*def genMain(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
     genMainImpl(targetDir, version, scalaVersion, false)
   }
 
   def genMainForScalaJS(targetDir: File, version: String, scalaVersion: String) {
     genMainImpl(targetDir, version, scalaVersion, true)
-  }
+  }*/
 
   def genTestImpl(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
     targetDir.mkdirs()

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -23,17 +23,18 @@ object GenSafeStyles {
   val generatorSource = new File("GenSafeStyles.scala")
 
   def translateLine(traitName: String)(line: String): String =
-    line.replaceAllLiterally("with TestRegistration", "with SafeTestRegistration")
-        .replaceAllLiterally("with org.scalatest.FixtureTestRegistration", "with org.scalatest.FixtureSafeTestRegistration")
+    line.replaceAllLiterally("TestRegistration", "SafeTestRegistration")
+        .replaceAllLiterally("org.scalatest.FixtureTestRegistration", "org.scalatest.FixtureSafeTestRegistration")
         .replaceAllLiterally("Any /* Assertion */", "Assertion")
-        .replaceAllLiterally(traitName, "Safe" + (if (traitName.startsWith("Any")) traitName.drop(3) else traitName))
+        .replaceAllLiterally(traitName, (if (traitName.startsWith("Any")) traitName.drop(3) else traitName))
         .replaceAllLiterally("Resources.concurrentSafe" + traitName + "Mod", "Resources.concurrent" + traitName + "Mod")
         .replaceAllLiterally("Resources.concurrentFixtureSafe" + traitName + "Mod", "Resources.concurrentFixture" + traitName + "Mod")
         //.replaceAllLiterally("final override val styleName: String = \"org.scalatest.Safe" + traitName + "\"", "final override val styleName: String = \"org.scalatest." + traitName + "\"")
         .replaceAllLiterally("@Finders(Array(\"org.scalatest.finders.Safe" + traitName + "Finder\"))", "@Finders(Array(\"org.scalatest.finders." + traitName + "Finder\"))")
+        .replaceAllLiterally("SafeTestRegistrationClosedException", "TestRegistrationClosedException")
 
   def translateTestLine(traitName: String)(line: String): String =
-    line.replaceAllLiterally(traitName, "Safe" + traitName.drop(3))
+    line.replaceAllLiterally(traitName, traitName.drop(3))
     .replaceAllLiterally("/* ASSERTION_SUCCEED */", "succeed")
 
   def translateFile(targetDir: File, fileName: String, sourceFileName: String, scalaVersion: String, scalaJS: Boolean, translateFun: String => String): File = {
@@ -92,10 +93,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
-      translateFile(targetDir, "SafeFunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
-      translateFile(targetDir, "FixtureSafeFunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
-      translateFile(targetDir, "FixtureSafeFunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureFunSuiteLike.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureFunSuite.scala", "jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala", scalaVersion, scalaJS, translateLine("AnyFunSuite")),
     )
   }
 
@@ -103,10 +104,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
-      translateFile(targetDir, "SafeFeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
-      translateFile(targetDir, "FixtureSafeFeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
-      translateFile(targetDir, "FixtureSafeFeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureFeatureSpecLike.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureFeatureSpec.scala", "jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpec.scala", scalaVersion, scalaJS, translateLine("AnyFeatureSpec")),
     )
   }
 
@@ -114,10 +115,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
-      translateFile(targetDir, "SafeFlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
-      translateFile(targetDir, "FixtureSafeFlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
-      translateFile(targetDir, "FixtureSafeFlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureFlatSpecLike.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureFlatSpec.scala", "jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpec.scala", scalaVersion, scalaJS, translateLine("AnyFlatSpec")),
     )
   }
 
@@ -125,10 +126,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
-      translateFile(targetDir, "SafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
-      translateFile(targetDir, "FixtureSafeFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
-      translateFile(targetDir, "FixtureSafeFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureFreeSpecLike.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureFreeSpec.scala", "jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala", scalaVersion, scalaJS, translateLine("AnyFreeSpec")),
     )
   }
 
@@ -136,10 +137,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
-      translateFile(targetDir, "SafeFunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
-      translateFile(targetDir, "FixtureSafeFunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
-      translateFile(targetDir, "FixtureSafeFunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureFunSpecLike.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureFunSpec.scala", "jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpec.scala", scalaVersion, scalaJS, translateLine("AnyFunSpec")),
     )
   }
 
@@ -147,10 +148,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafePropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
-      translateFile(targetDir, "SafePropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
-      translateFile(targetDir, "FixtureSafePropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
-      translateFile(targetDir, "FixtureSafePropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "PropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "PropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "FixturePropSpecLike.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
+      translateFile(targetDir, "FixturePropSpec.scala", "jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpec.scala", scalaVersion, scalaJS, translateLine("AnyPropSpec")),
     )
   }
 
@@ -158,10 +159,10 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeWordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
-      translateFile(targetDir, "SafeWordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
-      translateFile(targetDir, "FixtureSafeWordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
-      translateFile(targetDir, "FixtureSafeWordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec"))
+      translateFile(targetDir, "WordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "WordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureWordSpecLike.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureWordSpec.scala", "jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpec.scala", scalaVersion, scalaJS, translateLine("AnyWordSpec"))
     )
   }
 
@@ -169,8 +170,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
-      translateFile(targetDir, "FixtureSafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
+      translateFile(targetDir, "FunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
     )
   }
 
@@ -178,9 +179,9 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
-      translateFile(targetDir, "SafeFunSpecSuite.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
-      translateFile(targetDir, "FixtureSafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+      translateFile(targetDir, "FunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+      translateFile(targetDir, "FunSpecSuite.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
     )
   }
 
@@ -188,8 +189,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
-      translateFile(targetDir, "FixtureSafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
     )
   }
 
@@ -197,8 +198,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
-      translateFile(targetDir, "FixtureSafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
+      translateFile(targetDir, "FlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
+      translateFile(targetDir, "FixtureFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
     )
   }
 
@@ -206,8 +207,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
-      translateFile(targetDir, "FixtureSafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
+      translateFile(targetDir, "FreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
     )
   }
 
@@ -215,8 +216,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
-      translateFile(targetDir, "FixtureSafePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
+      translateFile(targetDir, "PropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
+      translateFile(targetDir, "FixturePropSpecSpec.scala", "jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyPropSpec")),
     )
   }
 
@@ -224,8 +225,8 @@ object GenSafeStyles {
     targetDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec")),
-      translateFile(targetDir, "FixtureSafeWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec"))
+      translateFile(targetDir, "WordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec")),
+      translateFile(targetDir, "FixtureWordSpecSpec.scala", "jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyWordSpec"))
     )
   }
 }

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -85,10 +85,6 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafeTestRegistration.scala", "jvm/core/src/main/scala/org/scalatest/TestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
       translateFile(targetDir, "FixtureSafeTestRegistration.scala", "jvm/core/src/main/scala/org/scalatest/FixtureTestRegistration.scala", scalaVersion, scalaJS, translateLine("TestRegistration")),
-
-      /*
-
-      */
     )
   }
 
@@ -184,7 +180,6 @@ object GenSafeStyles {
       translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
 
-      translateFile(fixtureDir, "SafeFunSuiteSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSuite")),
       translateFile(fixtureDir, "SafeFunSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
       translateFile(fixtureDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
       translateFile(fixtureDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
@@ -199,6 +194,7 @@ object GenSafeStyles {
 
     Seq(
       translateFile(targetDir, "SafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
+      translateFile(targetDir, "FixtureSafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -172,13 +172,11 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
       translateFile(targetDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
       translateFile(targetDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
 
-      translateFile(fixtureDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
       translateFile(fixtureDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
       translateFile(fixtureDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(fixtureDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
@@ -202,6 +200,15 @@ object GenSafeStyles {
       translateFile(targetDir, "SafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
       translateFile(targetDir, "SafeFunSpecSuite.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
       translateFile(targetDir, "FixtureSafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+    )
+  }
+
+  def genFeatureSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
+      translateFile(targetDir, "FixtureSafeFeatureSpecSpec.scala", "jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFeatureSpec")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -26,14 +26,14 @@ object GenSafeStyles {
     line.replaceAllLiterally("with TestRegistration", "with SafeTestRegistration")
         .replaceAllLiterally("with org.scalatest.FixtureTestRegistration", "with org.scalatest.FixtureSafeTestRegistration")
         .replaceAllLiterally("Any /* Assertion */", "Assertion")
-        .replaceAllLiterally(traitName, "Safe" + traitName)
+        .replaceAllLiterally(traitName, "Safe" + (if (traitName.startsWith("Any")) traitName.drop(3) else traitName))
         .replaceAllLiterally("Resources.concurrentSafe" + traitName + "Mod", "Resources.concurrent" + traitName + "Mod")
         .replaceAllLiterally("Resources.concurrentFixtureSafe" + traitName + "Mod", "Resources.concurrentFixture" + traitName + "Mod")
         //.replaceAllLiterally("final override val styleName: String = \"org.scalatest.Safe" + traitName + "\"", "final override val styleName: String = \"org.scalatest." + traitName + "\"")
         .replaceAllLiterally("@Finders(Array(\"org.scalatest.finders.Safe" + traitName + "Finder\"))", "@Finders(Array(\"org.scalatest.finders." + traitName + "Finder\"))")
 
   def translateTestLine(traitName: String)(line: String): String =
-    line.replaceAllLiterally(traitName, "Safe" + traitName)
+    line.replaceAllLiterally(traitName, "Safe" + traitName.drop(3))
     .replaceAllLiterally("/* ASSERTION_SUCCEED */", "succeed")
 
   def translateFile(targetDir: File, fileName: String, sourceFileName: String, scalaVersion: String, scalaJS: Boolean, translateFun: String => String): File = {
@@ -169,14 +169,6 @@ object GenSafeStyles {
     )
   }
 
-  /*def genMain(targetDir: File, version: String, scalaVersion: String): Seq[File] = {
-    genMainImpl(targetDir, version, scalaVersion, false)
-  }
-
-  def genMainForScalaJS(targetDir: File, version: String, scalaVersion: String) {
-    genMainImpl(targetDir, version, scalaVersion, true)
-  }*/
-
   def genTestImpl(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
     targetDir.mkdirs()
 
@@ -184,7 +176,6 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSuiteSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSuite")),
       translateFile(targetDir, "SafeFunSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
       translateFile(targetDir, "SafeFunSpecSuite.scala", "scalatest-test/src/test/scala/org/scalatest/FunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
       translateFile(targetDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
@@ -200,6 +191,14 @@ object GenSafeStyles {
       translateFile(fixtureDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(fixtureDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(fixtureDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec"))
+    )
+  }
+
+  def genFunSuiteTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -173,11 +173,9 @@ object GenSafeStyles {
 
     Seq(
       
-      translateFile(targetDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
 
-      translateFile(fixtureDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(fixtureDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(fixtureDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec"))
     )
@@ -217,6 +215,15 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
       translateFile(targetDir, "FixtureSafeFlatSpecSpec.scala", "jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFlatSpec")),
+    )
+  }
+
+  def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
+      translateFile(targetDir, "FixtureSafeFreeSpecSpec.scala", "jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFreeSpec")),
     )
   }
 

--- a/project/GenSafeStyles.scala
+++ b/project/GenSafeStyles.scala
@@ -172,15 +172,12 @@ object GenSafeStyles {
     fixtureDir.mkdirs()
 
     Seq(
-      translateFile(targetDir, "SafeFunSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
-      translateFile(targetDir, "SafeFunSpecSuite.scala", "scalatest-test/src/test/scala/org/scalatest/FunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
       translateFile(targetDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
       translateFile(targetDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
       translateFile(targetDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
       translateFile(targetDir, "SafePropSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/PropSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("PropSpec")),
       translateFile(targetDir, "SafeWordSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/WordSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("WordSpec")),
 
-      translateFile(fixtureDir, "SafeFunSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FunSpec")),
       translateFile(fixtureDir, "SafeFeatureSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FeatureSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FeatureSpec")),
       translateFile(fixtureDir, "SafeFlatSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FlatSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FlatSpec")),
       translateFile(fixtureDir, "SafeFreeSpecSpec.scala", "scalatest-test/src/test/scala/org/scalatest/fixture/FreeSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("FreeSpec")),
@@ -195,6 +192,16 @@ object GenSafeStyles {
     Seq(
       translateFile(targetDir, "SafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
       translateFile(targetDir, "FixtureSafeFunSuiteSpec.scala", "jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSuite")),
+    )
+  }
+
+  def genFunSpecTest(targetDir: File, version: String, scalaVersion: String, scalaJS: Boolean): Seq[File] = {
+    targetDir.mkdirs()
+
+    Seq(
+      translateFile(targetDir, "SafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+      translateFile(targetDir, "SafeFunSpecSuite.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
+      translateFile(targetDir, "FixtureSafeFunSpecSpec.scala", "jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala", scalaVersion, scalaJS, translateTestLine("AnyFunSpec")),
     )
   }
 

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -650,44 +650,52 @@ object GenScalaTestDotty {
     copyDirJS("jvm/featurespec-test/src/test/scala/org/scalatest/featurespec", "org/scalatest/featurespec", targetDir, List.empty)  
 
   def genFlatSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyDir("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", targetDir, List.empty)
+    copyDir("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", targetDir, 
+      List(
+        "FixtureAnyFlatSpecSpec.scala" // skipped because tests failed
+      )
+    )
 
   def genFlatSpecTestJS(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
-    copyDirJS("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", targetDir, List.empty)      
+    copyDirJS("jvm/flatspec-test/src/test/scala/org/scalatest/flatspec", "org/scalatest/flatspec", targetDir, 
+      List(
+        "FixtureAnyFlatSpecSpec.scala" // skipped because tests failed
+      )
+    )      
 
   def genFreeSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, 
       List(
-        "FixtureFreeSpecSpec.scala" // skipped because tests failed
+        "FixtureAnyFreeSpecSpec.scala" // skipped because tests failed
       )
     )
 
   def genFreeSpecTestJS(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDirJS("jvm/freespec-test/src/test/scala/org/scalatest/freespec", "org/scalatest/freespec", targetDir, 
       List(
-        "FixtureFreeSpecSpec.scala" // skipped because tests failed
+        "FixtureAnyFreeSpecSpec.scala" // skipped because tests failed
       )
     )  
 
   def genFunSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, 
       List(
-        "FixtureFunSpecSpec.scala" // skipped because tests failed
+        "FixtureAnyFunSpecSpec.scala" // skipped because tests failed
       )
     )
 
   def genFunSpecTestJS(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDirJS("jvm/funspec-test/src/test/scala/org/scalatest/funspec", "org/scalatest/funspec", targetDir, 
       List(
-        "FixtureFunSpecSpec.scala" // skipped because tests failed
+        "FixtureAnyFunSpecSpec.scala" // skipped because tests failed
       )
     )      
 
   def genFunSuiteTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, 
       List(
-        "FunSuiteSpec.scala", 
-        "FixtureFunSuiteSpec.scala"
+        "AnyFunSuiteSpec.scala", 
+        "FixtureAnyFunSuiteSpec.scala"
       )
     )
 
@@ -695,23 +703,23 @@ object GenScalaTestDotty {
     copyDirJS("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, 
       List(
         "FunSuiteSpec.scala", 
-        "FixtureFunSuiteSpec.scala"
+        "FixtureAnyFunSuiteSpec.scala"
       )
     )  
 
   def genPropSpecTest(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDir("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, 
       List(
-        "PropSpecSpec.scala", 
-        "FixturePropSpecSpec.scala"
+        "AnyPropSpecSpec.scala", 
+        "FixtureAnyPropSpecSpec.scala"
       )
     )
 
   def genPropSpecTestJS(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDirJS("jvm/propspec-test/src/test/scala/org/scalatest/propspec", "org/scalatest/propspec", targetDir, 
       List(
-        "PropSpecSpec.scala", 
-        "FixturePropSpecSpec.scala"
+        "AnyPropSpecSpec.scala", 
+        "FixtureAnyPropSpecSpec.scala"
       )
     )  
 
@@ -723,9 +731,9 @@ object GenScalaTestDotty {
         "FixtureAsyncWordSpecLikeSpec.scala", // skipped because does not compile yet
         "FixtureAsyncWordSpecSpec.scala", // skipped because does not compile yet
         "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-        "WordSpecSpec.scala", // skipped because does not compile yet
+        "AnyWordSpecSpec.scala", // skipped because does not compile yet
         "FixtureWordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-        "FixtureWordSpecSpec.scala" // skipped because does not compile yet
+        "FixtureAnyWordSpecSpec.scala" // skipped because does not compile yet
       )
     )
 
@@ -737,9 +745,9 @@ object GenScalaTestDotty {
         "FixtureAsyncWordSpecLikeSpec.scala", // skipped because does not compile yet
         "FixtureAsyncWordSpecSpec.scala", // skipped because does not compile yet
         "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-        "WordSpecSpec.scala", // skipped because does not compile yet
+        "AnyWordSpecSpec.scala", // skipped because does not compile yet
         "FixtureWordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-        "FixtureWordSpecSpec.scala" // skipped because does not compile yet
+        "AnyFixtureWordSpecSpec.scala" // skipped because does not compile yet
       )
     )      
 }

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -702,7 +702,7 @@ object GenScalaTestDotty {
   def genFunSuiteTestJS(targetDir: File, version: String, scalaVersion: String): Seq[File] = 
     copyDirJS("jvm/funsuite-test/src/test/scala/org/scalatest/funsuite", "org/scalatest/funsuite", targetDir, 
       List(
-        "FunSuiteSpec.scala", 
+        "AnyFunSuiteSpec.scala", 
         "FixtureAnyFunSuiteSpec.scala"
       )
     )  
@@ -747,7 +747,7 @@ object GenScalaTestDotty {
         "WordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
         "AnyWordSpecSpec.scala", // skipped because does not compile yet
         "FixtureWordSpecImportedMatchersSpec.scala", // skipped because does not compile yet
-        "AnyFixtureWordSpecSpec.scala" // skipped because does not compile yet
+        "FixtureAnyWordSpecSpec.scala" // skipped because does not compile yet
       )
     )      
 }

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -362,7 +362,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FlatSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genFlatSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genFlatSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
@@ -570,7 +571,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestFlatSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestFlatSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFlatSpec((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -414,7 +414,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest PropSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genPropSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
@@ -705,7 +706,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestPropSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestPropSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genPropSpec((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -427,7 +427,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest WordSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genWordSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++
+          GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)         
@@ -739,7 +740,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestWordSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestWordSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genWordSpec((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -375,7 +375,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FreeSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genFreeSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genFreeSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
@@ -604,7 +605,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestFreeSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestFreeSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFreeSpec((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -708,7 +708,7 @@ trait JsBuild { this: BuildCommons =>
       Compile / sourceGenerators += {
         Def.task {
           GenModulesJS.genScalaTestPropSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
-          GenSafeStyles.genPropSpec((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false)
+          GenSafeStyles.genPropSpec((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -397,7 +397,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FunSuite Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genFunSuiteTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genFunSuiteTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++
+          GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)         
@@ -462,7 +463,8 @@ trait JsBuild { this: BuildCommons =>
           ScalaTestGenResourcesJSVM.genFailureMessages((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value) ++
           ScalaTestGenResourcesJSVM.genResources((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value) ++
           GenGen.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest" / "prop", version.value, scalaVersion.value) ++
-          GenConfigMap.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value)
+          GenConfigMap.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value) ++
+          GenSafeStyles.genCore((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value, true)
         }
       },
       javaSourceManaged := target.value / "java",
@@ -630,7 +632,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestFunSuite((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestFunSuite((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFunSuite((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -388,7 +388,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FunSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genFunSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genFunSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++
+          GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
@@ -671,7 +672,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestFunSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestFunSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFunSpec((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -349,7 +349,8 @@ trait JsBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FeatureSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestJS.genFeatureSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value)
+          GenScalaTestJS.genFeatureSpecTest((sourceManaged in Test).value, version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestJS % "test").enablePlugins(ScalaJSPlugin)
@@ -536,7 +537,8 @@ trait JsBuild { this: BuildCommons =>
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
       Compile / sourceGenerators += {
         Def.task {
-          GenModulesJS.genScalaTestFeatureSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesJS.genScalaTestFeatureSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFeatureSpec((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true)
         }
       },
       scalacOptions ++= (if (scalaBinaryVersion.value == "2.10" || scalaVersion.value.startsWith("2.13")) Seq.empty[String] else Seq("-Ypartial-unification")),

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -486,7 +486,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-propspec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestPropSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestPropSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genPropSpec((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -849,7 +850,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest PropSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genPropSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genPropSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -426,7 +426,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-funsuite",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestFunSuite((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestFunSuite((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFunSuite((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -833,7 +834,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FunSuite Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genFunSuiteTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genFunSuiteTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFunSuiteTest((sourceManaged in Test).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -366,7 +366,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-flatspec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestFlatSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestFlatSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFlatSpec((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -793,7 +794,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FlatSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genFlatSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genFlatSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -456,7 +456,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-funspec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestFunSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestFunSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFunSpec((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -822,7 +823,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FunSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genFunSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genFunSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -270,7 +270,8 @@ trait NativeBuild { this: BuildCommons =>
           ScalaTestGenResourcesJSVM.genResources((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value) ++
           ScalaTestGenResourcesJSVM.genFailureMessages((sourceManaged in Compile).value / "scala" / "org" / "scalatest", version.value, scalaVersion.value) ++
           GenGen.genMain((sourceManaged in Compile).value / "scala" / "org" / "scalatest" / "prop", version.value, scalaVersion.value) ++
-          GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value)
+          GenConfigMap.genMain((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++  
+          GenSafeStyles.genCore((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value, true)
         }.taskValue
       },
       javaSourceManaged := target.value / "java",
@@ -335,7 +336,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-featurespec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestFeatureSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestFeatureSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genFeatureSpec((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -778,7 +780,8 @@ trait NativeBuild { this: BuildCommons =>
       nativeLink := file("test2.hnir"),
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genFeatureSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genFeatureSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -516,7 +516,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-wordspec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestWordSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestWordSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genWordSpec((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -863,7 +864,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest WordSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genWordSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genWordSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++ 
+          GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)  

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -396,7 +396,8 @@ trait NativeBuild { this: BuildCommons =>
       moduleName := "scalatest-freespec",
       sourceGenerators in Compile += {
         Def.task {
-          GenModulesNative.genScalaTestFreeSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value)
+          GenModulesNative.genScalaTestFreeSpec((sourceManaged in Compile).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFreeSpec((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).settings(osgiSettings: _*).settings(
@@ -807,7 +808,8 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest FreeSpec Test",
       sourceGenerators in Test += {
         Def.task {
-          GenScalaTestNative.genFreeSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)
+          GenScalaTestNative.genFreeSpecTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value) ++
+          GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, true)
         }.taskValue
       }
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -850,7 +850,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           (new File(crossTarget.value, "classes")).mkdirs()
           Seq.empty[File]
         }.taskValue
-      },
+      }, 
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genFunSpec((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, false)
+        }
+      }, 
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
@@ -885,6 +890,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           Seq.empty[File]
         }.taskValue
       },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genPropSpec((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false)
+        }
+      }, 
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
@@ -953,6 +963,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           Seq.empty[File]
         }.taskValue
       },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genWordSpec((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, false)
+        }
+      }, 
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -431,7 +431,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest PropSpec Test"
+      projectTitle := "ScalaTest PropSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genPropSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "propspec", version.value, scalaVersion.value, false)
+        }
+      }, 
     ).dependsOn(commonTest % "test")
 
   lazy val scalatestWordSpecTest = project.in(file("jvm/wordspec-test"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -399,7 +399,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest FunSuite Test"
+      projectTitle := "ScalaTest FunSuite Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genFunSuiteTest((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, false)
+        }
+      },  
     ).dependsOn(commonTest % "test")  
 
   lazy val scalatestPropSpecTest = project.in(file("jvm/propspec-test"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -371,7 +371,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest FeatureSpec Test"
+      projectTitle := "ScalaTest FeatureSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genFeatureSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, false)
+        }
+      },
     ).dependsOn(commonTest % "test")
 
   lazy val scalatestFlatSpecTest = project.in(file("jvm/flatspec-test"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -639,7 +639,8 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
          ScalaTestGenResourcesJVM.genFailureMessages((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++ 
          GenVersions.genScalaTestVersions((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value) ++ 
          GenGen.genMain((sourceManaged in Compile).value / "org" / "scalatest" / "prop", version.value, scalaVersion.value) ++
-         GenCompatibleClasses.genMain((sourceManaged in Compile).value / "org" / "scalatest" / "tools", version.value, scalaVersion.value)
+         GenCompatibleClasses.genMain((sourceManaged in Compile).value / "org" / "scalatest" / "tools", version.value, scalaVersion.value) ++ 
+         GenSafeStyles.genCore((sourceManaged in Compile).value / "org" / "scalatest", version.value, scalaVersion.value, false)
        }.taskValue
       },
       scalatestDocSettings,
@@ -694,6 +695,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           Seq.empty[File]
         }.taskValue
       },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genFeatureSpec((sourceManaged in Compile).value / "org" / "scalatest" / "featurespec", version.value, scalaVersion.value, false)
+        }
+      },
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
@@ -727,6 +733,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           (new File(crossTarget.value, "classes")).mkdirs()
           Seq.empty[File]
         }.taskValue
+      },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genFlatSpec((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, false)
+        }
       },
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
@@ -762,6 +773,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           Seq.empty[File]
         }.taskValue
       },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genFreeSpec((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, false)
+        }
+      },
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")
@@ -796,6 +812,11 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
           Seq.empty[File]
         }.taskValue
       },
+      sourceGenerators in Compile += {
+        Def.task {
+          GenSafeStyles.genFunSuite((sourceManaged in Compile).value / "org" / "scalatest" / "funsuite", version.value, scalaVersion.value, false)
+        }
+      }, 
       scalatestDocSettings,
       mimaPreviousArtifacts := Set(organization.value %% name.value % previousReleaseVersion),
       mimaCurrentClassfiles := (classDirectory in Compile).value.getParentFile / (name.value + "_" + scalaBinaryVersion.value + "-" + releaseVersion + ".jar")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -395,7 +395,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest FreeSpec Test"
+      projectTitle := "ScalaTest FreeSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genFreeSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "freespec", version.value, scalaVersion.value, false)
+        }
+      },
     ).dependsOn(commonTest % "test")
 
   lazy val scalatestFunSpecTest = project.in(file("jvm/funspec-test"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -443,7 +443,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest WordSpec Test"
+      projectTitle := "ScalaTest WordSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genWordSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "wordspec", version.value, scalaVersion.value, false)
+        }
+      },
     ).dependsOn(commonTest % "test")            
 
   lazy val scalatestApp = project.in(file("scalatest-app"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -392,7 +392,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest FunSpec Test"
+      projectTitle := "ScalaTest FunSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genFunSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "funspec", version.value, scalaVersion.value, false)
+        }
+      }, 
     ).dependsOn(commonTest % "test")
 
   lazy val scalatestFunSuiteTest = project.in(file("jvm/funsuite-test"))

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -383,7 +383,12 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     .settings(sharedSettings: _*)
     .settings(sharedTestSettings: _*)
     .settings(
-      projectTitle := "ScalaTest FlatSpec Test"
+      projectTitle := "ScalaTest FlatSpec Test", 
+      sourceGenerators in Test += {
+        Def.task {
+          GenSafeStyles.genFlatSpecTest((sourceManaged in Compile).value / "org" / "scalatest" / "flatspec", version.value, scalaVersion.value, false)
+        }
+      },
     ).dependsOn(commonTest % "test")
 
   lazy val scalatestFreeSpecTest = project.in(file("jvm/freespec-test"))


### PR DESCRIPTION
Please note that this branch is based on the following open PR: 

https://github.com/scalatest/scalatest/pull/2003

Please merge PR #2003 so that the diff here is clearer.

This PR brings back safe/pure style traits.