### PR TITLE
Fix compilation with -Xsource:3

### DIFF
--- a/jvm/common-test/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2355,7 +2355,7 @@ object Generator {
           new Iterator[String] {
             private var nextString = s.take(2)
             def hasNext: Boolean = nextString.length < s.length
-            def next: String = {
+            def next(): String = {
               val result = nextString
               nextString = s.take(result.length * 2)
               result
@@ -2425,7 +2425,7 @@ object Generator {
             new Iterator[List[T]] {
               private var nextT = xs.take(2)
               def hasNext: Boolean = nextT.length < xs.length
-              def next: List[T] = {
+              def next(): List[T] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT
@@ -3839,7 +3839,7 @@ object Generator {
             new Iterator[Vector[T]] {
               private var nextT = xs.take(2)
               def hasNext: Boolean = nextT.length < xs.length
-              def next: Vector[T] = {
+              def next(): Vector[T] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT
@@ -3949,7 +3949,7 @@ object Generator {
             new Iterator[Set[T]] {
               private var nextT = xs.take(2)
               def hasNext: Boolean = nextT.size < xs.size
-              def next: Set[T] = {
+              def next(): Set[T] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT
@@ -4059,7 +4059,7 @@ object Generator {
             new Iterator[SortedSet[T]] {
               private var nextT = xs.take(2)
               def hasNext: Boolean = nextT.size < xs.size
-              def next: SortedSet[T] = {
+              def next(): SortedSet[T] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT
@@ -4174,7 +4174,7 @@ object Generator {
             new Iterator[Map[K, V]] {
               private var nextT = xsList.take(2)
               def hasNext: Boolean = nextT.size < xsList.size
-              def next: Map[K, V] = {
+              def next(): Map[K, V] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT
@@ -4287,7 +4287,7 @@ object Generator {
             new Iterator[SortedMap[K, V]] {
               private var nextT = xs.take(2)
               def hasNext: Boolean = nextT.size < xs.size
-              def next: SortedMap[K, V] = {
+              def next(): SortedMap[K, V] = {
                 if (!hasNext)
                   throw new NoSuchElementException
                 val result = nextT

--- a/jvm/core/src/main/scala/org/scalatest/Outcome.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Outcome.scala
@@ -223,7 +223,7 @@ object Outcome {
         new Iterator[Throwable] {
           private var spent: Boolean = false
           def hasNext: Boolean = !spent
-          def next: Throwable =
+          def next(): Throwable =
             if (!spent) {
               spent = true
               ex
@@ -232,7 +232,7 @@ object Outcome {
       case _ => // Return an empty iterator
         new Iterator[Throwable] {
           def hasNext: Boolean = false
-          def next: Throwable = throw new NoSuchElementException
+          def next(): Throwable = throw new NoSuchElementException
         }
     }
 }

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
@@ -317,7 +317,7 @@ private[scalatest] object SuiteDiscoveryHelper {
   private def getFileNamesIteratorFromJar(file: JarFile): Iterator[String] = {
 
     class EnumerationWrapper[T](e: Enumeration[T]) extends Iterator[T] {
-      def next: T = e.nextElement
+      def next(): T = e.nextElement
       def hasNext: Boolean = e.hasMoreElements
     }
 

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -357,7 +357,7 @@ object Diagrams extends Diagrams {
       requireNonNull(clue)
       if (!bool.value) {
         val failureMessage =
-          Some(clue + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagram(sourceText, bool.anchorValues))
+          Some(clue.toString + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagram(sourceText, bool.anchorValues))
         throw newAssertionFailedException(failureMessage, None, pos, Vector.empty)
       }
       Succeeded
@@ -374,7 +374,7 @@ object Diagrams extends Diagrams {
       requireNonNull(clue)
       if (!bool.value) {
         val failureMessage =
-          Some(clue + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagram(sourceText, bool.anchorValues))
+          Some(clue.toString + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagram(sourceText, bool.anchorValues))
         throw newTestCanceledException(failureMessage, None, pos)
       }
       Succeeded

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaMapWrapper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaMapWrapper.scala
@@ -42,7 +42,7 @@ private[scalatest] class JavaMapWrapper[K, V](val underlying: java.util.Map[K, V
     if (underlying.containsKey(key)) Some(underlying.get(key)) else None
   override def iterator: Iterator[(K, V)] = new Iterator[(K, V)] {
     private val javaIterator = underlying.entrySet.iterator
-    def next: (K, V) = {
+    def next(): (K, V) = {
       val nextEntry = javaIterator.next
       (nextEntry.getKey, nextEntry.getValue)
     }

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
@@ -380,7 +380,7 @@ class PrettifierSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
         def iterator: Iterator[Fred] =
           new Iterator[Fred] {
             private var hasNextElement: Boolean = true
-            def next: Fred = {
+            def next(): Fred = {
               if (hasNextElement) {
                 hasNextElement = false
                 thisFred

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShellSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShellSuite.scala
@@ -24,402 +24,402 @@ class ShellSpec extends AnyFunSpec {
 
     // From default values
     org.scalatest.color should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.stats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
   }
 
   it("test from color") {
 
     org.scalatest.color.color should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.stats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.color.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.color.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
   }
 
   it("test from durations") {
 
     org.scalatest.durations.color should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.stats should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.durations.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.durations.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
   }
 
   it("test from shortstacks") {
 
     org.scalatest.shortstacks.color should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.stats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.shortstacks.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.shortstacks.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
   }
 
   it("test from full stacks") {
 
     org.scalatest.fullstacks.color should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.stats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.fullstacks.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
     org.scalatest.fullstacks.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (false)
     )
   }
 
   it("test from stats") {
 
     org.scalatest.stats.color should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.durations should have (
-      'colorPassed (true),
-      'durationsPassed (true),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (true),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.shortstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (true),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (true),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.fullstacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (true),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (true),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.stats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.nocolor should have (
-      'colorPassed (false),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (false),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.nodurations should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.nostacks should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (true)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (true)
     )
     org.scalatest.stats.nostats should have (
-      'colorPassed (true),
-      'durationsPassed (false),
-      'shortstacksPassed (false),
-      'fullstacksPassed (false),
-      'statsPassed (false)
+      Symbol("colorPassed") (true),
+      Symbol("durationsPassed") (false),
+      Symbol("shortstacksPassed") (false),
+      Symbol("fullstacksPassed") (false),
+      Symbol("statsPassed") (false)
     )
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
@@ -227,7 +227,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("a(Symbol) method returns Matcher") {
-      val mt = be a ('file)
+      val mt = be a (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("be a 'file")
@@ -237,10 +237,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe fileMock + " was not a file"
-        mr.negatedFailureMessage shouldBe fileMock + " was a file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was not a file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was a file"
+        mr.failureMessage shouldBe s"$fileMock was not a file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was a file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was not a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was a file"
         mr.rawFailureMessage shouldBe "{0} was not a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -256,10 +256,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe fileMock + " was a file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was not a file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not a file"
+        nmr.failureMessage shouldBe s"$fileMock was a file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was not a file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not a file"
         nmr.rawFailureMessage shouldBe "{0} was a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -300,10 +300,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not a file"
-        mr.negatedFailureMessage shouldBe myFile + " was a file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not a file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was a file"
+        mr.failureMessage shouldBe s"$myFile was not a file"
+        mr.negatedFailureMessage shouldBe s"$myFile was a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
         mr.rawFailureMessage shouldBe "{0} was not a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -319,10 +319,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was a file"
-        nmr.negatedFailureMessage shouldBe myFile + " was not a file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not a file"
+        nmr.failureMessage shouldBe s"$myFile was a file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
         nmr.rawFailureMessage shouldBe "{0} was a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -355,10 +355,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not a file"
-        mr.negatedFailureMessage shouldBe myFile + " was a file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not a file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was a file"
+        mr.failureMessage shouldBe s"$myFile was not a file"
+        mr.negatedFailureMessage shouldBe s"$myFile was a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
         mr.rawFailureMessage shouldBe "{0} was not a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -374,10 +374,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was a file"
-        nmr.negatedFailureMessage shouldBe myFile + " was not a file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not a file"
+        nmr.failureMessage shouldBe s"$myFile was a file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
         nmr.rawFailureMessage shouldBe "{0} was a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -392,7 +392,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("an(Symbol) method returns Matcher") {
-      val mt = be an ('file)
+      val mt = be an (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("be an 'file")
@@ -402,10 +402,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe fileMock + " was not an file"
-        mr.negatedFailureMessage shouldBe fileMock + " was an file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was not an file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was an file"
+        mr.failureMessage shouldBe s"$fileMock was not an file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was an file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was not an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was an file"
         mr.rawFailureMessage shouldBe "{0} was not an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -421,10 +421,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe fileMock + " was an file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was not an file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not an file"
+        nmr.failureMessage shouldBe s"$fileMock was an file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was not an file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not an file"
         nmr.rawFailureMessage shouldBe "{0} was an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -465,10 +465,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not an file"
-        mr.negatedFailureMessage shouldBe myFile + " was an file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not an file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was an file"
+        mr.failureMessage shouldBe s"$myFile was not an file"
+        mr.negatedFailureMessage shouldBe s"$myFile was an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
         mr.rawFailureMessage shouldBe "{0} was not an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -484,10 +484,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was an file"
-        nmr.negatedFailureMessage shouldBe myFile + " was not an file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an file"
+        nmr.failureMessage shouldBe s"$myFile was an file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
         nmr.rawFailureMessage shouldBe "{0} was an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -520,10 +520,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not an file"
-        mr.negatedFailureMessage shouldBe myFile + " was an file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not an file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was an file"
+        mr.failureMessage shouldBe s"$myFile was not an file"
+        mr.negatedFailureMessage shouldBe s"$myFile was an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
         mr.rawFailureMessage shouldBe "{0} was not an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -539,10 +539,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was an file"
-        nmr.negatedFailureMessage shouldBe myFile + " was not an file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an file"
+        nmr.failureMessage shouldBe s"$myFile was an file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
         nmr.rawFailureMessage shouldBe "{0} was an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -622,10 +622,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        mr.negatedFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        mr.midSentenceFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        mr.negatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
         mr.rawFailureMessage shouldBe "{0} was not the same instance as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was the same instance as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not the same instance as {1}"
@@ -641,10 +641,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        nmr.negatedFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        nmr.negatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
         nmr.rawFailureMessage shouldBe "{0} was the same instance as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not the same instance as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was the same instance as {1}"
@@ -753,7 +753,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("apply(Symbol) method returns Matcher") {
-      val mt = be ('file)
+      val mt = be (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("be ('file)")
@@ -763,10 +763,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe fileMock + " was not file"
-        mr.negatedFailureMessage shouldBe fileMock + " was file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was not file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was file"
+        mr.failureMessage shouldBe s"$fileMock was not file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was not file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was file"
         mr.rawFailureMessage shouldBe "{0} was not {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -782,10 +782,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe fileMock + " was file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was not file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not file"
+        nmr.failureMessage shouldBe s"$fileMock was file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was not file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not file"
         nmr.rawFailureMessage shouldBe "{0} was {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -884,10 +884,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not file"
-        mr.negatedFailureMessage shouldBe myFile + " was file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was file"
+        mr.failureMessage shouldBe s"$myFile was not file"
+        mr.negatedFailureMessage shouldBe s"$myFile was file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was file"
         mr.rawFailureMessage shouldBe "{0} was not {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -903,10 +903,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was file"
-        nmr.negatedFailureMessage shouldBe myFile + " was not file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not file"
+        nmr.failureMessage shouldBe s"$myFile was file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not file"
         nmr.rawFailureMessage shouldBe "{0} was {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -933,17 +933,17 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       val mt = be (myFileRight)
       
       it("should have pretty toString") {
-        mt.toString should be ("be (" + myFileRight + ")")
+        mt.toString should be (s"be ($myFileRight)")
       }
       
       val mr = mt(myFileLeft)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-        mr.negatedFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-        mr.midSentenceFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+        mr.negatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
         mr.rawFailureMessage shouldBe "{0} was not equal to {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was equal to {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not equal to {1}"
@@ -959,10 +959,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-        nmr.negatedFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+        nmr.negatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
         nmr.rawFailureMessage shouldBe "{0} was equal to {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not equal to {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was equal to {1}"
@@ -990,10 +990,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe leftList + " was not sorted"
-        mr.negatedFailureMessage shouldBe leftList + " was sorted"
-        mr.midSentenceFailureMessage shouldBe leftList + " was not sorted"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " was sorted"
+        mr.failureMessage shouldBe s"$leftList was not sorted"
+        mr.negatedFailureMessage shouldBe s"$leftList was sorted"
+        mr.midSentenceFailureMessage shouldBe s"$leftList was not sorted"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList was sorted"
         mr.rawFailureMessage shouldBe "{0} was not sorted"
         mr.rawNegatedFailureMessage shouldBe "{0} was sorted"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not sorted"
@@ -1009,10 +1009,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe leftList + " was sorted"
-        nmr.negatedFailureMessage shouldBe leftList + " was not sorted"
-        nmr.midSentenceFailureMessage shouldBe leftList + " was sorted"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " was not sorted"
+        nmr.failureMessage shouldBe s"$leftList was sorted"
+        nmr.negatedFailureMessage shouldBe s"$leftList was not sorted"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList was sorted"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList was not sorted"
         nmr.rawFailureMessage shouldBe "{0} was sorted"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not sorted"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was sorted"
@@ -1042,10 +1042,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe fraction + " was not defined at 8"
-        mr.negatedFailureMessage shouldBe fraction + " was defined at 8"
-        mr.midSentenceFailureMessage shouldBe fraction + " was not defined at 8"
-        mr.midSentenceNegatedFailureMessage shouldBe fraction + " was defined at 8"
+        mr.failureMessage shouldBe s"$fraction was not defined at 8"
+        mr.negatedFailureMessage shouldBe s"$fraction was defined at 8"
+        mr.midSentenceFailureMessage shouldBe s"$fraction was not defined at 8"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fraction was defined at 8"
         mr.rawFailureMessage shouldBe "{0} was not defined at {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was defined at {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not defined at {1}"
@@ -1061,10 +1061,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe fraction + " was defined at 8"
-        nmr.negatedFailureMessage shouldBe fraction + " was not defined at 8"
-        nmr.midSentenceFailureMessage shouldBe fraction + " was defined at 8"
-        nmr.midSentenceNegatedFailureMessage shouldBe fraction + " was not defined at 8"
+        nmr.failureMessage shouldBe s"$fraction was defined at 8"
+        nmr.negatedFailureMessage shouldBe s"$fraction was not defined at 8"
+        nmr.midSentenceFailureMessage shouldBe s"$fraction was defined at 8"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fraction was not defined at 8"
         nmr.rawFailureMessage shouldBe "{0} was defined at {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not defined at {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was defined at {1}"
@@ -1096,10 +1096,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe fraction + " was not defined at 8"
-        mr.negatedFailureMessage shouldBe fraction + " was defined at 8"
-        mr.midSentenceFailureMessage shouldBe fraction + " was not defined at 8"
-        mr.midSentenceNegatedFailureMessage shouldBe fraction + " was defined at 8"
+        mr.failureMessage shouldBe s"$fraction was not defined at 8"
+        mr.negatedFailureMessage shouldBe s"$fraction was defined at 8"
+        mr.midSentenceFailureMessage shouldBe s"$fraction was not defined at 8"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fraction was defined at 8"
         mr.rawFailureMessage shouldBe "{0} was not defined at {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was defined at {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not defined at {1}"
@@ -1115,10 +1115,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe fraction + " was defined at 8"
-        nmr.negatedFailureMessage shouldBe fraction + " was not defined at 8"
-        nmr.midSentenceFailureMessage shouldBe fraction + " was defined at 8"
-        nmr.midSentenceNegatedFailureMessage shouldBe fraction + " was not defined at 8"
+        nmr.failureMessage shouldBe s"$fraction was defined at 8"
+        nmr.negatedFailureMessage shouldBe s"$fraction was not defined at 8"
+        nmr.midSentenceFailureMessage shouldBe s"$fraction was defined at 8"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fraction was not defined at 8"
         nmr.rawFailureMessage shouldBe "{0} was defined at {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not defined at {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was defined at {1}"
@@ -1154,10 +1154,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.negatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.midSentenceFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
+        mr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
         mr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1173,10 +1173,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.negatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         nmr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1212,10 +1212,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.negatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.midSentenceFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
+        mr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
         mr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1231,10 +1231,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.negatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         nmr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1266,10 +1266,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not readable"
-        mr.negatedFailureMessage shouldBe myFile + " was readable"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not readable"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was readable"
+        mr.failureMessage shouldBe s"$myFile was not readable"
+        mr.negatedFailureMessage shouldBe s"$myFile was readable"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not readable"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was readable"
         mr.rawFailureMessage shouldBe "{0} was not readable"
         mr.rawNegatedFailureMessage shouldBe "{0} was readable"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not readable"
@@ -1285,10 +1285,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was readable"
-        nmr.negatedFailureMessage shouldBe myFile + " was not readable"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was readable"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not readable"
+        nmr.failureMessage shouldBe s"$myFile was readable"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not readable"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was readable"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not readable"
         nmr.rawFailureMessage shouldBe "{0} was readable"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not readable"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was readable"
@@ -1320,10 +1320,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFile + " was not writable"
-        mr.negatedFailureMessage shouldBe myFile + " was writable"
-        mr.midSentenceFailureMessage shouldBe myFile + " was not writable"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was writable"
+        mr.failureMessage shouldBe s"$myFile was not writable"
+        mr.negatedFailureMessage shouldBe s"$myFile was writable"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was not writable"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was writable"
         mr.rawFailureMessage shouldBe "{0} was not writable"
         mr.rawNegatedFailureMessage shouldBe "{0} was writable"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not writable"
@@ -1339,10 +1339,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFile + " was writable"
-        nmr.negatedFailureMessage shouldBe myFile + " was not writable"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was writable"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was not writable"
+        nmr.failureMessage shouldBe s"$myFile was writable"
+        nmr.negatedFailureMessage shouldBe s"$myFile was not writable"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was writable"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not writable"
         nmr.rawFailureMessage shouldBe "{0} was writable"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not writable"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was writable"
@@ -1370,10 +1370,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe leftList + " was not empty"
-        mr.negatedFailureMessage shouldBe leftList + " was empty"
-        mr.midSentenceFailureMessage shouldBe leftList + " was not empty"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " was empty"
+        mr.failureMessage shouldBe s"$leftList was not empty"
+        mr.negatedFailureMessage shouldBe s"$leftList was empty"
+        mr.midSentenceFailureMessage shouldBe s"$leftList was not empty"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList was empty"
         mr.rawFailureMessage shouldBe "{0} was not empty"
         mr.rawNegatedFailureMessage shouldBe "{0} was empty"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not empty"
@@ -1389,10 +1389,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe leftList + " was empty"
-        nmr.negatedFailureMessage shouldBe leftList + " was not empty"
-        nmr.midSentenceFailureMessage shouldBe leftList + " was empty"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " was not empty"
+        nmr.failureMessage shouldBe s"$leftList was empty"
+        nmr.negatedFailureMessage shouldBe s"$leftList was not empty"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList was empty"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList was not empty"
         nmr.rawFailureMessage shouldBe "{0} was empty"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not empty"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was empty"
@@ -1420,10 +1420,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe leftOption + " was not defined"
-        mr.negatedFailureMessage shouldBe leftOption + " was defined"
-        mr.midSentenceFailureMessage shouldBe leftOption + " was not defined"
-        mr.midSentenceNegatedFailureMessage shouldBe leftOption + " was defined"
+        mr.failureMessage shouldBe s"$leftOption was not defined"
+        mr.negatedFailureMessage shouldBe s"$leftOption was defined"
+        mr.midSentenceFailureMessage shouldBe s"$leftOption was not defined"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftOption was defined"
         mr.rawFailureMessage shouldBe "{0} was not defined"
         mr.rawNegatedFailureMessage shouldBe "{0} was defined"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not defined"
@@ -1439,10 +1439,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe leftOption + " was defined"
-        nmr.negatedFailureMessage shouldBe leftOption + " was not defined"
-        nmr.midSentenceFailureMessage shouldBe leftOption + " was defined"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftOption + " was not defined"
+        nmr.failureMessage shouldBe s"$leftOption was defined"
+        nmr.negatedFailureMessage shouldBe s"$leftOption was not defined"
+        nmr.midSentenceFailureMessage shouldBe s"$leftOption was defined"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftOption was not defined"
         nmr.rawFailureMessage shouldBe "{0} was defined"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not defined"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was defined"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
@@ -202,18 +202,18 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe leftList + " did not contain a file"
-        mr.negatedFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        mr.midSentenceFailureMessage shouldBe leftList + " did not contain a file"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
+        mr.failureMessage shouldBe s"$leftList did not contain a file"
+        mr.negatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        mr.midSentenceFailureMessage shouldBe s"$leftList did not contain a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
         mr.rawFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
 
       }
       
@@ -221,17 +221,17 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        nmr.negatedFailureMessage shouldBe leftList + " did not contain a file"
-        nmr.midSentenceFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " did not contain a file"
+        nmr.failureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        nmr.negatedFailureMessage shouldBe s"$leftList did not contain a file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain a file"
         nmr.rawFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain a {1}"
-        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -258,18 +258,18 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe leftList + " did not contain an file"
-        mr.negatedFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        mr.midSentenceFailureMessage shouldBe leftList + " did not contain an file"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
+        mr.failureMessage shouldBe s"$leftList did not contain an file"
+        mr.negatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        mr.midSentenceFailureMessage shouldBe s"$leftList did not contain an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
         mr.rawFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
 
       }
       
@@ -277,17 +277,17 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        nmr.negatedFailureMessage shouldBe leftList + " did not contain an file"
-        nmr.midSentenceFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " did not contain an file"
+        nmr.failureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        nmr.negatedFailureMessage shouldBe s"$leftList did not contain an file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain an file"
         nmr.rawFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain an {1}"
-        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -358,10 +358,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} did not contain at least one of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} contained at least one of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain at least one of ({1})"
@@ -377,10 +377,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} contained at least one of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain at least one of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained at least one of ({1})"
@@ -459,10 +459,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        mr.negatedFailureMessage shouldBe lhs + " contained the same elements as " + rhs
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained the same elements as " + rhs
+        mr.failureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        mr.negatedFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
         mr.rawFailureMessage shouldBe "{0} did not contain the same elements as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained the same elements as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain the same elements as {1}"
@@ -478,10 +478,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained the same elements as " + rhs
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained the same elements as " + rhs
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
+        nmr.failureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
         nmr.rawFailureMessage shouldBe "{0} contained the same elements as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain the same elements as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained the same elements as {1}"
@@ -510,10 +510,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        mr.negatedFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
+        mr.failureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        mr.negatedFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
         mr.rawFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
@@ -529,10 +529,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
+        nmr.failureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
         nmr.rawFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
@@ -560,10 +560,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain only (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " contained only (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain only (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained only (1, 2)"
+        mr.failureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs contained only (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained only (1, 2)"
         mr.rawFailureMessage shouldBe "{0} did not contain only ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} contained only ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain only ({1})"
@@ -579,10 +579,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained only (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain only (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained only (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain only (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs contained only (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained only (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} contained only ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain only ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained only ({1})"
@@ -610,10 +610,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        mr.negatedFailureMessage shouldBe lhs + " contained only (1, 2) in order"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained only (1, 2) in order"
+        mr.failureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        mr.negatedFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
         mr.rawFailureMessage shouldBe "{0} did not contain only ({1}) in order"
         mr.rawNegatedFailureMessage shouldBe "{0} contained only ({1}) in order"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain only ({1}) in order"
@@ -629,10 +629,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained only (1, 2) in order"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained only (1, 2) in order"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
+        nmr.failureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
         nmr.rawFailureMessage shouldBe "{0} contained only ({1}) in order"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain only ({1}) in order"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained only ({1}) in order"
@@ -660,10 +660,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " contained all of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained all of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs contained all of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained all of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} did not contain all of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} contained all of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain all of ({1})"
@@ -679,10 +679,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained all of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained all of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs contained all of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained all of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} contained all of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain all of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained all of ({1})"
@@ -710,10 +710,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        mr.negatedFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
+        mr.failureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        mr.negatedFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
         mr.rawFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
         mr.rawNegatedFailureMessage shouldBe "{0} contained all of ({1}) in order"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
@@ -729,10 +729,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
+        nmr.failureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
         nmr.rawFailureMessage shouldBe "{0} contained all of ({1}) in order"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained all of ({1}) in order"
@@ -760,10 +760,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} did not contain at most one of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} contained at most one of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain at most one of ({1})"
@@ -779,10 +779,10 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} contained at most one of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain at most one of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained at most one of ({1})"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ExistWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ExistWordSpec.scala
@@ -47,10 +47,10 @@ class ExistWordSpec extends AnyFunSpec with Matchers with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " does not exist"
-        mr.negatedFailureMessage shouldBe lhs + " exists"
-        mr.midSentenceFailureMessage shouldBe lhs + " does not exist"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " exists"
+        mr.failureMessage shouldBe s"$lhs does not exist"
+        mr.negatedFailureMessage shouldBe s"$lhs exists"
+        mr.midSentenceFailureMessage shouldBe s"$lhs does not exist"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs exists"
         mr.rawFailureMessage shouldBe "{0} does not exist"
         mr.rawNegatedFailureMessage shouldBe "{0} exists"
         mr.rawMidSentenceFailureMessage shouldBe "{0} does not exist"
@@ -66,10 +66,10 @@ class ExistWordSpec extends AnyFunSpec with Matchers with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " exists"
-        nmr.negatedFailureMessage shouldBe lhs + " does not exist"
-        nmr.midSentenceFailureMessage shouldBe lhs + " exists"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " does not exist"
+        nmr.failureMessage shouldBe s"$lhs exists"
+        nmr.negatedFailureMessage shouldBe s"$lhs does not exist"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs exists"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs does not exist"
         nmr.rawFailureMessage shouldBe "{0} exists"
         nmr.rawNegatedFailureMessage shouldBe "{0} does not exist"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} exists"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
@@ -143,10 +143,10 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe lhs + " had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""
-        mr.negatedFailureMessage shouldBe lhs + " had message \"Message from Mars!\""
-        mr.midSentenceFailureMessage shouldBe lhs + " had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " had message \"Message from Mars!\""
+        mr.failureMessage shouldBe s"""$lhs had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""""
+        mr.negatedFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\""""
+        mr.midSentenceFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""""
+        mr.midSentenceNegatedFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\""""
         mr.rawFailureMessage shouldBe "{0} had message {1} instead of expected message {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} had message {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} had message {1} instead of expected message {2}"
@@ -162,10 +162,10 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe lhs + " had message \"Message from Mars!\""
-        nmr.negatedFailureMessage shouldBe lhs + " had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""
-        nmr.midSentenceFailureMessage shouldBe lhs + " had message \"Message from Mars!\""
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""
+        nmr.failureMessage shouldBe s"""$lhs had message \"Message from Mars!\""""
+        nmr.negatedFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""""
+        nmr.midSentenceFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\""""
+        nmr.midSentenceNegatedFailureMessage shouldBe s"""$lhs had message \"Message from Mars!\" instead of expected message \"Message from Mars!\""""
         nmr.rawFailureMessage shouldBe "{0} had message {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} had message {1} instead of expected message {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} had message {1}"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
@@ -362,10 +362,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " exists"
-        mr.negatedFailureMessage shouldBe lhs + " does not exist"
-        mr.midSentenceFailureMessage shouldBe lhs + " exists"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " does not exist"
+        mr.failureMessage shouldBe s"$lhs exists"
+        mr.negatedFailureMessage shouldBe s"$lhs does not exist"
+        mr.midSentenceFailureMessage shouldBe s"$lhs exists"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs does not exist"
         mr.rawFailureMessage shouldBe "{0} exists"
         mr.rawNegatedFailureMessage shouldBe "{0} does not exist"
         mr.rawMidSentenceFailureMessage shouldBe "{0} exists"
@@ -381,10 +381,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " does not exist"
-        nmr.negatedFailureMessage shouldBe lhs + " exists"
-        nmr.midSentenceFailureMessage shouldBe lhs + " does not exist"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " exists"
+        nmr.failureMessage shouldBe s"$lhs does not exist"
+        nmr.negatedFailureMessage shouldBe s"$lhs exists"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs does not exist"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs exists"
         nmr.rawFailureMessage shouldBe "{0} does not exist"
         nmr.rawNegatedFailureMessage shouldBe "{0} exists"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} does not exist"
@@ -744,7 +744,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("be(Symbol) method returns Matcher") {
-      val mt = not be ('file)
+      val mt = not be (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("not be 'file")
@@ -754,10 +754,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe fileMock + " was file"
-        mr.negatedFailureMessage shouldBe fileMock + " was not file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not file"
+        mr.failureMessage shouldBe s"$fileMock was file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was not file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not file"
         mr.rawFailureMessage shouldBe "{0} was {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -773,10 +773,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe fileMock + " was not file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was not file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was file"
+        nmr.failureMessage shouldBe s"$fileMock was not file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was not file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was file"
         nmr.rawFailureMessage shouldBe "{0} was not {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -817,10 +817,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was file"
-        mr.negatedFailureMessage shouldBe myFile + " was not file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not file"
+        mr.failureMessage shouldBe s"$myFile was file"
+        mr.negatedFailureMessage shouldBe s"$myFile was not file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not file"
         mr.rawFailureMessage shouldBe "{0} was {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -836,10 +836,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not file"
-        nmr.negatedFailureMessage shouldBe myFile + " was file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was file"
+        nmr.failureMessage shouldBe s"$myFile was not file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was file"
         nmr.rawFailureMessage shouldBe "{0} was not {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -854,7 +854,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("apply(ResultOfAWordToSymbolApplication) method returns Matcher") {
-      val mt = not be a ('file)
+      val mt = not be a (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("not be a ('file)")
@@ -864,10 +864,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe fileMock + " was a file"
-        mr.negatedFailureMessage shouldBe fileMock + " was not a file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not a file"
+        mr.failureMessage shouldBe s"$fileMock was a file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was not a file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not a file"
         mr.rawFailureMessage shouldBe "{0} was a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -883,10 +883,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe fileMock + " was not a file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was a file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was not a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was a file"
+        nmr.failureMessage shouldBe s"$fileMock was not a file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was not a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was a file"
         nmr.rawFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -927,10 +927,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was a file"
-        mr.negatedFailureMessage shouldBe myFile + " was not a file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not a file"
+        mr.failureMessage shouldBe s"$myFile was a file"
+        mr.negatedFailureMessage shouldBe s"$myFile was not a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
         mr.rawFailureMessage shouldBe "{0} was a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -946,10 +946,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not a file"
-        nmr.negatedFailureMessage shouldBe myFile + " was a file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was a file"
+        nmr.failureMessage shouldBe s"$myFile was not a file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
         nmr.rawFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -982,10 +982,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was a file"
-        mr.negatedFailureMessage shouldBe myFile + " was not a file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not a file"
+        mr.failureMessage shouldBe s"$myFile was a file"
+        mr.negatedFailureMessage shouldBe s"$myFile was not a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
         mr.rawFailureMessage shouldBe "{0} was a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -1001,10 +1001,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not a file"
-        nmr.negatedFailureMessage shouldBe myFile + " was a file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was a file"
+        nmr.failureMessage shouldBe s"$myFile was not a file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
         nmr.rawFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -1019,7 +1019,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
 
     // SKIP-SCALATESTJS,NATIVE-START
     describe("be(ResultOfAnWordToSymbolApplication) method returns Matcher") {
-      val mt = not be an ('file)
+      val mt = not be an (Symbol("file"))
       
       it("should have pretty toString") {
         mt.toString should be ("not be an ('file)")
@@ -1029,10 +1029,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe fileMock + " was an file"
-        mr.negatedFailureMessage shouldBe fileMock + " was not an file"
-        mr.midSentenceFailureMessage shouldBe fileMock + " was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe fileMock + " was not an file"
+        mr.failureMessage shouldBe s"$fileMock was an file"
+        mr.negatedFailureMessage shouldBe s"$fileMock was not an file"
+        mr.midSentenceFailureMessage shouldBe s"$fileMock was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was not an file"
         mr.rawFailureMessage shouldBe "{0} was an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -1048,10 +1048,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe fileMock + " was not an file"
-        nmr.negatedFailureMessage shouldBe fileMock + " was an file"
-        nmr.midSentenceFailureMessage shouldBe fileMock + " was not an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe fileMock + " was an file"
+        nmr.failureMessage shouldBe s"$fileMock was not an file"
+        nmr.negatedFailureMessage shouldBe s"$fileMock was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$fileMock was not an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fileMock was an file"
         nmr.rawFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -1092,10 +1092,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was an file"
-        mr.negatedFailureMessage shouldBe myFile + " was not an file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an file"
+        mr.failureMessage shouldBe s"$myFile was an file"
+        mr.negatedFailureMessage shouldBe s"$myFile was not an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
         mr.rawFailureMessage shouldBe "{0} was an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -1111,10 +1111,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not an file"
-        nmr.negatedFailureMessage shouldBe myFile + " was an file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was an file"
+        nmr.failureMessage shouldBe s"$myFile was not an file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
         nmr.rawFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -1147,10 +1147,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was an file"
-        mr.negatedFailureMessage shouldBe myFile + " was not an file"
-        mr.midSentenceFailureMessage shouldBe myFile + " was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an file"
+        mr.failureMessage shouldBe s"$myFile was an file"
+        mr.negatedFailureMessage shouldBe s"$myFile was not an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
         mr.rawFailureMessage shouldBe "{0} was an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -1166,10 +1166,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not an file"
-        nmr.negatedFailureMessage shouldBe myFile + " was an file"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was an file"
+        nmr.failureMessage shouldBe s"$myFile was not an file"
+        nmr.negatedFailureMessage shouldBe s"$myFile was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
         nmr.rawFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -1195,17 +1195,17 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       val mt = not be theSameInstanceAs (myFileRight)
       
       it("should have pretty toString") {
-        mt.toString should be ("not be theSameInstanceAs (" + myFileRight + ")")
+        mt.toString should be ("not be theSameInstanceAs (" + s"$myFileRight)")
       }
       
       val mr = mt(myFileLeft)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        mr.negatedFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        mr.midSentenceFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        mr.negatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
         mr.rawFailureMessage shouldBe "{0} was the same instance as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not the same instance as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was the same instance as {1}"
@@ -1221,10 +1221,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        nmr.negatedFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe myFileLeft + " was not the same instance as " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was the same instance as " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        nmr.negatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
         nmr.rawFailureMessage shouldBe "{0} was not the same instance as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was the same instance as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not the same instance as {1}"
@@ -1301,10 +1301,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe fraction + " was defined at 8"
-        mr.negatedFailureMessage shouldBe fraction + " was not defined at 8"
-        mr.midSentenceFailureMessage shouldBe fraction + " was defined at 8"
-        mr.midSentenceNegatedFailureMessage shouldBe fraction + " was not defined at 8"
+        mr.failureMessage shouldBe s"$fraction was defined at 8"
+        mr.negatedFailureMessage shouldBe s"$fraction was not defined at 8"
+        mr.midSentenceFailureMessage shouldBe s"$fraction was defined at 8"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$fraction was not defined at 8"
         mr.rawFailureMessage shouldBe "{0} was defined at {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not defined at {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was defined at {1}"
@@ -1320,10 +1320,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe fraction + " was not defined at 8"
-        nmr.negatedFailureMessage shouldBe fraction + " was defined at 8"
-        nmr.midSentenceFailureMessage shouldBe fraction + " was not defined at 8"
-        nmr.midSentenceNegatedFailureMessage shouldBe fraction + " was defined at 8"
+        nmr.failureMessage shouldBe s"$fraction was not defined at 8"
+        nmr.negatedFailureMessage shouldBe s"$fraction was defined at 8"
+        nmr.midSentenceFailureMessage shouldBe s"$fraction was not defined at 8"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$fraction was defined at 8"
         nmr.rawFailureMessage shouldBe "{0} was not defined at {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was defined at {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not defined at {1}"
@@ -1359,10 +1359,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
         it("should have correct MatcherResult") {
           mr.matches shouldBe true
-          mr.failureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-          mr.negatedFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-          mr.midSentenceFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-          mr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
+          mr.failureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+          mr.negatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+          mr.midSentenceFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
           mr.rawFailureMessage shouldBe "{0} was equal to {1}"
           mr.rawNegatedFailureMessage shouldBe "{0} was not equal to {1}"
           mr.rawMidSentenceFailureMessage shouldBe "{0} was equal to {1}"
@@ -1378,10 +1378,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe false
-          nmr.failureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-          nmr.negatedFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
-          nmr.midSentenceFailureMessage shouldBe myFileLeft + " was not equal to " + myFileRight
-          nmr.midSentenceNegatedFailureMessage shouldBe myFileLeft + " was equal to " + myFileRight
+          nmr.failureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+          nmr.negatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+          nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+          nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
           nmr.rawFailureMessage shouldBe "{0} was not equal to {1}"
           nmr.rawNegatedFailureMessage shouldBe "{0} was equal to {1}"
           nmr.rawMidSentenceFailureMessage shouldBe "{0} was not equal to {1}"
@@ -1402,9 +1402,9 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
         it("should have correct MatcherResult") {
           mr.matches shouldBe true
           mr.failureMessage shouldBe "The reference was null"
-          mr.negatedFailureMessage shouldBe myFileRight + " was not null"
+          mr.negatedFailureMessage shouldBe s"$myFileRight was not null"
           mr.midSentenceFailureMessage shouldBe "the reference was null"
-          mr.midSentenceNegatedFailureMessage shouldBe myFileRight + " was not null"
+          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileRight was not null"
           mr.rawFailureMessage shouldBe "The reference was null"
           mr.rawNegatedFailureMessage shouldBe "{0} was not null"
           mr.rawMidSentenceFailureMessage shouldBe "the reference was null"
@@ -1420,9 +1420,9 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe false
-          nmr.failureMessage shouldBe myFileRight + " was not null"
+          nmr.failureMessage shouldBe s"$myFileRight was not null"
           nmr.negatedFailureMessage shouldBe "The reference was null"
-          nmr.midSentenceFailureMessage shouldBe myFileRight + " was not null"
+          nmr.midSentenceFailureMessage shouldBe s"$myFileRight was not null"
           nmr.midSentenceNegatedFailureMessage shouldBe "the reference was null"
           nmr.rawFailureMessage shouldBe "{0} was not null"
           nmr.rawNegatedFailureMessage shouldBe "The reference was null"
@@ -1452,10 +1452,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe leftList + " was sorted"
-        mr.negatedFailureMessage shouldBe leftList + " was not sorted"
-        mr.midSentenceFailureMessage shouldBe leftList + " was sorted"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " was not sorted"
+        mr.failureMessage shouldBe s"$leftList was sorted"
+        mr.negatedFailureMessage shouldBe s"$leftList was not sorted"
+        mr.midSentenceFailureMessage shouldBe s"$leftList was sorted"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList was not sorted"
         mr.rawFailureMessage shouldBe "{0} was sorted"
         mr.rawNegatedFailureMessage shouldBe "{0} was not sorted"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was sorted"
@@ -1471,10 +1471,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe leftList + " was not sorted"
-        nmr.negatedFailureMessage shouldBe leftList + " was sorted"
-        nmr.midSentenceFailureMessage shouldBe leftList + " was not sorted"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " was sorted"
+        nmr.failureMessage shouldBe s"$leftList was not sorted"
+        nmr.negatedFailureMessage shouldBe s"$leftList was sorted"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList was not sorted"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList was sorted"
         nmr.rawFailureMessage shouldBe "{0} was not sorted"
         nmr.rawNegatedFailureMessage shouldBe "{0} was sorted"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not sorted"
@@ -1506,10 +1506,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was readable"
-        mr.negatedFailureMessage shouldBe myFile + " was not readable"
-        mr.midSentenceFailureMessage shouldBe myFile + " was readable"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not readable"
+        mr.failureMessage shouldBe s"$myFile was readable"
+        mr.negatedFailureMessage shouldBe s"$myFile was not readable"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was readable"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not readable"
         mr.rawFailureMessage shouldBe "{0} was readable"
         mr.rawNegatedFailureMessage shouldBe "{0} was not readable"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was readable"
@@ -1525,10 +1525,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not readable"
-        nmr.negatedFailureMessage shouldBe myFile + " was readable"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not readable"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was readable"
+        nmr.failureMessage shouldBe s"$myFile was not readable"
+        nmr.negatedFailureMessage shouldBe s"$myFile was readable"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not readable"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was readable"
         nmr.rawFailureMessage shouldBe "{0} was not readable"
         nmr.rawNegatedFailureMessage shouldBe "{0} was readable"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not readable"
@@ -1560,10 +1560,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was writable"
-        mr.negatedFailureMessage shouldBe myFile + " was not writable"
-        mr.midSentenceFailureMessage shouldBe myFile + " was writable"
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not writable"
+        mr.failureMessage shouldBe s"$myFile was writable"
+        mr.negatedFailureMessage shouldBe s"$myFile was not writable"
+        mr.midSentenceFailureMessage shouldBe s"$myFile was writable"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not writable"
         mr.rawFailureMessage shouldBe "{0} was writable"
         mr.rawNegatedFailureMessage shouldBe "{0} was not writable"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was writable"
@@ -1579,10 +1579,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not writable"
-        nmr.negatedFailureMessage shouldBe myFile + " was writable"
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not writable"
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was writable"
+        nmr.failureMessage shouldBe s"$myFile was not writable"
+        nmr.negatedFailureMessage shouldBe s"$myFile was writable"
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not writable"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was writable"
         nmr.rawFailureMessage shouldBe "{0} was not writable"
         nmr.rawNegatedFailureMessage shouldBe "{0} was writable"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not writable"
@@ -1610,10 +1610,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe leftList + " was empty"
-        mr.negatedFailureMessage shouldBe leftList + " was not empty"
-        mr.midSentenceFailureMessage shouldBe leftList + " was empty"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " was not empty"
+        mr.failureMessage shouldBe s"$leftList was empty"
+        mr.negatedFailureMessage shouldBe s"$leftList was not empty"
+        mr.midSentenceFailureMessage shouldBe s"$leftList was empty"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList was not empty"
         mr.rawFailureMessage shouldBe "{0} was empty"
         mr.rawNegatedFailureMessage shouldBe "{0} was not empty"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was empty"
@@ -1629,10 +1629,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe leftList + " was not empty"
-        nmr.negatedFailureMessage shouldBe leftList + " was empty"
-        nmr.midSentenceFailureMessage shouldBe leftList + " was not empty"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " was empty"
+        nmr.failureMessage shouldBe s"$leftList was not empty"
+        nmr.negatedFailureMessage shouldBe s"$leftList was empty"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList was not empty"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList was empty"
         nmr.rawFailureMessage shouldBe "{0} was not empty"
         nmr.rawNegatedFailureMessage shouldBe "{0} was empty"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not empty"
@@ -1660,10 +1660,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe leftOption + " was defined"
-        mr.negatedFailureMessage shouldBe leftOption + " was not defined"
-        mr.midSentenceFailureMessage shouldBe leftOption + " was defined"
-        mr.midSentenceNegatedFailureMessage shouldBe leftOption + " was not defined"
+        mr.failureMessage shouldBe s"$leftOption was defined"
+        mr.negatedFailureMessage shouldBe s"$leftOption was not defined"
+        mr.midSentenceFailureMessage shouldBe s"$leftOption was defined"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftOption was not defined"
         mr.rawFailureMessage shouldBe "{0} was defined"
         mr.rawNegatedFailureMessage shouldBe "{0} was not defined"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was defined"
@@ -1679,10 +1679,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe leftOption + " was not defined"
-        nmr.negatedFailureMessage shouldBe leftOption + " was defined"
-        nmr.midSentenceFailureMessage shouldBe leftOption + " was not defined"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftOption + " was defined"
+        nmr.failureMessage shouldBe s"$leftOption was not defined"
+        nmr.negatedFailureMessage shouldBe s"$leftOption was defined"
+        nmr.midSentenceFailureMessage shouldBe s"$leftOption was not defined"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftOption was defined"
         nmr.rawFailureMessage shouldBe "{0} was not defined"
         nmr.rawNegatedFailureMessage shouldBe "{0} was defined"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not defined"
@@ -1718,10 +1718,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.negatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         mr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1737,10 +1737,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.negatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
+        nmr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
         nmr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1776,10 +1776,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.negatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        mr.midSentenceNegatedFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         mr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1795,10 +1795,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.negatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
-        nmr.midSentenceFailureMessage shouldBe myFile + " was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe myFile + " was an instance of " + clazz.getName
+        nmr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
         nmr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -2261,10 +2261,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} contained at least one of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain at least one of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained at least one of ({1})"
@@ -2280,10 +2280,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain at least one of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained at least one of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain at least one of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained at least one of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} did not contain at least one of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained at least one of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain at least one of ({1})"
@@ -2362,10 +2362,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained the same elements as " + rhs
-        mr.negatedFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        mr.midSentenceFailureMessage shouldBe lhs + " contained the same elements as " + rhs
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
+        mr.failureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
         mr.rawFailureMessage shouldBe "{0} contained the same elements as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain the same elements as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained the same elements as {1}"
@@ -2381,10 +2381,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        nmr.negatedFailureMessage shouldBe lhs + " contained the same elements as " + rhs
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain the same elements as " + rhs
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained the same elements as " + rhs
+        nmr.failureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        nmr.negatedFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain the same elements as " + rhs
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained the same elements as " + rhs
         nmr.rawFailureMessage shouldBe "{0} did not contain the same elements as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained the same elements as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain the same elements as {1}"
@@ -2413,10 +2413,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        mr.negatedFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        mr.midSentenceFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
+        mr.failureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
         mr.rawFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
@@ -2432,10 +2432,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        nmr.negatedFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain the same elements in the same (iterated) order as " + rhs
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained the same elements in the same (iterated) order as " + rhs
+        nmr.failureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        nmr.negatedFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain the same elements in the same (iterated) order as " + rhs
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained the same elements in the same (iterated) order as " + rhs
         nmr.rawFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained the same elements in the same (iterated) order as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain the same elements in the same (iterated) order as {1}"
@@ -2463,10 +2463,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained only (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain only (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained only (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain only (1, 2)"
+        mr.failureMessage shouldBe s"$lhs contained only (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained only (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
         mr.rawFailureMessage shouldBe "{0} contained only ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain only ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained only ({1})"
@@ -2482,10 +2482,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain only (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " contained only (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain only (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained only (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained only (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain only (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained only (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} did not contain only ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained only ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain only ({1})"
@@ -2513,10 +2513,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained only (1, 2) in order"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained only (1, 2) in order"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
+        mr.failureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
         mr.rawFailureMessage shouldBe "{0} contained only ({1}) in order"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain only ({1}) in order"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained only ({1}) in order"
@@ -2532,10 +2532,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        nmr.negatedFailureMessage shouldBe lhs + " contained only (1, 2) in order"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain only (1, 2) in order"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained only (1, 2) in order"
+        nmr.failureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain only (1, 2) in order"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained only (1, 2) in order"
         nmr.rawFailureMessage shouldBe "{0} did not contain only ({1}) in order"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained only ({1}) in order"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain only ({1}) in order"
@@ -2563,10 +2563,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained all of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained all of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs contained all of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained all of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} contained all of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain all of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained all of ({1})"
@@ -2582,10 +2582,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " contained all of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain all of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained all of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained all of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain all of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained all of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} did not contain all of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained all of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain all of ({1})"
@@ -2613,10 +2613,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
+        mr.failureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
         mr.rawFailureMessage shouldBe "{0} contained all of ({1}) in order"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained all of ({1}) in order"
@@ -2632,10 +2632,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        nmr.negatedFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain all of (1, 2) in order"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained all of (1, 2) in order"
+        nmr.failureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain all of (1, 2) in order"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained all of (1, 2) in order"
         nmr.rawFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained all of ({1}) in order"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain all of ({1}) in order"
@@ -2663,10 +2663,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        mr.negatedFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        mr.midSentenceFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        mr.midSentenceNegatedFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
+        mr.failureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        mr.negatedFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        mr.midSentenceFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
         mr.rawFailureMessage shouldBe "{0} contained at most one of ({1})"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain at most one of ({1})"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained at most one of ({1})"
@@ -2682,10 +2682,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        nmr.negatedFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
-        nmr.midSentenceFailureMessage shouldBe lhs + " did not contain at most one of (1, 2)"
-        nmr.midSentenceNegatedFailureMessage shouldBe lhs + " contained at most one of (1, 2)"
+        nmr.failureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        nmr.negatedFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
+        nmr.midSentenceFailureMessage shouldBe s"$lhs did not contain at most one of (1, 2)"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$lhs contained at most one of (1, 2)"
         nmr.rawFailureMessage shouldBe "{0} did not contain at most one of ({1})"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained at most one of ({1})"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain at most one of ({1})"
@@ -2817,17 +2817,17 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        mr.negatedFailureMessage shouldBe leftList + " did not contain a file"
-        mr.midSentenceFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " did not contain a file"
+        mr.failureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        mr.negatedFailureMessage shouldBe s"$leftList did not contain a file"
+        mr.midSentenceFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain a file"
         mr.rawFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain a {1}"
-        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -2836,18 +2836,18 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe leftList + " did not contain a file"
-        nmr.negatedFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
-        nmr.midSentenceFailureMessage shouldBe leftList + " did not contain a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " contained a file: " + myFile + " was a file"
+        nmr.failureMessage shouldBe s"$leftList did not contain a file"
+        nmr.negatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList did not contain a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
         nmr.rawFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
         nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was a file"))
+        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
 
       }
     }
@@ -2873,17 +2873,17 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        mr.negatedFailureMessage shouldBe leftList + " did not contain an file"
-        mr.midSentenceFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe leftList + " did not contain an file"
+        mr.failureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        mr.negatedFailureMessage shouldBe s"$leftList did not contain an file"
+        mr.midSentenceFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain an file"
         mr.rawFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain an {1}"
-        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -2892,18 +2892,18 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe leftList + " did not contain an file"
-        nmr.negatedFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
-        nmr.midSentenceFailureMessage shouldBe leftList + " did not contain an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe leftList + " contained an file: " + myFile + " was an file"
+        nmr.failureMessage shouldBe s"$leftList did not contain an file"
+        nmr.negatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftList did not contain an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
         nmr.rawFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
         nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(myFile + " was an file"))
+        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
 
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplicationSpec.scala
@@ -31,7 +31,7 @@ class ResultOfAWordToSymbolApplicationSpec extends AnyFunSpec {
     )
     
     it("should have pretty toString") {
-      val result = new ResultOfAWordToSymbolApplication('file)
+      val result = new ResultOfAWordToSymbolApplication(Symbol("file"))
       result.toString should be ("a ('file)")
     }
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplicationSpec.scala
@@ -31,7 +31,7 @@ class ResultOfAnWordToSymbolApplicationSpec extends AnyFunSpec {
     )
     
     it("should have pretty toString") {
-      val result = new ResultOfAnWordToSymbolApplication('file)
+      val result = new ResultOfAnWordToSymbolApplication(Symbol("file"))
       result.toString should be ("an ('file)")
     }
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/path/FunSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/path/FunSpecSpec.scala
@@ -396,7 +396,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec with GivenWhenThen {
     case class TestWasCalledCounts(var theTestThisCalled: Boolean, var theTestThatCalled: Boolean)
     
     class TestWasCalledSuite(val counts: TestWasCalledCounts) extends PathAnyFunSpec {
-      def this() { this(TestWasCalledCounts(false, false)) }
+      def this() = { this(TestWasCalledCounts(false, false)) }
       it("should run this") { counts.theTestThisCalled = true }
       it("should run that, maybe") { counts.theTestThatCalled = true }
       override def newInstance = new TestWasCalledSuite(counts)
@@ -493,7 +493,7 @@ class FunSpecSpec extends scalatest.freespec.AnyFreeSpec with GivenWhenThen {
       // If I provide a specific testName to run, then it should ignore an Ignore on that test
       // method and actually invoke it.
       class EFunSpec(val counts: TestWasCalledCounts) extends PathAnyFunSpec {
-        def this() { this(TestWasCalledCounts(false, false)) }
+        def this() = { this(TestWasCalledCounts(false, false)) }
         ignore("test this") { counts.theTestThisCalled = true }
         it("test that") { counts.theTestThatCalled = true }
         override def newInstance = new EFunSpec(counts)


### PR DESCRIPTION
This commit lets scalatest compile with the Scala 2.13 flag
`-Xsource:3` (but does not enable the flag in the build), this came up
in https://github.com/scala/scala-dev/issues/769.
The changes needed were:
- Add missing parens when overriding `Iterator#next()`
- Remove usages of symbol literal syntax
- Remove usages of procedure syntax
- Fix code that relied on any2stringadd