### PR TITLE
Scala 3: TypeCheck Support in Assertions and Expectations

### DIFF
--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -27,7 +27,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestPendingException
 import org.scalactic.anyvals.NonEmptyArray
 import scala.quoted._
-import scala.compiletime.testing.typeChecks
+import scala.compiletime.testing.{typeChecks, typeCheckErrors}
 import org.scalatest.compatible.Assertion
 import ArrayHelper.deep
 
@@ -663,7 +663,7 @@ trait Assertions extends TripleEquals  {
    * @param code the snippet of code that should not type check
    */
   transparent inline def assertTypeError(inline code: String): Assertion = {
-    ${ CompileMacro.assertTypeErrorImpl('code, '{typeChecks(code)}) }
+    ${ CompileMacro.assertTypeErrorImpl('code, '{typeCheckErrors(code)}) }
   }
 
   /**

--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -718,7 +718,7 @@ trait Assertions extends TripleEquals  {
    * @param code the snippet of code that should compile
    */
   transparent inline def assertCompiles(inline code: String): Assertion =
-    ${ CompileMacro.assertCompilesImpl('code, '{typeChecks(code)}) }
+    ${ CompileMacro.assertCompilesImpl('code, '{typeCheckErrors(code)}) }
 
   /**
    * Intercept and return an exception that's expected to

--- a/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
@@ -83,7 +83,7 @@ object CompileMacro {
     }
   }
 
-  def expectTypeErrorImpl(self: Expr[_], typeChecked: Expr[List[Error]], prettifier: Expr[Prettifier], pos: Expr[source.Position])(using Quotes): Expr[Fact] = {
+  def expectTypeErrorImpl(self: Expr[_], typeChecked: Expr[List[Error]], prettifier: Expr[Prettifier])(using Quotes): Expr[Fact] = {
     
     import quotes.reflect._
     

--- a/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
@@ -167,7 +167,7 @@ object CompileMacro {
   }
 
   // parse and type check a code snippet, generate code to return Fact (Yes or No).
-  def expectDoesNotCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], prettifier: Expr[Prettifier], pos: Expr[source.Position])(using Quotes): Expr[Fact] = {
+  def expectDoesNotCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], prettifier: Expr[Prettifier])(using Quotes): Expr[Fact] = {
     if (typeChecked.valueOrError)
       '{
           val messageExpr = Resources.expectedCompileErrorButGotNone($code)
@@ -244,7 +244,7 @@ object CompileMacro {
     }
   }
 
-  def expectCompilesImpl(self: Expr[_], typeChecked: Expr[List[Error]], prettifier: Expr[Prettifier], pos: Expr[source.Position])(using Quotes): Expr[Fact] = {
+  def expectCompilesImpl(self: Expr[_], typeChecked: Expr[List[Error]], prettifier: Expr[Prettifier])(using Quotes): Expr[Fact] = {
     
     import quotes.reflect._
 

--- a/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
@@ -107,8 +107,7 @@ object CompileMacro {
             Vector.empty,
             Vector.empty,
             Vector.empty
-          )($prettifier)
-          //Succeeded 
+          )($prettifier) 
         }
         case Error(msg, _, _, ErrorKind.Parser) :: _ => '{
           val messageExpr = Resources.expectedTypeErrorButGotParseError(${ Expr(msg) }, ${ Expr(code) })
@@ -122,7 +121,6 @@ object CompileMacro {
             Vector.empty,
             Vector.empty
           )($prettifier)
-          //throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, org.scalactic.source.Position(${Expr(fileName)}, ${Expr(filePath)}, ${Expr(lineNo)}))
         }
         case Nil => '{
           val messageExpr = Resources.expectedTypeErrorButGotNone(${ Expr(code) })
@@ -136,7 +134,6 @@ object CompileMacro {
             Vector.empty,
             Vector.empty
           )($prettifier)
-          //throw new TestFailedException((_: StackDepthException) => Some(messageExpr), None, org.scalactic.source.Position(${Expr(fileName)}, ${Expr(filePath)}, ${Expr(lineNo)}))
         }
       }
     }
@@ -152,36 +149,6 @@ object CompileMacro {
       case _ =>
         report.throwError("The 'assertTypeError' function only works with String literals.")
     }
-    
-    /*if (typeChecked.valueOrError)
-      '{
-          val messageExpr = Resources.expectedTypeErrorButGotNone($code)
-          Fact.No(
-            messageExpr,
-            messageExpr,
-            messageExpr,
-            messageExpr,
-            Vector.empty,
-            Vector.empty,
-            Vector.empty,
-            Vector.empty
-          )($prettifier)
-       }
-    else
-      '{
-          val messageExpr = Resources.gotTypeErrorAsExpected($code)
-
-          Fact.Yes(
-            messageExpr,
-            messageExpr,
-            messageExpr,
-            messageExpr,
-            Vector.empty,
-            Vector.empty,
-            Vector.empty,
-            Vector.empty
-          )($prettifier)
-       }*/
   }
 
   // parse and type check a code snippet, generate code to throw TestFailedException when both parse and type check succeeded

--- a/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -21,7 +21,7 @@ import Fact._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.reflect.ClassTag
-import scala.compiletime.testing.typeChecks
+import scala.compiletime.testing.{typeChecks, typeCheckErrors}
 
 private[scalatest] trait Expectations {
 
@@ -118,7 +118,7 @@ private[scalatest] trait Expectations {
     ${ CompileMacro.expectCompilesImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
 
   transparent inline def expectTypeError(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ CompileMacro.expectTypeErrorImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
+    ${ CompileMacro.expectTypeErrorImpl('code, '{typeCheckErrors(code)}, 'prettifier, 'pos) }
 
   import scala.language.implicitConversions
 

--- a/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -117,8 +117,8 @@ private[scalatest] trait Expectations {
   transparent inline def expectCompiles(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
     ${ CompileMacro.expectCompilesImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
 
-  transparent inline def expectTypeError(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ CompileMacro.expectTypeErrorImpl('code, '{typeCheckErrors(code)}, 'prettifier, 'pos) }
+  transparent inline def expectTypeError(inline code: String)(implicit prettifier: Prettifier): Fact =
+    ${ CompileMacro.expectTypeErrorImpl('code, '{typeCheckErrors(code)}, 'prettifier) }
 
   import scala.language.implicitConversions
 

--- a/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -115,7 +115,7 @@ private[scalatest] trait Expectations {
     ${ CompileMacro.expectDoesNotCompileImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
 
   transparent inline def expectCompiles(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ CompileMacro.expectCompilesImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
+    ${ CompileMacro.expectCompilesImpl('code, '{typeCheckErrors(code)}, 'prettifier, 'pos) }
 
   transparent inline def expectTypeError(inline code: String)(implicit prettifier: Prettifier): Fact =
     ${ CompileMacro.expectTypeErrorImpl('code, '{typeCheckErrors(code)}, 'prettifier) }

--- a/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/dotty/core/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -26,7 +26,7 @@ import scala.compiletime.testing.{typeChecks, typeCheckErrors}
 private[scalatest] trait Expectations {
 
   // TODO: Need to make this and assertResult use custom equality I think.
-  def expectResult(expected: Any)(actual: Any)(implicit prettifier: Prettifier, pos: source.Position): Fact = {
+  def expectResult(expected: Any)(actual: Any)(implicit prettifier: Prettifier): Fact = {
     if (!DefaultEquality.areEqualComparingArraysStructurally(actual, expected)) {
       val (act, exp) = Suite.getObjectsForFailureMessage(actual, expected)
       val rawFactMessage = Resources.rawExpectedButGot
@@ -108,14 +108,14 @@ private[scalatest] trait Expectations {
     }
   }
 
-  inline def expect(expression: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ ExpectationsMacro.expect('{expression})('{prettifier}, '{pos}) }
+  inline def expect(expression: Boolean)(implicit prettifier: Prettifier): Fact =
+    ${ ExpectationsMacro.expect('{expression})('{prettifier}) }
 
-  transparent inline def expectDoesNotCompile(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ CompileMacro.expectDoesNotCompileImpl('code, '{typeChecks(code)}, 'prettifier, 'pos) }
+  transparent inline def expectDoesNotCompile(inline code: String)(implicit prettifier: Prettifier): Fact =
+    ${ CompileMacro.expectDoesNotCompileImpl('code, '{typeChecks(code)}, 'prettifier) }
 
-  transparent inline def expectCompiles(inline code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ CompileMacro.expectCompilesImpl('code, '{typeCheckErrors(code)}, 'prettifier, 'pos) }
+  transparent inline def expectCompiles(inline code: String)(implicit prettifier: Prettifier): Fact =
+    ${ CompileMacro.expectCompilesImpl('code, '{typeCheckErrors(code)}, 'prettifier) }
 
   transparent inline def expectTypeError(inline code: String)(implicit prettifier: Prettifier): Fact =
     ${ CompileMacro.expectTypeErrorImpl('code, '{typeCheckErrors(code)}, 'prettifier) }
@@ -125,8 +125,8 @@ private[scalatest] trait Expectations {
   /**
     * Implicit conversion that makes (x &gt; 0) implies expect(x &gt; -1) syntax works
     */
-  implicit inline def booleanToFact(expression: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Fact =
-    ${ ExpectationsMacro.expect('expression)('prettifier, 'pos) }
+  implicit inline def booleanToFact(expression: Boolean)(implicit prettifier: Prettifier): Fact =
+    ${ ExpectationsMacro.expect('expression)('prettifier) }
 
   implicit def convertExpectationToAssertion(exp: Expectation): Assertion = exp.toAssertion
 }
@@ -135,7 +135,7 @@ object Expectations extends Expectations {
 
   class ExpectationsHelper {
 
-    def macroExpect(bool: Bool, clue: Any, prettifier: Prettifier, pos: source.Position): Fact = {
+    def macroExpect(bool: Bool, clue: Any, prettifier: Prettifier): Fact = {
       //requireNonNull(clue)
       if (!bool.value)
         No(

--- a/dotty/core/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
@@ -24,8 +24,8 @@ import org.scalatest.Fact
  */
 object ExpectationsMacro {
 
-  def expect(condition: Expr[Boolean])(prettifier: Expr[Prettifier], pos: Expr[source.Position])(using Quotes): Expr[Fact] = {
+  def expect(condition: Expr[Boolean])(prettifier: Expr[Prettifier])(using Quotes): Expr[Fact] = {
     val bool = BooleanMacro.parse(condition, prettifier)
-    '{ Expectations.expectationsHelper.macroExpect($bool, "", $prettifier, $pos) }
+    '{ Expectations.expectationsHelper.macroExpect($bool, "", $prettifier) }
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -6383,8 +6383,6 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
 
-      // SKIP-DOTTY-START
-      // different error message
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           assertCompiles("println(\"test)")
@@ -6395,7 +6393,6 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
 
       it("should do nothing when the code compiles with implicit view in scope") {
         import scala.collection.JavaConverters._
@@ -6434,8 +6431,6 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
       
-      // SKIP-DOTTY-START
-      // different error message
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           assertCompiles(
@@ -6450,8 +6445,7 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
-      // SKIP-DOTTY-END
-
+      
       it("should do nothing when the code compiles with implicit view in scope") {
         import scala.collection.JavaConverters._
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -6148,8 +6148,6 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
 
-      // SKIP-DOTTY-START
-      // no parse error support in Dotty
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           assertTypeError("println(\"test)")
@@ -6160,8 +6158,7 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
-
+      
       it("should do nothing when used with 'val i: Int = null'") {
         assertTypeError("val i: Int = null")
       }
@@ -6206,8 +6203,6 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 8)))
       }
       
-      // SKIP-DOTTY-START
-      // no parse error support in Dotty
       it("should throw TestFailedException with correct message and stack depth when parse failed ") {
         val e = intercept[TestFailedException] {
           assertTypeError(
@@ -6222,8 +6217,7 @@ class AssertionsSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
-      // SKIP-DOTTY-END
-
+      
       it("should do nothing when used with 'val i: Int = null'") {
         assertTypeError(
           """

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
@@ -6146,8 +6146,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
 
-      // SKIP-DOTTY-START
-      // no parse error support in Dotty
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertTypeError("println(\"test)")
@@ -6158,7 +6156,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -6171,8 +6168,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         )
       }
 
-      // SKIP-DOTTY-START
-      // different line number
       it("should throw TestFailedException with correct message and stack depth when type check passed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertTypeError(
@@ -6185,10 +6180,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 8)))
       }
-      // SKIP-DOTTY-END
-
-      // SKIP-DOTTY-START
-      // no parse error support in Dotty
+      
       it("should throw TestFailedException with correct message and stack depth when parse failed ") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertTypeError(
@@ -6203,7 +6195,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
-      // SKIP-DOTTY-END
     }
     it("should result in type Assertion and, on success, return the Succeeded value") {
       org.scalatest.Assertions.assert(assertTypeError("val x: String = 1") eq Succeeded)
@@ -6251,8 +6242,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         )
       }
 
-      // SKIP-DOTTY-START
-      // different line number
       it("should throw TestFailedException with correct message and stack depth when parse and type check passed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertDoesNotCompile(
@@ -6265,8 +6254,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 8)))
       }
-      // SKIP-DOTTY-END
-
+      
       it("should do nothing when parse failed ") {
         org.scalatest.Assertions.assertDoesNotCompile(
           """
@@ -6311,8 +6299,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
 
-      // SKIP-DOTTY-START
-      // different error message
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertCompiles("println(\"test)")
@@ -6323,7 +6309,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -6336,8 +6321,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         )
       }
 
-      // SKIP-DOTTY-START
-      // different line number
       it("should throw TestFailedException with correct message and stack depth when type check failed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertCompiles(
@@ -6352,10 +6335,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
-      // SKIP-DOTTY-END
 
-      // SKIP-DOTTY-START
-      // different error message
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         val e = intercept[TestFailedException] {
           org.scalatest.Assertions.assertCompiles(
@@ -6370,7 +6350,6 @@ class DirectAssertionsSpec extends AnyFunSpec {
         org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
         org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 10)))
       }
-      // SKIP-DOTTY-END
     }
     it("should result in type Assertion and, on success, return the Succeeded value") {
       org.scalatest.Assertions.assert(org.scalatest.Assertions.assertCompiles("val x: Int = 1") eq Succeeded)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/DirectExpectationsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/DirectExpectationsSpec.scala
@@ -491,15 +491,25 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when type check failed") {
         val fact = org.scalatest.expectations.Expectations.expectCompiles("val a: String = 2")
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
-        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
-          """type mismatch;
-            | found   : Int(2)
-            | required: String""".stripMargin, "val a: String = 2"))
+        if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """Found:    (2 : Int)
+              |Required: String
+              |
+              |The following import might fix the problem:
+              |
+              |  import org.scalactic.Prettifier.default
+              |
+              |""".stripMargin, "val a: String = 2"))
+        else
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """type mismatch;
+              | found   : Int(2)
+              | required: String""".stripMargin, "val a: String = 2"))
         assert(!fact.isVacuousYes)
       }
 
@@ -507,12 +517,13 @@ class DirectExpectationsSpec extends AnyFunSpec {
         val fact = org.scalatest.expectations.Expectations.expectCompiles("println(\"test)")
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but eof found.", "println(\"test)"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("expression expected but erroneous token found", "println(\"test)"))
         else
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("unclosed string literal", "println(\"test)"))
 
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -534,7 +545,6 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when type check failed") {
         val fact =
           org.scalatest.expectations.Expectations.expectCompiles(
@@ -544,13 +554,27 @@ class DirectExpectationsSpec extends AnyFunSpec {
           )
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
-        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
-          """type mismatch;
-            | found   : Int(2)
-            | required: String""".stripMargin,
-          """
-            |val a: String = 2
-            |""".stripMargin))
+        if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """Found:    (2 : Int)
+              |Required: String
+              |
+              |The following import might fix the problem:
+              |
+              |  import org.scalactic.Prettifier.default
+              |
+              |""".stripMargin, 
+            """
+              |val a: String = 2
+              |""".stripMargin))
+        else
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """type mismatch;
+              | found   : Int(2)
+              | required: String""".stripMargin,
+            """
+              |val a: String = 2
+              |""".stripMargin))
         assert(!fact.isVacuousYes)
       }
 
@@ -565,6 +589,13 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but '}' found.", "\nprintln(\"test)\n"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotParseError(
+            "')' expected, but eof found",
+            """
+              |println("test)
+              |""".stripMargin
+          ))
         else
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError(
             "unclosed string literal",
@@ -574,7 +605,6 @@ class DirectExpectationsSpec extends AnyFunSpec {
           ))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
     }
   }
 
@@ -598,18 +628,18 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when parse failed") {
         val fact = org.scalatest.expectations.Expectations.expectTypeError("println(\"test)")
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but eof found.", "println(\"test)"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("expression expected but erroneous token found", "println(\"test)"))
         else
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("unclosed string literal", "println(\"test)"))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
     }
 
     describe("when used with triple quotes string literal with stripMargin") {
@@ -648,7 +678,6 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when parse failed ") {
         val fact =
           org.scalatest.expectations.Expectations.expectTypeError(
@@ -661,6 +690,13 @@ class DirectExpectationsSpec extends AnyFunSpec {
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but '}' found.", "\nprintln(\"test)\n"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError(
+            "')' expected, but eof found",
+            """
+              |println("test)
+              |""".stripMargin
+          ))
         else
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError(
             "unclosed string literal",
@@ -670,7 +706,6 @@ class DirectExpectationsSpec extends AnyFunSpec {
           ))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
     }
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
@@ -527,15 +527,26 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
+      
       it("should return No with correct fact message when type check failed") {
         val fact = expectCompiles("val a: String = 2")
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
-        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
-          """type mismatch;
-            | found   : Int(2)
-            | required: String""".stripMargin, "val a: String = 2"))
+        if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """Found:    (2 : Int)
+              |Required: String
+              |
+              |The following import might fix the problem:
+              |
+              |  import org.scalactic.Prettifier.default
+              |
+              |""".stripMargin, "val a: String = 2"))
+        else    
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """type mismatch;
+              | found   : Int(2)
+              | required: String""".stripMargin, "val a: String = 2"))
         assert(!fact.isVacuousYes)
       }
 
@@ -543,13 +554,14 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         val fact = expectCompiles("println(\"test)")
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but eof found.", "println(\"test)"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("expression expected but erroneous token found", "println(\"test)"))
         else
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("unclosed string literal", "println(\"test)"))
 
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
-
+      
       it("should return Yes with correct fact message when the code compiles with implicit view in scope") {
         import scala.collection.JavaConverters._
 
@@ -585,7 +597,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when type check failed") {
         val fact =
           expectCompiles(
@@ -595,13 +606,27 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
           )
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
-        assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
-          """type mismatch;
-            | found   : Int(2)
-            | required: String""".stripMargin,
-          """
-            |val a: String = 2
-            |""".stripMargin))
+        if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """Found:    (2 : Int)
+              |Required: String
+              |
+              |The following import might fix the problem:
+              |
+              |  import org.scalactic.Prettifier.default
+              |
+              |""".stripMargin, 
+            """
+              |val a: String = 2
+              |""".stripMargin))
+        else
+          assert(fact.factMessage == Resources.expectedNoErrorButGotTypeError(
+            """type mismatch;
+              | found   : Int(2)
+              | required: String""".stripMargin,
+            """
+              |val a: String = 2
+              |""".stripMargin))
         assert(!fact.isVacuousYes)
       }
 
@@ -616,6 +641,13 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but '}' found.", "\nprintln(\"test)\n"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedNoErrorButGotParseError(
+            "')' expected, but eof found",
+            """
+              |println("test)
+              |""".stripMargin
+          ))
         else
           assert(fact.factMessage == Resources.expectedNoErrorButGotParseError(
             "unclosed string literal",
@@ -625,7 +657,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
           ))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
 
       it("should return Yes with correct fact message when the code compiles with implicit view in scope") {
         import scala.collection.JavaConverters._

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
@@ -326,7 +326,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
     }
   }
 
-  // SKIP-DOTTY-START
   describe("The expectThrows method") {
     it("should catch subtypes") {
       class MyException extends RuntimeException
@@ -371,7 +370,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
       }
     }
   }
-  // SKIP-DOTTY-END
 
   describe("The expect method") {
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
@@ -669,19 +669,19 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when parse failed ") {
         val fact = expectTypeError("println(\"test)")
         assert(fact.isInstanceOf[Fact.Leaf])
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but eof found.", "println(\"test)"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("expression expected but erroneous token found", "println(\"test)"))
         else
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("unclosed string literal", "println(\"test)"))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
-
+      
       it("should return Yes with correct fact message when used with 'val i: Int = null'") {
         val fact = expectTypeError("val i: Int = null")
         assert(fact.isInstanceOf[Fact.Leaf])
@@ -743,7 +743,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(!fact.isVacuousYes)
       }
 
-      // SKIP-DOTTY-START
       it("should return No with correct fact message when parse failed ") {
         val fact =
           expectTypeError(
@@ -756,6 +755,13 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
         assert(fact.isNo)
         if (ScalaTestVersions.BuiltForScalaVersion == "2.10")
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError("reflective compilation has failed: \n\nunclosed string literal\n')' expected but '}' found.", "\nprintln(\"test)\n"))
+        else if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3."))
+          assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError(
+            "')' expected, but eof found",
+            """
+              |println("test)
+              |""".stripMargin
+          ))
         else
           assert(fact.factMessage == Resources.expectedTypeErrorButGotParseError(
             "unclosed string literal",
@@ -765,7 +771,6 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
           ))
         assert(!fact.isVacuousYes)
       }
-      // SKIP-DOTTY-END
 
       it("should return Yes with correct fact message when used with 'val i: Int = null'") {
         val fact =


### PR DESCRIPTION
Ported changes from https://github.com/scalatest/scalatest/pull/2008 to Assertions and Expectations.