### PR TITLE
Release 3.2.9

### DIFF
--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -346,6 +346,27 @@ object Diagrams extends Diagrams {
       lines.mkString(Prettifier.lineSeparator)
     }
 
+    private[this] def filterAndSortByAnchorOld(anchorValues: List[org.scalatest.AnchorValue]): Traversable[org.scalatest.AnchorValue] = {
+      var map = TreeMap[Int, org.scalatest.AnchorValue]()(Ordering.by(-_))
+      // values stemming from compiler generated code often have the same anchor as regular values
+      // and get recorded before them; let's filter them out
+      for (value <- anchorValues) if (!map.contains(value.anchor)) map += (value.anchor -> value)
+      map.values
+    }
+
+    private[this] def renderDiagramOld(sourceText: String, anchorValues: List[org.scalatest.AnchorValue]): String = {
+      val offset = sourceText.prefixLength(_.isWhitespace)
+      val intro = new StringBuilder().append(sourceText.trim())
+      val lines = ListBuffer(new StringBuilder)
+
+      val rightToLeft = filterAndSortByAnchorOld(anchorValues)
+      for (anchorValue <- rightToLeft) placeValue(lines, anchorValue.value, anchorValue.anchor - offset)
+
+      lines.prepend(intro)
+      lines.append(new StringBuilder)
+      lines.mkString(Prettifier.lineSeparator)
+    }
+
     /**
       * Assert that the passed in <code>Bool</code> is <code>true</code>, else fail with <code>TestFailedException</code>
       * with error message that include a diagram showing expression values.
@@ -363,6 +384,17 @@ object Diagrams extends Diagrams {
       Succeeded
     }
 
+    @deprecated("This function is deprecated and will be removed in future, please use macroAssert that takes org.scalatest.diagrams.DiagrammedExpr")
+    def macroAssert(bool: org.scalatest.DiagrammedExpr[Boolean], clue: Any, sourceText: String, pos: source.Position): Assertion = {
+      requireNonNull(clue)
+      if (!bool.value) {
+        val failureMessage =
+          Some(clue.toString + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagramOld(sourceText, bool.anchorValues))
+        throw newAssertionFailedException(failureMessage, None, pos, Vector.empty)
+      }
+      Succeeded
+    }
+
     /**
       * Assume that the passed in <code>Bool</code> is <code>true</code>, else throw <code>TestCanceledException</code>
       * with error message that include a diagram showing expression values.
@@ -375,6 +407,17 @@ object Diagrams extends Diagrams {
       if (!bool.value) {
         val failureMessage =
           Some(clue.toString + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagram(sourceText, bool.anchorValues))
+        throw newTestCanceledException(failureMessage, None, pos)
+      }
+      Succeeded
+    }
+
+    @deprecated("This function is deprecated and will be removed in future, please use macroAssume that takes org.scalatest.diagrams.DiagrammedExpr")
+    def macroAssume(bool: org.scalatest.DiagrammedExpr[Boolean], clue: Any, sourceText: String, pos: source.Position): Assertion = {
+      requireNonNull(clue)
+      if (!bool.value) {
+        val failureMessage =
+          Some(clue.toString + Prettifier.lineSeparator + Prettifier.lineSeparator + renderDiagramOld(sourceText, bool.anchorValues))
         throw newTestCanceledException(failureMessage, None, pos)
       }
       Succeeded

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -20,8 +20,8 @@ trait BuildCommons {
 
   val previousReleaseVersion = "3.2.8"
 
-  val plusJUnitVersion = "3.2.8.0"
-  val plusTestNGVersion = "3.2.8.0"
+  val plusJUnitVersion = "3.2.9.0"
+  val plusTestNGVersion = "3.2.9.0"
   val flexmarkVersion = "0.36.8"
 
   def rootProject: Project

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -16,9 +16,9 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.8"
+  val releaseVersion = "3.2.9"
 
-  val previousReleaseVersion = "3.2.7"
+  val previousReleaseVersion = "3.2.8"
 
   val plusJUnitVersion = "3.2.8.0"
   val plusTestNGVersion = "3.2.8.0"

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -1,3 +1,4 @@
+import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaCurrentClassfiles, mimaBinaryIssueFilters}
@@ -233,7 +234,7 @@ trait DottyBuild { this: BuildCommons =>
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
       libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.0.0", 
-      libraryDependencies += ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13), 
+      libraryDependencies += ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).withDottyCompat(dottyVersion), 
       packageManagedSources,
       sourceGenerators in Compile += Def.task {
         GenModulesDotty.genScalaTestCoreJS((sourceManaged in Compile).value, version.value, scalaVersion.value) ++

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -15,7 +15,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.27/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.0.0-RC3")
+  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.0.0")
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     scalacOptions ++= List("-language:implicitConversions", "-noindent", "-Xprint-suspension")
@@ -232,7 +232,7 @@ trait DottyBuild { this: BuildCommons =>
       initialCommands in console := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.0.0-RC1", 
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.0.0", 
       libraryDependencies += ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13), 
       packageManagedSources,
       sourceGenerators in Compile += Def.task {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse(
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
+
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -131,7 +131,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
   def scalaXmlDependency(theScalaVersion: String): Seq[ModuleID] =
     CrossVersion.partialVersion(theScalaVersion) match {
       case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 3 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.0.0-RC1"))
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.0.0"))
       case Some((scalaEpoch, scalaMajor)) if scalaEpoch == 2 && scalaMajor >= 11 =>
         Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
       case other =>

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -164,7 +164,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
       case Some((3, _)) =>
         Seq(
-          "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.2.0-RC2"
+          "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.0.0"
         )  
 
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>


### PR DESCRIPTION
Changes made for release 3.2.9: 

- Updated to use Scala 3.0.0, and scala-xml and scala-combinator-parser 2.0.0.
- Fixed MIMA issues in Diagrams.scala
- Reverted back to use sbt 1.4.9 and sbt-dotty, as sbt 1.5 requires MIMA 0.9.1, but MIMA 0.9.1 has problem with overloaded functions in Configuration under org.scalatest.prop package.

For recording, this is the error we got when MIMA 0.9.1 is used for checking binary compatibility between 3.2.9 and 3.2.8: 

```
[error] 	at scala.Predef$.assert(Predef.scala:223)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.$anonfun$unpickleClass$8(MimaUnpickler.scala:66)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.$anonfun$unpickleClass$8$adapted(MimaUnpickler.scala:63)
[error] 	at scala.collection.immutable.HashMap$HashMap1.foreach(HashMap.scala:399)
[error] 	at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:725)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.doMethods$1(MimaUnpickler.scala:63)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.$anonfun$unpickleClass$18(MimaUnpickler.scala:91)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.$anonfun$unpickleClass$18$adapted(MimaUnpickler.scala:86)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at com.typesafe.tools.mima.core.MimaUnpickler$.unpickleClass(MimaUnpickler.scala:86)
[error] 	at com.typesafe.tools.mima.core.ClassfileParser.parsePickle(ClassfileParser.scala:147)
[error] 	at com.typesafe.tools.mima.core.ClassfileParser.parseClassAttributes(ClassfileParser.scala:64)
[error] 	at com.typesafe.tools.mima.core.ClassfileParser.com$typesafe$tools$mima$core$ClassfileParser$$parseClass(ClassfileParser.scala:19)
[error] 	at com.typesafe.tools.mima.core.ClassfileParser$.parseInPlace(ClassfileParser.scala:168)
[error] 	at com.typesafe.tools.mima.core.ConcreteClassInfo.afterLoading(ClassInfo.scala:44)
[error] 	at com.typesafe.tools.mima.core.ClassInfo.flags(ClassInfo.scala:76)
[error] 	at com.typesafe.tools.mima.core.InfoLike.isPublic(InfoLike.scala:14)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.isAccessible$1(PackageInfo.scala:81)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.$anonfun$accessibleClasses$1(PackageInfo.scala:75)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.$anonfun$accessibleClasses$1$adapted(PackageInfo.scala:75)
[error] 	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:515)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:62)
[error] 	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:53)
[error] 	at scala.collection.immutable.Set$SetBuilderImpl.$plus$plus$eq(Set.scala:381)
[error] 	at scala.collection.immutable.Set$SetBuilderImpl.$plus$plus$eq(Set.scala:329)
[error] 	at scala.collection.TraversableOnce.to(TraversableOnce.scala:366)
[error] 	at scala.collection.TraversableOnce.to$(TraversableOnce.scala:364)
[error] 	at scala.collection.AbstractIterator.to(Iterator.scala:1431)
[error] 	at scala.collection.TraversableOnce.toSet(TraversableOnce.scala:360)
[error] 	at scala.collection.TraversableOnce.toSet$(TraversableOnce.scala:360)
[error] 	at scala.collection.AbstractIterator.toSet(Iterator.scala:1431)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.loop$1(PackageInfo.scala:75)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.accessibleClasses$lzycompute(PackageInfo.scala:88)
[error] 	at com.typesafe.tools.mima.core.PackageInfo.accessibleClasses(PackageInfo.scala:73)
[error] 	at com.typesafe.tools.mima.lib.analyze.Analyzer$.analyze(Analyzer.scala:12)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.traversePackages(MiMaLib.scala:25)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.$anonfun$traversePackages$2(MiMaLib.scala:27)
[error] 	at scala.collection.immutable.Stream.flatMap(Stream.scala:493)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.traversePackages(MiMaLib.scala:25)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.$anonfun$traversePackages$2(MiMaLib.scala:27)
[error] 	at scala.collection.immutable.Stream.flatMap(Stream.scala:489)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.traversePackages(MiMaLib.scala:25)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.$anonfun$traversePackages$2(MiMaLib.scala:27)
[error] 	at scala.collection.immutable.Stream.flatMap(Stream.scala:493)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.traversePackages(MiMaLib.scala:25)
[error] 	at com.typesafe.tools.mima.lib.MiMaLib.collectProblems(MiMaLib.scala:38)
[error] 	at com.typesafe.tools.mima.plugin.SbtMima$.checkBC$1(SbtMima.scala:24)
[error] 	at com.typesafe.tools.mima.plugin.SbtMima$.runMima(SbtMima.scala:27)
[error] 	at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$binaryIssuesIterator$4(MimaPlugin.scala:87)
[error] 	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$1(MimaPlugin.scala:24)
[error] 	at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$1$adapted(MimaPlugin.scala:23)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (scalatestCore / mimaReportBinaryIssues) java.lang.AssertionError: assertion failed: method overloads mismatch; bytecode=List(def sizeRange: (I)Lorg.scalatest.prop.Configuration$SizeRange;, def sizeRange: ()Ljava.util.concurrent.atomic.AtomicReference;) pickle=Stream(SymbolInfo(VALsym, sizeRange, owner=474, isScopedPrivate=true)) for object org.scalatest.prop.Configuration
```

Using MIMA 0.7.0 does not have this error, and we didn't change Configuration.scala actually.  I'll try to report to MIMA issue tracker when I come back next week.