### PR TITLE
fix compilation error if Repeated is included in Diagrams assertion

### DIFF
--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
@@ -60,6 +60,8 @@ object DiagramsMacro {
         def handleArgs(argTps: List[TypeRepr], args: List[Term]): (List[Term], List[Term]) =
           args.zip(argTps).foldLeft(Nil -> Nil : (List[Term], List[Term])) { case ((diagrams, others), pair) =>
             pair match {
+              case (Typed(Repeated(args, _), _), AppliedType(_, _)) =>
+                (diagrams :++ args.map(parse), others)
               case (arg, ByNameType(_)) =>
                 (diagrams, others :+ arg)
               case (arg, tp) =>
@@ -187,8 +189,7 @@ object DiagramsMacro {
                 l.asExpr match {
                   case '{ $left: DiagrammedExpr[t] } =>
                     val rights = rs.map(_.asExprOf[DiagrammedExpr[_]])
-                    val res = Select.unique(l, "value").select(sel.symbol).appliedToTypes(targs.map(_.tpe))
-                                    .appliedToArgs(diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
+                    val res = Select.overloaded(Select.unique(l, "value"), op, targs.map(_.tpe), diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
                     '{ DiagrammedExpr.applyExpr[r]($left, ${Expr.ofList(rights)}, $res, $anchor) }.asTerm
                 }
               }

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
@@ -60,7 +60,7 @@ object DiagramsMacro {
         def handleArgs(argTps: List[TypeRepr], args: List[Term]): (List[Term], List[Term]) =
           args.zip(argTps).foldLeft(Nil -> Nil : (List[Term], List[Term])) { case ((diagrams, others), pair) =>
             pair match {
-              case (Typed(Repeated(args, _), _), AppliedType(_, _)) =>            
+              case (Typed(Repeated(args, _), _), AppliedType(_, _)) =>
                 (diagrams :++ args.map(parse), others)
               case (arg, ByNameType(_)) =>
                 (diagrams, others :+ arg)

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
@@ -60,7 +60,7 @@ object DiagramsMacro {
         def handleArgs(argTps: List[TypeRepr], args: List[Term]): (List[Term], List[Term]) =
           args.zip(argTps).foldLeft(Nil -> Nil : (List[Term], List[Term])) { case ((diagrams, others), pair) =>
             pair match {
-              case (Typed(Repeated(args, _), _), AppliedType(_, _)) =>
+              case (Typed(Repeated(args, _), _), AppliedType(_, _)) =>            
                 (diagrams :++ args.map(parse), others)
               case (arg, ByNameType(_)) =>
                 (diagrams, others :+ arg)
@@ -133,7 +133,7 @@ object DiagramsMacro {
                     l.asExpr match {
                       case '{ $left: DiagrammedExpr[t] } =>
                         val rights = rs.map(_.asExprOf[DiagrammedExpr[_]])
-                        val res = Select.unique(l, "value").select(sel.symbol).appliedToArgs(diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
+                        val res = Select.overloaded(Select.unique(l, "value"), op, Nil, diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
                         '{ DiagrammedExpr.applyExpr[r]($left, ${Expr.ofList(rights)}, $res, $anchor) }.asTerm
                     }
                   }
@@ -152,7 +152,7 @@ object DiagramsMacro {
                 l.asExpr match {
                   case '{ $left: DiagrammedExpr[t] } =>
                     val rights = rs.map(_.asExprOf[DiagrammedExpr[_]])
-                    val res = Select.unique(l, "value").select(sel.symbol).appliedToArgs(diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
+                    val res = Select.overloaded(Select.unique(l, "value"), op, Nil, diagrams.map(r => Select.unique(r, "value")) ++ others).asExprOf[r]
                     '{ DiagrammedExpr.applyExpr[r]($left, ${Expr.ofList(rights)}, $res, $anchor) }.asTerm
                 }
               }

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DiagramsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DiagramsSpec.scala
@@ -95,6 +95,12 @@ class DiagramsSpec extends AnyFunSpec with Matchers with Diagrams {
   def woof(f: => Unit) = "woof"
   def meow(x: Int = 0, y: Int = 3) = "meow"
 
+  def varargs(x: Int, y: String*): (Int, Seq[String]) = (x, y.toSeq)
+  class CustomList(value: List[Int]) {
+    def contains(x: Int*): Boolean = x.forall(value.contains(_))
+  }
+  val cList1 = new CustomList(List(1, 2, 3))
+ 
   describe("Diagrams") {
 
     val a = 3
@@ -582,6 +588,26 @@ class DiagramsSpec extends AnyFunSpec with Matchers with Diagrams {
         )
         e.failedCodeFileName should be (Some(fileName))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 15))
+      }
+
+      it("should do nothing when is used to check Seq(a, b) == Seq(3, 5)") {
+        assert(Seq(a, b) == Seq(3, 5))
+      }
+
+      it("should throw TestFailedException when is used to check Set(a, b) == Set(4)") {
+        val e = intercept[TestFailedException] {
+          assert(Set(a, b) == Set(4))
+        }
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
+      }
+
+      it("should do nothing when is used to check varargs(1, y, z) == 1 -> Seq(y, z)") {
+        assert(varargs(1, "y", "z") == 1 -> Seq("y", "z"))
+      }
+
+      it("should do nothing when is used to check cList1.contains(1, 2)") {
+        assert(cList1.contains(1, 2))
       }
 
       it("should do nothing when is used to check a === 3") {

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
@@ -583,6 +583,18 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
         e.failedCodeFileName should be (Some(fileName))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 15))
       }
+      
+      it("should do nothing when is used to check Seq(a, b) == Seq(3, 5)") {
+        org.scalatest.diagrams.Diagrams.assert(Seq(a, b) == Seq(3, 5))
+      }
+
+      it("should throw TestFailedException when is used to check Set(a, b) == Set(4)") {
+        val e = intercept[TestFailedException] {
+          org.scalatest.diagrams.Diagrams.assert(Set(a, b) == Set(4))
+        }
+        e.failedCodeFileName should be (Some(fileName))
+        e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
+      }
 
       it("should do nothing when is used to check a === 3") {
         org.scalatest.diagrams.Diagrams.assert(a === 3)

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
@@ -95,7 +95,11 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
   def meow(x: Int = 0, y: Int = 3) = "meow"
 
   def varargs(x: Int, y: String*): (Int, Seq[String]) = (x, y.toSeq)
-
+  class CustomList(value: List[Int]) {
+    def contains(x: Int*): Boolean = x.forall(value.contains(_))
+  }
+  val cList1 = new CustomList(List(1, 2, 3))
+ 
   describe("DiagrammedAssertions") {
 
     val a = 3
@@ -600,6 +604,10 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
 
       it("should do nothing when is used to check varargs(1, y, z) == 1 -> Seq(y, z)") {
         org.scalatest.diagrams.Diagrams.assert(varargs(1, "y", "z") == 1 -> Seq("y", "z"))
+      }
+
+      it("should do nothing when is used to check cList1.contains(1, 2)") {
+        org.scalatest.diagrams.Diagrams.assert(cList1.contains(1, 2))
       }
 
       it("should do nothing when is used to check a === 3") {

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
@@ -596,6 +596,11 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
       }
 
+      def varargs(x: Int, y: String*): (Int, Seq[String]) = (x, y.toSeq)
+      it("should do nothing when is used to check varargs(1, y, z) == 1 -> Seq(y, z)") {
+        org.scalatest.diagrams.Diagrams.assert(varargs(1, "y", "z") == 1 -> Seq("y", "z"))
+      }
+
       it("should do nothing when is used to check a === 3") {
         org.scalatest.diagrams.Diagrams.assert(a === 3)
       }

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
@@ -94,6 +94,8 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
   def woof(f: => Unit) = "woof"
   def meow(x: Int = 0, y: Int = 3) = "meow"
 
+  def varargs(x: Int, y: String*): (Int, Seq[String]) = (x, y.toSeq)
+
   describe("DiagrammedAssertions") {
 
     val a = 3
@@ -596,7 +598,6 @@ class DirectDiagrammedAssertionsSpec extends AnyFunSpec with org.scalatest.match
         e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
       }
 
-      def varargs(x: Int, y: String*): (Int, Seq[String]) = (x, y.toSeq)
       it("should do nothing when is used to check varargs(1, y, z) == 1 -> Seq(y, z)") {
         org.scalatest.diagrams.Diagrams.assert(varargs(1, "y", "z") == 1 -> Seq("y", "z"))
       }


### PR DESCRIPTION
I'd like to report a bug with the latest combination, Scala 3.0.0, ScalaTest 3.2.9 and sbt 1.5.2, and fix the bug by this PR.

# About the bug:
`Test/compile` fails  in Diagrams `assert` which takes an expression including varargs in Scala 3.0.0. It compiles in Scala 2.13.6.

```
[error] -- [E007] Type Mismatch Error: /home/taisukeoe/workspace/Sandbox/scala3-scalatest/src/test/scala/DiagramTest.scala:7:4 
[error] 7 |    assert(Seq("a", "b") == Seq("a"))
[error]   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   |    Found:    String*
[error]   |    Required: String
[error]   |
[error]   |    The following import might make progress towards fixing the problem:
[error]   |
[error]   |      import org.scalactic.Prettifier.default
[error]   |
[error]   | This location contains code that was inlined from DiagramTest.scala:9
[error] -- [E007] Type Mismatch Error: /home/taisukeoe/workspace/Sandbox/scala3-scalatest/src/test/scala/DiagramTest.scala:7:4 
[error] 7 |    assert(Seq("a", "b") == Seq("a"))
[error]   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   |    Found:    (11 : Int)
[error]   |    Required: String
[error]   |
[error]   |    The following import might make progress towards fixing the problem:
[error]   |
[error]   |      import org.scalactic.Prettifier.default
[error]   |
[error]   | This location contains code that was inlined from DiagramTest.scala:9
```

## Minimal Reproducible project

https://github.com/taisukeoe/scala3-scalatest/tree/aba74a99d00cd42b1215147f62d094a2ce628488

# About This PR

This PR fixes the above compilation error, and make Diagrams assertion works with varargs, which is represented by `Typed(Repeated(_, _), _)` term.

# Note
There is still a Diagrams assertion error message corruption in Scala 3.0.0, as follows.

```
[info]   org.scalatest.diagrams.Diagrams.assert(Seq(a, b) != Seq(3, 5))
[info]                                        | |   |  |  || |   |  |
[info]                                        | |   3  5  || |   3  5
[info]                                        | |         || scala.collection.immutable.Seq$@2c58b1c9
[info]                                        | |         |List(3, 5)
[info]                                        | |         false
[info]                                        | scala.collection.immutable.Seq$@2c58b1c9
[info]                                        List(3, 5) (DirectDiagrammedAssertionsSpec.scala:527)
```