### PR TITLE
Fixed a bunch of broken scaladoc links

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
@@ -34,7 +34,7 @@ AFTER MOVING, DROP THE .. in the link to AsyncTestSuite below
  * remaining tests, because they would not see the same flag. For this reason, this trait contains
  * a final implementation of a method defined in <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>,
  * to prevent it from being mixed into any class that also mixes in <code>OneInstancePerTest</code>, 
- * including by mixing in <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a>
+ * including by mixing in <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a>
  * or a <a href="path/package.html">path traits</a>.
  * </p>
  */

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
@@ -32,7 +32,7 @@ AFTER MOVING, DROP THE .. in the link to AsyncTestSuite below
  * it uses a private volatile instance variable as a flag to indicate whether or not a test has failed.
  * If you are running each test in its own instance, therefore, it would not cancel the
  * remaining tests, because they would not see the same flag. For this reason, this trait contains
- * a final implementation of a method defined in <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>,
+ * a final implementation of a method defined in <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>,
  * to prevent it from being mixed into any class that also mixes in <code>OneInstancePerTest</code>, 
  * including by mixing in <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a>
  * or a <a href="path/package.html">path traits</a>.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Eventually.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Eventually.scala
@@ -288,7 +288,7 @@ trait Eventually extends PatienceConfiguration {
    * The by-name parameter "succeeds" if it returns a result. It "fails" if it throws any exception that
    * would normally cause a test to fail. (These are any exceptions except <a href="TestPendingException"><code>TestPendingException</code></a> and
    * <code>Error</code>s listed in the
-   * <a href="Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
+   * <a href="../Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
    * documentation of trait <code>Suite</code>.)
    * </p>
    *
@@ -323,7 +323,7 @@ trait Eventually extends PatienceConfiguration {
    * The by-name parameter "succeeds" if it returns a result. It "fails" if it throws any exception that
    * would normally cause a test to fail. (These are any exceptions except <a href="TestPendingException"><code>TestPendingException</code></a> and
    * <code>Error</code>s listed in the
-   * <a href="Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
+   * <a href="../Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
    * documentation of trait <code>Suite</code>.)
    * </p>
    *
@@ -358,7 +358,7 @@ trait Eventually extends PatienceConfiguration {
    * The by-name parameter "succeeds" if it returns a result. It "fails" if it throws any exception that
    * would normally cause a test to fail. (These are any exceptions except <a href="TestPendingException"><code>TestPendingException</code></a> and
    * <code>Error</code>s listed in the
-   * <a href="Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
+   * <a href="../Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
    * documentation of trait <code>Suite</code>.)
    * </p>
    *
@@ -392,7 +392,7 @@ trait Eventually extends PatienceConfiguration {
    * The by-name parameter "succeeds" if it returns a result. It "fails" if it throws any exception that
    * would normally cause a test to fail. (These are any exceptions except <a href="TestPendingException"><code>TestPendingException</code></a> and
    * <code>Error</code>s listed in the
-   * <a href="Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
+   * <a href="../Suite.html#errorHandling">Treatment of <code>java.lang.Error</code>s</a> section of the
    * documentation of trait <code>Suite</code>.)
    * </p>
    *

--- a/jvm/core/src/main/scala/org/scalatest/events/Event.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Event.scala
@@ -1237,7 +1237,7 @@ final case class SuiteAborted (
  * @param ordinal an <a href="Ordinal.html"><code>Ordinal</code></a> that can be used to place this event in order in the context of
  *        other events reported during the same run
  * @param testCount the number of tests expected during this run
- * @param configMap a <a href="../ConfigMap.html"><code>ConfigMap</code></a> of key-value pairs that can be used by custom <a href="Reporter.html"><code>Reporter</code></a>s
+ * @param configMap a <a href="../ConfigMap.html"><code>ConfigMap</code></a> of key-value pairs that can be used by custom <a href="../Reporter.html"><code>Reporter</code></a>s
  * @param formatter an optional <a href="Formatter.html"><code>Formatter</code></a> that provides extra information that can be used by reporters in determining
  *        how to present this event to the user
  * @param location An optional <a href="Location.html"><code>Location</code></a> that provides information indicating where in the source code an event originated.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
@@ -584,7 +584,7 @@ import org.scalatest._
  * optionally be included and/or excluded. To tag a <code>AnyFeatureSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name, 
@@ -656,7 +656,7 @@ import org.scalatest._
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>AnyFeatureSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -912,7 +912,7 @@ import org.scalatest._
  * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
  * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
- * lifecycle methods defined in trait <a href="Suite.html"><code>Suite</code></a>.
+ * lifecycle methods defined in trait <a href="../Suite.html"><code>Suite</code></a>.
  * </p>
  *
  * <p>
@@ -1003,7 +1003,7 @@ import org.scalatest._
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
@@ -117,7 +117,7 @@ import org.scalatest._
  * Scenarios can only be registered with the <code>scenario</code> method while the <code>AnyFeatureSpec</code> is
  * in its registration phase. Any attempt to register a scenario after the <code>AnyFeatureSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AnyFeatureSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
  * of using <code>AnyFeatureSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
  * <code>TestRegistrationClosedException</code>.
@@ -130,7 +130,7 @@ import org.scalatest._
  * </p>
  *
  * <p>
- * When you run a <code>AnyFeatureSpec</code>, it will send <a href="events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
+ * When you run a <code>AnyFeatureSpec</code>, it will send <a href="../events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
  * <a href="Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
  * that the output is easy to read as an informal specification of the <em>subject</em> being tested.
  * For example, were you to run <code>TVSetSpec</code> from within the Scala interpreter:
@@ -258,7 +258,7 @@ import org.scalatest._
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -273,7 +273,7 @@ import org.scalatest._
  * <code>AnyFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -401,7 +401,7 @@ import org.scalatest._
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -428,7 +428,7 @@ import org.scalatest._
  * To support this style of testing, a test can be given a name that specifies one
  * bit of behavior required by the system being tested. The test can also include some code that
  * sends more information about the behavior to the reporter when the tests run. At the end of the test,
- * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
+ * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="../exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
  * </p>
  *
  * <p>
@@ -1406,7 +1406,7 @@ import org.scalatest._
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code> 
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  * 
  * <a name="sharedScenarios"></a><h2>Shared scenarios</h2>

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
@@ -1004,7 +1004,7 @@ import org.scalatest._
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1197,7 +1197,7 @@ import org.scalatest._
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  * 
@@ -1243,7 +1243,7 @@ import org.scalatest._
  * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
  * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
  * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
- * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+ * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
  * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
  * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
  * </p>
@@ -1333,8 +1333,8 @@ import org.scalatest._
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest._
  * </td></tr></table>
  * 
  * <p>
- * Although not required, <code>AnyFeatureSpec</code> is often used together with <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> to express acceptance requirements
+ * Although not required, <code>AnyFeatureSpec</code> is often used together with <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> to express acceptance requirements
  * in more detail. Here's an example:
  * </p>
  *
@@ -87,7 +87,7 @@ import org.scalatest._
  *
  * <p>
  * Note: for more information on the calls to <code>Given</code>, <code>When</code>, and <code>Then</code>, see the documentation 
- * for trait <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> and the <a href="#informers"><code>Informers</code> section</a> below.
+ * for trait <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> and the <a href="#informers"><code>Informers</code> section</a> below.
  * </p>
  *
  * <p>
@@ -131,7 +131,7 @@ import org.scalatest._
  *
  * <p>
  * When you run a <code>AnyFeatureSpec</code>, it will send <a href="../events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
- * <a href="Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
+ * <a href="../Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
  * that the output is easy to read as an informal specification of the <em>subject</em> being tested.
  * For example, were you to run <code>TVSetSpec</code> from within the Scala interpreter:
  * </p>
@@ -252,10 +252,10 @@ import org.scalatest._
  * One of the parameters to <code>AnyFeatureSpec</code>'s <code>run</code> method is a <code>Reporter</code>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
- * and tests that were ignored will be passed to the <a href="Reporter.html"><code>Reporter</code></a> as the suite runs.
+ * and tests that were ignored will be passed to the <a href="../Reporter.html"><code>Reporter</code></a> as the suite runs.
  * Most often the default reporting done by <code>AnyFeatureSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -270,7 +270,7 @@ import org.scalatest._
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -354,8 +354,8 @@ import org.scalatest._
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -230,12 +230,12 @@ import org.scalatest.Suite
  * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
  *
  * <p>
- * <code>AsyncFeatureSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+ * <code>AsyncFeatureSpec</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
  * execution context is used by <code>AsyncFeatureSpec</code> to 
  * transform the <code>Future[Assertion]</code>s returned by each test
- * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+ * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
@@ -358,9 +358,9 @@ import org.scalatest.Suite
  * parallelExecution in Test := true // the default in sbt
  * </pre>
  * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
- * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+ * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
  * run in parallel very much like traditional (such as <a href="AnyFeatureSpec.html"><code>AnyFeatureSpec</code></a>) tests run in
  * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -372,7 +372,7 @@ import org.scalatest.Suite
  * </p>
  * 
  * <p>
- * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+ * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
  * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
  * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -397,7 +397,7 @@ import org.scalatest.Suite
  * <p>
  * If you need to test for expected exceptions in the context of futures, you can use the
  * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
- * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+ * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
  * supertrait <code>AsyncTestSuite</code>, both of these methods are
  * available by default in an <code>AsyncFeatureSpec</code>.
  * </p>
@@ -415,7 +415,7 @@ import org.scalatest.Suite
  *
  * <p>
  * The <code>recoverToSucceededIf</code> method performs a job similar to
- * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+ * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
  * in the context of a future. It transforms a <code>Future</code> of any type into a
  * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
  * exception. Here's an example in the REPL:
@@ -482,8 +482,8 @@ import org.scalatest.Suite
  *
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
- * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+ * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>
@@ -1146,7 +1146,7 @@ import org.scalatest.Suite
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFeatureSpec</code>.
+ * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFeatureSpec</code>.
  * </p>
  *
  * <p>
@@ -1166,7 +1166,7 @@ import org.scalatest.Suite
  * <p>
  * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
  * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
- * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+ * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
  * The <code>complete</code>-<code>lastly</code> syntax will ensure that
  * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
  * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -1270,7 +1270,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1549,7 +1549,7 @@ import org.scalatest.Suite
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  *
@@ -1778,8 +1778,8 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -163,7 +163,7 @@ import org.scalatest.Suite
  * Scenarios can only be registered with the <code>scenario</code> method while the <code>AsyncFeatureSpec</code> is
  * in its registration phase. Any attempt to register a scenario after the <code>AsyncFeatureSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AsyncFeatureSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The
  * recommended style
  * of using <code>AsyncFeatureSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
@@ -177,7 +177,7 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * When you run a <code>AsyncFeatureSpec</code>, it will send <a href="events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
+ * When you run a <code>AsyncFeatureSpec</code>, it will send <a href="../events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
  * <a href="Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
  * that the output is easy to read as an informal specification of the <em>subject</em> being tested.
  * For example, were you to run <code>TVSetSpec</code> from within the Scala interpreter:
@@ -307,7 +307,7 @@ import org.scalatest.Suite
  * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
  * want to block in your tests, you may wish to just use a
  * traditional <a href="AnyFeatureSpec.html"><code>AnyFeatureSpec</code></a> with
- * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+ * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
  * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
  * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
  * shared mutable state.
@@ -350,7 +350,7 @@ import org.scalatest.Suite
  * <p>
  * If you want the tests of an <code>AsyncFeatureSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
  * 
@@ -642,7 +642,7 @@ import org.scalatest.Suite
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -657,7 +657,7 @@ import org.scalatest.Suite
  * <code>AsyncFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -786,7 +786,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1903,7 +1903,7 @@ import org.scalatest.Suite
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  *
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -897,7 +897,7 @@ import org.scalatest.Suite
  * optionally be included and/or excluded. To tag an <code>AsyncFeatureSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -969,7 +969,7 @@ import org.scalatest.Suite
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFeatureSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1269,7 +1269,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -39,7 +39,7 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * Although not required, <code>AsyncFeatureSpec</code> is often used together with <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> to express acceptance requirements
+ * Although not required, <code>AsyncFeatureSpec</code> is often used together with <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> to express acceptance requirements
  * in more detail.
  * Here's an example <code>AsyncFeatureSpec</code>:
  * </p>
@@ -111,7 +111,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note: for more information on the calls to <code>Given</code>, <code>When</code>, and <code>Then</code>, see the documentation 
- * for trait <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> and the <a href="#informers"><code>Informers</code> section</a> below.
+ * for trait <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> and the <a href="#informers"><code>Informers</code> section</a> below.
  * </p>
  *
  * <p>
@@ -178,7 +178,7 @@ import org.scalatest.Suite
  *
  * <p>
  * When you run a <code>AsyncFeatureSpec</code>, it will send <a href="../events/Formatter.html"><code>Formatter</code></a>s in the events it sends to the
- * <a href="Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
+ * <a href="../Reporter.html"><code>Reporter</code></a>. ScalaTest's built-in reporters will report these events in such a way
  * that the output is easy to read as an informal specification of the <em>subject</em> being tested.
  * For example, were you to run <code>TVSetSpec</code> from within the Scala interpreter:
  * </p>
@@ -618,7 +618,7 @@ import org.scalatest.Suite
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
  * annotation instead.
  * </p>
  *
@@ -636,7 +636,7 @@ import org.scalatest.Suite
  * One of the parameters to <code>AsyncFeatureSpec</code>'s <code>run</code> method is a <code>Reporter</code>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
- * and tests that were ignored will be passed to the <a href="Reporter.html"><code>Reporter</code></a> as the suite runs.
+ * and tests that were ignored will be passed to the <a href="../Reporter.html"><code>Reporter</code></a> as the suite runs.
  * Most often the default reporting done by <code>AsyncFeatureSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
@@ -654,7 +654,7 @@ import org.scalatest.Suite
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AsyncFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AsyncFeatureSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -739,8 +739,8 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
@@ -158,7 +158,7 @@ import org.scalatest.{Finders, Suite}
  * Tests can only be registered while the <code>AnyFlatSpec</code> is
  * in its registration phase. Any attempt to register a test after the <code>AnyFlatSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AnyFlatSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
  * of using <code>AnyFlatSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
  * <code>TestRegistrationClosedException</code>.
@@ -311,7 +311,7 @@ import org.scalatest.{Finders, Suite}
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -368,7 +368,7 @@ import org.scalatest.{Finders, Suite}
  * <code>AnyFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -492,7 +492,7 @@ import org.scalatest.{Finders, Suite}
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -519,7 +519,7 @@ import org.scalatest.{Finders, Suite}
  * To support this style of testing, a test can be given a name that specifies one
  * bit of behavior required by the system being tested. The test can also include some code that
  * sends more information about the behavior to the reporter when the tests run. At the end of the test,
- * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
+ * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="../exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
  * </p>
  *
  * <p>
@@ -1401,7 +1401,7 @@ import org.scalatest.{Finders, Suite}
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code> 
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  * 
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
@@ -618,7 +618,7 @@ import org.scalatest.{Finders, Suite}
  * optionally be included and/or excluded. To tag a <code>AnyFlatSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name, 
@@ -664,7 +664,7 @@ import org.scalatest.{Finders, Suite}
  * </p>
  *
  * <p>
- * The <code>run</code> method takes a <a href="Filter.html"><code>Filter</code></a>, whose constructor takes an optional
+ * The <code>run</code> method takes a <a href="../Filter.html"><code>Filter</code></a>, whose constructor takes an optional
  * <code>Set[String]</code> called <code>tagsToInclude</code> and a <code>Set[String]</code> called
  * <code>tagsToExclude</code>. If <code>tagsToInclude</code> is <code>None</code>, all tests will be run
  * except those those belonging to tags listed in the
@@ -677,7 +677,7 @@ import org.scalatest.{Finders, Suite}
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>AnyFlatSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -923,7 +923,7 @@ import org.scalatest.{Finders, Suite}
  * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
  * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
- * lifecycle methods defined in trait <a href="Suite.html"><code>Suite</code></a>.
+ * lifecycle methods defined in trait <a href="../Suite.html"><code>Suite</code></a>.
  * </p>
  *
  * <p>
@@ -1015,7 +1015,7 @@ import org.scalatest.{Finders, Suite}
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes [[org.scalatest.TestData <code>TestData</code>]] such as the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
@@ -1016,7 +1016,7 @@ import org.scalatest.{Finders, Suite}
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes [[org.scalatest.TestData <code>TestData</code>]] such as the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes [[org.scalatest.TestData <code>TestData</code>]] such as the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1198,7 +1198,7 @@ import org.scalatest.{Finders, Suite}
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  * 
@@ -1242,7 +1242,7 @@ import org.scalatest.{Finders, Suite}
  * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
  * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
  * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
- * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+ * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
  * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
  * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
  * </p>
@@ -1330,8 +1330,8 @@ import org.scalatest.{Finders, Suite}
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
@@ -296,19 +296,19 @@ import org.scalatest.{Finders, Suite}
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
  * </p>
  *
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AnyFlatSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AnyFlatSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AnyFlatSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -316,7 +316,7 @@ import org.scalatest.{Finders, Suite}
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>FlatSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>FlatSpec</code>
  * to pass such information to the reporter.  Here's an example:
  * </p>
  *
@@ -365,7 +365,7 @@ import org.scalatest.{Finders, Suite}
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -447,8 +447,8 @@ import org.scalatest.{Finders, Suite}
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -895,7 +895,7 @@ import org.scalatest.Suite
  * optionally be included and/or excluded. To tag an <code>AsyncFlatSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -961,7 +961,7 @@ import org.scalatest.Suite
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFlatSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1257,7 +1257,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -578,7 +578,7 @@ import org.scalatest.Suite
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
  * annotation instead.
  * </p>
  *
@@ -593,13 +593,13 @@ import org.scalatest.Suite
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AsyncFlatSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AsyncFlatSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AsyncFlatSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -607,7 +607,7 @@ import org.scalatest.Suite
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncFlatSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncFlatSpec</code>
  * to pass such information to the reporter.  Here's an example:
  * </p>
  *
@@ -657,7 +657,7 @@ import org.scalatest.Suite
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AsyncFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AsyncFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -740,8 +740,8 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -265,7 +265,7 @@ import org.scalatest.Suite
  * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
  * want to block in your tests, you may wish to just use a
  * traditional <a href="AnyFlatSpec.html"><code>AnyFlatSpec</code></a> with
- * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+ * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
  * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
  * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
  * shared mutable state.
@@ -308,7 +308,7 @@ import org.scalatest.Suite
  * <p>
  * If you want the tests of an <code>AsyncFlatSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
  * 
@@ -602,7 +602,7 @@ import org.scalatest.Suite
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -660,7 +660,7 @@ import org.scalatest.Suite
  * <code>AsyncFlatSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -785,7 +785,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1882,7 +1882,7 @@ import org.scalatest.Suite
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  *
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -188,12 +188,12 @@ import org.scalatest.Suite
  * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
  *
  * <p>
- * <code>AsyncFlatSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+ * <code>AsyncFlatSpec</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
  * execution context is used by <code>AsyncFlatSpec</code> to 
  * transform the <code>Future[Assertion]</code>s returned by each test
- * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+ * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
@@ -316,9 +316,9 @@ import org.scalatest.Suite
  * parallelExecution in Test := true // the default in sbt
  * </pre>
  * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
- * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+ * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
  * run in parallel very much like traditional (such as <a href="AnyFlatSpec.html"><code>AnyFlatSpec</code></a>) tests run in
  * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -330,7 +330,7 @@ import org.scalatest.Suite
  * </p>
  * 
  * <p>
- * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+ * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
  * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
  * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -355,7 +355,7 @@ import org.scalatest.Suite
  * <p>
  * If you need to test for expected exceptions in the context of futures, you can use the
  * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
- * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+ * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
  * supertrait <code>AsyncTestSuite</code>, both of these methods are
  * available by default in an <code>AsyncFlatSpec</code>.
  * </p>
@@ -373,7 +373,7 @@ import org.scalatest.Suite
  *
  * <p>
  * The <code>recoverToSucceededIf</code> method performs a job similar to
- * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+ * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
  * in the context of a future. It transforms a <code>Future</code> of any type into a
  * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
  * exception. Here's an example in the REPL:
@@ -440,8 +440,8 @@ import org.scalatest.Suite
  *
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
- * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+ * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>
@@ -1136,7 +1136,7 @@ import org.scalatest.Suite
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFlatSpec</code>.
+ * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFlatSpec</code>.
  * </p>
  *
  * <p>
@@ -1156,7 +1156,7 @@ import org.scalatest.Suite
  * <p>
  * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
  * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
- * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+ * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
  * The <code>complete</code>-<code>lastly</code> syntax will ensure that
  * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
  * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -1258,7 +1258,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1535,7 +1535,7 @@ import org.scalatest.Suite
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  *
@@ -1760,8 +1760,8 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
@@ -207,7 +207,7 @@ import org.scalatest.{Suite, Finders}
  * Tests can only be registered while the <code>AnyFreeSpec</code> is
  * in its registration phase. Any attempt to register a test after the <code>AnyFreeSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AnyFreeSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
  * of using <code>AnyFreeSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
  * <code>TestRegistrationClosedException</code>.
@@ -328,7 +328,7 @@ import org.scalatest.{Suite, Finders}
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -386,7 +386,7 @@ import org.scalatest.{Suite, Finders}
  * <code>AnyFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -508,7 +508,7 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -535,7 +535,7 @@ import org.scalatest.{Suite, Finders}
  * To support this style of testing, a test can be given a name that specifies one
  * bit of behavior required by the system being tested. The test can also include some code that
  * sends more information about the behavior to the reporter when the tests run. At the end of the test,
- * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
+ * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="../exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
  * </p>
  *
  * <p>
@@ -1452,7 +1452,7 @@ import org.scalatest.{Suite, Finders}
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code> 
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  * 
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
@@ -313,19 +313,19 @@ import org.scalatest.{Suite, Finders}
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
  * </p>
  *
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AnyFreeSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AnyFreeSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AnyFreeSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -333,7 +333,7 @@ import org.scalatest.{Suite, Finders}
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AnyFreeSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AnyFreeSpec</code>
  * to pass such information to the reporter. Here's an example:
  * </p>
  *
@@ -383,7 +383,7 @@ import org.scalatest.{Suite, Finders}
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -467,8 +467,8 @@ import org.scalatest.{Suite, Finders}
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
@@ -640,7 +640,7 @@ import org.scalatest.{Suite, Finders}
  * optionally be included and/or excluded. To tag a <code>AnyFreeSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name, 
@@ -692,7 +692,7 @@ import org.scalatest.{Suite, Finders}
  * </p>
  *
  * <p>
- * The <code>run</code> method takes a <a href="Filter.html"><code>Filter</code></a>, whose constructor takes an optional
+ * The <code>run</code> method takes a <a href="../Filter.html"><code>Filter</code></a>, whose constructor takes an optional
  * <code>Set[String]</code> called <code>tagsToInclude</code> and a <code>Set[String]</code> called
  * <code>tagsToExclude</code>. If <code>tagsToInclude</code> is <code>None</code>, all tests will be run
  * except those those belonging to tags listed in the
@@ -705,7 +705,7 @@ import org.scalatest.{Suite, Finders}
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>AnyFreeSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -956,7 +956,7 @@ import org.scalatest.{Suite, Finders}
  * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
  * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
- * lifecycle methods defined in trait <a href="Suite.html"><code>Suite</code></a>.
+ * lifecycle methods defined in trait <a href="../Suite.html"><code>Suite</code></a>.
  * </p>
  *
  * <p>
@@ -1050,7 +1050,7 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
@@ -1051,7 +1051,7 @@ import org.scalatest.{Suite, Finders}
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1241,7 +1241,7 @@ import org.scalatest.{Suite, Finders}
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  * 
@@ -1288,7 +1288,7 @@ import org.scalatest.{Suite, Finders}
  * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
  * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
  * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
- * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+ * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
  * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
  * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
  * </p>
@@ -1378,8 +1378,8 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -197,12 +197,12 @@ import org.scalatest.Suite
  * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
  *
  * <p>
- * <code>AsyncFreeSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+ * <code>AsyncFreeSpec</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
  * execution context is used by <code>AsyncFreeSpec</code> to 
  * transform the <code>Future[Assertion]</code>s returned by each test
- * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+ * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
@@ -325,9 +325,9 @@ import org.scalatest.Suite
  * parallelExecution in Test := true // the default in sbt
  * </pre>
  * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
- * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+ * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
  * run in parallel very much like traditional (such as <a href="AnyFreeSpec.html"><code>AnyFreeSpec</code></a>) tests run in
  * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -339,7 +339,7 @@ import org.scalatest.Suite
  * </p>
  * 
  * <p>
- * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+ * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
  * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
  * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -364,7 +364,7 @@ import org.scalatest.Suite
  * <p>
  * If you need to test for expected exceptions in the context of futures, you can use the
  * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
- * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+ * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
  * supertrait <code>AsyncTestSuite</code>, both of these methods are
  * available by default in an <code>AsyncFreeSpec</code>.
  * </p>
@@ -382,7 +382,7 @@ import org.scalatest.Suite
  *
  * <p>
  * The <code>recoverToSucceededIf</code> method performs a job similar to
- * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+ * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
  * in the context of a future. It transforms a <code>Future</code> of any type into a
  * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
  * exception. Here's an example in the REPL:
@@ -449,8 +449,8 @@ import org.scalatest.Suite
  *
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
- * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+ * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>
@@ -1160,7 +1160,7 @@ import org.scalatest.Suite
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFreeSpec</code>.
+ * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFreeSpec</code>.
  * </p>
  *
  * <p>
@@ -1180,7 +1180,7 @@ import org.scalatest.Suite
  * <p>
  * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
  * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
- * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+ * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
  * The <code>complete</code>-<code>lastly</code> syntax will ensure that
  * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
  * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -274,7 +274,7 @@ import org.scalatest.Suite
  * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
  * want to block in your tests, you may wish to just use a
  * traditional <a href="AnyFreeSpec.html"><code>AnyFreeSpec</code></a> with
- * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+ * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
  * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
  * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
  * shared mutable state.
@@ -317,7 +317,7 @@ import org.scalatest.Suite
  * <p>
  * If you want the tests of an <code>AsyncFreeSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
  * 
@@ -616,7 +616,7 @@ import org.scalatest.Suite
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -675,7 +675,7 @@ import org.scalatest.Suite
  * <code>AsyncFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -798,7 +798,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1921,7 +1921,7 @@ import org.scalatest.Suite
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  *
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -912,7 +912,7 @@ import org.scalatest.Suite
  * optionally be included and/or excluded. To tag an <code>AsyncFreeSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -983,7 +983,7 @@ import org.scalatest.Suite
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFreeSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1283,7 +1283,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -592,7 +592,7 @@ import org.scalatest.Suite
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
  * annotation instead.
  * </p>
  *
@@ -607,13 +607,13 @@ import org.scalatest.Suite
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AsyncFreeSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AsyncFreeSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AsyncFreeSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -621,7 +621,7 @@ import org.scalatest.Suite
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncFreeSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncFreeSpec</code>
  * to pass such information to the reporter. Here's an example:
  * </p>
  *
@@ -672,7 +672,7 @@ import org.scalatest.Suite
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AsyncFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AsyncFreeSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -757,8 +757,8 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -1284,7 +1284,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1567,7 +1567,7 @@ import org.scalatest.Suite
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  *
@@ -1796,8 +1796,8 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
@@ -132,10 +132,10 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * You can also pass to <code>execute</code> a <a href="ConfigMap.html"><em>config map</em></a> of key-value
+ * You can also pass to <code>execute</code> a <a href="../ConfigMap.html"><em>config map</em></a> of key-value
  * pairs, which will be passed down into suites and tests, as well as other parameters that configure the run itself.
  * For more information on running in the Scala interpreter, see the documentation for <code>execute</code> (below) and the
- * <a href="Shell.html">ScalaTest shell</a>.
+ * <a href="../Shell.html">ScalaTest shell</a>.
  * </p>
  *
  * <p>
@@ -947,7 +947,7 @@ import org.scalatest.{Suite, Finders}
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1143,7 +1143,7 @@ import org.scalatest.{Suite, Finders}
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  * 
@@ -1190,7 +1190,7 @@ import org.scalatest.{Suite, Finders}
  * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
  * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
  * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
- * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+ * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
  * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
  * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
  * </p>
@@ -1280,8 +1280,8 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
@@ -141,7 +141,7 @@ import org.scalatest.{Suite, Finders}
  * <p>
  * The <code>execute</code> method invokes a <code>run</code> method that takes two
  * parameters. This <code>run</code> method, which actually executes the suite, will usually be invoked by a test runner, such
- * as <a href="run$.html"><code>run</code></a>, <a href="tools/Runner$.html"><code>tools.Runner</code></a>, a build tool, or an IDE.
+ * as <a href="run$.html"><code>run</code></a>, <a href="../tools/Runner$.html"><code>tools.Runner</code></a>, a build tool, or an IDE.
  * </p>
  * <p>
  * <em>Note: <code>AnyFunSpec</code>'s syntax is in great part inspired by <a href="http://rspec.info/" target="_blank">RSpec</a>, a Ruby BDD framework.</em>
@@ -313,7 +313,7 @@ import org.scalatest.{Suite, Finders}
  * <code>AnyFunSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -441,7 +441,7 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1354,7 +1354,7 @@ import org.scalatest.{Suite, Finders}
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code> 
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  * 
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
@@ -246,7 +246,7 @@ import org.scalatest.{Suite, Finders}
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
  * </p>
  *
  * <a name="informers"></a><h2>Informers</h2>
@@ -310,7 +310,7 @@ import org.scalatest.{Suite, Finders}
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyFunSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyFunSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -394,8 +394,8 @@ import org.scalatest.{Suite, Finders}
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
@@ -534,7 +534,7 @@ import org.scalatest.{Suite, Finders}
  * optionally be included and/or excluded. To tag a <code>AnyFunSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -595,7 +595,7 @@ import org.scalatest.{Suite, Finders}
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>AnyFunSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -852,7 +852,7 @@ import org.scalatest.{Suite, Finders}
  * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
  * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
- * lifecycle methods defined in trait <a href="Suite.html"><code>Suite</code></a>.
+ * lifecycle methods defined in trait <a href="../Suite.html"><code>Suite</code></a>.
  * </p>
  *
  * <p>
@@ -946,7 +946,7 @@ import org.scalatest.{Suite, Finders}
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -589,7 +589,7 @@ import org.scalatest.Suite
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
  * annotation instead.
  * </p>
  *
@@ -663,7 +663,7 @@ import org.scalatest.Suite
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AsyncFunSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AsyncFunSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -748,8 +748,8 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -1282,7 +1282,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1565,7 +1565,7 @@ import org.scalatest.Suite
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  *
@@ -1794,8 +1794,8 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -271,7 +271,7 @@ import org.scalatest.Suite
  * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
  * want to block in your tests, you may wish to just use a
  * traditional <a href="AnyFunSpec.html"><code>AnyFunSpec</code></a> with
- * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+ * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
  * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
  * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
  * shared mutable state.
@@ -314,7 +314,7 @@ import org.scalatest.Suite
  * <p>
  * If you want the tests of an <code>AsyncFunSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
  * 
@@ -666,7 +666,7 @@ import org.scalatest.Suite
  * <code>AsyncFunSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -795,7 +795,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1919,7 +1919,7 @@ import org.scalatest.Suite
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  *
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -194,12 +194,12 @@ import org.scalatest.Suite
  * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
  *
  * <p>
- * <code>AsyncFunSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+ * <code>AsyncFunSpec</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
  * execution context is used by <code>AsyncFunSpec</code> to 
  * transform the <code>Future[Assertion]</code>s returned by each test
- * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+ * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
@@ -322,9 +322,9 @@ import org.scalatest.Suite
  * parallelExecution in Test := true // the default in sbt
  * </pre>
  * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
- * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+ * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
  * run in parallel very much like traditional (such as <a href="AnyFunSpec.html"><code>AnyFunSpec</code></a>) tests run in
  * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -336,7 +336,7 @@ import org.scalatest.Suite
  * </p>
  * 
  * <p>
- * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+ * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
  * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
  * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -361,7 +361,7 @@ import org.scalatest.Suite
  * <p>
  * If you need to test for expected exceptions in the context of futures, you can use the
  * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
- * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+ * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
  * supertrait <code>AsyncTestSuite</code>, both of these methods are
  * available by default in an <code>AsyncFunSpec</code>.
  * </p>
@@ -379,7 +379,7 @@ import org.scalatest.Suite
  *
  * <p>
  * The <code>recoverToSucceededIf</code> method performs a job similar to
- * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+ * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
  * in the context of a future. It transforms a <code>Future</code> of any type into a
  * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
  * exception. Here's an example in the REPL:
@@ -446,8 +446,8 @@ import org.scalatest.Suite
  *
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
- * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+ * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>
@@ -1158,7 +1158,7 @@ import org.scalatest.Suite
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSpec</code>.
+ * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSpec</code>.
  * </p>
  *
  * <p>
@@ -1178,7 +1178,7 @@ import org.scalatest.Suite
  * <p>
  * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
  * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
- * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+ * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
  * The <code>complete</code>-<code>lastly</code> syntax will ensure that
  * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
  * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -909,7 +909,7 @@ import org.scalatest.Suite
  * optionally be included and/or excluded. To tag an <code>AsyncFunSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -981,7 +981,7 @@ import org.scalatest.Suite
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFunSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1281,7 +1281,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -868,7 +868,7 @@ import org.scalatest.{Suite, Finders}
   *
   * <p>
   * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
-  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
   * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
   * implementation.
   * </p>
@@ -1058,7 +1058,7 @@ import org.scalatest.{Suite, Finders}
   * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
   * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
   * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
-  * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+  * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
   * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
   * </p>
   *
@@ -1103,7 +1103,7 @@ import org.scalatest.{Suite, Finders}
   * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
   * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
   * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
-  * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+  * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
   * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
   * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
   * </p>
@@ -1191,8 +1191,8 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
-  * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+  * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+  * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
   * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
   * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
   * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -165,7 +165,7 @@ import org.scalatest.{Suite, Finders}
   * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
   * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
   * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
-  * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
+  * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
   * </p>
   *
   * <a name="informers"></a><h2>Informers</h2>
@@ -177,12 +177,12 @@ import org.scalatest.{Suite, Finders}
   * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
   * Most often the reporting done by default by <code>AnyFunSuite</code>'s methods will be sufficient, but
   * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
-  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information
+  * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information
   * to the current <code>Reporter</code> is provided via the <code>info</code> parameterless method.
   * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
   * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <code>InfoProvided</code> event.
   * Here's an example that shows both a direct use as well as an indirect use through the methods
-  * of <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a>:
+  * of <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a>:
   * </p>
   *
   * <pre class="stHighlight">
@@ -229,7 +229,7 @@ import org.scalatest.{Suite, Finders}
   * <a name="documenters"></a><h2>Documenters</h2>
   *
   * <p>
-  * <code>AnyFunSuite</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+  * <code>AnyFunSuite</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
   * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
   * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
   * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -312,8 +312,8 @@ import org.scalatest.{Suite, Finders}
   * </p>
   *
   * <p>
-  * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
-  * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+  * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+  * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
   * </p>
   *
   * <pre class="stHighlight">

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -232,7 +232,7 @@ import org.scalatest.{Suite, Finders}
   * <code>AnyFunSuite</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
   * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
   * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
-  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
   * </p>
   *
   * <p>
@@ -356,7 +356,7 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+  * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
   * If you find a test is taking a long time to complete, but you're not sure which test, you can enable
   * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
   * longer than a specified amount of time.
@@ -1267,7 +1267,7 @@ import org.scalatest.{Suite, Finders}
   * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
   * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
   * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
-  * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+  * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
   * </p>
   *
   * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -467,7 +467,7 @@ import org.scalatest.{Suite, Finders}
   * optionally be included and/or excluded. To tag a <code>AnyFunSuite</code>'s tests,
   * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
   * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
-  * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+  * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
   * will probably want to use tag names on your test functions that match. To do so, simply
   * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
   * defined a tag annotation interface with fully qualified name,
@@ -525,7 +525,7 @@ import org.scalatest.{Suite, Finders}
   * It is recommended, though not required, that you create a corresponding tag annotation when you
   * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>AnyFunSuite</code> in
   * one stroke by annotating the class. For more information and examples, see the
-  * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+  * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
   * tag each test individually at the test site.
   * </p>
   *
@@ -776,7 +776,7 @@ import org.scalatest.{Suite, Finders}
   * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
   * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
   * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
-  * lifecycle methods defined in trait <a href="Suite.html"><code>Suite</code></a>.
+  * lifecycle methods defined in trait <a href="../Suite.html"><code>Suite</code></a>.
   * </p>
   *
   * <p>
@@ -867,7 +867,7 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+  * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
   * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
   * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
   * implementation.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -554,7 +554,7 @@ import org.scalatest.{Suite, Finders}
   * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
   * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
   * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
-  * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+  * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
   * annotation instead.
   * </p>
   *
@@ -575,12 +575,12 @@ import org.scalatest.{Suite, Finders}
   * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
   * Most often the reporting done by default by <code>AsyncFunSuite</code>'s methods will be sufficient, but
   * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
-  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information
+  * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information
   * to the current <code>Reporter</code> is provided via the <code>info</code> parameterless method.
   * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
   * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <code>InfoProvided</code> event.
   * Here's an example that shows both a direct use as well as an indirect use through the methods
-  * of <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a>:
+  * of <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a>:
   * </p>
   *
   * <pre class="stHighlight">
@@ -628,7 +628,7 @@ import org.scalatest.{Suite, Finders}
   * <a name="documenters"></a><h2>Documenters</h2>
   *
   * <p>
-  * <code>AsyncFunSuite</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+  * <code>AsyncFunSuite</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
   * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
   * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
   * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -712,8 +712,8 @@ import org.scalatest.{Suite, Finders}
   * </p>
   *
   * <p>
-  * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
-  * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+  * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+  * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
   * </p>
   *
   * <pre class="stHighlight">

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -249,7 +249,7 @@ import org.scalatest.{Suite, Finders}
   * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do
   * want to block in your tests, you may wish to just use a
   * traditional <a href="AnyFunSuite.html"><code>AnyFunSuite</code></a> with
-  * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+  * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
   * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
   * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
   * shared mutable state.
@@ -292,7 +292,7 @@ import org.scalatest.{Suite, Finders}
   * <p>
   * If you want the tests of an <code>AsyncFunSuite</code> to be executed in parallel, you
   * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
-  * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
+  * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
   * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
   * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
   *
@@ -631,7 +631,7 @@ import org.scalatest.{Suite, Finders}
   * <code>AsyncFunSuite</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
   * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
   * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
-  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
   * </p>
   *
   * <p>
@@ -756,7 +756,7 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+  * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
   * If you find a test is taking a long time to complete, but you're not sure which test, you can enable
   * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
   * longer than a specified amount of time.
@@ -1857,7 +1857,7 @@ import org.scalatest.{Suite, Finders}
   * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
   * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
   * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
-  * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+  * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
   * </p>
   *
   * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -1231,7 +1231,7 @@ import org.scalatest.{Suite, Finders}
   *
   * <p>
   * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
-  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
   * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
   * implementation.
   * </p>
@@ -1509,7 +1509,7 @@ import org.scalatest.{Suite, Finders}
   * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
   * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
   * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
-  * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+  * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
   * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
   * </p>
   *
@@ -1735,8 +1735,8 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
-  * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+  * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+  * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
   * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
   * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
   * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -172,12 +172,12 @@ import org.scalatest.{Suite, Finders}
   * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
   *
   * <p>
-  * <code>AsyncFunSuite</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+  * <code>AsyncFunSuite</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
   * implicit <code>scala.concurrent.ExecutionContext</code>
   * named <code>executionContext</code>. This
   * execution context is used by <code>AsyncFunSuite</code> to
   * transform the <code>Future[Assertion]</code>s returned by each test
-  * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+  * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
   * passed to <code>withFixture</code>.
   * This <code>ExecutionContext</code> is also intended to be used in the tests,
   * including when you map assertions onto futures.
@@ -300,9 +300,9 @@ import org.scalatest.{Suite, Finders}
   * parallelExecution in Test := true // the default in sbt
   * </pre>
   *
-  * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and
+  * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and
   * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
-  * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+  * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
   * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
   * run in parallel very much like traditional (such as <a href="AnyFunSuite.html"><code>AnyFunSuite</code></a>) tests run in
   * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -314,7 +314,7 @@ import org.scalatest.{Suite, Finders}
   * </p>
   *
   * <p>
-  * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+  * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
   * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
   * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
   * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -339,7 +339,7 @@ import org.scalatest.{Suite, Finders}
   * <p>
   * If you need to test for expected exceptions in the context of futures, you can use the
   * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
-  * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+  * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
   * supertrait <code>AsyncTestSuite</code>, both of these methods are
   * available by default in an <code>AsyncFunSuite</code>.
   * </p>
@@ -357,7 +357,7 @@ import org.scalatest.{Suite, Finders}
   *
   * <p>
   * The <code>recoverToSucceededIf</code> method performs a job similar to
-  * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+  * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
   * in the context of a future. It transforms a <code>Future</code> of any type into a
   * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
   * exception. Here's an example in the REPL:
@@ -424,8 +424,8 @@ import org.scalatest.{Suite, Finders}
   *
   * <p>
   * In other words, <code>recoverToExpectionIf</code> is to
-  * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
-  * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+  * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+  * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
   * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
   * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
   * </p>
@@ -1109,7 +1109,7 @@ import org.scalatest.{Suite, Finders}
   * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
   * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
   * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
-  * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSuite</code>.
+  * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSuite</code>.
   * </p>
   *
   * <p>
@@ -1129,7 +1129,7 @@ import org.scalatest.{Suite, Finders}
   * <p>
   * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
   * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
-  * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+  * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
   * The <code>complete</code>-<code>lastly</code> syntax will ensure that
   * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
   * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -865,7 +865,7 @@ import org.scalatest.{Suite, Finders}
   * optionally be included and/or excluded. To tag an <code>AsyncFunSuite</code>'s tests,
   * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
   * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
-  * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+  * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
   * will probably want to use tag names on your test functions that match. To do so, simply
   * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
   * defined a tag annotation interface with fully qualified name,
@@ -933,7 +933,7 @@ import org.scalatest.{Suite, Finders}
   * It is recommended, though not required, that you create a corresponding tag annotation when you
   * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFunSuite</code> in
   * one stroke by annotating the class. For more information and examples, see the
-  * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+  * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
   * tag each test individually at the test site.
   * </p>
   *
@@ -1230,7 +1230,7 @@ import org.scalatest.{Suite, Finders}
   * </pre>
   *
   * <p>
-  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+  * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
   * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
   * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
   * implementation.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
@@ -101,7 +101,7 @@ import org.scalatest.{Finders, Suite}
  * <p>
  * The <code>execute</code> method invokes a <code>run</code> method that takes two
  * parameters. This <code>run</code> method, which actually executes the suite, will usually be invoked by a test runner, such
- * as <a href="run$.html"><code>run</code></a>, <a href="tools/Runner$.html"><code>tools.Runner</code></a>, a build tool, or an IDE.
+ * as <a href="run$.html"><code>run</code></a>, <a href="../tools/Runner$.html"><code>tools.Runner</code></a>, a build tool, or an IDE.
  * </p>
  *
  * <p>
@@ -122,7 +122,7 @@ import org.scalatest.{Finders, Suite}
  * Tests can only be registered with the <code>property</code> method while the <code>AnyPropSpec</code> is
  * in its registration phase. Any attempt to register a test after the <code>AnyPropSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AnyPropSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
  * of using <code>AnyPropSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
  * <code>TestRegistrationClosedException</code>.
@@ -197,7 +197,7 @@ import org.scalatest.{Finders, Suite}
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information
  * to the current <code>Reporter</code> is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * Here's an example that shows both a direct use as well as an indirect use through the methods
  * of <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a>:
  * </p>
@@ -271,7 +271,7 @@ import org.scalatest.{Finders, Suite}
  * <code>AnyPropSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -421,7 +421,7 @@ import org.scalatest.{Finders, Suite}
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -448,7 +448,7 @@ import org.scalatest.{Finders, Suite}
  * To support this style of testing, a test can be given a name that specifies one
  * bit of behavior required by the system being tested. The test can also include some code that
  * sends more information about the behavior to the reporter when the tests run. At the end of the test,
- * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
+ * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="../exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
  * </p>
  *
  * <p>

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
@@ -92,10 +92,10 @@ import org.scalatest.{Finders, Suite}
  * </pre>
  *
  * <p>
- * You can also pass to <code>execute</code> a <a href="ConfigMap.html"><em>config map</em></a> of key-value
+ * You can also pass to <code>execute</code> a <a href="../ConfigMap.html"><em>config map</em></a> of key-value
  * pairs, which will be passed down into suites and tests, as well as other parameters that configure the run itself.
  * For more information on running in the Scala interpreter, see the documentation for <code>execute</code> (below) and the
- * <a href="Shell.html">ScalaTest shell</a>.
+ * <a href="../Shell.html">ScalaTest shell</a>.
  * </p>
  *
  * <p>

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
@@ -539,7 +539,7 @@ import org.scalatest.{Finders, Suite}
  * optionally be included and/or excluded. To tag a <code>AnyPropSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified names,

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
@@ -188,18 +188,18 @@ import org.scalatest.{Finders, Suite}
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AnyPropSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AnyPropSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AnyPropSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information
  * to the current <code>Reporter</code> is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * Here's an example that shows both a direct use as well as an indirect use through the methods
- * of <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a>:
+ * of <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a>:
  * </p>
  *
  * <pre class="stHighlight">
@@ -268,7 +268,7 @@ import org.scalatest.{Finders, Suite}
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyPropSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyPropSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -365,8 +365,8 @@ import org.scalatest.{Finders, Suite}
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -80,7 +80,7 @@ import org.scalatest.exceptions._
  * <p>
  * Here <code>result</code> is a variable, and can be of any type. If the object is an
  * <code>Int</code> with the value 3, execution will continue (<em>i.e.</em>, the expression will result
- * in the unit value, <code>()</code>). Otherwise, a <a href="exceptions/TestFailedException.html"><code>TestFailedException</code></a>
+ * in the unit value, <code>()</code>). Otherwise, a <a href="../../exceptions/TestFailedException.html"><code>TestFailedException</code></a>
  * will be thrown with a detail message that explains the problem, such as <code>"7 did not equal 3"</code>.
  * This <code>TestFailedException</code> will cause the test to fail.
  * </p>
@@ -273,7 +273,7 @@ import org.scalatest.exceptions._
  * Similarly, the <code>size</code> syntax can be used with <code>Array</code>, any <code>scala.collection.GenTraversable</code>,
  * any <code>java.util.Collection</code>, any <code>java.util.Map</code>, and any type <code>T</code> for which an implicit <code>Size[T]</code> type class is
  * available in scope. You can enable the <code>length</code> or <code>size</code> syntax for your own arbitrary types, therefore,
- * by defining <a href="enablers/Length.html"><code>Length</code></a> or <a href="enablers/Size.html"><code>Size</code></a> type
+ * by defining <a href="../../enablers/Length.html"><code>Length</code></a> or <a href="../../enablers/Size.html"><code>Size</code></a> type
  * classes for those types.
  * </p>
  *
@@ -1100,7 +1100,7 @@ import org.scalatest.exceptions._
  * </pre>
  *
  * <p>
- * You can invoke <code>loneElement</code> on any type <code>T</code> for which an implicit <a href="enablers/Collecting.html"><code>Collecting[E, T]</code></a>
+ * You can invoke <code>loneElement</code> on any type <code>T</code> for which an implicit <a href="../../enablers/Collecting.html"><code>Collecting[E, T]</code></a>
  * is available, where <code>E</code> is the element type returned by the <code>loneElement</code> invocation. By default, you can use <code>loneElement</code>
  * on <code>GenTraversable</code>, Java <code>Collection</code>, Java <code>Map</code>, <code>Array</code>, and <code>String</code>.
  * </p>
@@ -1240,7 +1240,7 @@ import org.scalatest.exceptions._
  * <p>
  * As with <code>equal</code> used with default equality, using <code>be</code> on arrays results in <code>deep</code> being called on both arrays prior to
  * calling <code>equal</code>. As a result,
- * the following expression would <em>not</em> throw a <a href="exceptions/TestFailedException.html"><code>TestFailedException</code></a>:
+ * the following expression would <em>not</em> throw a <a href="../../exceptions/TestFailedException.html"><code>TestFailedException</code></a>:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -968,7 +968,7 @@ import org.scalatest.exceptions._
  * <h2>Inspector shorthands</h2>
  *
  * <p>
- * You can use the <a href="Inspectors.html"><code>Inspectors</code></a> syntax with matchers as well as assertions. If you have a multi-dimensional collection, such as a
+ * You can use the <a href="../../Inspectors.html"><code>Inspectors</code></a> syntax with matchers as well as assertions. If you have a multi-dimensional collection, such as a
  * list of lists, using <code>Inspectors</code> is your best option:
  * </p>
  *
@@ -1089,7 +1089,7 @@ import org.scalatest.exceptions._
  *
  * <p>
  * To assert both that a collection contains just one "lone" element as well as something else about that element, you can use
- * the <code>loneElement</code> syntax provided by trait <a href="LoneElement.html"><code>LoneElement</code></a>. For example, if a
+ * the <code>loneElement</code> syntax provided by trait <a href="../../LoneElement.html"><code>LoneElement</code></a>. For example, if a
  * <code>Set[Int]</code> should contain just one element, an <code>Int</code>
  * less than or equal to 10, you could write:
  * </p>
@@ -1155,7 +1155,7 @@ import org.scalatest.exceptions._
  * a collection of <code>Entry</code>. To make Java <code>Map</code>s easier to work with, however,
  * ScalaTest matchers allows you to treat a Java <code>Map</code> as a collection of <code>Entry</code>,
  * and defines a convenience implementation of <code>java.util.Map.Entry</code> in
- * <a href="Entry.html"><code>org.scalatest.Entry</code></a>. Here's how you use it:
+ * <a href="../../Entry.html"><code>org.scalatest.Entry</code></a>. Here's how you use it:
  * </p>
  *
  * <pre class="stHighlight">
@@ -1474,7 +1474,7 @@ import org.scalatest.exceptions._
  * </pre>
  *
  * <p>
- * If you mix in (or import the members of) <a href="OptionValues.html"><code>OptionValues</code></a>,
+ * If you mix in (or import the members of) <a href="../../OptionValues.html"><code>OptionValues</code></a>,
  * you can write one statement that indicates you believe an option should be defined and then say something else about its value. Here's an example:
  * </p>
  *
@@ -1610,7 +1610,7 @@ import org.scalatest.exceptions._
  * <h2>Checking that an expression matches a pattern</h2>
  *
  * <p>
- * ScalaTest's <a href="Inside.html"><code>Inside</code></a> trait allows you to make assertions after a pattern match.
+ * ScalaTest's <a href="../../Inside.html"><code>Inside</code></a> trait allows you to make assertions after a pattern match.
  * Here's an example:
  * </p>
  *

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
@@ -1203,7 +1203,7 @@ import org.scalatest.{ Suite, Finders }
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1389,7 +1389,7 @@ import org.scalatest.{ Suite, Finders }
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  * 
@@ -1435,7 +1435,7 @@ import org.scalatest.{ Suite, Finders }
  * reassigning instance <code>var</code>s or by changing the state of mutable objects held from instance <code>val</code>s (as in this example). If using
  * instance <code>var</code>s or mutable objects held from instance <code>val</code>s you wouldn't be able to run tests in parallel in the same instance
  * of the test class (on the JVM, not Scala.js) unless you synchronized access to the shared, mutable state. This is why ScalaTest's <code>ParallelTestExecution</code> trait extends
- * <a href="OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
+ * <a href="../OneInstancePerTest.html"><code>OneInstancePerTest</code></a>. By running each test in its own instance of the class, each test has its own copy of the instance variables, so you
  * don't need to synchronize. If you mixed <code>ParallelTestExecution</code> into the <code>ExampleSuite</code> above, the tests would run in parallel just fine
  * without any synchronization needed on the mutable <code>StringBuilder</code> and <code>ListBuffer[String]</code> objects.
  * </p>
@@ -1525,8 +1525,8 @@ import org.scalatest.{ Suite, Finders }
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
@@ -796,7 +796,7 @@ import org.scalatest.{ Suite, Finders }
  * optionally be included and/or excluded. To tag a <code>AnyWordSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply 
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -844,7 +844,7 @@ import org.scalatest.{ Suite, Finders }
  * </p>
  *
  * <p>
- * The <code>run</code> method takes a <a href="Filter.html"><code>Filter</code></a>, whose constructor takes an optional
+ * The <code>run</code> method takes a <a href="../Filter.html"><code>Filter</code></a>, whose constructor takes an optional
  * <code>Set[String]</code> called <code>tagsToInclude</code> and a <code>Set[String]</code> called
  * <code>tagsToExclude</code>. If <code>tagsToInclude</code> is <code>None</code>, all tests will be run
  * except those those belonging to tags listed in the
@@ -857,7 +857,7 @@ import org.scalatest.{ Suite, Finders }
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of a <code>WordSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1108,7 +1108,7 @@ import org.scalatest.{ Suite, Finders }
  * Although the get-fixture method and fixture-context object approaches take care of setting up a fixture at the beginning of each
  * test, they don't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgTest)</code>, one of ScalaTest's
- * lifecycle methods defined in trait <a href="Suite.html#lifecyle-methods"><code>Suite</code></a>.
+ * lifecycle methods defined in trait <a href="../Suite.html#lifecyle-methods"><code>Suite</code></a>.
  * </p>
  *
  * <p>
@@ -1202,7 +1202,7 @@ import org.scalatest.{ Suite, Finders }
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
@@ -353,7 +353,7 @@ import org.scalatest.{ Suite, Finders }
  * Tests can only be registered while the <code>AnyWordSpec</code> is
  * in its registration phase. Any attempt to register a test after the <code>AnyWordSpec</code> has
  * entered its ready phase, <em>i.e.</em>, after <code>run</code> has been invoked on the <code>AnyWordSpec</code>,
- * will be met with a thrown <a href="exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
+ * will be met with a thrown <a href="../exceptions/TestRegistrationClosedException.html"><code>TestRegistrationClosedException</code></a>. The recommended style
  * of using <code>AnyWordSpec</code> is to register tests during object construction as is done in all
  * the examples shown here. If you keep to the recommended style, you should never see a
  * <code>TestRegistrationClosedException</code>.
@@ -478,7 +478,7 @@ import org.scalatest.{ Suite, Finders }
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -536,7 +536,7 @@ import org.scalatest.{ Suite, Finders }
  * <code>AnyWordSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -664,7 +664,7 @@ import org.scalatest.{ Suite, Finders }
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -691,7 +691,7 @@ import org.scalatest.{ Suite, Finders }
  * To support this style of testing, a test can be given a name that specifies one
  * bit of behavior required by the system being tested. The test can also include some code that
  * sends more information about the behavior to the reporter when the tests run. At the end of the test,
- * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
+ * it can call method <code>pending</code>, which will cause it to complete abruptly with <a href="../exceptions/TestPendingException.html"><code>TestPendingException</code></a>.
  * </p>
  *
  * <p>
@@ -1378,7 +1378,7 @@ import org.scalatest.{ Suite, Finders }
  * <p>
  * In this example, the tests actually required two fixture objects, a <code>File</code> and a <code>FileWriter</code>. In such situations you can
  * simply define the <code>FixtureParam</code> type to be a tuple containing the objects, or as is done in this example, a case class containing
- * the objects.  For more information on the <code>withFixture(OneArgTest)</code> technique, see the <a href="fixture/WordSpec.html">documentation for <code>fixture.WordSpec</code></a>.
+ * the objects.  For more information on the <code>withFixture(OneArgTest)</code> technique, see the <a href="../fixture/WordSpec.html">documentation for <code>fixture.WordSpec</code></a>.
  * </p>
  *
  * <a name="beforeAndAfter"></a>
@@ -1599,7 +1599,7 @@ import org.scalatest.{ Suite, Finders }
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code> 
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  * 
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
@@ -463,19 +463,19 @@ import org.scalatest.{ Suite, Finders }
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a> annotation instead.
  * </p>
  *
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AnyWordSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AnyWordSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AnyWordSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -483,7 +483,7 @@ import org.scalatest.{ Suite, Finders }
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>WordSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>WordSpec</code>
  * to pass such information to the reporter. Here's an example:
  * </p>
  *
@@ -533,7 +533,7 @@ import org.scalatest.{ Suite, Finders }
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AnyWordSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AnyWordSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -617,8 +617,8 @@ import org.scalatest.{ Suite, Finders }
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -1317,7 +1317,7 @@ import org.scalatest.Suite
  *
  * <p>
  * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
- * an <code>apply</code> method that executes the test, also includes the test name and the <a href="ConfigMap.html">config
+ * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.
  * </p>
@@ -1600,7 +1600,7 @@ import org.scalatest.Suite
  * performed <em>during</em> the test.  This means that if an exception occurs during any of these activities, it will be reported as a test failure.
  * Sometimes, however, you may want setup to happen <em>before</em> the test starts, and cleanup <em>after</em> the test has completed, so that if an
  * exception occurs during setup or cleanup, the entire suite aborts and no more tests are attempted. The simplest way to accomplish this in ScalaTest is
- * to mix in trait <a href="BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
+ * to mix in trait <a href="../BeforeAndAfter.html"><code>BeforeAndAfter</code></a>.  With this trait you can denote a bit of code to run before each test
  * with <code>before</code> and/or after each test each test with <code>after</code>, like this:
  * </p>
  *
@@ -1829,8 +1829,8 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another way to create stackable fixture traits is by extending the <a href="BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
- * and/or <a href="BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
+ * Another way to create stackable fixture traits is by extending the <a href="../BeforeAndAfterEach.html"><code>BeforeAndAfterEach</code></a>
+ * and/or <a href="../BeforeAndAfterAll.html"><code>BeforeAndAfterAll</code></a> traits.
  * <code>BeforeAndAfterEach</code> has a <code>beforeEach</code> method that will be run before each test (like JUnit's <code>setUp</code>),
  * and an <code>afterEach</code> method that will be run after (like JUnit's <code>tearDown</code>).
  * Similarly, <code>BeforeAndAfterAll</code> has a <code>beforeAll</code> method that will be run before all tests,

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -302,7 +302,7 @@ import org.scalatest.Suite
  * enable <a href="Runner.scala#slowpokeNotifications">slowpoke notifications</a>.) If you really do 
  * want to block in your tests, you may wish to just use a
  * traditional <a href="AnyWordSpec.html"><code>AnyWordSpec</code></a> with
- * <a href="concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
+ * <a href="../concurrent/ScalaFutures.html"><code>ScalaFutures</code></a> instead. Alternatively, you could override
  * the <code>executionContext</code> and use a traditional <code>ExecutionContext</code> backed by a thread pool. This
  * will enable you to block in an asynchronous-style test on the JVM, but you'll need to worry about synchronizing access to
  * shared mutable state.
@@ -345,7 +345,7 @@ import org.scalatest.Suite
  * <p>
  * If you want the tests of an <code>AsyncWordSpec</code> to be executed in parallel, you
  * must mix in <code>ParallelTestExecution</code> and enable parallel execution of tests in your build.
- * You enable parallel execution in <a href="tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag. 
+ * You enable parallel execution in <a href="../tools/Runner$.html"><code>Runner</code></a> with the <code>-P</code> command line flag.
  * In the ScalaTest Maven Plugin, set <code>parallel</code> to <code>true</code>.
  * In <code>sbt</code>, parallel execution is the default, but to be explicit you can write:
  * 
@@ -644,7 +644,7 @@ import org.scalatest.Suite
  * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
- * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="events/InfoProvided.html"><code>InfoProvided</code></a> event.
+ * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
  * </p>
  * 
  * <p>
@@ -703,7 +703,7 @@ import org.scalatest.Suite
  * <code>AsyncWordSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
- * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
+ * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
  * </p>
  *
  * <p>
@@ -832,7 +832,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Another example is <a href="tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
+ * Another example is <a href="../tools/Runner$.html#slowpokeNotifications">slowpoke notifications</a>.
  * If you find a test is taking a long time to complete, but you're not sure which test, you can enable 
  * slowpoke notifications. ScalaTest will use an <code>Alerter</code> to fire an event whenever a test has been running
  * longer than a specified amount of time.
@@ -1589,7 +1589,7 @@ import org.scalatest.Suite
  * In this example, the tests required one fixture object, a <code>StringActor</code>. If your tests need multiple fixture objects, you can
  * simply define the <code>FixtureParam</code> type to be a tuple containing the objects or, alternatively, a case class containing
  * the objects.  For more information on the <code>withFixture(OneArgAsyncTest)</code> technique, see
- * the <a href="fixture/AsyncFunSpec.html">documentation for <code>fixture.AsyncFunSpec</code></a>.
+ * the <a href="../fixture/AsyncFunSpec.html">documentation for <code>fixture.AsyncFunSpec</code></a>.
  * </p>
  *
  * <a name="beforeAndAfter"></a>
@@ -1954,7 +1954,7 @@ import org.scalatest.Suite
  * that setup and cleanup code happens before and after the test in <code>BeforeAndAfterEach</code>, but at the beginning and
  * end of the test in <code>withFixture</code>. Thus if a <code>withFixture</code> method completes abruptly with an exception, it is
  * considered a failed test. By contrast, if any of the <code>beforeEach</code> or <code>afterEach</code> methods of <code>BeforeAndAfterEach</code>
- * complete abruptly, it is considered an aborted suite, which will result in a <a href="events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
+ * complete abruptly, it is considered an aborted suite, which will result in a <a href="../events/SuiteAborted.html"><code>SuiteAborted</code></a> event.
  * </p>
  *
  * <a name="sharedTests"></a><h2>Shared tests</h2>

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -225,12 +225,12 @@ import org.scalatest.Suite
  * <a name="asyncExecutionModel"></a><h2>Asynchronous execution model</h2>
  *
  * <p>
- * <code>AsyncWordSpec</code> extends <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
+ * <code>AsyncWordSpec</code> extends <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, which provides an
  * implicit <code>scala.concurrent.ExecutionContext</code>
  * named <code>executionContext</code>. This
  * execution context is used by <code>AsyncWordSpec</code> to 
  * transform the <code>Future[Assertion]</code>s returned by each test
- * into the <a href="FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
+ * into the <a href="../FutureOutcome.html"><code>FutureOutcome</code></a> returned by the <code>test</code> function
  * passed to <code>withFixture</code>.
  * This <code>ExecutionContext</code> is also intended to be used in the tests,
  * including when you map assertions onto futures.
@@ -353,9 +353,9 @@ import org.scalatest.Suite
  * parallelExecution in Test := true // the default in sbt
  * </pre>
  * 
- * On the JVM, if both <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
+ * On the JVM, if both <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in and 
  * parallel execution is enabled in the build, tests in an async-style suite will be started in parallel, using threads from
- * the <a href="Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
+ * the <a href="../Distributor"><code>Distributor</code></a>, and allowed to complete in parallel, using threads from the
  * <code>executionContext</code>. If you are using ScalaTest's serial execution context, the JVM default, asynchronous tests will
  * run in parallel very much like traditional (such as <a href="AnyWordSpec.html"><code>AnyWordSpec</code></a>) tests run in
  * parallel: 1) Because <code>ParallelTestExecution</code> extends
@@ -367,7 +367,7 @@ import org.scalatest.Suite
  * </p>
  * 
  * <p>
- * If <a href="ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
+ * If <a href="../ParallelTestExecution.html"><code>ParallelTestExecution</code></a> is mixed in but
  * parallel execution of suites is <em>not</em> enabled, asynchronous tests on the JVM will be started sequentially, by the single thread
  * that invoked <code>run</code>, but without waiting for one test to complete before the next test is started. As a result,
  * asynchronous tests will be allowed to <em>complete</em> in parallel, using threads
@@ -392,7 +392,7 @@ import org.scalatest.Suite
  * <p>
  * If you need to test for expected exceptions in the context of futures, you can use the
  * <code>recoverToSucceededIf</code> and <code>recoverToExceptionIf</code> methods of trait
- * <a href="RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
+ * <a href="../RecoverMethods.html"><code>RecoverMethods</code></a>. Because this trait is mixed into
  * supertrait <code>AsyncTestSuite</code>, both of these methods are
  * available by default in an <code>AsyncWordSpec</code>.
  * </p>
@@ -410,7 +410,7 @@ import org.scalatest.Suite
  *
  * <p>
  * The <code>recoverToSucceededIf</code> method performs a job similar to
- * <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
+ * <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>, except
  * in the context of a future. It transforms a <code>Future</code> of any type into a
  * <code>Future[Assertion]</code> that succeeds only if the original future fails with the specified
  * exception. Here's an example in the REPL:
@@ -477,8 +477,8 @@ import org.scalatest.Suite
  *
  * <p>
  * In other words, <code>recoverToExpectionIf</code> is to
- * <a href="Assertions.html#interceptMethod"><code>intercept</code></a> as
- * <code>recovertToSucceededIf</code> is to <a href="Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
+ * <a href="../Assertions.html#interceptMethod"><code>intercept</code></a> as
+ * <code>recovertToSucceededIf</code> is to <a href="../Assertions.html#assertThrowsMethod"><code>assertThrows</code></a>. The first one allows you to
  * perform further assertions on the expected exception. The second one gives you a result type that will satisfy the type checker
  * at the end of the test body. Here's an example showing <code>recoverToExceptionIf</code> in the REPL:
  * </p>
@@ -1193,7 +1193,7 @@ import org.scalatest.Suite
  * Although the get-fixture method approach takes care of setting up a fixture at the beginning of each
  * test, it doesn't address the problem of cleaning up a fixture at the end of the test. If you just need to perform a side-effect at the beginning or end of
  * a test, and don't need to actually pass any fixture objects into the test, you can override <code>withFixture(NoArgAsyncTest)</code>, a
- * method defined in trait <a href="AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSpec</code>.
+ * method defined in trait <a href="../AsyncTestSuite.html"><code>AsyncTestSuite</code></a>, a supertrait of <code>AsyncFunSpec</code>.
  * </p>
  *
  * <p>
@@ -1213,7 +1213,7 @@ import org.scalatest.Suite
  * <p>
  * You can, therefore, override <code>withFixture</code> to perform setup before invoking the test function,
  * and/or perform cleanup after the test completes. The recommended way to ensure cleanup is performed after a test completes is
- * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="CompleteLastly.html"><code>CompleteLastly</code></a>.
+ * to use the <code>complete</code>-<code>lastly</code> syntax, defined in supertrait <a href="../CompleteLastly.html"><code>CompleteLastly</code></a>.
  * The <code>complete</code>-<code>lastly</code> syntax will ensure that
  * cleanup will occur whether future-producing code completes abruptly by throwing an exception, or returns
  * normally yielding a future. In the latter case, <code>complete</code>-<code>lastly</code> will register the cleanup code

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -945,7 +945,7 @@ import org.scalatest.Suite
  * optionally be included and/or excluded. To tag an <code>AsyncFunSpec</code>'s tests,
  * you pass objects that extend class <code>org.scalatest.Tag</code> to methods
  * that register tests. Class <code>Tag</code> takes one parameter, a string name.  If you have
- * created tag annotation interfaces as described in the <a href="Tag.html"><code>Tag</code> documentation</a>, then you
+ * created tag annotation interfaces as described in the <a href="../Tag.html"><code>Tag</code> documentation</a>, then you
  * will probably want to use tag names on your test functions that match. To do so, simply
  * pass the fully qualified names of the tag interfaces to the <code>Tag</code> constructor. For example, if you've
  * defined a tag annotation interface with fully qualified name,
@@ -1016,7 +1016,7 @@ import org.scalatest.Suite
  * It is recommended, though not required, that you create a corresponding tag annotation when you
  * create a <code>Tag</code> object. A tag annotation (on the JVM, not Scala.js) allows you to tag all the tests of an <code>AsyncFunSpec</code> in
  * one stroke by annotating the class. For more information and examples, see the
- * <a href="Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
+ * <a href="../Tag.html">documentation for class <code>Tag</code></a>. On Scala.js, to tag all tests of a suite, you'll need to
  * tag each test individually at the test site.
  * </p>
  *
@@ -1316,7 +1316,7 @@ import org.scalatest.Suite
  * </pre>
  *
  * <p>
- * Note that the <a href="Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
+ * Note that the <a href="../Suite$NoArgTest.html"><code>NoArgAsyncTest</code></a> passed to <code>withFixture</code>, in addition to
  * an <code>apply</code> method that executes the test, also includes the test name and the <a href="../ConfigMap.html">config
  * map</a> passed to <code>runTest</code>. Thus you can also use the test name and configuration objects in your <code>withFixture</code>
  * implementation.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -620,7 +620,7 @@ import org.scalatest.Suite
  * Note that marking a test class as ignored won't prevent it from being discovered by ScalaTest. Ignored classes
  * will be discovered and run, and all their tests will be reported as ignored. This is intended to keep the ignored
  * class visible, to encourage the developers to eventually fix and &ldquo;un-ignore&rdquo; it. If you want to
- * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="DoNotDiscover.html"><code>DoNotDiscover</code></a>
+ * prevent a class from being discovered at all (on the JVM, not Scala.js), use the <a href="../DoNotDiscover.html"><code>DoNotDiscover</code></a>
  * annotation instead.
  * </p>
  *
@@ -635,13 +635,13 @@ import org.scalatest.Suite
  * <a name="informers"></a><h2>Informers</h2>
  *
  * <p>
- * One of the parameters to <code>AsyncWordSpec</code>'s <code>run</code> method is a <a href="Reporter.html"><code>Reporter</code></a>, which
+ * One of the parameters to <code>AsyncWordSpec</code>'s <code>run</code> method is a <a href="../Reporter.html"><code>Reporter</code></a>, which
  * will collect and report information about the running suite of tests.
  * Information about suites and tests that were run, whether tests succeeded or failed, 
  * and tests that were ignored will be passed to the <code>Reporter</code> as the suite runs.
  * Most often the reporting done by default by <code>AsyncWordSpec</code>'s methods will be sufficient, but
  * occasionally you may wish to provide custom information to the <code>Reporter</code> from a test.
- * For this purpose, an <a href="Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
+ * For this purpose, an <a href="../Informer.html"><code>Informer</code></a> that will forward information to the current <code>Reporter</code>
  * is provided via the <code>info</code> parameterless method.
  * You can pass the extra information to the <code>Informer</code> via its <code>apply</code> method.
  * The <code>Informer</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/InfoProvided.html"><code>InfoProvided</code></a> event.
@@ -649,7 +649,7 @@ import org.scalatest.Suite
  * 
  * <p>
  * One use case for the <code>Informer</code> is to pass more information about a specification to the reporter. For example,
- * the <a href="GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncWordSpec</code>
+ * the <a href="../GivenWhenThen.html"><code>GivenWhenThen</code></a> trait provides methods that use the implicit <code>info</code> provided by <code>AsyncWordSpec</code>
  * to pass such information to the reporter. Here's an example:
  * </p>
  *
@@ -700,7 +700,7 @@ import org.scalatest.Suite
  * <a name="documenters"></a><h2>Documenters</h2>
  *
  * <p>
- * <code>AsyncWordSpec</code> also provides a <code>markup</code> method that returns a <a href="Documenter.html"><code>Documenter</code></a>, which allows you to send
+ * <code>AsyncWordSpec</code> also provides a <code>markup</code> method that returns a <a href="../Documenter.html"><code>Documenter</code></a>, which allows you to send
  * to the <code>Reporter</code> text formatted in <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown syntax</a>.
  * You can pass the extra information to the <code>Documenter</code> via its <code>apply</code> method.
  * The <code>Documenter</code> will then pass the information to the <code>Reporter</code> via an <a href="../events/MarkupProvided.html"><code>MarkupProvided</code></a> event.
@@ -785,8 +785,8 @@ import org.scalatest.Suite
  * </p>
  *
  * <p>
- * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
- * (an <a href="Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
+ * To get immediate (<em>i.e.</em>, non-recorded) notifications from tests, you can use <code>note</code> (a <a href="../Notifier.html"><code>Notifier</code></a>) and <code>alert</code>
+ * (an <a href="../Alerter.html"><code>Alerter</code></a>). Here's an example showing the differences:
  * </p>
  *
  * <pre class="stHighlight">


### PR DESCRIPTION
To improve developer experience while browsing the scaladoc on [scalatest.org](https://www.scalatest.org/) this PR aims to fix a lot of broken links.