### PR TITLE
Enhance type inference for intercept and assertThrows

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Assertions.scala
@@ -716,6 +716,7 @@ trait Assertions extends TripleEquals  {
    * function. If the function throws an exception that's an instance of the specified type,
    * this method returns that exception. Else, whether the passed function returns normally
    * or completes abruptly with a different exception, this method throws <code>TestFailedException</code>.
+   * If the type parameter is left to the type inferencer, any Exception will be caught.
    *
    * <p>
    * Note that the type specified as this method's type parameter may represent any subtype of
@@ -743,7 +744,7 @@ trait Assertions extends TripleEquals  {
    * @throws TestFailedException if the passed function does not complete abruptly with an exception
    *    that's an instance of the specified type.
    */
-  def intercept[T <: AnyRef](f: => Any)(implicit classTag: ClassTag[T], pos: source.Position): T = {
+  def intercept[T <: AnyRef](f: => Any)(implicit classTag: ClassTag[T], pos: source.Position): T with Exception = {
     val clazz = classTag.runtimeClass
     val caught = try {
       f
@@ -751,7 +752,7 @@ trait Assertions extends TripleEquals  {
     }
     catch {
       case u: Throwable => {
-        if (!clazz.isAssignableFrom(u.getClass)) {
+        if (!clazz.isAssignableFrom(u.getClass) && clazz.getName != "scala.runtime.Nothing$") {
           val s = Resources.wrongException(clazz.getName, u.getClass.getName)
           throw newAssertionFailedException(Some(s), Some(u), pos, Vector.empty)
         }
@@ -764,7 +765,7 @@ trait Assertions extends TripleEquals  {
       case None =>
         val message = Resources.exceptionExpected(clazz.getName)
         throw newAssertionFailedException(Some(message), None, pos, Vector.empty)
-      case Some(e) => e.asInstanceOf[T] // I know this cast will succeed, becuase isAssignableFrom succeeded above
+      case Some(e) => e.asInstanceOf[T with Exception] // We know this cast will succeed, because isAssignableFrom succeeded above
     }
   }
 
@@ -774,6 +775,7 @@ trait Assertions extends TripleEquals  {
    * function. If the function throws an exception that's an instance of the specified type,
    * this method returns <code>Succeeded</code>. Else, whether the passed function returns normally
    * or completes abruptly with a different exception, this method throws <code>TestFailedException</code>.
+   * If the type parameter is left to the type inferencer, any Exception will be caught.
    *
    * <p>
    * Note that the type specified as this method's type parameter may represent any subtype of
@@ -810,7 +812,7 @@ trait Assertions extends TripleEquals  {
       }
       catch {
           case u: Throwable => {
-          if (!clazz.isAssignableFrom(u.getClass)) {
+          if (!clazz.isAssignableFrom(u.getClass) && clazz.getName != "scala.runtime.Nothing$") {
             val s = Resources.wrongException(clazz.getName, u.getClass.getName)
             throw newAssertionFailedException(Some(s), Some(u), pos, Vector.empty)
           }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -131,6 +131,14 @@ class AssertionsSpec extends AnyFunSpec {
       assert(result eq e)
     }
 
+    it("should catch any exception when the type parameter is left blank") {
+      val e = new RuntimeException
+      val result = intercept {
+        throw e
+      }
+      assert(result == e)
+    }
+
     describe("when the bit of code throws the wrong exception") {
       it("should include that wrong exception as the TFE's cause") {
         val wrongException = new RuntimeException("oops!")
@@ -178,6 +186,13 @@ class AssertionsSpec extends AnyFunSpec {
           assertThrows[Exception] { "hi" }
         }
       assert(caught.isInstanceOf[TestFailedException])
+    }
+
+    it("should catch any exception if the type parameter is left blank") {
+      val result = assertThrows {
+        throw new IllegalArgumentException
+      }
+      assert(result eq Succeeded)
     }
 
     describe("when the bit of code throws the wrong exception") {


### PR DESCRIPTION
This PR makes it possible to leave out the type parameter on `assertThrows` and `intercept`. In this case, it will catch any Exception.