### PR TITLE
[3.2] Backport produceMatcher Fix for Scala 3

### DIFF
--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -3191,14 +3191,23 @@ If it doesn't show up for a while, please delete this comment.
 	case class Quatro(value: Int) extends Numero
         case class Cinco(value: Int) extends Numero
 
+        // SKIP-DOTTY-START
         val unos = instancesOf(Uno) { uno => uno.value }
         val doses = instancesOf(Dos) { dos => dos.value }
         val treses = instancesOf(Tres) { tres => tres.value }
         val quatros = instancesOf(Quatro) { quatro => quatro.value }
         val cincos = instancesOf(Cinco) { cinco => cinco.value }
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val unos = instancesOf[Int, Uno](Uno.apply) { uno => uno.value }
+        //DOTTY-ONLY val doses = instancesOf[Int, Dos](Dos.apply) { dos => dos.value }
+        //DOTTY-ONLY val treses = instancesOf[Int, Tres](Tres.apply) { tres => tres.value }
+        //DOTTY-ONLY val quatros = instancesOf[Int, Quatro](Quatro.apply) { quatro => quatro.value }
+        //DOTTY-ONLY val cincos = instancesOf[Int, Cinco](Cinco.apply) { cinco => cinco.value }
 
-        // val numeros: Generator[Numero] = evenly(unos, doses, treses, quatros, cincos)
+        // SKIP-DOTTY-START
         val numeros = evenly(unos, doses, treses, quatros, cincos)
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val numeros = evenly[Numero](unos, doses, treses, quatros, cincos)
 
         val classification: Classification =
           classify(10000, numeros) {
@@ -4953,13 +4962,19 @@ If it doesn't show up for a while, please delete this comment.
       // users. Having their tests fail when they upgrade to 2.13 might help them prevent bugs from escaping to production.
       "produces generators given construct and deconstruct functions for 1 type" in {
         case class Person(age: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p => p.age } (posZIntValues)
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf[Int, Person](Person.apply) { p => p.age } (posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(ag) => ag should be >= 0 } // A contrived property check to do something with the generator
       }
       "produces generators given construct and deconstruct functions for 2 types" in {
         case class Person(name: String, age: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age)
         } (strings, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -4967,7 +4982,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 3 types" in {
         case class Person(name: String, age: Int, attr3: Long)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3)
         } (strings, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -4978,7 +4996,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 4 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4)
         } (strings, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -4990,7 +5011,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 5 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5003,7 +5027,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 6 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5017,7 +5044,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 7 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5032,7 +5062,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 8 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5048,7 +5081,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 9 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5065,7 +5101,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 10 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5083,7 +5122,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 11 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5102,7 +5144,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 12 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5122,7 +5167,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 13 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5143,7 +5191,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 14 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5165,7 +5216,10 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 15 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -5189,7 +5243,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 16 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double)
+        // SKIP-DOTTY-START                  
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues)
@@ -5215,7 +5272,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 17 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues)
@@ -5242,7 +5302,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 18 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues)
@@ -5270,7 +5333,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 19 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
@@ -5299,7 +5365,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 20 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
@@ -5329,7 +5398,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 21 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
@@ -5360,7 +5432,10 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 22 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float, attr22: Int)
+        // SKIP-DOTTY-START
         val persons = instancesOf(Person) { p =>
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21, p.attr22)
         } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -20,9 +20,57 @@ import org.scalatest.exceptions.TestFailedException
 import scala.collection.immutable.SortedSet
 import scala.collection.immutable.SortedMap
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.should.Matchers._
 
-class GeneratorSpec extends AnyFunSpec with Matchers {
+/**
+  * Boilerplate reduction for those `(Iterator[T], Randomizer)` pairs returned
+  * from `canonicals()` and `shrink()`
+  *
+  * @param pair the returned values from the Generator method
+  * @tparam T the type of the Generator
+  */
+// SKIP-DOTTY-START  
+class GeneratorIteratorPairOps[T](pair: (Iterator[T], Randomizer)) {
+// SKIP-DOTTY-END
+//DOTTY-ONLY implicit class GeneratorIteratorPairOps[T](pair: (Iterator[T], Randomizer)) {  
+  /**
+    * Helper method for testing canonicals and shrinks, which should always be
+    * "growing".
+    *
+    * The definition of "growing" means, essentially, "moving further from zero".
+    * Sometimes that's in the positive direction (eg, PosInt), sometimes negative
+    * (NegFloat), sometimes both (NonZeroInt).
+    *
+    * This returns Unit, because it's all about the assertion.
+    *
+    * This is a bit loose and approximate, but sufficient for the various
+    * Scalactic types.
+    *
+    * @param iter an Iterator over a type, typically a Scalactic type
+    * @param conv a conversion function from the Scalactic type to an ordinary Numeric
+    * @tparam T the Scalactic type
+    * @tparam N the underlying ordered numeric type
+    */
+  def shouldGrowWith[N: Ordering](conv: T => N)(implicit nOps: Numeric[N]): Unit = {
+    val iter: Iterator[T] = pair._1
+    iter.reduce { (last, cur) =>
+      // Duplicates not allowed:
+      last should not equal cur
+      val nLast = nOps.abs(conv(last))
+      val nCur = nOps.abs(conv(cur))
+      nLast should be <= nCur
+      cur
+    }
+  }
+}
+
+class GeneratorSpec extends AnyFunSpec {
+
+  // SKIP-DOTTY-START
+  implicit def convertToGeneratorIteratorPairOps[T](pair: (Iterator[T], Randomizer)): GeneratorIteratorPairOps[T] = 
+    new GeneratorIteratorPairOps(pair)
+  // SKIP-DOTTY-END  
+
   describe("A Generator") {
     it("should offer a map and flatMap method that composes the next methods") {
       import Generator._
@@ -92,7 +140,10 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
     it("should offer a filter method so that pattern matching can be used in for expressions with Generator generators") {
       """for ((a, b) <- CommonGenerators.tuple2s[String, Int]) yield (b, a)""" should compile
       case class Person(name: String, age: Int)
+      // SKIP-DOTTY-START
       val persons = CommonGenerators.instancesOf(Person) { p => (p.name, p.age) }
+      // SKIP-DOTTY-END
+      //DOTTY-ONLY val persons = CommonGenerators.instancesOf[(String, Int), Person](Person.apply) { p => (p.name, p.age) }
       """for (Person(a, b) <- persons) yield (b, a)""" should compile
     }
     it("should offer a filter method that throws an exception if too many objects are filtered out") {
@@ -148,7 +199,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       count shouldEqual generatorDrivenConfig.minSuccessful.value
 
       {
-        implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 10)
+        implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 10)
         count = 0
         forAll { (i: Int) => 
           count += 1
@@ -782,14 +833,16 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
     }
 
+    // SKIP-DOTTY-START
     /**
       * Boilerplate reduction for those `(Iterator[T], Randomizer)` pairs returned
       * from `canonicals()` and `shrink()`
       *
       * @param pair the returned values from the Generator method
       * @tparam T the type of the Generator
-      */
+      */  
     implicit class GeneratorIteratorPairOps[T](pair: (Iterator[T], Randomizer)) {
+    // SKIP-DOTTY-END  
       /**
         * Helper method for testing canonicals and shrinks, which should always be
         * "growing".
@@ -808,7 +861,10 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         * @tparam T the Scalactic type
         * @tparam N the underlying ordered numeric type
         */
-      def shouldGrowWith[N: Ordering](conv: T => N)(implicit nOps: Numeric[N]): Unit = {
+      // SKIP-DOTTY-START  
+      def shouldGrowWithForGeneratorIteratorPair[N: Ordering](conv: T => N)(implicit nOps: Numeric[N]): Unit = {
+      // SKIP-DOTTY-END  
+      //DOTTY-ONLY extension [T](pair: (Iterator[T], Randomizer)) def shouldGrowWithForGeneratorIteratorPair[N: Ordering](conv: T => N)(implicit nOps: Numeric[N]): Unit = {  
         val iter: Iterator[T] = pair._1
         iter.reduce { (last, cur) =>
           // Duplicates not allowed:
@@ -819,7 +875,9 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           cur
         }
       }
+    // SKIP-DOTTY-START  
     }
+    // SKIP-DOTTY-END
 
     describe("for PosInts") {
       it("should produce the same PosInt values in the same order given the same Randomizer") {
@@ -2800,8 +2858,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should offer an implicit provider that uses hashCode to tweak a seed and has a pretty toString") {
         val gen = implicitly[Generator[Option[Int] => List[Int]]]
         val sample = gen.sample
+        // SKIP-DOTTY-START
         sample.toString should include ("Option[Int]")
         sample.toString should include ("List[Int]")
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY sample.toString should include ("scala.Option[scala.Int]")
+        //DOTTY-ONLY sample.toString should include ("scala.collection.immutable.List[scala.Int]")
       }
     }
     describe("for Tuple2s") {
@@ -2870,31 +2932,31 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Vector[T] following size determined by havingSize method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingSize(PosZInt(3))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingSize(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.size shouldBe 3
         }
       }
       it("should produce Vector[T] following length determined by havingLength method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingLength(PosZInt(3))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingLength(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.length shouldBe 3
         }
       }
       it("should produce Vector[T] following sizes determined by havingSizeBetween method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.size should (be >= 3 and be <= 5)
         }
       }
@@ -2910,11 +2972,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Vector[T] following lengths determined by havingLengthBetween method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.length should (be >= 3 and be <= 5)
         }
       }
@@ -2930,21 +2992,21 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Vector[T] following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.size shouldBe 5
         }
       }
       it("should produce Vector[T] following sizes determined by havingLengthsDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int]
-        implicit val sGen = aGen.havingLengthsDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[Vector[Int]] = aGen.havingLengthsDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { v: Vector[Int] =>
+        forAll { (v: Vector[Int]) =>
           v.length shouldBe 5
         }
       }
@@ -3027,21 +3089,21 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Set[T] following size determined by havingSize method") {
         val aGen= Generator.setGenerator[Int]
-        implicit val sGen = aGen.havingSize(PosZInt(3))
+        implicit val sGen: Generator[Set[Int]] = aGen.havingSize(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Set[Int] =>
+        forAll { (s: Set[Int]) =>
           s.size shouldBe 3
         }
       }
       it("should produce Set[T] following sizes determined by havingSizeBetween method") {
         val aGen= Generator.setGenerator[Int]
-        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[Set[Int]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Set[Int] =>
+        forAll { (s: Set[Int]) =>
           s.size should (be >= 3 and be <= 5)
         }
       }
@@ -3057,11 +3119,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Set[T] following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.setGenerator[Int]
-        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[Set[Int]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Set[Int] =>
+        forAll { (s: Set[Int]) =>
           s.size shouldBe 5
         }
       }
@@ -3146,21 +3208,21 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Set[T] following size determined by havingSize method") {
         val aGen= Generator.sortedSetGenerator[Int]
-        implicit val sGen = aGen.havingSize(PosZInt(3))
+        implicit val sGen: Generator[SortedSet[Int]] = aGen.havingSize(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedSet[Int] =>
+        forAll { (s: SortedSet[Int]) =>
           s.size shouldBe 3
         }
       }
       it("should produce Set[T] following sizes determined by havingSizeBetween method") {
         val aGen= Generator.sortedSetGenerator[Int]
-        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[SortedSet[Int]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedSet[Int] =>
+        forAll { (s: SortedSet[Int]) =>
           s.size should (be >= 3 and be <= 5)
         }
       }
@@ -3176,11 +3238,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Set[T] following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.sortedSetGenerator[Int]
-        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[SortedSet[Int]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedSet[Int] =>
+        forAll { (s: SortedSet[Int]) =>
           s.size shouldBe 5
         }
       }
@@ -3303,21 +3365,21 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Map[K, V] following size determined by havingSize method") {
         val aGen= Generator.mapGenerator[Int, String]
-        implicit val sGen = aGen.havingSize(PosZInt(3))
+        implicit val sGen: Generator[Map[Int, String]] = aGen.havingSize(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Map[Int, String] =>
+        forAll { (s: Map[Int, String]) =>
           s.size shouldBe 3
         }
       }
       it("should produce Map[K, V] following sizes determined by havingSizeBetween method") {
         val aGen= Generator.mapGenerator[Int, String]
-        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[Map[Int, String]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Map[Int, String] =>
+        forAll { (s: Map[Int, String]) =>
           s.size should (be >= 3 and be <= 5)
         }
       }
@@ -3333,11 +3395,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Map[K, V] following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.mapGenerator[Int, String]
-        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[Map[Int, String]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: Map[Int, String] =>
+        forAll { (s: Map[Int, String]) =>
           s.size shouldBe 5
         }
       }
@@ -3463,21 +3525,21 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce SortedMap[K, V] following size determined by havingSize method") {
         val aGen= Generator.sortedMapGenerator[Int, String]
-        implicit val sGen = aGen.havingSize(PosZInt(3))
+        implicit val sGen: Generator[SortedMap[Int, String]] = aGen.havingSize(PosZInt(3))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedMap[Int, String] =>
+        forAll { (s: SortedMap[Int, String]) =>
           s.size shouldBe 3
         }
       }
       it("should produce SortedMap[K, V] following sizes determined by havingSizeBetween method") {
         val aGen= Generator.sortedMapGenerator[Int, String]
-        implicit val sGen = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        implicit val sGen: Generator[SortedMap[Int, String]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedMap[Int, String] =>
+        forAll { (s: SortedMap[Int, String]) =>
           s.size should (be >= 3 and be <= 5)
         }
       }
@@ -3493,11 +3555,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce SortedMap[K, V] following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.sortedMapGenerator[Int, String]
-        implicit val sGen = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+        implicit val sGen: Generator[SortedMap[Int, String]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
 
         import GeneratorDrivenPropertyChecks._
 
-        forAll { s: SortedMap[Int, String] =>
+        forAll { (s: SortedMap[Int, String]) =>
           s.size shouldBe 5
         }
       }
@@ -3603,6 +3665,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       val genColor = specificValues(Red, Green)
       val genLine = for { color <- genColor } yield Line(color)
       val genCircle = for { color <- genColor } yield Circle(color)
+      
+      /*lazy val genShape = evenly[Shape](genLine, genCircle, genBox)
+      lazy val genBox: Generator[Box] = for {
+        color <- genColor
+        shape <- genShape
+      } yield Box(color, shape)*/
+      
+      // SKIP-DOTTY-START
       """
       lazy val genShape = evenly(genLine, genCircle, genBox)
       lazy val genBox: Generator[Box] = for {
@@ -3610,6 +3680,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         shape <- genShape
       } yield Box(color, shape)
       """ should compile
+      // SKIP-DOTTY-END
+      //DOTTY-ONLY """
+      //DOTTY-ONLY lazy val genShape = evenly[Shape](genLine, genCircle, genBox)
+      //DOTTY-ONLY lazy val genBox: Generator[Box] = for {
+      //DOTTY-ONLY   color <- genColor
+      //DOTTY-ONLY   shape <- genShape
+      //DOTTY-ONLY } yield Box(color, shape)
+      //DOTTY-ONLY """ should compile
     }
   }
 }

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -2876,7 +2876,7 @@ object MatcherFactory$arity$ {
    * @param matcherFactory a MatcherFactory$arity$ to convert
    * @return a Matcher produced by the passed MatcherFactory$arity$
    */
-  implicit def produceMatcher[SC: Type, $typeConstructors$, T <: SC : $colonSeparatedTCNs$](matcherFactory: MatcherFactory$arity$[SC, $commaSeparatedTCNs$]): Matcher[T] =
+  implicit def produceMatcher[SC, $typeConstructors$, T <: SC : $colonSeparatedTCNs$](matcherFactory: MatcherFactory$arity$[SC, $commaSeparatedTCNs$]): Matcher[T] =
     matcherFactory.matcher
 
   /**

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -404,11 +404,7 @@ object GenScalaTestDotty {
         "NoArgSpec.scala",  // skipped because tests failed.
       )) ++ 
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
-    copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, 
-      List(
-        "CommonGeneratorsSpec.scala", 
-        "GeneratorSpec.scala"
-      )) ++
+    copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop", "org/scalatest/suiteprop", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/matchers", "org/scalatest/matchers", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/time", "org/scalatest/time", targetDir, List.empty) ++
@@ -503,11 +499,7 @@ object GenScalaTestDotty {
         "SuiteSpec.scala"    // skipped because depends on java reflections
       )) ++ 
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
-    copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, 
-      List(
-        "CommonGeneratorsSpec.scala", 
-        "GeneratorSpec.scala"
-      )) ++
+    copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, List.empty) ++
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop", "org/scalatest/suiteprop", targetDir, List.empty) ++
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/matchers", "org/scalatest/matchers", targetDir, List.empty) ++
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/time", "org/scalatest/time", targetDir, List.empty) ++


### PR DESCRIPTION
Backported produceMatcher fix Scala 3, and got CommonGeneratorSpec and GeneratorSpec to work for Scala 3.