### PR TITLE
HtmlReporter Update

### DIFF
--- a/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -725,3 +725,5 @@ fromGreaterThanToHavingSizesBetween=The from value passed to havingSizesBetween,
 analysis=Analysis:
 
 deprecatedChosenStyleWarning=Warning: The chosen style has been deprecated and will be removed in future version of ScalaTest, because each style trait will be available as its own module.
+
+flexmarkClassNotFound=Flexmark Pegdown adapter class not found, please add flexmark-all (https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark/0.62.2) to your test classpath.

--- a/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -113,6 +113,14 @@ private[scalatest] class HtmlReporter(
   copyResource(getResource("images/graybullet.gif"), imagesDir, "infoprovided.gif")
   
   private val results = resultHolder.getOrElse(new SuiteResultHolder)
+  
+  try {
+    Class.forName("com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter")
+  }
+  catch {
+    case _: ClassNotFoundException => 
+      new ClassNotFoundException(Resources.flexmarkClassNotFound)
+  }
 
   private val pegdownOptions = PegdownOptionsAdapter.flexmarkOptions(PegdownExtensions.ALL)
   private val markdownParser = Parser.builder(pegdownOptions).build()

--- a/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -250,23 +250,27 @@ private[scalatest] class HtmlReporter(
           }
         }
         <script type="text/javascript">
-        //<![CDATA[
-            function toggleDetails(contentId, linkId) { 
-              var ele = document.getElementById(contentId); 
-              var text = document.getElementById(linkId); 
-              if(ele.style.display == "block") { 
-                ele.style.display = "none"; 
-                text.innerHTML = "(Show Details)"; 
+          {
+            unparsedXml(
+              """
+              function toggleDetails(contentId, linkId) { 
+                var ele = document.getElementById(contentId); 
+                var text = document.getElementById(linkId); 
+                if(ele.style.display == "block") { 
+                  ele.style.display = "none"; 
+                  text.innerHTML = "(Show Details)"; 
+                } 
+                else { 
+                  ele.style.display = "block"; 
+                  text.innerHTML = "(Hide Details)";
+                }
               } 
-              else { 
-                ele.style.display = "block"; 
-                text.innerHTML = "(Hide Details)";
+              function hideOpenInNewTabIfRequired() { 
+                if (top === self) { document.getElementById('printlink').style.display = 'none'; } 
               }
-            } 
-            function hideOpenInNewTabIfRequired() { 
-              if (top === self) { document.getElementById('printlink').style.display = 'none'; } 
-            }
-        //]]>
+              """
+            )
+          }
         </script>
       </head>
       <body class="specification">
@@ -532,7 +536,9 @@ private[scalatest] class HtmlReporter(
         <script type="text/javascript" src="js/d3.v2.min.js"></script>
         <script type="text/javascript" src="js/sorttable.js"></script>
         <script type="text/javascript">
-        //<![CDATA[
+          {
+          unparsedXml(
+            """
             var tagMap = {};     
             var SUCCEEDED_BIT = 1; 
             var FAILED_BIT = 2; 
@@ -573,8 +579,9 @@ private[scalatest] class HtmlReporter(
               detailsView.style.left = left + "px"; 
               detailsView.style.width = (window.innerWidth - left - 30) + "px";
               detailsView.style.height = (window.innerHeight - headerView.offsetHeight - 20) + "px";
-            }
-        //]]>
+            }"""
+          )
+          }
         </script>
       </head>
       <body onresize="resizeDetailsView()">
@@ -634,9 +641,7 @@ private[scalatest] class HtmlReporter(
           { unparsedXml(tagMapScript) }
         </script>
         <script type="text/javascript">
-          //<![CDATA[
           resizeDetailsView();
-          //]]>
         </script>
       </body>
     </html>

--- a/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -46,8 +46,8 @@ import Suite.unparsedXml
 import Suite.xmlContent
 import org.scalatest.exceptions.TestFailedException
 
-import com.vladsch.flexmark.profiles.pegdown.Extensions
-import com.vladsch.flexmark.profiles.pegdown.PegdownOptionsAdapter
+import com.vladsch.flexmark.parser.PegdownExtensions
+import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.html.HtmlRenderer
 
@@ -114,7 +114,7 @@ private[scalatest] class HtmlReporter(
   
   private val results = resultHolder.getOrElse(new SuiteResultHolder)
 
-  private val pegdownOptions = PegdownOptionsAdapter.flexmarkOptions(Extensions.ALL)
+  private val pegdownOptions = PegdownOptionsAdapter.flexmarkOptions(PegdownExtensions.ALL)
   private val markdownParser = Parser.builder(pegdownOptions).build()
   private val htmlRenderer = HtmlRenderer.builder(pegdownOptions).build()
   

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -22,7 +22,7 @@ trait BuildCommons {
 
   val plusJUnitVersion = "3.2.9.0"
   val plusTestNGVersion = "3.2.9.0"
-  val flexmarkVersion = "0.36.8"
+  val flexmarkVersion = "0.62.2"
 
   def rootProject: Project
 


### PR DESCRIPTION
- Updated flexmark version to 0.62.2.
- Give a friendly message when Flexmark not available on classpath.
- Fixed javascript error in html reports generated under Scala 3.