### PR TITLE
label another test in EventuallySpec as Flicker

### DIFF
--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
@@ -359,7 +359,7 @@ class EventuallySpec extends AsyncFunSpec with Matchers with OptionValues /*with
       }
     }
 
-    it("should, if an alternate implicit Timeout is provided, invoke an always-failing by-name by at least the specified timeout") {
+    it("should, if an alternate implicit Timeout is provided, invoke an always-failing by-name by at least the specified timeout", Flicker) {
 
       implicit val patienceConfig = PatienceConfig(timeout = Span(1500, Millis))
 


### PR DESCRIPTION
because I saw it fail here:
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk8-integrate-community-build/4429/artifact/logs/scalatest-tests-build.log