### PR TITLE
Scala 3: CompileMacro Enhancement

### DIFF
--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
@@ -43,6 +43,9 @@ object CompileMacro {
         // LHS is a normal string literal, call checkCompile with the extracted code string to generate code
         checkCompile(code.toString)
 
+      case Apply(Select(_, "stripMargin"), List(Literal(StringConstant(code)))) =>
+        checkCompile(code.stripMargin.toString)  
+
       case other =>
         report.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
@@ -66,6 +66,9 @@ object CompileMacro {
         // LHS is a normal string literal, call checkCompile with the extracted code string to generate code
         checkNotCompile(code.toString)
 
+      case Apply(Select(_, "stripMargin"), List(Literal(StringConstant(code)))) =>
+        checkNotCompile(code.stripMargin.toString)  
+
       case other =>
         report.throwError("The '" + shouldOrMust + " compile' syntax only works with String literals.")
     }

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
@@ -125,7 +125,7 @@ object CompileMacro {
         checkNotTypeCheck(code.toString)
 
       case Apply(Select(_, "stripMargin"), List(Literal(StringConstant(code)))) =>
-        checkNotTypeCheck(code.toString.stripMargin)
+        checkNotTypeCheck(code.stripMargin)
 
       case _ =>
         report.throwError("The '" + shouldOrMust + "Not typeCheck' syntax only works with String literals.")

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
@@ -32,7 +32,6 @@ class ShouldCompileSpec extends AnyFunSpec {
         "val a = 1" should compile
       }
 
-      // SKIP-DOTTY-START
       it("should throw TestFailedException with correct message and stack depth when type check failed") {
         val e = intercept[TestFailedException] {
           "val a: String = 2" should compile
@@ -43,8 +42,7 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
-      // SKIP-DOTTY-END
-
+      
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
         
         // SKIP-DOTTY-START

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
@@ -100,7 +100,6 @@ class ShouldCompileSpec extends AnyFunSpec {
       
     }
 
-    // SKIP-DOTTY-START
     describe("when work with triple quotes string literal with stripMargin") {
 
       it("should do nothing when type check passed") {
@@ -123,18 +122,22 @@ class ShouldCompileSpec extends AnyFunSpec {
       }
 
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
+        // SKIP-DOTTY-START
+        val errMsg = Resources.expectedNoErrorButGotParseError("", "")
+        // SKIP-DOTTY-END
+        //DOTTY-ONLY val errMsg = Resources.expectedNoErrorButGotTypeError("", "")
+
         val e = intercept[TestFailedException] {
           """
             |println("test)
             |""".stripMargin should compile
         }
-        val errMsg = Resources.expectedNoErrorButGotParseError("", "")
+        
         assert(e.message.get.startsWith(errMsg.substring(0, errMsg.indexOf(':'))))
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
       }
     }
-    // SKIP-DOTTY-END
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
@@ -107,7 +107,6 @@ class ShouldNotCompileSpec extends AnyFunSpec {
       }
     }
 
-    // SKIP-DOTTY-START
     describe("when work with triple quotes string literal with stripMargin") {
 
       it("should do nothing when type check failed") {
@@ -157,7 +156,6 @@ class ShouldNotCompileSpec extends AnyFunSpec {
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
       }
     }
-    // SKIP-DOTTY-END
 
   }
 


### PR DESCRIPTION
Enhanced Scala 3 build to support 'shouldNot compile' and 'should compile' syntax for """ string.