### PR TITLE
Add missing semicolon to Tag.scala scaladoc

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/Tag.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Tag.scala
@@ -38,7 +38,7 @@ package org.scalatest
  * package com.mycompany.myproject.testing.tags;
  *
  * import java.lang.annotation.*; 
- * import org.scalatest.TagAnnotation
+ * import org.scalatest.TagAnnotation;
  *
  * @TagAnnotation
  * @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
An example from `org.scalatest.Tag` is missing a semicolon. This PR is adding that semicolon.