### PR TITLE
Scala 3: Tweak EitherValues and OptionValues Valuable Class Name

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
@@ -106,7 +106,10 @@ trait EitherValues extends Serializable {
    *
    * @param either the <code>Either</code> on which to add the <code>value</code> method
    */
+  // SKIP-DOTTY-START  
   implicit def convertEitherToValuable[L, R](either: Either[L, R])(implicit pos: source.Position): Valuable[L, R] = new Valuable(either, pos)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY implicit def convertEitherToValuable[L, R](either: Either[L, R])(implicit pos: source.Position): EitherValuable[L, R] = new EitherValuable(either, pos)
 
   /**
    * Wrapper class that adds a <code>value</code> method to <code>LeftProjection</code>, allowing
@@ -164,7 +167,7 @@ trait EitherValues extends Serializable {
     }
   }
 
-
+  // SKIP-DOTTY-START
   /**
    * Wrapper class that adds a <code>value</code> method to <code>Either</code>, allowing
    * you to make statements to inspect the value if a Right, like:
@@ -175,8 +178,21 @@ trait EitherValues extends Serializable {
    *
    * @param either An <code>Either</code> to convert to <code>Valuable</code>, which provides the
    *   <code>value</code> method.
-   */
+   */ 
   class Valuable[L, R](either: Either[L, R], pos: source.Position) extends Serializable {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Wrapper class that adds a <code>value</code> method to <code>Either</code>, allowing
+  //DOTTY-ONLY  * you to make statements to inspect the value if a Right, like:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * either.value should be &gt; 9
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param either An <code>Either</code> to convert to <code>EitherValuable</code>, which provides the
+  //DOTTY-ONLY  *   <code>value</code> method.
+  //DOTTY-ONLY  */ 
+  //DOTTY-ONLY class EitherValuable[L, R](either: Either[L, R], pos: source.Position) extends Serializable {
 
     /**
      * Returns the <code>Right</code> value contained in the wrapped <code>RightProjection</code>, if defined as a <code>Right</code>, else throws <code>TestFailedException</code> with

--- a/jvm/core/src/main/scala/org/scalatest/OptionValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/OptionValues.scala
@@ -87,8 +87,12 @@ trait OptionValues {
    *
    * @param opt the <code>Option</code> on which to add the <code>value</code> method
    */
+  // SKIP-DOTTY-START 
   implicit def convertOptionToValuable[T](opt: Option[T])(implicit pos: source.Position): Valuable[T] = new Valuable(opt, pos)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY implicit def convertOptionToValuable[T](opt: Option[T])(implicit pos: source.Position): OptionValuable[T] = new OptionValuable(opt, pos)
 
+  // SKIP-DOTTY-START
   /**
    * Wrapper class that adds a <code>value</code> method to <code>Option</code>, allowing
    * you to make statements like:
@@ -100,6 +104,18 @@ trait OptionValues {
    * @param opt An option to convert to <code>Valuable</code>, which provides the <code>value</code> method.
    */
   class Valuable[T](opt: Option[T], pos: source.Position) {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Wrapper class that adds a <code>value</code> method to <code>Option</code>, allowing
+  //DOTTY-ONLY  * you to make statements like:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * opt.value should be &gt; 9
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param opt An option to convert to <code>OptionValuable</code>, which provides the <code>value</code> method.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY class OptionValuable[T](opt: Option[T], pos: source.Position) {  
 
     /**
      * Returns the value contained in the wrapped <code>Option</code>, if defined, else throws <code>TestFailedException</code> with

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -107,5 +107,9 @@ class EitherValuesSpec extends AnyFunSpec {
       val righty: Either[String, Map[String, Int]] = Right(Map("I" -> 1, "II" -> 2))
       righty.value("II") shouldBe 2
     }
+
+    it("should be able to used with OptionValues") {
+      class TestSpec extends AnyFunSpec with EitherValues with OptionValues
+    }
   } 
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionValuesSpec.scala
@@ -48,6 +48,10 @@ class OptionValuesSpec extends AnyFunSpec {
       val opt: Option[Map[String, Int]] = Some(Map("I" -> 1, "II" -> 2))
       opt.value("II") shouldBe 2
     }
+
+    it("should be able to used with EitherValues") {
+      class TestSpec extends AnyFunSpec with OptionValues with EitherValues
+    }
   }
 }
 


### PR DESCRIPTION
Changed Valuable class in EitherValues to EitherValuable, and in OptionValues to OptionValuable, for Scala 3 build to avoid name crash error when both EitherValues and OptionValues are being used together.