### PR TITLE
Handle Non-Serializable Exception Payload

### DIFF
--- a/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -731,3 +731,4 @@ flexmarkClassNotFound=Flexmark Pegdown adapter class not found, please add flexm
 unableToSerializePayload=Warning: Unable to serialize payload of type {0} for {1}, setting it to None.
 unableToSerializeThrowable=Warning: Unable to serialize throwable of type {0} for {1}, setting it to None.
 unableToReadSerializedEvent=Warning: Unable to read from client, please check on client for futher details of the problem.
+unableToContinueRun=Fatal: Existing as unable to continue running tests, after 3 failing attempts to read event from server socket. 

--- a/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -727,3 +727,7 @@ analysis=Analysis:
 deprecatedChosenStyleWarning=Warning: The chosen style has been deprecated and will be removed in future version of ScalaTest, because each style trait will be available as its own module.
 
 flexmarkClassNotFound=Flexmark Pegdown adapter class not found, please add flexmark-all (https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark/0.62.2) to your test classpath.
+
+unableToSerializePayload=Warning: Unable to serialize payload of type {0} for {1}, setting it to None.
+unableToSerializeThrowable=Warning: Unable to serialize throwable of type {0} for {1}, setting it to None.
+unableToReadSerializedEvent=Warning: Unable to read from client, please check on client for futher details of the problem.

--- a/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -728,7 +728,7 @@ deprecatedChosenStyleWarning=Warning: The chosen style has been deprecated and w
 
 flexmarkClassNotFound=Flexmark Pegdown adapter class not found, please add flexmark-all (https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark/0.62.2) to your test classpath.
 
-unableToSerializePayload=Warning: Unable to serialize payload of type {0} for {1}, setting it to None.
-unableToSerializeThrowable=Warning: Unable to serialize throwable of type {0} for {1}, setting it to None.
+unableToSerializePayload=Warning: Unable to serialize payload of type {0} for {1}, wrapping it as NotSerializableWrapperException.
+unableToSerializeThrowable=Warning: Unable to serialize throwable of type {0} for {1}, setting it as NotSerializableWrapperException.
 unableToReadSerializedEvent=Warning: Unable to read from client, please check on client for futher details of the problem.
 unableToContinueRun=Fatal: Existing as unable to continue running tests, after 3 failing attempts to read event from server socket. 

--- a/jvm/core/src/main/scala/org/scalatest/events/Event.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Event.scala
@@ -26,6 +26,7 @@ import java.util.Date
 import scala.xml.Elem
 // SKIP-SCALATESTJS,NATIVE-END
 import exceptions.StackDepthException
+import exceptions.NotSerializableWrapperException
 
 /**
  * A base class for the events that can be passed to the report function passed
@@ -316,8 +317,10 @@ sealed abstract class Event extends Ordered[Event] with Product with Serializabl
   private[scalatest] def ensureThrowableSerializable(throwable: Option[Throwable]): Event = 
     throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
-        withThrowable(None)
+        val className = t.getClass().getName()
+        println(Resources.unableToSerializeThrowable(className, this.toString()))
+        val ex = new NotSerializableWrapperException(t.getMessage, className, t.getStackTrace)
+        withThrowable(Some(ex))
 
       case _ => this
     }  

--- a/jvm/core/src/main/scala/org/scalatest/events/Event.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Event.scala
@@ -20,6 +20,7 @@ import org.scalactic.Requirements._
 import java.io.BufferedWriter
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.io.NotSerializableException
 import java.util.Date
 // SKIP-SCALATESTJS,NATIVE-START
 import scala.xml.Elem
@@ -293,7 +294,7 @@ sealed abstract class Event extends Ordered[Event] with Product with Serializabl
       true
     }
     catch {
-      case _: Throwable => false
+      case _: NotSerializableException => false
     }
   }
 

--- a/jvm/core/src/main/scala/org/scalatest/events/Event.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Event.scala
@@ -416,7 +416,7 @@ final case class TestStarting (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -532,7 +532,7 @@ final case class TestSucceeded (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -659,14 +659,14 @@ final case class TestFailed (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -771,7 +771,7 @@ final case class TestIgnored (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -876,7 +876,7 @@ final case class TestPending (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -996,14 +996,14 @@ final case class TestCanceled (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -1104,7 +1104,7 @@ final case class SuiteStarting (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -1209,7 +1209,7 @@ final case class SuiteCompleted (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -1326,14 +1326,14 @@ final case class SuiteAborted (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -1429,7 +1429,7 @@ final case class RunStarting (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -1527,7 +1527,7 @@ final case class RunCompleted (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -1626,7 +1626,7 @@ final case class RunStopped (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -1725,14 +1725,14 @@ final case class RunAborted (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -1826,14 +1826,14 @@ final case class InfoProvided (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -1936,14 +1936,14 @@ final case class AlertProvided (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -2046,14 +2046,14 @@ final case class NoteProvided (
     val serializablePayload = 
       payload match {
         case Some(p) if !serializeRoundtrip(p) =>
-          println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+          println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
           copy(payload = None)
 
         case _ => this
       }
     serializablePayload.throwable match {
       case Some(t) if !serializeRoundtrip(t) =>
-        println("Warning: Unable to serialize throwable of type " + t.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializeThrowable(t.getClass().getName(), this.toString()))
         serializablePayload.copy(throwable = None)
 
       case _ => serializablePayload
@@ -2140,7 +2140,7 @@ final case class MarkupProvided (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -2225,7 +2225,7 @@ final case class ScopeOpened (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -2309,7 +2309,7 @@ final case class ScopeClosed (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this
@@ -2391,7 +2391,7 @@ final case class ScopePending (
   private[scalatest] def ensureSerializable(): Event = 
     payload match {
       case Some(p) if !serializeRoundtrip(p) =>
-        println("Warning: Unable to serialize payload of type " + p.getClass().getName() + " for " + this.toString() + ", setting it to None.")
+        println(Resources.unableToSerializePayload(p.getClass().getName(), this.toString()))
         copy(payload = None)
 
       case _ => this

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/NotSerializableWrapperException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/NotSerializableWrapperException.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest.exceptions
+
+class NotSerializableWrapperException(msg: String, exceptionClassName: String, exceptionStackTrace: Array[StackTraceElement]) extends Exception with Serializable

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -896,6 +896,7 @@ import java.net.{ServerSocket, InetAddress}
             catch {
               case t: Throwable => 
                 // Restart server socket
+                println(Resources.unableToReadSerializedEvent)
                 is.get.close()
                 socket.set(server.accept())
                 is.set(new SkeletonObjectInputStream(socket.get.getInputStream, getClass.getClassLoader))

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -21,7 +21,7 @@ import ArgsParser._
 import SuiteDiscoveryHelper._
 
 import scala.collection.JavaConverters._
-import java.io.{PrintWriter, StringWriter}
+import java.io.{PrintWriter, StringWriter, IOException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
 
@@ -894,7 +894,7 @@ import java.net.{ServerSocket, InetAddress}
               react()  
             }
             catch {
-              case t: Throwable => 
+              case t: IOException => 
                 // Restart server socket
                 println(Resources.unableToReadSerializedEvent)
                 is.get.close()

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -895,7 +895,7 @@ import java.net.{ServerSocket, InetAddress}
             }
             catch {
               case t: Throwable => 
-                t.printStackTrace()
+                // Restart server socket
                 is.get.close()
                 socket.set(server.accept())
                 is.set(new SkeletonObjectInputStream(socket.get.getInputStream, getClass.getClassLoader))

--- a/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
@@ -15,28 +15,67 @@
  */
 package org.scalatest.tools
 
-import org.scalatest.events.Event
+import org.scalatest.events._
 import org.scalatest.ResourcefulReporter
 import java.net.Socket
 import java.io.ObjectOutputStream
 import java.io.BufferedOutputStream
+import java.util.concurrent.atomic.AtomicReference
 
 private[scalatest] class SocketReporter(host: String, port: Int) extends ResourcefulReporter {
 
-  private val socket = new Socket(host, port)
-  private val out = new ObjectOutputStream(socket.getOutputStream)
+  private val socket = new AtomicReference(new Socket(host, port))
+  private val out = new AtomicReference(new ObjectOutputStream(socket.get.getOutputStream))
+
+  /*def serializeRoundtrip[A](a: A): A = {
+    val baos = new java.io.ByteArrayOutputStream
+    val oos = new java.io.ObjectOutputStream(baos)
+    oos.writeObject(a)
+    oos.flush()
+    val ois = new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(baos.toByteArray))
+    ois.readObject.asInstanceOf[A]
+  }*/
+
+  def refresh(): Unit = {
+    try {
+      out.get.close()
+      socket.get.close()
+    }
+    catch {
+      case _: Throwable =>
+    }
+    socket.set(new Socket(host, port))
+    out.set(new ObjectOutputStream(socket.get.getOutputStream))
+  }
   
   def apply(event: Event): Unit = {
     synchronized {
-      out.writeObject(event)
-      out.flush()
+      try {
+        out.get.writeObject(event)
+        out.get.flush()
+      }
+      catch {
+        case e: java.io.NotSerializableException =>
+          refresh()
+          event match {
+            case testFailed: TestFailed => 
+              out.get.writeObject(testFailed.copy(throwable = None))
+
+            case _ =>  
+          }
+
+        case e: Throwable => 
+          refresh()
+          out.get.writeObject(event)
+          out.get.flush()  
+      }
     }
   }
 
   def dispose(): Unit = {
-    out.flush()
-    out.close()
-    socket.close()
+    out.get.flush()
+    out.get.close()
+    socket.get.close()
   }
   
 }

--- a/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
@@ -27,15 +27,6 @@ private[scalatest] class SocketReporter(host: String, port: Int) extends Resourc
   private val socket = new AtomicReference(new Socket(host, port))
   private val out = new AtomicReference(new ObjectOutputStream(socket.get.getOutputStream))
 
-  /*def serializeRoundtrip[A](a: A): A = {
-    val baos = new java.io.ByteArrayOutputStream
-    val oos = new java.io.ObjectOutputStream(baos)
-    oos.writeObject(a)
-    oos.flush()
-    val ois = new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(baos.toByteArray))
-    ois.readObject.asInstanceOf[A]
-  }*/
-
   def refresh(): Unit = {
     try {
       out.get.close()
@@ -57,17 +48,9 @@ private[scalatest] class SocketReporter(host: String, port: Int) extends Resourc
       catch {
         case e: java.io.NotSerializableException =>
           refresh()
-          event match {
-            case testFailed: TestFailed => 
-              out.get.writeObject(testFailed.copy(throwable = None))
+          out.get.writeObject(event.ensureSerializable())
 
-            case _ =>  
-          }
-
-        case e: Throwable => 
-          refresh()
-          out.get.writeObject(event)
-          out.get.flush()  
+        case e: Throwable => refresh()
       }
     }
   }

--- a/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
@@ -17,6 +17,7 @@ package org.scalatest.tools
 
 import org.scalatest.events._
 import org.scalatest.ResourcefulReporter
+import org.scalatest.Suite.anExceptionThatShouldCauseAnAbort
 import java.net.Socket
 import java.io.ObjectOutputStream
 import java.io.BufferedOutputStream
@@ -33,7 +34,7 @@ private[scalatest] class SocketReporter(host: String, port: Int) extends Resourc
       socket.get.close()
     }
     catch {
-      case _: Throwable =>
+      case t: Throwable if anExceptionThatShouldCauseAnAbort(t) =>
     }
     socket.set(new Socket(host, port))
     out.set(new ObjectOutputStream(socket.get.getOutputStream))
@@ -50,7 +51,7 @@ private[scalatest] class SocketReporter(host: String, port: Int) extends Resourc
           refresh()
           out.get.writeObject(event.ensureSerializable())
 
-        case e: Throwable => refresh()
+        case e: Throwable if anExceptionThatShouldCauseAnAbort(e) => refresh()
       }
     }
   }


### PR DESCRIPTION
Set non-serializable event's payload field to None and wrapped non-serializable throwable as NotSerializableWrapperException when failed to serialize them, and print out a warning message on both the client and server side so that user can follow-up to make the related throwable or payload type serializable, if they needs them to.  This approach avoid the non-serializable payload or throwable from crashing the test run.