### PR TITLE
Fix Runner Hang Problem

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1489,8 +1489,17 @@ object Runner {
         // getDispatchReporter may complete abruptly with an exception, if there is an problem trying to load
         // or instantiate a custom reporter class.
         case ex: Throwable => {
-          System.err.println(Resources.bigProblemsMaybeCustomReporter)
+          val msg = Resources.bigProblemsMaybeCustomReporter
+          System.err.println(msg)
           ex.printStackTrace(System.err)
+          val tracker = new Tracker(new Ordinal(1))
+          val runAborted = RunAborted(tracker.nextOrdinal(), msg, None)
+          graphicReporter.foreach { rep =>
+            rep(runAborted)
+          }
+          passFailReporter.foreach { rep =>
+            rep(runAborted)
+          }
         }
       }
     }


### PR DESCRIPTION
Fire RunAborted event when error in creating dispatch reporter, fixing hang problem when it happens.

This should fix the following issue: 

https://github.com/scalatest/scalatest/issues/2069#issuecomment-1007611928