### PR TITLE
Ant Version Update

### DIFF
--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -148,7 +148,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
     Seq(
       "org.scala-sbt" % "test-interface" % "1.0" % "optional",
       "com.google.inject" % "guice" % "4.0" % "optional",
-      "org.apache.ant" % "ant" % "1.7.1" % "optional",
+      "org.apache.ant" % "ant" % "1.10.12" % "optional",
       "org.ow2.asm" % "asm-all" % "4.1" % "optional",
       flexmarkAll
     )


### PR DESCRIPTION
Updated to use ant 1.10.12, to fix the CVE vulnerabilities warnings shown in https://mvnrepository.com/artifact/org.scalatest/scalatest-core_3/3.2.10 .