### PR TITLE
Adjustments for 3.2.11

### DIFF
--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -18,12 +18,12 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.10"
+  val releaseVersion = "3.2.11"
 
-  val previousReleaseVersion = "3.2.9"
+  val previousReleaseVersion = "3.2.10"
 
-  val plusJUnitVersion = "3.2.9.0"
-  val plusTestNGVersion = "3.2.9.0"
+  val plusJUnitVersion = "3.2.10.0"
+  val plusTestNGVersion = "3.2.10.0"
   val flexmarkVersion = "0.62.2"
 
   def rootProject: Project

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -452,7 +452,8 @@ trait JsBuild { this: BuildCommons =>
       mimaBinaryIssueFilters ++= {
        Seq(
          exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.failAfterImpl"),  // New function not in current version
-         exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.cancelAfterImpl")  // New function not in current version
+         exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.cancelAfterImpl"),  // New function not in current version
+         exclude[ReversedMissingMethodProblem]("org.scalatest.events.Event.withPayload") // New private[scalatest] function not in current version
        )
      }
     ).settings(osgiSettings: _*).settings(

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -14,7 +14,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 trait NativeBuild { this: BuildCommons =>
 
-  val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0")
+  val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.3")
 
   lazy val nativeCrossBuildLibraryDependencies = Def.setting {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
 
-val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0")
+val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.3")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -609,7 +609,9 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       mimaBinaryIssueFilters ++= {
         Seq(
           exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.failAfterImpl"),  // New function not in current version
-          exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.cancelAfterImpl")  // New function not in current version
+          exclude[DirectMissingMethodProblem]("org.scalatest.concurrent.TimeLimits.cancelAfterImpl"),  // New function not in current version
+          exclude[ReversedMissingMethodProblem]("org.scalatest.events.Event.withPayload"), // New private[scalatest] function not in current version
+          exclude[IncompatibleMethTypeProblem]("org.scalatest.tools.Framework#ScalaTestRunner#Skeleton#1#React.this")  // SBT integration class not meant for third-party use.
         )
       }
     ).settings(osgiSettings: _*).settings(

--- a/publish.sh
+++ b/publish.sh
@@ -11,7 +11,7 @@ sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.15 "project scalacticJS" clean publishSigned
 sbt ++2.13.6 "project scalacticJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.0
+export SCALANATIVE_VERSION=0.4.3
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalacticNative" clean publishSigned
 sbt ++2.12.15 "project scalacticNative" clean publishSigned
@@ -36,7 +36,7 @@ sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.15 "project scalatestJS" clean publishSigned
 sbt ++2.13.6 "project scalatestJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.0
+export SCALANATIVE_VERSION=0.4.3
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestNative" clean publishSigned
 sbt ++2.12.15 "project scalatestNative" clean publishSigned
@@ -60,7 +60,7 @@ sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.15 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.6 "project scalatestAppJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.0
+export SCALANATIVE_VERSION=0.4.3
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestAppNative" clean publishSigned
 sbt ++2.12.15 "project scalatestAppNative" clean publishSigned


### PR DESCRIPTION
Adjustments for 3.2.11 release, updated to build with just released scala-native 0.4.3.