### PR TITLE
Make PropertyCheckConfigParam non sealed

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/prop/Configuration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Configuration.scala
@@ -89,7 +89,7 @@ trait Configuration {
    *
    * @author Bill Venners
    */
-  sealed abstract class PropertyCheckConfigParam extends Product with Serializable
+  abstract class PropertyCheckConfigParam extends Product with Serializable
   
   /**
    * A <code>PropertyCheckConfigParam</code> that specifies the minimum number of successful


### PR DESCRIPTION
This PR makes the `PropertyCheckConfigParam` non sealed. The argument for this change is that by design Scalacheck's property driven tests are extensible, i.e. you can specify your own "engine" for running property tests such as https://github.com/scalatest/scalatestplus-scalacheck. Given this the scenario is that you then want to configure one of these implementations specifically, in my case I want to configure scalacheck so that I can both view the seed if a test fails and also force a seed so I can precisely replicate that failing test.

There is already an initial implementation for this at https://github.com/scalatest/scalatestplus-scalacheck/pull/53 but unfortunately  due to `PropertyCheckConfigParam` being sealed, the only way I can configure the `forAll` property check is by overriding an implicit value in the `ScalaCheckDrivenPropertyChecks` trait. Ideally I would also like to be able to pass in the configuration in the `forAll` parameter list, i.e. `forAll(viewFailingSeed(true)) { (n: Int, d: Int) => ...` just like you can do with `MinSuccessful` and the other subclasses of `PropertyCheckConfigParam`.

Afaik making `PropertyCheckConfigParam` non sealed also should have no effect on binary compatibility so its a safe change that shouldn't effect binary compatibility.

Of course another solution would be to just add `ViewFailingSeed`/`SpecifyInitialSeed` to `PropertyCheckConfigParam` but that means every implementer of property checks needs to implement this functionality (ontop of this `SpecifyInitialSeed` would like have to be type parameterized rather than just `String` because its not given that every seed implementation will be a `String` although arguably you can always serialize a string into another value).