### PR TITLE
JUnitXmlReporter and DeferredAbortedSuite Enhancement

### DIFF
--- a/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -138,12 +138,12 @@ println("GOT TO THIS RECOVER CALL")
       }
 
     val formatter = Suite.formatterForSuiteStarting(suite)
-    val suiteClass = suite.getClass
+    val suiteClassName = Suite.getSuiteClassName(suite)
 
     val reporter = new SbtReporter(suite.suiteId, task.fullyQualifiedName, task.fingerprint, eventHandler, sbtLogInfoReporter)
 
     if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-      reporter(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), formatter, Some(TopOfClass(suiteClass.getName))))
+      reporter(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName))))
 
     val args = Args(reporter, Stopper.default, filter, ConfigMap.empty, None, tracker, Set.empty)
 
@@ -156,23 +156,23 @@ println("GOT TO THIS RECOVER CALL")
           val duration = Platform.currentTime
           status.unreportedException match {
             case Some(ue) =>
-              reporter(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
+              reporter(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
               promise.complete(scala.util.Failure(ue))
 
             case None =>
-              reporter(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(duration), formatter, Some(TopOfClass(suiteClass.getName))))
+              reporter(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName))))
               promise.complete(Success(()))
           }
         }
         promise.future
       } catch {
           case e: Throwable =>
-            val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClass.getName
+            val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClassName
             val formatter = Suite.formatterForSuiteAborted(suite, rawString)
   
             val duration = Platform.currentTime - suiteStartTime
             // Do fire SuiteAborted even if a DistributedTestRunnerSuite, consistent with SuiteRunner behavior
-            reporter(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
+            reporter(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
         Future.failed(e)
       }
 

--- a/jvm/core/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
@@ -17,7 +17,7 @@ package org.scalatest
 
 import org.scalactic.NameUtil
 
-private[scalatest] case class DeferredAbortedSuite(suiteClassName: String, t: Throwable) extends Suite {
+private[scalatest] case class DeferredAbortedSuite(override val suiteId: String, suiteClassName: String, t: Throwable) extends Suite {
 
   override def run(testName: Option[String], args: Args): Status = {
     throw t

--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -20,6 +20,7 @@ import org.scalatest.events._
 import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
+import Suite.getSuiteClassName
 import org.scalatest.tools.Utils.wrapReporterIfNecessary
 import collection.mutable.ListBuffer
 
@@ -55,10 +56,11 @@ trait StepwiseNestedSuiteExecution extends SuiteMixin { thisSuite: Suite =>
       if (!stopper.stopRequested) {
         val rawString = Resources.suiteExecutionStarting
         val formatter = formatterForSuiteStarting(nestedSuite)
+        val suiteClassName = getSuiteClassName(nestedSuite)
 
         val suiteStartTime = System.currentTimeMillis
 
-        report(SuiteStarting(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+        report(SuiteStarting(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
 
         try { // TODO: pass runArgs down and that will get the chosenStyles passed down
           // Same thread, so OK to send same tracker
@@ -68,7 +70,7 @@ trait StepwiseNestedSuiteExecution extends SuiteMixin { thisSuite: Suite =>
           val formatter = formatterForSuiteCompleted(nestedSuite)
 
           val duration = System.currentTimeMillis - suiteStartTime
-          report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+          report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
           SucceededStatus
         }
         catch {       
@@ -82,7 +84,7 @@ trait StepwiseNestedSuiteExecution extends SuiteMixin { thisSuite: Suite =>
             val formatter = formatterForSuiteAborted(nestedSuite, rawString)
 
             val duration = System.currentTimeMillis - suiteStartTime
-            report(SuiteAborted(tracker.nextOrdinal(), rawString, nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
+            report(SuiteAborted(tracker.nextOrdinal(), rawString, nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
             FailedStatus
           }
         }

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -68,6 +68,7 @@ import Suite.getTopOfMethod
 import Suite.isTestMethodGoodies
 import Suite.reportTestIgnored
 import Suite.takesInformer
+import Suite.getSuiteClassName
 import org.scalatest.tools.Utils.wrapReporterIfNecessary
 import annotation.tailrec
 import collection.GenTraversable
@@ -788,6 +789,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
           dynaTags = DynaTags(Map.empty, Map(suiteId -> taggedTests))
         )
       }
+    val suiteClassName = getSuiteClassName(thisSuite)  
     val runStartTime = System.currentTimeMillis
     if (stats)
       dispatch(RunStarting(tracker.nextOrdinal(), expectedTestCount(filter), configMap))
@@ -802,13 +804,13 @@ trait Suite extends Assertions with Serializable { thisSuite =>
           Resources.runOnSuiteExceptionWithMessage(eMessage)
       val formatter = formatterForSuiteAborted(thisSuite, rawString)
       val duration = System.currentTimeMillis - suiteStartTime
-      dispatch(SuiteAborted(tracker.nextOrdinal(), rawString, thisSuite.suiteName, thisSuite.suiteId, Some(thisSuite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
+      dispatch(SuiteAborted(tracker.nextOrdinal(), rawString, thisSuite.suiteName, thisSuite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
     }
 
     try {
 
       val formatter = formatterForSuiteStarting(thisSuite)
-      dispatch(SuiteStarting(tracker.nextOrdinal(), thisSuite.suiteName, thisSuite.suiteId, Some(thisSuite.getClass.getName), formatter, Some(getTopOfClass(thisSuite))))
+      dispatch(SuiteStarting(tracker.nextOrdinal(), thisSuite.suiteName, thisSuite.suiteId, Some(suiteClassName), formatter, Some(getTopOfClass(thisSuite))))
 
       val status =
         run(
@@ -824,7 +826,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
       status.waitUntilCompleted()
       val suiteCompletedFormatter = formatterForSuiteCompleted(thisSuite)
       val duration = System.currentTimeMillis - suiteStartTime
-      dispatch(SuiteCompleted(tracker.nextOrdinal(), thisSuite.suiteName, thisSuite.suiteId, Some(thisSuite.getClass.getName), Some(duration), suiteCompletedFormatter, Some(getTopOfClass(thisSuite))))
+      dispatch(SuiteCompleted(tracker.nextOrdinal(), thisSuite.suiteName, thisSuite.suiteId, Some(suiteClassName), Some(duration), suiteCompletedFormatter, Some(getTopOfClass(thisSuite))))
       if (stats) {
         val duration = System.currentTimeMillis - runStartTime
         dispatch(RunCompleted(tracker.nextOrdinal(), Some(duration)))
@@ -1165,10 +1167,11 @@ trait Suite extends Assertions with Serializable { thisSuite =>
 
         val rawString = Resources.suiteExecutionStarting
         val formatter = formatterForSuiteStarting(nestedSuite)
+        val suiteClassName = getSuiteClassName(nestedSuite)
 
         val suiteStartTime = System.currentTimeMillis
 
-        report(SuiteStarting(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+        report(SuiteStarting(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName)), nestedSuite.rerunner))
 
         try { // TODO: pass runArgs down and that will get the chosenStyles passed down
           // Same thread, so OK to send same tracker
@@ -1181,11 +1184,11 @@ trait Suite extends Assertions with Serializable { thisSuite =>
 
           status.unreportedException match {
             case Some(ue) =>
-              report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
+              report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
               FailedStatus
 
             case None =>
-              report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+              report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName)), nestedSuite.rerunner))
               SucceededStatus
           }
         }
@@ -1200,7 +1203,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
             val formatter = formatterForSuiteAborted(nestedSuite, rawString)
 
             val duration = System.currentTimeMillis - suiteStartTime
-            report(SuiteAborted(tracker.nextOrdinal(), rawString, nestedSuite.suiteName, nestedSuite.suiteId, Some(nestedSuite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
+            report(SuiteAborted(tracker.nextOrdinal(), rawString, nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), nestedSuite.rerunner))
             if (NonFatal(e.getCause))
               FailedStatus
             else
@@ -1409,6 +1412,12 @@ private[scalatest] object Suite {
       }
     Some(IndentedText(actualSuiteName, message, 0))
   }
+
+  def getSuiteClassName(suite: Suite): String = 
+    suite match {
+      case DeferredAbortedSuite(suiteId, suiteClassName, deferredThrowable) => suiteClassName
+      case _ => suite.getClass.getName
+    }
 
 /*
   def simpleNameForTest(testName: String) =
@@ -2013,9 +2022,9 @@ used for test events like succeeded/failed, etc.
   }
 
   // SKIP-SCALATESTJS,NATIVE-START
-  def getTopOfClass(theSuite: Suite) = TopOfClass(theSuite.getClass.getName)
-  def getTopOfMethod(theSuite: Suite, method: Method) = TopOfMethod(theSuite.getClass.getName, method.toGenericString())
-  def getTopOfMethod(theSuite: Suite, testName: String) = TopOfMethod(theSuite.getClass.getName, getMethodForTestName(theSuite, testName).toGenericString())
+  def getTopOfClass(theSuite: Suite) = TopOfClass(getSuiteClassName(theSuite))
+  def getTopOfMethod(theSuite: Suite, method: Method) = TopOfMethod(getSuiteClassName(theSuite), method.toGenericString())
+  def getTopOfMethod(theSuite: Suite, testName: String) = TopOfMethod(getSuiteClassName(theSuite), getMethodForTestName(theSuite, testName).toGenericString())
 
   // Factored out to share this with FixtureSuite.runTest
   def getSuiteRunTestGoodies(theSuite: Suite, stopper: Stopper, reporter: Reporter, testName: String): (Stopper, Reporter, Method, Long) = {

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -1404,7 +1404,7 @@ private[scalatest] object Suite {
   def formatterForSuiteAborted(suite: Suite, message: String): Option[Formatter] = {
     val actualSuiteName =
       suite match {
-        case DeferredAbortedSuite(suiteClassName, deferredThrowable) => suiteClassName
+        case DeferredAbortedSuite(suiteId, suiteClassName, deferredThrowable) => suiteClassName
         case _ => suite.getClass.getName
       }
     Some(IndentedText(actualSuiteName, message, 0))

--- a/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
@@ -64,7 +64,7 @@ private[scalatest] class SuiteRerunner(suiteClassName: String) extends Rerunner 
         val rawString = Resources.suiteExecutionStarting
         val formatter = formatterForSuiteStarting(suite)
 
-        report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+        report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
         // TODO: I had to pass Set.empty for chosenStyles now. Fix this later.
         suite.run(None, Args(report, stopper, filter, configMap, distributor, tracker, Set.empty))
 
@@ -72,7 +72,7 @@ private[scalatest] class SuiteRerunner(suiteClassName: String) extends Rerunner 
         val formatter2 = formatterForSuiteCompleted(suite)
         val duration = System.currentTimeMillis - suiteStartTime
 
-        report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(duration), formatter2, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+        report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter2, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
       }
       catch {
         case e: RuntimeException => {
@@ -85,7 +85,7 @@ private[scalatest] class SuiteRerunner(suiteClassName: String) extends Rerunner 
           val formatter3 = formatterForSuiteAborted(suite, rawString3)
 
           val duration = System.currentTimeMillis - suiteStartTime
-          report(SuiteAborted(tracker.nextOrdinal(), rawString3, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(e), Some(duration), formatter3, Some(SeeStackDepthException), suite.rerunner))
+          report(SuiteAborted(tracker.nextOrdinal(), rawString3, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter3, Some(SeeStackDepthException), suite.rerunner))
         }
       }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
@@ -78,7 +78,7 @@ private[scalatest] object DiscoverySuite {
       case t: Throwable => { // TODO: Maybe include the e.getClass.getName and the message for e in the message cannotLoadDiscoveredSuite, because Jess had the problem
                              // That gradle cut off the stack trace so she couldn't see the cause.
         val msg = Resources.cannotLoadDiscoveredSuite(suiteClassName)
-        new DeferredAbortedSuite(suiteClassName, new RuntimeException(msg, t))
+        new DeferredAbortedSuite(suiteClassName, suiteClassName, new RuntimeException(msg, t))
       }
     }
   }

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -36,6 +36,7 @@ import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
 import Suite.mergeMap
+import Suite.getSuiteClassName
 // import org.scalatest.prop.Randomizer
 
 
@@ -259,6 +260,7 @@ class Framework extends SbtFramework {
     val suiteClass = suite.getClass
     val report = new SbtReporter(rerunSuiteId, taskDefinition.fullyQualifiedName, taskDefinition.fingerprint, eventHandler, suiteSortingReporter, summaryCounter)
     val formatter = formatterForSuiteStarting(suite)
+    val suiteClassName = getSuiteClassName(suite)
         
     val filter = 
       if ((selectors.length == 1 && selectors(0).isInstanceOf[SuiteSelector] && !explicitlySpecified))  // selectors will always at least have one SuiteSelector, according to javadoc of TaskDef
@@ -303,7 +305,7 @@ class Framework extends SbtFramework {
       }
 
     if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-      report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), formatter, Some(TopOfClass(suiteClass.getName))))
+      report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName))))
 
     val args = Args(report, Stopper.default, filter, configMap, None, tracker, Set.empty, false, None, Some(suiteSortingReporter))
 
@@ -327,10 +329,10 @@ class Framework extends SbtFramework {
       if (!suite.isInstanceOf[DistributedTestRunnerSuite]) {
         status.unreportedException match {
           case Some(ue) =>
-            report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
+            report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
 
           case None =>
-            report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(duration), formatter, Some(TopOfClass(suiteClass.getName))))
+            report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName))))
         }
       }
     }

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -449,7 +449,7 @@ class Framework extends SbtFramework {
             else
               suiteClass.newInstance.asInstanceOf[Suite] 
           } catch {
-            case t: Throwable => new DeferredAbortedSuite(suiteClass.getName, t)
+            case t: Throwable => new DeferredAbortedSuite(suiteClass.getName, suiteClass.getName, t)
           }
 
         if (useSbtLogInfoReporter) {

--- a/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -171,6 +171,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
         case e: SuiteAborted =>
           assert(endIndex == idx)
           testsuite.errors += 1
+          testsuite.abortedError = e.throwable
           testsuite.time = e.timeStamp - testsuite.timeStamp
           idx += 1
 
@@ -348,6 +349,9 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
   // Creates an xml string describing a run of a test suite.
   //
   def xmlify(testsuite: Testsuite): String = {
+
+    val errMsg = testsuite.abortedError.map(getStackTrace(_)).getOrElse("")
+
     val xmlVal =
       <testsuite
         errors    = { "" + testsuite.errors         }
@@ -374,8 +378,8 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
           </testcase>
         }
       }
-        <system-out><![CDATA[]]></system-out>
-        <system-err><![CDATA[]]></system-err>
+        <system-out></system-out>
+        <system-err>{ errMsg }</system-err>
       </testsuite>
 
     val prettified = (new PrettyPrinter(76, 2, true)).format(xmlVal)
@@ -505,6 +509,7 @@ private[scalatest] class JUnitXmlReporter(directory: String) extends Reporter {
     var errors   = 0
     var failures = 0
     var time     = 0L
+    var abortedError: Option[Throwable] = None
     val testcases = new ListBuffer[Testcase]
   }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference
 import org.scalatest.Suite.formatterForSuiteAborted
 import org.scalatest.Suite.formatterForSuiteCompleted
 import org.scalatest.Suite.formatterForSuiteStarting
+import org.scalatest.Suite.getSuiteClassName
 import org.scalatest.events.SeeStackDepthException
 import org.scalatest.events.SuiteAborted
 import org.scalatest.events.SuiteCompleted
@@ -439,8 +440,9 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
             }
 
             val formatter = formatterForSuiteStarting(suite)
+            val suiteClassName = getSuiteClassName(suite)
 
-            report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), formatter, Some(TopOfClass(suiteClass.getName))))
+            report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName))))
 
             try {  // TODO: I had to pass Set.empty for chosen styles now. Fix this later.
               val status = suite.run(None, Args(report, Stopper.default, filter, configMap, None, tracker, Set.empty, false, None, None))
@@ -454,10 +456,10 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
 
               status.unreportedException match {
                 case Some(ue) =>
-                  report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
+                  report(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
 
                 case None =>
-                  report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(duration), formatter, Some(TopOfClass(suiteClass.getName))))
+                  report(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName))))
               }
 
             }
@@ -468,11 +470,11 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
                 // java.util.MissingResourceException: Can't find bundle for base name org.scalatest.ScalaTestBundle, locale en_US
                 // TODO Chee Seng, I wonder why we couldn't access resources, and if that's still true. I'd rather get this stuff
                 // from the resource file so we can later localize.
-                val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClass.getName
+                val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClassName
                 val formatter = formatterForSuiteAborted(suite, rawString)
 
                 val duration = System.currentTimeMillis - suiteStartTime
-                report(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
+                report(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
               }
             }
           }

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteRunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteRunner.scala
@@ -20,6 +20,7 @@ import org.scalatest.events._
 import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
+import Suite.getSuiteClassName
 import org.scalatest.exceptions.NotAllowedException
 import scala.util.{Success, Failure}
 
@@ -33,13 +34,14 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
     if (!stopper.stopRequested) {
       val rawString = Resources.suiteExecutionStarting
       val formatter = formatterForSuiteStarting(suite)
+      val suiteClassName = getSuiteClassName(suite)
       val dispatch = args.reporter
       val tracker = args.tracker
 
       val suiteStartTime = System.currentTimeMillis
 
       if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-        dispatch(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+        dispatch(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
         
       try {
         val runStatus = suite.run(None, args)
@@ -56,11 +58,11 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
                 if (!succeeded)
                   status.setFailed()
                 if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-                  dispatch(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(duration), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
+                  dispatch(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName)), suite.rerunner))
               case Failure(ue) =>
                 status.setFailed() // Don't forward the unreportedException to the returned status, because reporting it here in this SuiteAborted
                 if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-                  dispatch(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException), suite.rerunner))
+                  dispatch(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException), suite.rerunner))
             }
           }
           finally status.setCompleted()

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
@@ -275,7 +275,7 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
       
   val reporter = new JUnitXmlReporter("target")
 
-  /*test("SuiteAborted and SuiteCompleted are recognized as test terminators") {
+  test("SuiteAborted and SuiteCompleted are recognized as test terminators") {
     reporter(start1)
     reporter(start2)
     reporter(abort2)
@@ -323,7 +323,7 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
     assert(!(tcFailed \ "failure").isEmpty)
     assert(!(tcPending \ "skipped").isEmpty)
     assert(!(tcCanceled \ "skipped").isEmpty)
-  }*/
+  }
   
   test("AlertProvided and NoteProvided should be ignored") {
     reporter(alertProvided1)
@@ -365,7 +365,7 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
     assert(!(tcCanceled \ "skipped").isEmpty)
   }
 
-  /*test("testcase failure message xmlified properly"){
+  test("testcase failure message xmlified properly"){
     //"" - not used parameters
     val bigFail = TestFailed(new Ordinal(0),
         "Unusually formed message: \n less:'<', amp:'&', double-quote:\"",
@@ -374,12 +374,16 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
         None,
         "",
         "",
-        null,
+        Vector.empty, 
+        Vector.empty, 
         Some(new Exception("Unusually formed exception: \n less:'<', more:'>' amp:'&', double-quote:\"")))
 
     val testsuite = reporter.Testsuite("TestSuite", 10L)
     testsuite.testcases += reporter.Testcase("TestCase", Some("someClass"), 1L)
-    testsuite.testcases.foreach(tc => tc.failure = Some(bigFail))
+    testsuite.testcases.foreach { tc => 
+      tc.failed = true
+      tc.failure = bigFail.throwable
+    }
 
     val rawXml:String = reporter.xmlify(testsuite)
 
@@ -387,6 +391,6 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
     val res= scala.xml.XML.loadString(rawXml)
 
     val message = (res \\ "failure" \ "@message").toString
-    assert(message==="""Unusually formed message: &amp;#010; less:'&lt;', amp:'&amp;', double-quote:&quot;""","failure/@message is not as expected")
-  }*/
+    assert(message startsWith """java.lang.Exception: Unusually formed exception: &amp;#010; less:'&lt;', more:'&gt;' amp:'&amp;', double-quote:&quot;""","failure/@message is not as expected")
+  }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
@@ -391,6 +391,10 @@ class JUnitXmlReporterSuite extends AnyFunSuite {
     val res= scala.xml.XML.loadString(rawXml)
 
     val message = (res \\ "failure" \ "@message").toString
-    assert(message startsWith """java.lang.Exception: Unusually formed exception: &amp;#010; less:'&lt;', more:'&gt;' amp:'&amp;', double-quote:&quot;""","failure/@message is not as expected")
+    
+    assert(message == """Unusually formed exception:   less:'&lt;', more:'&gt;' amp:'&amp;', double-quote:&quot;""")
+
+    val failureBodyText = (res \\ "failure").text.trim
+    assert(failureBodyText startsWith """java.lang.Exception: Unusually formed exception:""", "failure/@message is not as expected")
   }
 }

--- a/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -138,11 +138,12 @@ println("GOT TO THIS RECOVER CALL")
 
     val formatter = Suite.formatterForSuiteStarting(suite)
     val suiteClass = suite.getClass
+    val suiteClassName = Suite.getSuiteClassName(suite)
 
     val reporter = new SbtReporter(suite.suiteId, task.fullyQualifiedName, task.fingerprint, eventHandler, sbtLogInfoReporter)
 
     if (!suite.isInstanceOf[DistributedTestRunnerSuite])
-      reporter(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), formatter, Some(TopOfClass(suiteClass.getName))))
+      reporter(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName))))
 
     val args = Args(reporter, Stopper.default, filter, ConfigMap.empty, None, tracker, Set.empty)
 
@@ -155,23 +156,23 @@ println("GOT TO THIS RECOVER CALL")
           val duration = Platform.currentTime
           status.unreportedException match {
             case Some(ue) =>
-              reporter(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
+              reporter(SuiteAborted(tracker.nextOrdinal(), ue.getMessage, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(ue), Some(duration), formatter, Some(SeeStackDepthException)))
               promise.complete(scala.util.Failure(ue))
 
             case None =>
-              reporter(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(duration), formatter, Some(TopOfClass(suiteClass.getName))))
+              reporter(SuiteCompleted(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(suiteClassName))))
               promise.complete(Success(()))
           }
         }
         promise.future
       } catch {
           case e: Throwable =>
-            val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClass.getName
+            val rawString = "Exception encountered when attempting to run a suite with class name: " + suiteClassName
             val formatter = Suite.formatterForSuiteAborted(suite, rawString)
   
             val duration = Platform.currentTime - suiteStartTime
             // Do fire SuiteAborted even if a DistributedTestRunnerSuite, consistent with SuiteRunner behavior
-            reporter(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
+            reporter(SuiteAborted(tracker.nextOrdinal(), rawString, suite.suiteName, suite.suiteId, Some(suiteClassName), Some(e), Some(duration), formatter, Some(SeeStackDepthException)))
         Future.failed(e)
       }
 


### PR DESCRIPTION
- Get JUnitXmlReporter to handle SuiteAborted event correctly.
- Handle DeferredAbortedSuite correctly when firing SuiteStarting, SuiteCompleted and SuiteAborted in multiple places.
- Tweaked failure XML tag in JUnit xml to show only error message in its message attribute, and the stack trace only in the tag body.