### PR TITLE
[3.2] Resurrect Generator Seed Argument (-S)

### DIFF
--- a/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -21,6 +21,7 @@ import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => Sbt
 
 import scala.compat.Platform
 import ArgsParser._
+import org.scalatest.prop.Seed
 
 class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClassLoader: ClassLoader) extends Runner {
 
@@ -87,8 +88,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   }
 
   parseLongArgument(seedArgs, "-S") match {
-    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
     case None => // do nothing
   }
 

--- a/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -43,7 +43,8 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   tagsToIncludeArgs,
   tagsToExcludeArgs,
   membersOnlyArgs,
-  wildcardArgs
+  wildcardArgs, 
+  seedArgs
   ) = parseArgs(args)
 
   val (
@@ -83,6 +84,12 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
       throw new IllegalArgumentException("Only one -o can be passed in as test argument.")
     else
       (false, !sbtNoFormat, false, false, false, false, false, false, false, false, false, Set.empty[ReporterConfigParam])
+  }
+
+  parseLongArgument(seedArgs, "-S") match {
+    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
+      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case None => // do nothing
   }
 
   val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")

--- a/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -21,6 +21,7 @@ import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => Sbt
 import ArgsParser._
 
 import scala.compat.Platform
+import org.scalatest.prop.Seed
 
 class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClassLoader: ClassLoader, notifyServer: String => Unit) extends Runner {
 
@@ -75,8 +76,7 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
   }
 
   parseLongArgument(seedArgs, "-S") match {
-    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
     case None => // do nothing
   }
 

--- a/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -31,7 +31,8 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
     tagsToIncludeArgs,
     tagsToExcludeArgs,
     membersOnlyArgs,
-    wildcardArgs
+    wildcardArgs, 
+    seedArgs
   ) = parseArgs(args)
 
   val (
@@ -71,6 +72,12 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
       throw new IllegalArgumentException("Only one -o can be passed in as test argument.")
     else
       (false, !sbtNoFormat, false, false, false, false, false, false, false, false, false, Set.empty[ReporterConfigParam])
+  }
+
+  parseLongArgument(seedArgs, "-S") match {
+    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
+      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case None => // do nothing
   }
 
   val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")

--- a/jvm/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -2202,13 +2202,6 @@ object Randomizer {
   import java.util.concurrent.atomic.AtomicReference
 
   /**
-    * This seed is empty under ordinary circumstances. It is here so that the test
-    * Runner can poke in a seed value to be used during a test run. If set, it will be used
-    * as the seed for all calls to [[Randomizer.default]].
-    */
-  private[scalatest] val defaultSeed: AtomicReference[Option[Long]] = new AtomicReference(None)
-
-  /**
     * Creates a new Randomizer, whose seed is initialized based on the current time.
     *
     * This should not be considered a strong source of randomness -- in cases where high entropy really
@@ -2216,13 +2209,7 @@ object Randomizer {
     *
     * @return A Randomizer, ready to begin producing random values.
     */
-  def default: Randomizer =
-    apply(
-      defaultSeed.get() match {
-        case Some(seed) => seed
-        case None => System.currentTimeMillis()
-      }
-    )
+  def default: Randomizer = new Randomizer(Seed.default.value)
 
   /**
     * A Randomizer, initialized with the specified seed value.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
@@ -33,7 +33,7 @@ object Seed {
     * Runner can poke in a seed value to be used during a test run. If set, it will be used
     * as the seed for all calls to [[Seed.default]].
     */
-  private[scalatest] val defaultRef: AtomicReference[Option[Long]] = new AtomicReference(None)
+  private[scalatest] val configuredRef: AtomicReference[Option[Long]] = new AtomicReference(None)
 
   /**
    * Creates a new Seed using default approach, which is initialized based on the current time.
@@ -43,9 +43,11 @@ object Seed {
    */
   def default: Seed = 
     Seed(
-      defaultRef.get() match {
+      configuredRef.get() match {
         case Some(value) => value
         case None => System.currentTimeMillis()
       }
     )
+
+  def configured: Option[Seed] = configuredRef.get().map(Seed(_))  
 }

--- a/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
@@ -1,0 +1,51 @@
+package org.scalatest.prop
+
+/*
+ * Copyright 2001-2022 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Seed data class holding seed value used for generating random value.
+ */
+final case class Seed(value: Long)
+
+/**
+ * Companion object for Seed class.
+ */
+object Seed {
+
+  import java.util.concurrent.atomic.AtomicReference
+
+  /**
+    * This seed is empty under ordinary circumstances. It is here so that the test
+    * Runner can poke in a seed value to be used during a test run. If set, it will be used
+    * as the seed for all calls to [[Seed.default]].
+    */
+  private[scalatest] val defaultRef: AtomicReference[Option[Long]] = new AtomicReference(None)
+
+  /**
+   * Creates a new Seed using default approach, which is initialized based on the current time.
+   *
+   * This should not be considered a strong source of seed for randomness -- in cases where high entropy really
+   * matters, it's a bit mediocre -- but for general purposes it's typically good enough.
+   */
+  def default: Seed = 
+    Seed(
+      defaultRef.get() match {
+        case Some(value) => value
+        case None => System.currentTimeMillis()
+      }
+    )
+}

--- a/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
@@ -468,8 +468,8 @@ private[tools] object ArgsParser {
       concurrent.toList,
       // SKIP-SCALATESTJS,NATIVE-END
       membersOnly.toList,
-      // SKIP-SCALATESTJS,NATIVE-START
       wildcard.toList,
+      // SKIP-SCALATESTJS,NATIVE-START
       testNGXMLFiles.toList,
       genSuffixesPattern(suffixes.toList),
       chosenStyles.toList,

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -36,7 +36,7 @@ import Suite.formatterForSuiteAborted
 import Suite.formatterForSuiteCompleted
 import Suite.formatterForSuiteStarting
 import Suite.mergeMap
-// import org.scalatest.prop.Randomizer
+import org.scalatest.prop.Seed
 
 
 /**
@@ -1027,8 +1027,7 @@ class Framework extends SbtFramework {
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 
     parseLongArgument(seedArgs, "-S") match {
-      case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-        println("Note: -S for setting the Randomizer seed is not yet supported.")
+      case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
       case None => // do nothing
     }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -1027,7 +1027,7 @@ class Framework extends SbtFramework {
     runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 
     parseLongArgument(seedArgs, "-S") match {
-      case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
+      case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
       case None => // do nothing
     }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/ParsedArgs.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ParsedArgs.scala
@@ -34,8 +34,8 @@ private[scalatest] case class ParsedArgs(
   concurrent: List[String],
   // SKIP-SCALATESTJS,NATIVE-END
   membersOnly: List[String],
-  // SKIP-SCALATESTJS,NATIVE-START
   wildcard: List[String],
+  // SKIP-SCALATESTJS,NATIVE-START
   testNGXMLFiles: List[String],
   genSuffixesPattern: Option[Pattern],
   chosenStyles: List[String], 

--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -859,7 +859,7 @@ object Runner {
     val testSortingReporterTimeout = Span(parseDoubleArgument(testSortingReporterTimeouts, "-T", Suite.defaultTestSortingReporterTimeoutInSeconds), Seconds)
 
     seedList match {
-      case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
+      case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
       case None => // do nothing
     }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import Suite.{mergeMap, CHOSEN_STYLES, SELECTED_TAG}
 import ArgsParser._
 import org.scalactic.Requirements._
-// import org.scalatest.prop.Randomizer
+import org.scalatest.prop.Seed
 
 /*
 Command line args:
@@ -859,8 +859,7 @@ object Runner {
     val testSortingReporterTimeout = Span(parseDoubleArgument(testSortingReporterTimeouts, "-T", Suite.defaultTestSortingReporterTimeoutInSeconds), Seconds)
 
     seedList match {
-      case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-        println("Note: -S for setting the Randomizer seed is not yet supported.")
+      case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
       case None => // do nothing
     }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -217,7 +217,7 @@ class ScalaTestFramework extends SbtFramework {
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 
           parseLongArgument(seedArgs, "-S") match {
-            case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
+            case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
             case None => // do nothing
           }
           

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -33,7 +33,7 @@ import org.scalatest.events.SuiteStarting
 import org.scalatest.events.TopOfClass
 import org.scalatest.time.{Seconds, Span}
 import org.scalatools.testing.{Framework => SbtFramework, _}
-// import org.scalatest.prop.Randomizer
+import org.scalatest.prop.Seed
 
 /**
  * Class that makes ScalaTest tests visible to SBT (prior to version 0.13).
@@ -217,8 +217,7 @@ class ScalaTestFramework extends SbtFramework {
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
 
           parseLongArgument(seedArgs, "-S") match {
-            case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-              println("Note: -S for setting the Randomizer seed is not yet supported.")
+            case Some(seed) => Seed.defaultRef.getAndSet(Some(seed))
             case None => // do nothing
           }
           

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
@@ -65,8 +65,8 @@ class ArgsParserSpec extends AnyFunSpec {
       concurrentList,
       // SKIP-SCALATESTJS,NATIVE-END
       memberOfList,
-      // SKIP-SCALATESTJS,NATIVE-START
       beginsWithList,
+      // SKIP-SCALATESTJS,NATIVE-START
       testNGList,
       suffixes,
       chosenStyleList,
@@ -545,8 +545,8 @@ class ArgsParserSpec extends AnyFunSpec {
       concurrentList,
       // SKIP-SCALATESTJS,NATIVE-END
       memberOfList,
-      // SKIP-SCALATESTJS,NATIVE-START
       beginsWithList,
+      // SKIP-SCALATESTJS,NATIVE-START
       testNGList,
       suffixes,
       chosenStyleList,

--- a/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -21,6 +21,7 @@ import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => Sbt
 
 import scala.compat.Platform
 import ArgsParser._
+import org.scalatest.prop.Seed
 
 class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClassLoader: ClassLoader) extends Runner {
 
@@ -87,8 +88,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   }
 
   parseLongArgument(seedArgs, "-S") match {
-    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
     case None => // do nothing
   }
 

--- a/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -43,7 +43,8 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   tagsToIncludeArgs,
   tagsToExcludeArgs,
   membersOnlyArgs,
-  wildcardArgs
+  wildcardArgs, 
+  seedArgs
   ) = parseArgs(args)
 
   val (
@@ -83,6 +84,12 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
       throw new IllegalArgumentException("Only one -o can be passed in as test argument.")
     else
       (false, !sbtNoFormat, false, false, false, false, false, false, false, false, false, Set.empty[ReporterConfigParam])
+  }
+
+  parseLongArgument(seedArgs, "-S") match {
+    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
+      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case None => // do nothing
   }
 
   val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")

--- a/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -19,6 +19,7 @@ import org.scalatest.{Resources, Tracker}
 import org.scalatest.events.Summary
 import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => SbtStatus, _}
 import ArgsParser._
+import org.scalatest.prop.Seed
 
 import scala.compat.Platform
 
@@ -75,8 +76,7 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
   }
 
   parseLongArgument(seedArgs, "-S") match {
-    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
-      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case Some(seed) => Seed.configuredRef.getAndSet(Some(seed))
     case None => // do nothing
   }
 

--- a/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -31,7 +31,8 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
     tagsToIncludeArgs,
     tagsToExcludeArgs,
     membersOnlyArgs,
-    wildcardArgs
+    wildcardArgs, 
+    seedArgs
   ) = parseArgs(args)
 
   val (
@@ -71,6 +72,12 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
       throw new IllegalArgumentException("Only one -o can be passed in as test argument.")
     else
       (false, !sbtNoFormat, false, false, false, false, false, false, false, false, false, Set.empty[ReporterConfigParam])
+  }
+
+  parseLongArgument(seedArgs, "-S") match {
+    case Some(seed) => // Randomizer.defaultSeed.getAndSet(Some(seed))
+      println("Note: -S for setting the Randomizer seed is not yet supported.")
+    case None => // do nothing
   }
 
   val tagsToInclude: Set[String] = parseCompoundArgIntoSet(tagsToIncludeArgs, "-n")

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -18,7 +18,7 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.12"
+  val releaseVersion = "3.2.12-RC1"
 
   val previousReleaseVersion = "3.2.10"
 

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -18,7 +18,7 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.11"
+  val releaseVersion = "3.2.12"
 
   val previousReleaseVersion = "3.2.10"
 


### PR DESCRIPTION
We made -S as unsupported when moving scalatest+scalacheck out as separate module, but that dis-allowed the user from specifying seed even when using scalatest+scalacheck.  Re-enabling this to be used by both scalacheck generator as well as upcoming built-in generator in 3.3.