### PR TITLE
Macro Enhancement for OrderingOps - Both Scala 2 and 3

### DIFF
--- a/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -18,6 +18,8 @@ package org.scalactic
 import scala.quoted._
 
 object BooleanMacro {
+  // Reference: https://www.scala-lang.org/api/3.0.0/scala/quoted/Quotes$reflectModule.html
+
   private val logicOperators = Set("&&", "||", "&", "|")
 
   private val supportedBinaryOperations =
@@ -168,21 +170,16 @@ object BooleanMacro {
 
           case ">" | "<" | ">=" | "<=" =>
             lhs match {
-              case Apply(Apply(TypeApply(Ident(infixOrderingOps), List(_)), List(wrapped)), List(Apply(TypeApply(Ident(_), List(_)), List(TypeApply(Ident(_), List(_)))))) if infixOrderingOps == "infixOrderingOps" =>
-                let(Symbol.spliceOwner, lhs) { left =>
-                  let(Symbol.spliceOwner, rhs) { right =>
-                    val app = left.select(sel.symbol).appliedTo(right)
-                    let(Symbol.spliceOwner, app) { result =>
-                      val l = wrapped.asExpr
-                      val r = right.asExpr
-                      val b = result.asExprOf[Boolean]
-                      val code = '{ Bool.binaryMacroBool($l, ${Expr(op)}, $r, $b, $prettifier) }
-                      code.asTerm
-                    }
-                  }
-                }.asExprOf[Bool]
-
-              case Apply(Apply(TypeApply(Ident(infixOrderingOps), List(_)), List(wrapped)), List(Ident(evidence$1))) if infixOrderingOps == "infixOrderingOps" =>
+              case Apply(
+                     Apply(
+                       TypeApply(
+                         Ident(infixOrderingOps), 
+                         List(_)
+                       ), 
+                       List(wrapped)
+                     ), 
+                     List(_)
+                   ) if infixOrderingOps == "infixOrderingOps" =>
                 let(Symbol.spliceOwner, lhs) { left =>
                   let(Symbol.spliceOwner, rhs) { right =>
                     val app = left.select(sel.symbol).appliedTo(right)
@@ -198,8 +195,6 @@ object BooleanMacro {
                         
               case _ => binaryDefault
             }
-
-          // Apply(Apply(TypeApply(Ident(infixOrderingOps),List(TypeTree[TypeRef(NoPrefix,type A)])),List(Ident(first))),List(Ident(evidence$1)))  
 
           case "exists" =>
             rhs match {

--- a/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -181,9 +181,25 @@ object BooleanMacro {
                     }
                   }
                 }.asExprOf[Bool]
+
+              case Apply(Apply(TypeApply(Ident(infixOrderingOps), List(_)), List(wrapped)), List(Ident(evidence$1))) if infixOrderingOps == "infixOrderingOps" =>
+                let(Symbol.spliceOwner, lhs) { left =>
+                  let(Symbol.spliceOwner, rhs) { right =>
+                    val app = left.select(sel.symbol).appliedTo(right)
+                    let(Symbol.spliceOwner, app) { result =>
+                      val l = wrapped.asExpr
+                      val r = right.asExpr
+                      val b = result.asExprOf[Boolean]
+                      val code = '{ Bool.binaryMacroBool($l, ${Expr(op)}, $r, $b, $prettifier) }
+                      code.asTerm
+                    }
+                  }
+                }.asExprOf[Bool]
                         
               case _ => binaryDefault
             }
+
+          // Apply(Apply(TypeApply(Ident(infixOrderingOps),List(TypeTree[TypeRef(NoPrefix,type A)])),List(Ident(first))),List(Ident(evidence$1)))  
 
           case "exists" =>
             rhs match {

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -630,7 +630,7 @@ private[org] class BooleanMacro[C <: Context](val context: C) {
                              ), 
                              List(wrapped)
                            ), 
-                           List(Ident(_))
+                           List(_)
                          ) 
                          if infixOrderingOps.decodedName.toString() == "infixOrderingOps" &&
                             implicitsClass.decodedName.toString() == "Implicits" &&

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -571,7 +571,7 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should  throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+    it("should throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
       import scala.math.Ordering.Implicits.infixOrderingOps
       val first = new java.lang.Integer(5)
       val second = new java.lang.Integer(4)
@@ -581,6 +581,28 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.message === Some(wasNotLessThan(5, 4)))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used in another function to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+      import scala.math.Ordering.Implicits.infixOrderingOps
+
+      @scala.annotation.tailrec
+      def assertInOrder2[A : Ordering](list: List[A]): Assertion =
+        list match {
+          case first :: (more @ second :: _) =>
+            assert(first <= second)
+            assertInOrder2[A](more)
+          case _ => Succeeded
+        }
+
+      val first = new java.lang.Integer(5)
+      val second = new java.lang.Integer(4)
+      val e = intercept[TestFailedException] {
+        assertInOrder2(List(first, second))
+      }
+      assert(e.message === Some(wasNotLessThanOrEqualTo(5, 4)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 12)))
     }
 
     it("should do nothing when is used to check bob == \"bob\"") {
@@ -2035,7 +2057,7 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should  throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+    it("should throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
       import scala.math.Ordering.Implicits.infixOrderingOps
       val first = new java.lang.Integer(5)
       val second = new java.lang.Integer(4)
@@ -2045,6 +2067,28 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.message === Some(wasNotLessThan(5, 4) + "; dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used in another function to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+      import scala.math.Ordering.Implicits.infixOrderingOps
+
+      @scala.annotation.tailrec
+      def assertInOrder2[A : Ordering](list: List[A]): Assertion =
+        list match {
+          case first :: (more @ second :: _) =>
+            assert(first <= second, "; dude")
+            assertInOrder2[A](more)
+          case _ => Succeeded
+        }
+
+      val first = new java.lang.Integer(5)
+      val second = new java.lang.Integer(4)
+      val e = intercept[TestFailedException] {
+        assertInOrder2(List(first, second))
+      }
+      assert(e.message === Some(wasNotLessThanOrEqualTo(5, 4) + "; dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 12)))
     }
 
     it("should do nothing when is used to check bob == \"bob\"") {
@@ -3490,7 +3534,7 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should  throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+    it("should  throw TestCanceledException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
       import scala.math.Ordering.Implicits.infixOrderingOps
       val first = new java.lang.Integer(5)
       val second = new java.lang.Integer(4)
@@ -3500,6 +3544,28 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.message === Some(wasNotLessThan(5, 4)))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should throw TestCanceledException with correct message and stack depth when is used in another function to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+      import scala.math.Ordering.Implicits.infixOrderingOps
+
+      @scala.annotation.tailrec
+      def assertInOrder2[A : Ordering](list: List[A]): Assertion =
+        list match {
+          case first :: (more @ second :: _) =>
+            assume(first <= second)
+            assertInOrder2[A](more)
+          case _ => Succeeded
+        }
+
+      val first = new java.lang.Integer(5)
+      val second = new java.lang.Integer(4)
+      val e = intercept[TestCanceledException] {
+        assertInOrder2(List(first, second))
+      }
+      assert(e.message === Some(wasNotLessThanOrEqualTo(5, 4)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 12)))
     }
 
     it("should do nothing when is used to check bob == \"bob\"") {
@@ -4951,7 +5017,7 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should  throw TestFailedException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+    it("should  throw TestCanceledException with correct message and stack depth when is used to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
       import scala.math.Ordering.Implicits.infixOrderingOps
       val first = new java.lang.Integer(5)
       val second = new java.lang.Integer(4)
@@ -4961,6 +5027,28 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.message === Some(wasNotLessThan(5, 4) + "; dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should throw TestCanceledException with correct message and stack depth when is used in another function to check java.lang.Integer(5) < java.lang.Integer(4) with import scala.math.Ordering.Implicits.infixOrderingOps in scope") {
+      import scala.math.Ordering.Implicits.infixOrderingOps
+
+      @scala.annotation.tailrec
+      def assertInOrder2[A : Ordering](list: List[A]): Assertion =
+        list match {
+          case first :: (more @ second :: _) =>
+            assume(first <= second, "; dude")
+            assertInOrder2[A](more)
+          case _ => Succeeded
+        }
+
+      val first = new java.lang.Integer(5)
+      val second = new java.lang.Integer(4)
+      val e = intercept[TestCanceledException] {
+        assertInOrder2(List(first, second))
+      }
+      assert(e.message === Some(wasNotLessThanOrEqualTo(5, 4) + "; dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 12)))
     }
 
     it("should do nothing when is used to check bob == \"bob\"") {

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -18,7 +18,7 @@ trait BuildCommons {
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
     )
 
-  val releaseVersion = "3.2.12-RC1"
+  val releaseVersion = "3.2.12-RC2"
 
   val previousReleaseVersion = "3.2.10"
 


### PR DESCRIPTION
Enhanced both Scala 2 and Scala 3 macro to support assertion that involves scala.math.Ordering implicit, even when the assert is called in another function, not directly in the test function itself.  This should fix the following issue: 

https://github.com/scalatest/scalatest/issues/2087