### PR TITLE
Adapt test following Scala 3 bytecode change

### DIFF
--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
@@ -369,28 +369,28 @@ class XmlSocketReporterSpec extends AnyFunSpec with Eventually {
       assert(eventRecorder.scopePendingEvents.length === 1)
       checkScopeEvents(eventRecorder.scopePendingEvents(0), "A Pending Feature", spec.suiteName, spec.suiteId, 
                      Some(spec.getClass.getName), "XmlSocketReporterSpec.scala", thisLineNumber - 27)
-                     
+      val rerunner = if (Suite.checkForPublicNoArgConstructor(spec.getClass)) Some(spec.getClass.getName) else None // Logic from SuiteRerunner
       assert(eventRecorder.testStartingEvents.length === 4)
       checkTestStarting(eventRecorder.testStartingEvents(0), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
                         "A Feature should succeed", "should succeed", "XmlSocketReporterSpec.scala", thisLineNumber - 37, 
-                        None) // rerunner should be none, as the suite is an inner class.
+                        rerunner)
       checkTestStarting(eventRecorder.testStartingEvents(1), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
                         "A Feature should failed", "should failed", "XmlSocketReporterSpec.scala", thisLineNumber - 39, 
-                        None)
+                        rerunner)
       checkTestStarting(eventRecorder.testStartingEvents(2), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
                         "A Feature should pending", "should pending", "XmlSocketReporterSpec.scala", thisLineNumber - 40, 
-                        None)
+                        rerunner)
       checkTestStarting(eventRecorder.testStartingEvents(3), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
                         "A Feature should canceled", "should canceled", "XmlSocketReporterSpec.scala", thisLineNumber - 42, 
-                        None)
+                        rerunner)
       
       assert(eventRecorder.testSucceededEvents.length === 1)
       checkTestSucceeded(eventRecorder.testSucceededEvents(0), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
-                         "A Feature should succeed", "should succeed", "XmlSocketReporterSpec.scala", thisLineNumber - 51, None)
+                         "A Feature should succeed", "should succeed", "XmlSocketReporterSpec.scala", thisLineNumber - 51, rerunner)
       
       assert(eventRecorder.testFailedEvents.length === 1)
       checkTestFailed(eventRecorder.testFailedEvents(0), "1 did not equal 2", spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 
-                      "A Feature should failed", "should failed", None)
+                      "A Feature should failed", "should failed", rerunner)
 
       assert(eventRecorder.testPendingEvents.length === 1)
       checkTestPending(eventRecorder.testPendingEvents(0), spec.suiteName, spec.suiteId, Some(spec.getClass.getName), 


### PR DESCRIPTION
After https://github.com/lampepfl/dotty/pull/14686, Scala 3 emits all
classes (even local classes) as public, just like Scala 2. But unlike Scala 2,
the local class TestSpec in XmlSocketReporterSpec will be emitted with a
zero-argument constructor (in Scala 2 its constructor takes an
XmlSocketReporterSpec outer parameter which is never used which seems like a
bug). This matters because Scalatest considers a test suite "rerunnable" if it
has a zero argument public constructor. So to get the test suite to pass, we
need to check for the presence of this constructor just like SuiteRerunner does.