### PR TITLE
Scala 3: Should Compile Matcher Fix

### DIFF
--- a/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
+++ b/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
@@ -25,7 +25,7 @@ import scala.compiletime.testing.Error
 object CompileMacro {
 
   // used by must compile syntax, delegate to assertCompileImpl to generate code
-  def mustCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], compileWord: Expr[CompileWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
+  def mustCompileImpl(code: Expr[String], typeChecked: Expr[List[Error]], compileWord: Expr[CompileWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
     org.scalatest.matchers.CompileMacro.assertCompileImpl(code, typeChecked, compileWord, pos)("must")
 
   // used by mustNot compile syntax, delegate to assertNotCompileImpl to generate code

--- a/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
+++ b/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
@@ -25,7 +25,7 @@ import scala.compiletime.testing.Error
 object CompileMacro {
 
   // used by should compile syntax, delegate to assertCompileImpl to generate code
-  def shouldCompileImpl(code: Expr[String], typeChecked: Expr[Boolean], compileWord: Expr[CompileWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
+  def shouldCompileImpl(code: Expr[String], typeChecked: Expr[List[Error]], compileWord: Expr[CompileWord])(pos: Expr[source.Position])(using Quotes): Expr[Assertion] =
     org.scalatest.matchers.CompileMacro.assertCompileImpl(code, typeChecked, compileWord, pos)("should")
 
   // used by shouldNot compile syntax, delegate to assertNotCompileImpl to generate code

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
@@ -41,15 +41,12 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("val a: String = 2") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "Required: String" else "required: String") >= 0)
       }
       
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
-        
-        // SKIP-DOTTY-START
         val errMsg = Resources.expectedNoErrorButGotParseError("", "")
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val errMsg = Resources.expectedNoErrorButGotTypeError("", "")
-
+        
         val e = intercept[TestFailedException] {
           "println(\"test)" should compile
         }
@@ -58,6 +55,7 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "expression expected but erroneous token found" else "unclosed string literal") >= 0)
       }
 
     }
@@ -77,14 +75,11 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("val a: String = 2") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "Required: String" else "required: String") >= 0)
       }
 
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
-        
-        // SKIP-DOTTY-START
         val errMsg = Resources.expectedNoErrorButGotParseError("", "")
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val errMsg = Resources.expectedNoErrorButGotTypeError("", "")
         
         val e = intercept[TestFailedException] {
           """println("test)""" should compile
@@ -94,6 +89,7 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "expression expected but erroneous token found" else "unclosed string literal") >= 0)
       }
       
     }
@@ -117,14 +113,12 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("val a: String = 2") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "Required: String" else "required: String") >= 0)
       }
 
       it("should throw TestFailedException with correct message and stack depth when parse failed") {
-        // SKIP-DOTTY-START
         val errMsg = Resources.expectedNoErrorButGotParseError("", "")
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val errMsg = Resources.expectedNoErrorButGotTypeError("", "")
-
+        
         val e = intercept[TestFailedException] {
           """
             |println("test)
@@ -135,6 +129,7 @@ class ShouldCompileSpec extends AnyFunSpec {
         assert(e.message.get.indexOf("println(\"test)") >= 0)
         assert(e.failedCodeFileName === (Some(fileName)))
         assert(e.failedCodeLineNumber === (Some(thisLineNumber - 6)))
+        assert(e.message.get.indexOf(if (ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) "')' expected, but eof found" else "unclosed string literal") >= 0)
       }
     }
   }

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -7793,7 +7793,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     // SKIP-DOTTY-START
     def should(compileWord: CompileWord)(implicit pos: source.Position): Assertion = macro CompileMacro.shouldCompileImpl
     // SKIP-DOTTY-END
-    //DOTTY-ONLY extension (inline leftSideString: String)(using pos: source.Position, prettifier: Prettifier) transparent inline def should(compileWord: CompileWord): Assertion = ${ org.scalatest.matchers.should.CompileMacro.shouldCompileImpl('{leftSideString}, '{typeChecks(leftSideString)}, '{compileWord})('{pos}) }
+    //DOTTY-ONLY extension (inline leftSideString: String)(using pos: source.Position, prettifier: Prettifier) transparent inline def should(compileWord: CompileWord): Assertion = ${ org.scalatest.matchers.should.CompileMacro.shouldCompileImpl('{leftSideString}, '{typeCheckErrors(leftSideString)}, '{compileWord})('{pos}) }
 
     /**
      * This method enables syntax such as the following:


### PR DESCRIPTION
Fixed missing original error message in the error message raised by 'should compile' matcher in Scala 3, also made it to use different message for parse and type error.