### PR TITLE
WordSpec Error Message Enhancement

### DIFF
--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
@@ -1141,6 +1141,33 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       assert(reporter.testSucceededEventsReceived.length == 3)
     }
 
+    it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
+      class TestSpec extends AsyncWordSpec {
+
+        // SKIP-SCALATESTJS,NATIVE-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS,NATIVE-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        import org.scalatest.prop.TableDrivenPropertyChecks._
+        "trying something" should {
+          val scenarios = Table("value", "first", "first")
+          
+          forAll(scenarios) { value =>
+            s"work as expected for $value " in {
+              succeed
+            }
+          } 
+        }
+      }
+      val e = intercept[DuplicateTestNameException] {
+        new TestSpec
+      }
+      assert("AsyncWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert(e.failedCodeLineNumber.get == thisLineNumber - 10)
+      assert(e.message == Some(FailureMessages.duplicateTestName(prettifier, UnquotedString("trying something should work as expected for first"))))
+    }
+
   }
 
 }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
@@ -1229,6 +1229,36 @@ class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.testSucceededEventsReceived.length == 3)
     }
 
+    it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
+      class TestSpec extends wordspec.FixtureAsyncWordSpecLike {
+
+        // SKIP-SCALATESTJS,NATIVE-START
+        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        // SKIP-SCALATESTJS,NATIVE-END
+        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+
+        type FixtureParam = String
+        def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
+
+        import org.scalatest.prop.TableDrivenPropertyChecks._
+        "trying something" should {
+          val scenarios = Table("value", "first", "first")
+          
+          forAll(scenarios) { value =>
+            s"work as expected for $value " in { fixture =>
+              succeed
+            }
+          } 
+        }
+      }
+      val e = intercept[DuplicateTestNameException] {
+        new TestSpec
+      }
+      assert("FixtureAsyncWordSpecLikeSpec.scala" == e.failedCodeFileName.get)
+      assert(e.failedCodeLineNumber.get == thisLineNumber - 10)
+      assert(e.message == Some(FailureMessages.duplicateTestName(prettifier, UnquotedString("trying something should work as expected for first"))))
+    }
+
   }
 
 }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecSpec.scala
@@ -4496,5 +4496,30 @@ class FixtureWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
+      class TestSpec extends wordspec.FixtureAnyWordSpec {
+        type FixtureParam = String
+        def withFixture(test: OneArgTest): Outcome = { test("hi") }
+        "a feature" can {
+          //DOTTY-ONLY ()
+        }
+        import org.scalatest.prop.TableDrivenPropertyChecks._
+        "trying something" should {
+          val scenarios = Table("value", "first", "first")
+          
+          forAll(scenarios) { value =>
+            s"work as expected for $value " in { fixture =>
+            }
+          } 
+        }
+      }
+      val e = intercept[DuplicateTestNameException] {
+        new TestSpec
+      }
+      assert("FixtureWordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert(e.failedCodeLineNumber.get == thisLineNumber - 9)
+      assert(e.message == Some(FailureMessages.duplicateTestName(prettifier, UnquotedString("trying something should work as expected for first"))))
+    }
+
   }
 }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecSpec.scala
@@ -4053,5 +4053,25 @@ class WordSpecSpec extends AnyFunSpec with GivenWhenThen {
       assert(cause.getMessage == FailureMessages.duplicateTestName(prettifier, UnquotedString("a feature can test 1")))
     }
 
+    it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
+      class TestSpec extends AnyWordSpec {
+        import org.scalatest.prop.TableDrivenPropertyChecks._
+        "trying something" should {
+          val scenarios = Table("value", "first", "first")
+          
+          forAll(scenarios) { value =>
+            s"work as expected for $value " in {
+            }
+          } 
+        }
+      }
+      val e = intercept[DuplicateTestNameException] {
+        new TestSpec
+      }
+      assert("WordSpecSpec.scala" == e.failedCodeFileName.get)
+      assert(e.failedCodeLineNumber.get == thisLineNumber - 9)
+      assert(e.message == Some(FailureMessages.duplicateTestName(prettifier, UnquotedString("trying something should work as expected for first"))))
+    }
+
   }
 }

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -196,6 +196,18 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
       case "can" => FailureMessages.exceptionWasThrownInCanClause(Prettifier.default, className, description, errorMessage)
     }
 
+  private def rethrowIfCauseIsNAEOrDTNE(e: StackDepthException, pos: source.Position): Unit = 
+    e.cause match {  
+      case Some(c) if c.isInstanceOf[NotAllowedException] || c.isInstanceOf[DuplicateTestNameException] =>
+        throw c 
+      case _ => 
+        throw new NotAllowedException(
+          FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, 
+          Some(e), 
+          e.position.getOrElse(pos)
+        )
+    }  
+
   private def registerBranch(description: String, childPrefix: Option[String], verb: String, pos: source.Position, fun: () => Unit): Unit = {
     def registrationClosedMessageFun: String =
       verb match {
@@ -211,8 +223,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
       registerNestedBranch(description, childPrefix, fun(), registrationClosedMessageFun, None, pos)
     }
     catch {
-      case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
-      case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
+      case e: TestFailedException => rethrowIfCauseIsNAEOrDTNE(e, pos)
+      case e: TestCanceledException => rethrowIfCauseIsNAEOrDTNE(e, pos)
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
       case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
@@ -245,8 +257,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
                 registerNestedBranch(descriptionText, childPrefix, fun(), registrationClosedMessageFun, None, pos)
               }
               catch {
-                case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
-                case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
+                case e: TestFailedException => rethrowIfCauseIsNAEOrDTNE(e, pos)
+                case e: TestCanceledException => rethrowIfCauseIsNAEOrDTNE(e, pos)
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
                 case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -187,6 +187,18 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       case "can" => FailureMessages.exceptionWasThrownInCanClause(Prettifier.default, className, description, errorMessage)
     }
 
+  private def rethrowIfCauseIsNAEOrDTNE(e: StackDepthException, pos: source.Position): Unit = 
+    e.cause match {  
+      case Some(c) if c.isInstanceOf[NotAllowedException] || c.isInstanceOf[DuplicateTestNameException] =>
+        throw c 
+      case _ => 
+        throw new NotAllowedException(
+          FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, 
+          Some(e), 
+          e.position.getOrElse(pos)
+        )
+    }  
+
   private def registerBranch(description: String, childPrefix: Option[String], verb: String, pos: source.Position, fun: () => Unit): Unit = {
     def registrationClosedMessageFun: String =
       verb match {
@@ -202,8 +214,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerNestedBranch(description, childPrefix, fun(), registrationClosedMessageFun, None, pos)
     }
     catch {
-      case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
-      case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
+      case e: TestFailedException => rethrowIfCauseIsNAEOrDTNE(e, pos)
+      case e: TestCanceledException => rethrowIfCauseIsNAEOrDTNE(e, pos)
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
       case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
@@ -236,8 +248,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
                 registerNestedBranch(descriptionText, childPrefix, fun(), registrationClosedMessageFun, None, pos)
               }
               catch {
-                case e: TestFailedException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
-                case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
+                case e: TestFailedException => rethrowIfCauseIsNAEOrDTNE(e, pos)
+                case e: TestCanceledException => rethrowIfCauseIsNAEOrDTNE(e, pos)
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
                 case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))


### PR DESCRIPTION
Propogate cause of TestFailedException and TestCanceledException in registerBranch and registerShorthandBranch function when the cause of NotAllowedException or DuplicateTestNameException.