### PR TITLE
Change ConfigMapWrapperSuite to use wrapped suite's name

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
@@ -87,6 +87,8 @@ final class ConfigMapWrapperSuite(clazz: Class[_ <: Suite]) extends Suite {
 
   override def suiteId = clazz.getName
 
+  override def suiteName = wrappedSuite.suiteName
+
   /**
    * Returns the result obtained from invoking <code>expectedTestCount</code> on an instance of the wrapped
    * suite, constructed by passing an empty config map to its constructor, passing into the wrapped suite's


### PR DESCRIPTION
This changes the output of:
```scala
@WrapWith(classOf[ConfigMapWrapperSuite])
class SomeSpec(configMap: Map[String, Any]) extends AnyFlatSpec {
  it should "do something" in {}
}
```
From:
```
ConfigMapWrapperSuite:
- should do something
```
To:
```
SomeSpec:
- should do something
```