### PR TITLE
Change ConfigMapWrapperSuite to use wrapped suite's name and ID

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
@@ -87,6 +87,8 @@ final class ConfigMapWrapperSuite(clazz: Class[_ <: Suite]) extends Suite {
 
   override def suiteId = clazz.getName
 
+  override def suiteName = wrappedSuite.suiteName
+
   /**
    * Returns the result obtained from invoking <code>expectedTestCount</code> on an instance of the wrapped
    * suite, constructed by passing an empty config map to its constructor, passing into the wrapped suite's

--- a/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
@@ -85,7 +85,7 @@ final class ConfigMapWrapperSuite(clazz: Class[_ <: Suite]) extends Suite {
     constructor.newInstance(Map.empty)
   }
 
-  override def suiteId = clazz.getName
+  override def suiteId = wrappedSuite.suiteId
 
   override def suiteName = wrappedSuite.suiteName
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
@@ -53,4 +53,16 @@ class ConfigMapWrapperSuiteSpec extends AnyFunSuite with SeveredStackTraces {
     val suite = new ConfigMapWrapperSuite(clazz)
     assert(suite.tags === Map("blue test" -> Set("org.scalatest.FastAsLight"), "ignore me" -> Set("org.scalatest.Ignore")))
   }
+
+  test("configMap's suiteId method should return the underlying's value") {
+    val clazz = getClass.getClassLoader.loadClass("org.scalatest.SavesConfigMapSuite").asInstanceOf[Class[_ <: Suite]]
+    val suite = new ConfigMapWrapperSuite(clazz)
+    assert(suite.suiteId === "suite_id_of_SavesConfigMapSuite")
+  }
+
+  test("configMap's suiteName method should return the underlying's value") {
+    val clazz = getClass.getClassLoader.loadClass("org.scalatest.SavesConfigMapSuite").asInstanceOf[Class[_ <: Suite]]
+    val suite = new ConfigMapWrapperSuite(clazz)
+    assert(suite.suiteName === "suite_name_of_SavesConfigMapSuite")
+  }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
@@ -31,6 +31,8 @@ class SavesConfigMapSuite(configMap: Map[String, Any]) extends AnyFunSuite {
     override val suiteId = getClass.getName + "-" + UUID.randomUUID.toString
   }
   override def nestedSuites: Vector[Suite] = Vector(new NSuite, new NSuite, new NSuite)
+  override def suiteId: String = "suite_id_of_SavesConfigMapSuite"
+  override def suiteName: String = "suite_name_of_SavesConfigMapSuite"
 }
 
 object SavesConfigMapSuite {


### PR DESCRIPTION
This PR is based on @JMdoubleU 's PR earlier: 

https://github.com/scalatest/scalatest/pull/2141

This is submitted against 3.2.x-new, and I fixed the suiteId also in the same way, and added unit tests.