### PR TITLE
Modify Prettifier.truncateAt to work on case classes

### DIFF
--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
@@ -345,6 +345,10 @@ class PrettifierSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
     it("should pretty print nested string Java Map") {
       Prettifier.default(javaSortedMap(Entry("akey", javaSortedMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))))) should be ("{\"akey\"={1=\"one\", 2=\"two\", 3=\"three\"}}")
     }
+    case class CaseClazzWithArray(data: Array[Int])
+    it("should pretty print data inside a case class") {
+      Prettifier.default(CaseClazzWithArray(Array(1,2,3))) should be ("CaseClazzWithArray(Array(1, 2, 3))")
+    }
     it("should pretty print xml <a></a>") {
       Prettifier.default(<a></a>) should be ("<a></a>")
     }

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
@@ -402,6 +402,14 @@ class PrettifierSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
       val prettifier = Prettifier.truncateAt(SizeLimit(2))
       prettifier(col) shouldBe "List(1, 2, ...)"
     }
+
+    case class CaseClazz(data: List[Int])
+
+    it("should truncate collection inside of a case class when used with Prettifier.truncateAt") {
+      val caseClass = CaseClazz(List(1, 2, 3))
+      val prettifier = Prettifier.truncateAt(SizeLimit(2))
+      prettifier(caseClass) shouldBe "CaseClazz(List(1, 2, ...))"
+    }
   }
 }
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -177,6 +177,13 @@ private[scalactic] class DefaultPrettifier extends Prettifier {
         else
           theToString
       // SKIP-SCALATESTJS,NATIVE-END
+      case caseClazz: Product if caseClazz.productArity != 0 =>
+        // If the case class's toString starts with .productPrefix its likely the .toString hasn't been
+        // overridden so lets use our custom prettifying otherwise we just use .toString.
+        if (caseClazz.toString.startsWith(s"${caseClazz.productPrefix}("))
+          s"${caseClazz.productPrefix}(" + caseClazz.productIterator.map(prettify(_, processed + caseClazz)).mkString(", ") + ")"
+        else
+          caseClazz.toString
       case anythingElse => anythingElse.toString
     }
 
@@ -277,7 +284,10 @@ private[scalactic] class TruncatingPrettifier(sizeLimit: SizeLimit) extends Defa
         else
           theToString
       // SKIP-SCALATESTJS,NATIVE-END
-      case caseClazz: Product =>
+      case caseClazz: Product if caseClazz.productArity != 0 =>
+        // Unlike in DefaultPrettifier where we check if a custom `.toString` has been overridden, with
+        // TruncatingPrettifier the priority is truncating the enclosed data at all costs hence why we always
+        // truncate the inner fields.
         s"${caseClazz.productPrefix}(" + caseClazz.productIterator.map(prettify(_, processed + caseClazz)).mkString(", ") + ")"
       case anythingElse => anythingElse.toString
     }

--- a/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -277,6 +277,8 @@ private[scalactic] class TruncatingPrettifier(sizeLimit: SizeLimit) extends Defa
         else
           theToString
       // SKIP-SCALATESTJS,NATIVE-END
+      case caseClazz: Product =>
+        s"${caseClazz.productPrefix}(" + caseClazz.productIterator.map(prettify(_, processed + caseClazz)).mkString(", ") + ")"
       case anythingElse => anythingElse.toString
     }
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AMatcherSpec.scala
@@ -345,10 +345,11 @@ class AMatcherSpec extends funspec.AnyFunSpec {
       
       it("should throw TestFailedException with correct stack depth and message when 'should be a' assertion failed") {
         val tom = Person("Tom", 60)
+        val tomPrettified = "Person(\"Tom\", 60)"
         val e = intercept[exceptions.TestFailedException] {
           tom should be a youngMan
         }
-        e.message should be (Some(s"${tom.toString()} was not a young man"))
+        e.message should be (Some(s"$tomPrettified was not a young man"))
         e.failedCodeFileName should be (Some("AMatcherSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 4))
       }
@@ -359,10 +360,11 @@ class AMatcherSpec extends funspec.AnyFunSpec {
       
       it("should throw TestFailedException with correct stack depth and message when 'should not be a' assertion failed") {
         val tom = Person("Tom", 30)
+        val tomPrettified = "Person(\"Tom\", 30)"
         val e = intercept[exceptions.TestFailedException] {
           tom should not be a (youngMan)
         }
-        e.message should be (Some(s"${tom.toString()} was a young man"))
+        e.message should be (Some(s"$tomPrettified was a young man"))
         e.failedCodeFileName should be (Some("AMatcherSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 4))
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AnMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AnMatcherSpec.scala
@@ -346,10 +346,11 @@ class AnMatcherSpec extends funspec.AnyFunSpec {
       
       it("should throw TestFailedException with correct stack depth and message when 'should be a' assertion failed") {
         val tom = Person("Tom", 30)
+        val tomPrettified = "Person(\"Tom\", 30)"
         val e = intercept[exceptions.TestFailedException] {
           tom should be an oldMan
         }
-        e.message should be (Some(s"${tom.toString()} was not an old man"))
+        e.message should be (Some(s"$tomPrettified was not an old man"))
         e.failedCodeFileName should be (Some("AnMatcherSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 4))
       }
@@ -360,10 +361,11 @@ class AnMatcherSpec extends funspec.AnyFunSpec {
       
       it("should throw TestFailedException with correct stack depth and message when 'should not be a' assertion failed") {
         val tom = Person("Tom", 60)
+        val tomPrettified = "Person(\"Tom\", 60)"
         val e = intercept[exceptions.TestFailedException] {
           tom should not be an (oldMan)
         }
-        e.message should be (Some(s"${tom.toString()} was an old man"))
+        e.message should be (Some(s"$tomPrettified was an old man"))
         e.failedCodeFileName should be (Some("AnMatcherSpec.scala"))
         e.failedCodeLineNumber should be (Some(thisLineNumber - 4))
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
@@ -49,9 +49,12 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
     def directory = new DirectoryBePropertyMatcher
 
     val myFile = new MyFile("temp.txt", true, false)
+    val myFilePrettified = "MyFile(\"temp.txt\", true, false)"
 
     val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
+    val bookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, true)"
     val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
+    val badBookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, false)"
 
     it("should do nothing if the property is true") {
       book should be (goodRead)
@@ -68,17 +71,17 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         badBook should be (goodRead)
       }
-      assert(caught1.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,false) was not goodRead")
+      assert(caught1.getMessage === s"$badBookPrettified was not goodRead")
 
       val caught2 = intercept[TestFailedException] {
         badBook should be a (goodRead)
       }
-      assert(caught2.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,false) was not a goodRead")
+      assert(caught2.getMessage === s"$badBookPrettified was not a goodRead")
 
       val caught3 = intercept[TestFailedException] {
         badBook should be an (goodRead)
       }
-      assert(caught3.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,false) was not an goodRead")
+      assert(caught3.getMessage === s"$badBookPrettified was not an goodRead")
       
 /*
       val caught4 = intercept[TestFailedException] {
@@ -109,47 +112,47 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         book should not be (goodRead)
       }
-      assert(caught1.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead")
+      assert(caught1.getMessage === s"$bookPrettified was goodRead")
 
       val caught2 = intercept[TestFailedException] {
         book should not be a (goodRead)
       }
-      assert(caught2.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead")
+      assert(caught2.getMessage === s"$bookPrettified was a goodRead")
 
       val caught3 = intercept[TestFailedException] {
         book should not be an (goodRead)
       }
-      assert(caught3.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead")
+      assert(caught3.getMessage === s"$bookPrettified was an goodRead")
 
       val caught4 = intercept[TestFailedException] {
         book should not (be (goodRead))
       }
-      assert(caught4.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead")
+      assert(caught4.getMessage === s"$bookPrettified was goodRead")
 
       val caught5 = intercept[TestFailedException] {
         book should not (be a (goodRead))
       }
-      assert(caught5.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead")
+      assert(caught5.getMessage === s"$bookPrettified was a goodRead")
 
       val caught6 = intercept[TestFailedException] {
         book should not (be an (goodRead))
       }
-      assert(caught6.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead")
+      assert(caught6.getMessage === s"$bookPrettified was an goodRead")
 
       val caught7 = intercept[TestFailedException] {
         book should (not (be (goodRead)))
       }
-      assert(caught7.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead")
+      assert(caught7.getMessage === s"$bookPrettified was goodRead")
 
       val caught8 = intercept[TestFailedException] {
         book should (not (be a (goodRead)))
       }
-      assert(caught8.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead")
+      assert(caught8.getMessage === s"$bookPrettified was a goodRead")
 
       val caught9 = intercept[TestFailedException] {
         book should (not (be an (goodRead)))
       }
-      assert(caught9.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead")
+      assert(caught9.getMessage === s"$bookPrettified was an goodRead")
     }
 
     it("should do nothing if the the property returns true, when used in a logical-and expression") {
@@ -173,147 +176,147 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         myFile should ((be (directory)) and (be (file)))
       }
-      assert(caught1.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught1.getMessage === s"$myFilePrettified was not directory")
 
       val caught2 = intercept[TestFailedException] {
         myFile should (be (directory) and (be (file)))
       }
-      assert(caught2.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught2.getMessage === s"$myFilePrettified was not directory")
 
       val caught3 = intercept[TestFailedException] {
         myFile should (be (directory) and be (file))
       }
-      assert(caught3.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught3.getMessage === s"$myFilePrettified was not directory")
 
 
       val caught4 = intercept[TestFailedException] {
         myFile should ((be a (directory)) and (be a (file)))
       }
-      assert(caught4.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught4.getMessage === s"$myFilePrettified was not a directory")
 
       val caught5 = intercept[TestFailedException] {
         myFile should (be a (directory) and (be a (file)))
       }
-      assert(caught5.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught5.getMessage === s"$myFilePrettified was not a directory")
 
       val caught6 = intercept[TestFailedException] {
         myFile should (be a (directory) and be a (file))
       }
-      assert(caught6.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught6.getMessage === s"$myFilePrettified was not a directory")
 
 
       val caught7 = intercept[TestFailedException] {
         myFile should ((be an (directory)) and (be an (file)))
       }
-      assert(caught7.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught7.getMessage === s"$myFilePrettified was not an directory")
 
       val caught8 = intercept[TestFailedException] {
         myFile should (be an (directory) and (be an (file)))
       }
-      assert(caught8.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught8.getMessage === s"$myFilePrettified was not an directory")
 
       val caught9 = intercept[TestFailedException] {
         myFile should (be an (directory) and be an (file))
       }
-      assert(caught9.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught9.getMessage === s"$myFilePrettified was not an directory")
 
 
       // second false
       val caught10 = intercept[TestFailedException] {
         myFile should ((be (file)) and (be (directory)))
       }
-      assert(caught10.getMessage === "MyFile(temp.txt,true,false) was file, but MyFile(temp.txt,true,false) was not directory")
+      assert(caught10.getMessage === s"$myFilePrettified was file, but $myFilePrettified was not directory")
 
       val caught11 = intercept[TestFailedException] {
         myFile should (be (file) and (be (directory)))
       }
-      assert(caught11.getMessage === "MyFile(temp.txt,true,false) was file, but MyFile(temp.txt,true,false) was not directory")
+      assert(caught11.getMessage === s"$myFilePrettified was file, but $myFilePrettified was not directory")
 
       val caught12 = intercept[TestFailedException] {
         myFile should (be (file) and be (directory))
       }
-      assert(caught12.getMessage === "MyFile(temp.txt,true,false) was file, but MyFile(temp.txt,true,false) was not directory")
+      assert(caught12.getMessage === s"$myFilePrettified was file, but $myFilePrettified was not directory")
 
 
       val caught13 = intercept[TestFailedException] {
         myFile should ((be a (file)) and (be a (directory)))
       }
-      assert(caught13.getMessage === "MyFile(temp.txt,true,false) was a file, but MyFile(temp.txt,true,false) was not a directory")
+      assert(caught13.getMessage === s"$myFilePrettified was a file, but $myFilePrettified was not a directory")
 
       val caught14 = intercept[TestFailedException] {
         myFile should (be a (file) and (be a (directory)))
       }
-      assert(caught14.getMessage === "MyFile(temp.txt,true,false) was a file, but MyFile(temp.txt,true,false) was not a directory")
+      assert(caught14.getMessage === s"$myFilePrettified was a file, but $myFilePrettified was not a directory")
 
       val caught15 = intercept[TestFailedException] {
         myFile should (be a (file) and be a (directory))
       }
-      assert(caught15.getMessage === "MyFile(temp.txt,true,false) was a file, but MyFile(temp.txt,true,false) was not a directory")
+      assert(caught15.getMessage === s"$myFilePrettified was a file, but $myFilePrettified was not a directory")
 
 
       val caught16 = intercept[TestFailedException] {
         myFile should ((be an (file)) and (be an (directory)))
       }
-      assert(caught16.getMessage === "MyFile(temp.txt,true,false) was an file, but MyFile(temp.txt,true,false) was not an directory")
+      assert(caught16.getMessage === s"$myFilePrettified was an file, but $myFilePrettified was not an directory")
 
       val caught17 = intercept[TestFailedException] {
         myFile should (be an (file) and (be an (directory)))
       }
-      assert(caught17.getMessage === "MyFile(temp.txt,true,false) was an file, but MyFile(temp.txt,true,false) was not an directory")
+      assert(caught17.getMessage === s"$myFilePrettified was an file, but $myFilePrettified was not an directory")
 
       val caught18 = intercept[TestFailedException] {
         myFile should (be an (file) and be an (directory))
       }
-      assert(caught18.getMessage === "MyFile(temp.txt,true,false) was an file, but MyFile(temp.txt,true,false) was not an directory")
+      assert(caught18.getMessage === s"$myFilePrettified was an file, but $myFilePrettified was not an directory")
 
 
       // both false
       val caught19 = intercept[TestFailedException] {
         myFile should ((be (directory)) and (be (directory)))
       }
-      assert(caught19.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught19.getMessage === s"$myFilePrettified was not directory")
 
       val caught20 = intercept[TestFailedException] {
         myFile should (be (directory) and (be (directory)))
       }
-      assert(caught20.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught20.getMessage === s"$myFilePrettified was not directory")
 
       val caught21 = intercept[TestFailedException] {
         myFile should (be (directory) and be (directory))
       }
-      assert(caught21.getMessage === "MyFile(temp.txt,true,false) was not directory")
+      assert(caught21.getMessage === s"$myFilePrettified was not directory")
 
 
       val caught22 = intercept[TestFailedException] {
         myFile should ((be a (directory)) and (be a (directory)))
       }
-      assert(caught22.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught22.getMessage === s"$myFilePrettified was not a directory")
 
       val caught23 = intercept[TestFailedException] {
         myFile should (be a (directory) and (be a (directory)))
       }
-      assert(caught23.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught23.getMessage === s"$myFilePrettified was not a directory")
 
       val caught24 = intercept[TestFailedException] {
         myFile should (be a (directory) and be a (directory))
       }
-      assert(caught24.getMessage === "MyFile(temp.txt,true,false) was not a directory")
+      assert(caught24.getMessage === s"$myFilePrettified was not a directory")
 
 
       val caught25 = intercept[TestFailedException] {
         myFile should ((be an (directory)) and (be an (directory)))
       }
-      assert(caught25.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught25.getMessage === s"$myFilePrettified was not an directory")
 
       val caught26 = intercept[TestFailedException] {
         myFile should (be an (directory) and (be an (directory)))
       }
-      assert(caught26.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught26.getMessage === s"$myFilePrettified was not an directory")
 
       val caught27 = intercept[TestFailedException] {
         myFile should (be an (directory) and be an (directory))
       }
-      assert(caught27.getMessage === "MyFile(temp.txt,true,false) was not an directory")
+      assert(caught27.getMessage === s"$myFilePrettified was not an directory")
     }
 
     it("should do nothing if the property returns true, when used in a logical-or expression") {
@@ -363,49 +366,49 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         myFile should ((be (directory)) or (be (directory)))
       }
-      assert(caught1.getMessage === "MyFile(temp.txt,true,false) was not directory, and MyFile(temp.txt,true,false) was not directory")
+      assert(caught1.getMessage === s"$myFilePrettified was not directory, and $myFilePrettified was not directory")
 
       val caught2 = intercept[TestFailedException] {
         myFile should (be (directory) or (be (directory)))
       }
-      assert(caught2.getMessage === "MyFile(temp.txt,true,false) was not directory, and MyFile(temp.txt,true,false) was not directory")
+      assert(caught2.getMessage === s"$myFilePrettified was not directory, and $myFilePrettified was not directory")
 
       val caught3 = intercept[TestFailedException] {
         myFile should (be (directory) or be (directory))
       }
-      assert(caught3.getMessage === "MyFile(temp.txt,true,false) was not directory, and MyFile(temp.txt,true,false) was not directory")
+      assert(caught3.getMessage === s"$myFilePrettified was not directory, and $myFilePrettified was not directory")
 
 
       val caught4 = intercept[TestFailedException] {
         myFile should ((be a (directory)) or (be a (directory)))
       }
-      assert(caught4.getMessage === "MyFile(temp.txt,true,false) was not a directory, and MyFile(temp.txt,true,false) was not a directory")
+      assert(caught4.getMessage === s"$myFilePrettified was not a directory, and $myFilePrettified was not a directory")
 
       val caught5 = intercept[TestFailedException] {
         myFile should (be a (directory) or (be a (directory)))
       }
-      assert(caught5.getMessage === "MyFile(temp.txt,true,false) was not a directory, and MyFile(temp.txt,true,false) was not a directory")
+      assert(caught5.getMessage === s"$myFilePrettified was not a directory, and $myFilePrettified was not a directory")
 
       val caught6 = intercept[TestFailedException] {
         myFile should (be a (directory) or be a (directory))
       }
-      assert(caught6.getMessage === "MyFile(temp.txt,true,false) was not a directory, and MyFile(temp.txt,true,false) was not a directory")
+      assert(caught6.getMessage === s"$myFilePrettified was not a directory, and $myFilePrettified was not a directory")
 
 
       val caught7 = intercept[TestFailedException] {
         myFile should ((be an (directory)) or (be an (directory)))
       }
-      assert(caught7.getMessage === "MyFile(temp.txt,true,false) was not an directory, and MyFile(temp.txt,true,false) was not an directory")
+      assert(caught7.getMessage === s"$myFilePrettified was not an directory, and $myFilePrettified was not an directory")
 
       val caught8 = intercept[TestFailedException] {
         myFile should (be an (directory) or (be an (directory)))
       }
-      assert(caught8.getMessage === "MyFile(temp.txt,true,false) was not an directory, and MyFile(temp.txt,true,false) was not an directory")
+      assert(caught8.getMessage === s"$myFilePrettified was not an directory, and $myFilePrettified was not an directory")
 
       val caught9 = intercept[TestFailedException] {
         myFile should (be an (directory) or be an (directory))
       }
-      assert(caught9.getMessage === "MyFile(temp.txt,true,false) was not an directory, and MyFile(temp.txt,true,false) was not an directory")
+      assert(caught9.getMessage === s"$myFilePrettified was not an directory, and $myFilePrettified was not an directory")
     }
 
     it("should do nothing if the property returns false, when used in a logical-and expression with not") {
@@ -429,147 +432,147 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         myFile should (not (be (directory)) and not (be (file)))
       }
-      assert(caught1.getMessage === "MyFile(temp.txt,true,false) was not directory, but MyFile(temp.txt,true,false) was file")
+      assert(caught1.getMessage === s"$myFilePrettified was not directory, but $myFilePrettified was file")
 
       val caught2 = intercept[TestFailedException] {
         myFile should ((not be (directory)) and (not be (file)))
       }
-      assert(caught2.getMessage === "MyFile(temp.txt,true,false) was not directory, but MyFile(temp.txt,true,false) was file")
+      assert(caught2.getMessage === s"$myFilePrettified was not directory, but $myFilePrettified was file")
 
       val caught3 = intercept[TestFailedException] {
         myFile should (not be (directory) and not be (file))
       }
-      assert(caught3.getMessage === "MyFile(temp.txt,true,false) was not directory, but MyFile(temp.txt,true,false) was file")
+      assert(caught3.getMessage === s"$myFilePrettified was not directory, but $myFilePrettified was file")
 
 
       val caught4 = intercept[TestFailedException] {
         myFile should (not (be a (directory)) and not (be a (file)))
       }
-      assert(caught4.getMessage === "MyFile(temp.txt,true,false) was not a directory, but MyFile(temp.txt,true,false) was a file")
+      assert(caught4.getMessage === s"$myFilePrettified was not a directory, but $myFilePrettified was a file")
 
       val caught5 = intercept[TestFailedException] {
         myFile should ((not be a (directory)) and (not be a (file)))
       }
-      assert(caught5.getMessage === "MyFile(temp.txt,true,false) was not a directory, but MyFile(temp.txt,true,false) was a file")
+      assert(caught5.getMessage === s"$myFilePrettified was not a directory, but $myFilePrettified was a file")
 
       val caught6 = intercept[TestFailedException] {
         myFile should (not be a (directory) and not be a (file))
       }
-      assert(caught6.getMessage === "MyFile(temp.txt,true,false) was not a directory, but MyFile(temp.txt,true,false) was a file")
+      assert(caught6.getMessage === s"$myFilePrettified was not a directory, but $myFilePrettified was a file")
 
 
       val caught7 = intercept[TestFailedException] {
         myFile should (not (be an (directory)) and not (be an (file)))
       }
-      assert(caught7.getMessage === "MyFile(temp.txt,true,false) was not an directory, but MyFile(temp.txt,true,false) was an file")
+      assert(caught7.getMessage === s"$myFilePrettified was not an directory, but $myFilePrettified was an file")
 
       val caught8 = intercept[TestFailedException] {
         myFile should ((not be an (directory)) and (not be an (file)))
       }
-      assert(caught8.getMessage === "MyFile(temp.txt,true,false) was not an directory, but MyFile(temp.txt,true,false) was an file")
+      assert(caught8.getMessage === s"$myFilePrettified was not an directory, but $myFilePrettified was an file")
 
       val caught9 = intercept[TestFailedException] {
         myFile should (not be an (directory) and not be an (file))
       }
-      assert(caught9.getMessage === "MyFile(temp.txt,true,false) was not an directory, but MyFile(temp.txt,true,false) was an file")
+      assert(caught9.getMessage === s"$myFilePrettified was not an directory, but $myFilePrettified was an file")
 
 
       // first false
       val caught10 = intercept[TestFailedException] {
         myFile should (not (be (file)) and not (be (directory)))
       }
-      assert(caught10.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught10.getMessage === s"$myFilePrettified was file")
 
       val caught11 = intercept[TestFailedException] {
         myFile should ((not be (file)) and (not be (directory)))
       }
-      assert(caught11.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught11.getMessage === s"$myFilePrettified was file")
 
       val caught12 = intercept[TestFailedException] {
         myFile should (not be (file) and not be (directory))
       }
-      assert(caught12.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught12.getMessage === s"$myFilePrettified was file")
 
 
       val caught13 = intercept[TestFailedException] {
         myFile should (not (be a (file)) and not (be a (directory)))
       }
-      assert(caught13.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught13.getMessage === s"$myFilePrettified was a file")
 
       val caught14 = intercept[TestFailedException] {
         myFile should ((not be a (file)) and (not be a (directory)))
       }
-      assert(caught14.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught14.getMessage === s"$myFilePrettified was a file")
 
       val caught15 = intercept[TestFailedException] {
         myFile should (not be a (file) and not be a (directory))
       }
-      assert(caught15.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught15.getMessage === s"$myFilePrettified was a file")
 
 
       val caught16 = intercept[TestFailedException] {
         myFile should (not (be an (file)) and not (be an (directory)))
       }
-      assert(caught16.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught16.getMessage === s"$myFilePrettified was an file")
 
       val caught17 = intercept[TestFailedException] {
         myFile should ((not be an (file)) and (not be an (directory)))
       }
-      assert(caught17.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught17.getMessage === s"$myFilePrettified was an file")
 
       val caught18 = intercept[TestFailedException] {
         myFile should (not be an (file) and not be an (directory))
       }
-      assert(caught18.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught18.getMessage === s"$myFilePrettified was an file")
 
 
       // both false
       val caught19 = intercept[TestFailedException] {
         myFile should (not (be (file)) and not (be (file)))
       }
-      assert(caught19.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught19.getMessage === s"$myFilePrettified was file")
 
       val caught20 = intercept[TestFailedException] {
         myFile should ((not be (file)) and (not be (file)))
       }
-      assert(caught20.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught20.getMessage === s"$myFilePrettified was file")
 
       val caught21 = intercept[TestFailedException] {
         myFile should (not be (file) and not be (file))
       }
-      assert(caught21.getMessage === "MyFile(temp.txt,true,false) was file")
+      assert(caught21.getMessage === s"$myFilePrettified was file")
 
 
       val caught22 = intercept[TestFailedException] {
         myFile should (not (be a (file)) and not (be a (file)))
       }
-      assert(caught22.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught22.getMessage === s"$myFilePrettified was a file")
 
       val caught23 = intercept[TestFailedException] {
         myFile should ((not be a (file)) and (not be a (file)))
       }
-      assert(caught23.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught23.getMessage === s"$myFilePrettified was a file")
 
       val caught24 = intercept[TestFailedException] {
         myFile should (not be a (file) and not be a (file))
       }
-      assert(caught24.getMessage === "MyFile(temp.txt,true,false) was a file")
+      assert(caught24.getMessage === s"$myFilePrettified was a file")
 
 
       val caught25 = intercept[TestFailedException] {
         myFile should (not (be an (file)) and not (be an (file)))
       }
-      assert(caught25.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught25.getMessage === s"$myFilePrettified was an file")
 
       val caught26 = intercept[TestFailedException] {
         myFile should ((not be an (file)) and (not be an (file)))
       }
-      assert(caught26.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught26.getMessage === s"$myFilePrettified was an file")
 
       val caught27 = intercept[TestFailedException] {
         myFile should (not be an (file) and not be an (file))
       }
-      assert(caught27.getMessage === "MyFile(temp.txt,true,false) was an file")
+      assert(caught27.getMessage === s"$myFilePrettified was an file")
     }
 
     it("should do nothing if the property returns false, when used in a logical-or expression with not") {
@@ -619,49 +622,49 @@ class ShouldBePropertyMatcherSpec extends AnyFunSpec with ReturnsNormallyThrowsA
       val caught1 = intercept[TestFailedException] {
         myFile should (not (be (file)) or not (be (file)))
       }
-      assert(caught1.getMessage === "MyFile(temp.txt,true,false) was file, and MyFile(temp.txt,true,false) was file")
+      assert(caught1.getMessage === s"$myFilePrettified was file, and $myFilePrettified was file")
 
       val caught2 = intercept[TestFailedException] {
         myFile should ((not be (file)) or (not be (file)))
       }
-      assert(caught2.getMessage === "MyFile(temp.txt,true,false) was file, and MyFile(temp.txt,true,false) was file")
+      assert(caught2.getMessage === s"$myFilePrettified was file, and $myFilePrettified was file")
 
       val caught3 = intercept[TestFailedException] {
         myFile should (not be (file) or not be (file))
       }
-      assert(caught3.getMessage === "MyFile(temp.txt,true,false) was file, and MyFile(temp.txt,true,false) was file")
+      assert(caught3.getMessage === s"$myFilePrettified was file, and $myFilePrettified was file")
 
 
       val caught4 = intercept[TestFailedException] {
         myFile should (not (be a (file)) or not (be a (file)))
       }
-      assert(caught4.getMessage === "MyFile(temp.txt,true,false) was a file, and MyFile(temp.txt,true,false) was a file")
+      assert(caught4.getMessage === s"$myFilePrettified was a file, and $myFilePrettified was a file")
 
       val caught5 = intercept[TestFailedException] {
         myFile should ((not be a (file)) or (not be a (file)))
       }
-      assert(caught5.getMessage === "MyFile(temp.txt,true,false) was a file, and MyFile(temp.txt,true,false) was a file")
+      assert(caught5.getMessage === s"$myFilePrettified was a file, and $myFilePrettified was a file")
 
       val caught6 = intercept[TestFailedException] {
         myFile should (not be a (file) or not be a (file))
       }
-      assert(caught6.getMessage === "MyFile(temp.txt,true,false) was a file, and MyFile(temp.txt,true,false) was a file")
+      assert(caught6.getMessage === s"$myFilePrettified was a file, and $myFilePrettified was a file")
 
 
       val caught7 = intercept[TestFailedException] {
         myFile should (not (be an (file)) or not (be an (file)))
       }
-      assert(caught7.getMessage === "MyFile(temp.txt,true,false) was an file, and MyFile(temp.txt,true,false) was an file")
+      assert(caught7.getMessage === s"$myFilePrettified was an file, and $myFilePrettified was an file")
 
       val caught8 = intercept[TestFailedException] {
         myFile should ((not be an (file)) or (not be an (file)))
       }
-      assert(caught8.getMessage === "MyFile(temp.txt,true,false) was an file, and MyFile(temp.txt,true,false) was an file")
+      assert(caught8.getMessage === s"$myFilePrettified was an file, and $myFilePrettified was an file")
 
       val caught9 = intercept[TestFailedException] {
         myFile should (not be an (file) or not be an (file))
       }
-      assert(caught9.getMessage === "MyFile(temp.txt,true,false) was an file, and MyFile(temp.txt,true,false) was an file")
+      assert(caught9.getMessage === s"$myFilePrettified was an file, and $myFilePrettified was an file")
     }
   }
   describe("the compose method on BePropertyMatcher") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
@@ -227,14 +227,15 @@ class ShouldBeShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookPr
 
       val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
       val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
-      
+      val badBookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, false)"
+
       all(List(book)) shouldBe goodRead
       
       val list1 = List(badBook)
       val caught1 = intercept[TestFailedException] {
         all(list1) shouldBe goodRead
       }
-      assert(caught1.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,false) was not goodRead", thisLineNumber - 2, list1)))
+      assert(caught1.message === Some(errorMessage(0, s"$badBookPrettified was not goodRead", thisLineNumber - 2, list1)))
       assert(caught1.failedCodeFileName === Some("ShouldBeShorthandForAllSpec.scala"))
       assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
@@ -244,7 +245,7 @@ class ShouldBeShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookPr
       val caught2 = intercept[TestFailedException] {
         all(list2) shouldBe a (goodRead)
       }
-      assert(caught2.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,false) was not a goodRead", thisLineNumber - 2, list2)))
+      assert(caught2.message === Some(errorMessage(0, s"$badBookPrettified was not a goodRead", thisLineNumber - 2, list2)))
       assert(caught2.failedCodeFileName === Some("ShouldBeShorthandForAllSpec.scala"))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
@@ -254,7 +255,7 @@ class ShouldBeShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookPr
       val caught3 = intercept[TestFailedException] {
         all(list3) shouldBe an (goodRead)
       }
-      assert(caught3.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,false) was not an goodRead", thisLineNumber - 2, list3)))
+      assert(caught3.message === Some(errorMessage(0, s"$badBookPrettified was not an goodRead", thisLineNumber - 2, list3)))
       assert(caught3.failedCodeFileName === Some("ShouldBeShorthandForAllSpec.scala"))
       assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
@@ -225,13 +225,14 @@ class ShouldBeShorthandSpec extends AnyFunSpec with EmptyMocks with BookProperty
 
       val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
       val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
-      
+      val badBookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, false)"
+
       book shouldBe goodRead
       
       val caught1 = intercept[TestFailedException] {
         badBook shouldBe goodRead
       }
-      assert(caught1.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,false) was not goodRead"))
+      assert(caught1.message === Some(s"$badBookPrettified was not goodRead"))
       assert(caught1.failedCodeFileName === Some("ShouldBeShorthandSpec.scala"))
       assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
@@ -240,7 +241,7 @@ class ShouldBeShorthandSpec extends AnyFunSpec with EmptyMocks with BookProperty
       val caught2 = intercept[TestFailedException] {
         badBook shouldBe a (goodRead)
       }
-      assert(caught2.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,false) was not a goodRead"))
+      assert(caught2.message === Some(s"$badBookPrettified was not a goodRead"))
       assert(caught2.failedCodeFileName === Some("ShouldBeShorthandSpec.scala"))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
@@ -248,7 +249,7 @@ class ShouldBeShorthandSpec extends AnyFunSpec with EmptyMocks with BookProperty
       val caught3 = intercept[TestFailedException] {
         badBook shouldBe an (goodRead)
       }
-      assert(caught3.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,false) was not an goodRead"))
+      assert(caught3.message === Some(s"$badBookPrettified was not an goodRead"))
       assert(caught3.failedCodeFileName === Some("ShouldBeShorthandSpec.scala"))
       assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldHavePropertiesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldHavePropertiesSpec.scala
@@ -33,6 +33,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
     describe("on an object with properties") {
 
       val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
+      val bookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, true)"
       val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
       // val bookshelf = new Bookshelf(book, badBook, book)
 
@@ -248,13 +249,13 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught1 = intercept[TestFailedException] {
           book should have (author ("Gibson"))
         }
-        assert(caught1.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught2 = intercept[TestFailedException] {
           book should have (Symbol("author") ("Gibson"))
         }
-        assert(caught2.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught2.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -267,7 +268,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
             pubYear (1859)
           )
         }
-        assert(caught1.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught2 = intercept[TestFailedException] {
@@ -277,7 +278,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
             pubYear (1859)
           )
         }
-        assert(caught2.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught2.getMessage === "The author property had value \"Dickens\", instead of its expected value \"Gibson\", on object " + bookPrettified)
 
         val caught3 = intercept[TestFailedException] {
           book should have (
@@ -286,7 +287,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
             Symbol("pubYear") (1959)
           )
         }
-        assert(caught3.getMessage === "The pubYear property had value 1859, instead of its expected value 1959, on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught3.getMessage === "The pubYear property had value 1859, instead of its expected value 1959, on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -295,13 +296,13 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught1 = intercept[TestFailedException] {
           book should not have (author ("Dickens"))
         }
-        assert(caught1.getMessage === "The author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "The author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught2 = intercept[TestFailedException] {
           book should not have (Symbol("author") ("Dickens"))
         }
-        assert(caught2.getMessage === "The author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught2.getMessage === "The author property had its expected value \"Dickens\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -342,7 +343,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
             author ("Dickens")
           )
         }
-        assert(caught1.getMessage === "All properties had their expected values, respectively, on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "All properties had their expected values, respectively, on object " + bookPrettified)
       }
 
       it("should throw TestFailedException if at least one property does not match, when used with and") {
@@ -351,69 +352,69 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught1 = intercept[TestFailedException] {
           book should (have (title ("A Tale of Two Cities")) and (have (author ("Melville"))))
         }
-        assert(caught1.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         val caught2 = intercept[TestFailedException] {
           book should (have (title ("A Tale of Two Cities")) and have (author ("Melville")))
         }
-        assert(caught2.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught2.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught3 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("A Tale of Two Cities")) and (have (Symbol("author") ("Melville"))))
         }
-        assert(caught3.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught3.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         val caught4 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("A Tale of Two Cities")) and have (Symbol("author") ("Melville")))
         }
-        assert(caught4.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught4.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", but the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         // first false
         val caught11 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) and (have (author ("Dickens"))))
         }
-        assert(caught11.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught11.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         val caught12 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) and have (author ("Dickens")))
         }
-        assert(caught12.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught12.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught13 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) and (have (Symbol("author") ("Dickens"))))
         }
-        assert(caught13.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught13.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         val caught14 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) and have (Symbol("author") ("Dickens")))
         }
-        assert(caught14.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught14.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         // both false
         val caught21 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) and (have (author ("Melville"))))
         }
-        assert(caught21.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught21.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         val caught22 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) and have (author ("Melville")))
         }
-        assert(caught22.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught22.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught23 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) and (have (Symbol("author") ("Melville"))))
         }
-        assert(caught23.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught23.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
 
         val caught24 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) and have (Symbol("author") ("Melville")))
         }
-        assert(caught24.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught24.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -423,23 +424,23 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught21 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) or (have (author ("Melville"))))
         }
-        assert(caught21.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught21.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         val caught22 = intercept[TestFailedException] {
           book should (have (title ("Moby Dick")) or have (author ("Melville")))
         }
-        assert(caught22.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught22.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught23 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) or (have (Symbol("author") ("Melville"))))
         }
-        assert(caught23.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught23.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
 
         val caught24 = intercept[TestFailedException] {
           book should (have (Symbol("title") ("Moby Dick")) or have (Symbol("author") ("Melville")))
         }
-        assert(caught24.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught24.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", and the author property had value \"Dickens\", instead of its expected value \"Melville\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -449,105 +450,105 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught1 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and not (have (author ("Melville"))))
         }
-        assert(caught1.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught1.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         val caught2 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and not have (author ("Melville")))
         }
-        assert(caught2.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught2.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught3 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and not (have (Symbol("author") ("Melville"))))
         }
-        assert(caught3.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught3.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         val caught4 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and not have (Symbol("author") ("Melville")))
         }
-        assert(caught4.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught4.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         val caught5 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and (not have (author ("Melville"))))
         }
-        assert(caught5.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught5.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught6 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and (not have (Symbol("author") ("Melville"))))
         }
-        assert(caught6.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught6.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         // first false
         val caught11 = intercept[TestFailedException] {
           book should (not have (title ("Moby Dick")) and not (have (author ("Dickens"))))
         }
-        assert(caught11.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught11.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         val caught12 = intercept[TestFailedException] {
           book should (not have (title ("Moby Dick")) and not have (author ("Dickens")))
         }
-        assert(caught12.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught12.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught13 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("Moby Dick")) and (not have (Symbol("author") ("Dickens"))))
         }
-        assert(caught13.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught13.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         val caught14 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("Moby Dick")) and not have (Symbol("author") ("Dickens")))
         }
-        assert(caught14.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught14.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         val caught15 = intercept[TestFailedException] {
           book should (not have (title ("Moby Dick")) and (not have (author ("Dickens"))))
         }
-        assert(caught15.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught15.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught16 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("Moby Dick")) and (not have (Symbol("author") ("Dickens"))))
         }
-        assert(caught16.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), but the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught16.getMessage === "The title property had value \"A Tale of Two Cities\", instead of its expected value \"Moby Dick\", on object " + bookPrettified + ", but the author property had its expected value \"Dickens\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         // both true
         val caught21 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and (not have (author ("Dickens"))))
         }
-        assert(caught21.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught21.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         val caught22 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and not have (author ("Dickens")))
         }
-        assert(caught22.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught22.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught23 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and (not have (Symbol("author") ("Dickens"))))
         }
-        assert(caught23.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught23.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         val caught24 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and not have (Symbol("author") ("Dickens")))
         }
-        assert(caught24.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught24.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         val caught25 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) and (not (have (author ("Dickens")))))
         }
-        assert(caught25.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught25.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught26 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) and (not (have (Symbol("author") ("Dickens")))))
         }
-        assert(caught26.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught26.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
       }
 
@@ -557,35 +558,35 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
         val caught21 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) or (not have (author ("Dickens"))))
         }
-        assert(caught21.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught21.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         val caught22 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) or not have (author ("Dickens")))
         }
-        assert(caught22.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught22.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught23 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) or (not have (Symbol("author") ("Dickens"))))
         }
-        assert(caught23.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught23.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         val caught24 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) or not have (Symbol("author") ("Dickens")))
         }
-        assert(caught24.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught24.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         val caught25 = intercept[TestFailedException] {
           book should (not have (title ("A Tale of Two Cities")) or (not have (author ("Dickens"))))
         }
-        assert(caught25.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught25.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
 
         // SKIP-SCALATESTJS,NATIVE-START
         val caught26 = intercept[TestFailedException] {
           book should (not have (Symbol("title") ("A Tale of Two Cities")) or (not have (Symbol("author") ("Dickens"))))
         }
-        assert(caught26.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object Book(A Tale of Two Cities,Dickens,1859,45,true), and the author property had its expected value \"Dickens\", on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught26.getMessage === "The title property had its expected value \"A Tale of Two Cities\", on object " + bookPrettified + ", and the author property had its expected value \"Dickens\", on object " + bookPrettified)
         // SKIP-SCALATESTJS,NATIVE-END
 
         // A double one, so that I can see the mid-sentence version of the 'all properties...' error message
@@ -600,7 +601,7 @@ class ShouldHavePropertiesSpec extends AnyFunSpec with ReturnsNormallyThrowsAsse
             )
           )
         }
-        assert(caught31.getMessage === "All properties had their expected values, respectively, on object Book(A Tale of Two Cities,Dickens,1859,45,true), and all properties had their expected values, respectively, on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
+        assert(caught31.getMessage === "All properties had their expected values, respectively, on object " + bookPrettified + ", and all properties had their expected values, respectively, on object " + bookPrettified)
       }
 
 /*
@@ -632,7 +633,7 @@ hard to read. Better to have people pull things out and then just do a non-neste
           book should have (length (43))
         }
         // assert(caught1.getMessage === "The length property had value 45, instead of its expected value 43, on object Book(A Tale of Two Cities,Dickens,1859,45,true)")
-        assert(caught1.getMessage === "Book(A Tale of Two Cities,Dickens,1859,45,true) had length 45 instead of expected length 43")
+        assert(caught1.getMessage === bookPrettified + " had length 45 instead of expected length 43")
       }
 
       it("should work with size not a symbol without anything special, in case someone forgets you don't need the parens with size") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
@@ -265,6 +265,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val myFile = new MyFile("temp.txt", true, false)
 
       val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
+      val bookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, true)"
       val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
       
       all(List(badBook)) shouldNot be (goodRead)
@@ -275,7 +276,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught1 = intercept[TestFailedException] {
         all(list1) shouldNot be (goodRead)
       }
-      assert(caught1.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead", thisLineNumber - 2, list1)))
+      assert(caught1.message === Some(errorMessage(0, s"$bookPrettified was goodRead", thisLineNumber - 2, list1)))
       assert(caught1.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
@@ -283,7 +284,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught2 = intercept[TestFailedException] {
         all(list2) shouldNot be a goodRead
       }
-      assert(caught2.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead", thisLineNumber - 2, list2)))
+      assert(caught2.message === Some(errorMessage(0, s"$bookPrettified was a goodRead", thisLineNumber - 2, list2)))
       assert(caught2.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
 
@@ -291,7 +292,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught3 = intercept[TestFailedException] {
         all(list3) shouldNot be an goodRead
       }
-      assert(caught3.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead", thisLineNumber - 2, list3)))
+      assert(caught3.message === Some(errorMessage(0, s"$bookPrettified was an goodRead", thisLineNumber - 2, list3)))
       assert(caught3.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
 
@@ -299,7 +300,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught4 = intercept[TestFailedException] {
         all(list4) shouldNot (be (goodRead))
       }
-      assert(caught4.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead", thisLineNumber - 2, list4)))
+      assert(caught4.message === Some(errorMessage(0, s"$bookPrettified was goodRead", thisLineNumber - 2, list4)))
       assert(caught4.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
@@ -307,7 +308,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught5 = intercept[TestFailedException] {
         all(list5) shouldNot (be a (goodRead))
       }
-      assert(caught5.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead", thisLineNumber - 2, list5)))
+      assert(caught5.message === Some(errorMessage(0, s"$bookPrettified was a goodRead", thisLineNumber - 2, list5)))
       assert(caught5.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
 
@@ -315,7 +316,7 @@ class ShouldNotShorthandForAllSpec extends AnyFunSpec with EmptyMocks with BookP
       val caught6 = intercept[TestFailedException] {
         all(list6) shouldNot (be an (goodRead))
       }
-      assert(caught6.message === Some(errorMessage(0, "Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead", thisLineNumber - 2, list6)))
+      assert(caught6.message === Some(errorMessage(0, s"$bookPrettified was an goodRead", thisLineNumber - 2, list6)))
       assert(caught6.failedCodeFileName === Some("ShouldNotShorthandForAllSpec.scala"))
       assert(caught6.failedCodeLineNumber === Some(thisLineNumber - 4))
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
@@ -232,6 +232,7 @@ class ShouldNotShorthandSpec extends AnyFunSpec with EmptyMocks with BookPropert
       val myFile = new MyFile("temp.txt", true, false)
 
       val book = new Book("A Tale of Two Cities", "Dickens", 1859, 45, true)
+      val badBookPrettified = "Book(\"A Tale of Two Cities\", \"Dickens\", 1859, 45, true)"
       val badBook = new Book("A Tale of Two Cities", "Dickens", 1859, 45, false)
 
       badBook shouldNot be (goodRead)
@@ -241,42 +242,42 @@ class ShouldNotShorthandSpec extends AnyFunSpec with EmptyMocks with BookPropert
       val caught1 = intercept[TestFailedException] {
         book shouldNot be (goodRead)
       }
-      assert(caught1.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead"))
+      assert(caught1.message === Some(s"$badBookPrettified was goodRead"))
       assert(caught1.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
 
       val caught2 = intercept[TestFailedException] {
         book shouldNot be a goodRead
       }
-      assert(caught2.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead"))
+      assert(caught2.message === Some(s"$badBookPrettified was a goodRead"))
       assert(caught2.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
 
       val caught3 = intercept[TestFailedException] {
         book shouldNot be an goodRead
       }
-      assert(caught3.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead"))
+      assert(caught3.message === Some(s"$badBookPrettified was an goodRead"))
       assert(caught3.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
 
       val caught4 = intercept[TestFailedException] {
         book shouldNot (be (goodRead))
       }
-      assert(caught4.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was goodRead"))
+      assert(caught4.message === Some(s"$badBookPrettified was goodRead"))
       assert(caught4.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught4.failedCodeLineNumber === Some(thisLineNumber - 4))
 
       val caught5 = intercept[TestFailedException] {
         book shouldNot (be a (goodRead))
       }
-      assert(caught5.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was a goodRead"))
+      assert(caught5.message === Some(s"$badBookPrettified was a goodRead"))
       assert(caught5.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught5.failedCodeLineNumber === Some(thisLineNumber - 4))
 
       val caught6 = intercept[TestFailedException] {
         book shouldNot (be an (goodRead))
       }
-      assert(caught6.message === Some("Book(A Tale of Two Cities,Dickens,1859,45,true) was an goodRead"))
+      assert(caught6.message === Some(s"$badBookPrettified was an goodRead"))
       assert(caught6.failedCodeFileName === Some("ShouldNotShorthandSpec.scala"))
       assert(caught6.failedCodeLineNumber === Some(thisLineNumber - 4))
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
@@ -288,6 +288,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = be a (file)
@@ -300,10 +301,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not a file"
-        mr.negatedFailureMessage shouldBe s"$myFile was a file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
+        mr.failureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was a file"
         mr.rawFailureMessage shouldBe "{0} was not a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -319,10 +320,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was a file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was not a file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not a file"
         nmr.rawFailureMessage shouldBe "{0} was a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -344,6 +345,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = be a (file)
       
@@ -355,10 +357,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not a file"
-        mr.negatedFailureMessage shouldBe s"$myFile was a file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
+        mr.failureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was a file"
         mr.rawFailureMessage shouldBe "{0} was not a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -374,10 +376,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was a file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was not a file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not a file"
         nmr.rawFailureMessage shouldBe "{0} was a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -453,6 +455,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = be an (file)
@@ -465,10 +468,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not an file"
-        mr.negatedFailureMessage shouldBe s"$myFile was an file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
+        mr.failureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an file"
         mr.rawFailureMessage shouldBe "{0} was not an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -484,10 +487,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was an file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was not an file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an file"
         nmr.rawFailureMessage shouldBe "{0} was an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -509,6 +512,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AnMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = be an (file)
       
@@ -520,10 +524,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not an file"
-        mr.negatedFailureMessage shouldBe s"$myFile was an file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
+        mr.failureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an file"
         mr.rawFailureMessage shouldBe "{0} was not an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -539,10 +543,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was an file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was not an file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an file"
         nmr.rawFailureMessage shouldBe "{0} was an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -610,22 +614,24 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       )
       
       val myFileLeft = MyFile("left", true, false)
+      val myFileLeftPrettified = "MyFile(\"left\", true, false)"
       val myFileRight = MyFile("right", true, false)
-      
+      val myFileRightPrettified = "MyFile(\"right\", true, false)"
+
       val mt = be theSameInstanceAs (myFileRight)
       
-      it("should have pretty toString") {
-        mt.toString should be ("be theSameInstanceAs " + myFileRight)
+      it("should have pretty via DefaultPrettifier") {
+        mt.toString should be ("be theSameInstanceAs " + myFileRightPrettified)
       }
       
       val mr = mt(myFileLeft)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        mr.negatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        mr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
         mr.rawFailureMessage shouldBe "{0} was not the same instance as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was the same instance as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not the same instance as {1}"
@@ -641,10 +647,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        nmr.negatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        nmr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
         nmr.rawFailureMessage shouldBe "{0} was the same instance as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not the same instance as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was the same instance as {1}"
@@ -872,6 +878,7 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = be (file)
@@ -884,10 +891,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not file"
-        mr.negatedFailureMessage shouldBe s"$myFile was file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was file"
+        mr.failureMessage shouldBe s"$myFilePrettified was not file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was file"
         mr.rawFailureMessage shouldBe "{0} was not {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -903,10 +910,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was not file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not file"
         nmr.rawFailureMessage shouldBe "{0} was {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -928,22 +935,24 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       )
 
       val myFileLeft = MyFile("test left", true, false)
+      val myFileLeftPrettified = "MyFile(\"test left\", true, false)"
       val myFileRight = MyFile("test right", true, false)
-      
+      val myFileRightPrettified = "MyFile(\"test right\", true, false)"
+
       val mt = be (myFileRight)
       
-      it("should have pretty toString") {
-        mt.toString should be (s"be ($myFileRight)")
+      it("should have pretty via DefaultPrettifier") {
+        mt.toString should be (s"be ($myFileRightPrettified)")
       }
       
       val mr = mt(myFileLeft)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-        mr.negatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+        mr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
         mr.rawFailureMessage shouldBe "{0} was not equal to {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was equal to {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not equal to {1}"
@@ -959,10 +968,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-        nmr.negatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+        nmr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
         nmr.rawFailureMessage shouldBe "{0} was equal to {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not equal to {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was equal to {1}"
@@ -1149,15 +1158,16 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = new MyFile("test", true, false)
-      
+      val myFilePrettified = "MyFile(\"test\", true, false)"
+
       val mr = mt(myFile)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.failureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
         mr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1173,10 +1183,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.failureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         nmr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1207,15 +1217,16 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = new MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mr = mt(myFile)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        mr.failureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
         mr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1231,10 +1242,10 @@ class BeWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.failureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         nmr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
@@ -190,7 +190,8 @@ class ContainWordSpec extends AnyFunSpec {
       
       val file = AMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
-      
+      val myFilePrettified = "MyFile(\"test\", true, false)"
+
       val mt = contain a (file)
       
       it("should have pretty toString") {
@@ -198,22 +199,23 @@ class ContainWordSpec extends AnyFunSpec {
       }
       
       val leftList = List(myFile)
+      val leftListPrettified = "List(MyFile(\"test\", true, false))"
       val mr = mt(leftList)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$leftList did not contain a file"
-        mr.negatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        mr.midSentenceFailureMessage shouldBe s"$leftList did not contain a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        mr.failureMessage shouldBe s"$leftListPrettified did not contain a file"
+        mr.negatedFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        mr.midSentenceFailureMessage shouldBe s"$leftListPrettified did not contain a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
         mr.rawFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
 
       }
       
@@ -221,17 +223,17 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        nmr.negatedFailureMessage shouldBe s"$leftList did not contain a file"
-        nmr.midSentenceFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain a file"
+        nmr.failureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        nmr.negatedFailureMessage shouldBe s"$leftListPrettified did not contain a file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified did not contain a file"
         nmr.rawFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain a {1}"
-        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -246,7 +248,8 @@ class ContainWordSpec extends AnyFunSpec {
       
       val file = AnMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
-      
+      val myFilePrettified = "MyFile(\"test\", true, false)"
+
       val mt = contain an (file)
       
       it("should have pretty toString") {
@@ -254,22 +257,23 @@ class ContainWordSpec extends AnyFunSpec {
       }
       
       val leftList = List(myFile)
+      val leftListPrettified = "List(MyFile(\"test\", true, false))"
       val mr = mt(leftList)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$leftList did not contain an file"
-        mr.negatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        mr.midSentenceFailureMessage shouldBe s"$leftList did not contain an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        mr.failureMessage shouldBe s"$leftListPrettified did not contain an file"
+        mr.negatedFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        mr.midSentenceFailureMessage shouldBe s"$leftListPrettified did not contain an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
         mr.rawFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
 
       }
       
@@ -277,17 +281,17 @@ class ContainWordSpec extends AnyFunSpec {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        nmr.negatedFailureMessage shouldBe s"$leftList did not contain an file"
-        nmr.midSentenceFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain an file"
+        nmr.failureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        nmr.negatedFailureMessage shouldBe s"$leftListPrettified did not contain an file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified did not contain an file"
         nmr.rawFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain an {1}"
-        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
@@ -303,14 +303,15 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       describe("when evaluate to true") {
         
         val lhs = Person("Bob")
+        val lhsPrettified = "Person(\"Bob\")"
         val mr = mt(lhs)
       
         it("should have correct MatcherResult") {
           mr.matches shouldBe true
-          mr.failureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhs
-          mr.negatedFailureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhs
-          mr.midSentenceFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhs
-          mr.midSentenceNegatedFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhs
+          mr.failureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhsPrettified
+          mr.negatedFailureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhsPrettified
+          mr.midSentenceFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhsPrettified
+          mr.midSentenceNegatedFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhsPrettified
           mr.rawFailureMessage shouldBe "The {0} property had its expected value {1}, on object {2}"
           mr.rawNegatedFailureMessage shouldBe "The {0} property had its expected value {1}, on object {2}"
           mr.rawMidSentenceFailureMessage shouldBe "the {0} property had its expected value {1}, on object {2}"
@@ -326,10 +327,10 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe false
-          nmr.failureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhs
-          nmr.negatedFailureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhs
-          nmr.midSentenceFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhs
-          nmr.midSentenceNegatedFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhs
+          nmr.failureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhsPrettified
+          nmr.negatedFailureMessage shouldBe "The name property had its expected value \"Bob\", on object " + lhsPrettified
+          nmr.midSentenceFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhsPrettified
+          nmr.midSentenceNegatedFailureMessage shouldBe "the name property had its expected value \"Bob\", on object " + lhsPrettified
           nmr.rawFailureMessage shouldBe "The {0} property had its expected value {1}, on object {2}"
           nmr.rawNegatedFailureMessage shouldBe "The {0} property had its expected value {1}, on object {2}"
           nmr.rawMidSentenceFailureMessage shouldBe "the {0} property had its expected value {1}, on object {2}"
@@ -346,14 +347,15 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       describe("when evaluate to false") {
         
         val lhs = Person("Alice")
+        val lhsPrettified = "Person(\"Alice\")"
         val mr = mt(lhs)
       
         it("should have correct MatcherResult") {
           mr.matches shouldBe false
-          mr.failureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          mr.negatedFailureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          mr.midSentenceFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          mr.midSentenceNegatedFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
+          mr.failureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          mr.negatedFailureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          mr.midSentenceFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          mr.midSentenceNegatedFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
           mr.rawFailureMessage shouldBe "The {0} property had value {2}, instead of its expected value {1}, on object {3}"
           mr.rawNegatedFailureMessage shouldBe "The {0} property had value {2}, instead of its expected value {1}, on object {3}"
           mr.rawMidSentenceFailureMessage shouldBe "the {0} property had value {2}, instead of its expected value {1}, on object {3}"
@@ -369,10 +371,10 @@ class HaveWordSpec extends AnyFunSpec with Matchers {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe true
-          nmr.failureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          nmr.negatedFailureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          nmr.midSentenceFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
-          nmr.midSentenceNegatedFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhs
+          nmr.failureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          nmr.negatedFailureMessage shouldBe "The name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          nmr.midSentenceFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
+          nmr.midSentenceNegatedFailureMessage shouldBe "the name property had value \"Alice\", instead of its expected value \"Bob\", on object " + lhsPrettified
           nmr.rawFailureMessage shouldBe "The {0} property had value {2}, instead of its expected value {1}, on object {3}"
           nmr.rawNegatedFailureMessage shouldBe "The {0} property had value {2}, instead of its expected value {1}, on object {3}"
           nmr.rawMidSentenceFailureMessage shouldBe "the {0} property had value {2}, instead of its expected value {1}, on object {3}"

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
@@ -805,6 +805,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = not be (file)
@@ -817,10 +818,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was file"
-        mr.negatedFailureMessage shouldBe s"$myFile was not file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not file"
+        mr.failureMessage shouldBe s"$myFilePrettified was file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not file"
         mr.rawFailureMessage shouldBe "{0} was {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was {1}"
@@ -836,10 +837,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was not file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was file"
         nmr.rawFailureMessage shouldBe "{0} was not {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not {1}"
@@ -915,6 +916,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = not be a (file)
@@ -927,10 +929,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was a file"
-        mr.negatedFailureMessage shouldBe s"$myFile was not a file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
+        mr.failureMessage shouldBe s"$myFilePrettified was a file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not a file"
         mr.rawFailureMessage shouldBe "{0} was a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -946,10 +948,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not a file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was a file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was a file"
         nmr.rawFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -971,6 +973,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = not be a (file)
       
@@ -982,10 +985,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was a file"
-        mr.negatedFailureMessage shouldBe s"$myFile was not a file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not a file"
+        mr.failureMessage shouldBe s"$myFilePrettified was a file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not a file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not a file"
         mr.rawFailureMessage shouldBe "{0} was a {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was a {1}"
@@ -1001,10 +1004,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not a file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was a file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was a file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was a file"
         nmr.rawFailureMessage shouldBe "{0} was not a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was a {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not a {1}"
@@ -1080,6 +1083,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       val file = new FileBePropertyMatcher
       
       val mt = not be an (file)
@@ -1092,10 +1096,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was an file"
-        mr.negatedFailureMessage shouldBe s"$myFile was not an file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
+        mr.failureMessage shouldBe s"$myFilePrettified was an file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an file"
         mr.rawFailureMessage shouldBe "{0} was an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -1111,10 +1115,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not an file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was an file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an file"
         nmr.rawFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -1136,6 +1140,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AnMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = not be an (file)
       
@@ -1147,10 +1152,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was an file"
-        mr.negatedFailureMessage shouldBe s"$myFile was not an file"
-        mr.midSentenceFailureMessage shouldBe s"$myFile was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an file"
+        mr.failureMessage shouldBe s"$myFilePrettified was an file"
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not an file"
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an file"
         mr.rawFailureMessage shouldBe "{0} was an {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an {1}"
@@ -1166,10 +1171,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not an file"
-        nmr.negatedFailureMessage shouldBe s"$myFile was an file"
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an file"
+        nmr.failureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an file"
         nmr.rawFailureMessage shouldBe "{0} was not an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an {1}"
@@ -1191,21 +1196,23 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       val myFileLeft = MyFile("left", true, false)
       val myFileRight = MyFile("right", true, false)
-      
+      val myFileLeftPrettified = "MyFile(\"left\", true, false)"
+      val myFileRightPrettified = "MyFile(\"right\", true, false)"
+
       val mt = not be theSameInstanceAs (myFileRight)
       
-      it("should have pretty toString") {
-        mt.toString should be ("not be theSameInstanceAs (" + s"$myFileRight)")
+      it("should have pretty via DefaultPrettifier") {
+        mt.toString should be ("not be theSameInstanceAs (" + s"$myFileRightPrettified)")
       }
       
       val mr = mt(myFileLeft)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe true
-        mr.failureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        mr.negatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        mr.midSentenceFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
+        mr.failureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        mr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        mr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
         mr.rawFailureMessage shouldBe "{0} was the same instance as {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not the same instance as {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was the same instance as {1}"
@@ -1221,10 +1228,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe false
-        nmr.failureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        nmr.negatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
-        nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was not the same instance as " + myFileRight
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was the same instance as " + myFileRight
+        nmr.failureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        nmr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
+        nmr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was not the same instance as " + myFileRightPrettified
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was the same instance as " + myFileRightPrettified
         nmr.rawFailureMessage shouldBe "{0} was not the same instance as {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was the same instance as {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not the same instance as {1}"
@@ -1345,24 +1352,26 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       )
 
       val myFileRight = MyFile("test right", true, false)
+      val myFileRightPrettified = "MyFile(\"test right\", true, false)"
       
       val mt = not be (myFileRight)
       
-      it("should have pretty toString") {
-        mt.toString should be ("not be " + myFileRight)
+      it("should have pretty via DefaultPrettifier") {
+        mt.toString should be ("not be " + myFileRightPrettified)
       }
       
       describe("when left is not null") {
       
         val myFileLeft = MyFile("test left", true, false)
+        val myFileLeftPrettified = "MyFile(\"test left\", true, false)"
         val mr = mt(myFileLeft)
       
         it("should have correct MatcherResult") {
           mr.matches shouldBe true
-          mr.failureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-          mr.negatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-          mr.midSentenceFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
+          mr.failureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+          mr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+          mr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
           mr.rawFailureMessage shouldBe "{0} was equal to {1}"
           mr.rawNegatedFailureMessage shouldBe "{0} was not equal to {1}"
           mr.rawMidSentenceFailureMessage shouldBe "{0} was equal to {1}"
@@ -1378,10 +1387,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe false
-          nmr.failureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-          nmr.negatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
-          nmr.midSentenceFailureMessage shouldBe s"$myFileLeft was not equal to " + myFileRight
-          nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeft was equal to " + myFileRight
+          nmr.failureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+          nmr.negatedFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
+          nmr.midSentenceFailureMessage shouldBe s"$myFileLeftPrettified was not equal to " + myFileRightPrettified
+          nmr.midSentenceNegatedFailureMessage shouldBe s"$myFileLeftPrettified was equal to " + myFileRightPrettified
           nmr.rawFailureMessage shouldBe "{0} was not equal to {1}"
           nmr.rawNegatedFailureMessage shouldBe "{0} was equal to {1}"
           nmr.rawMidSentenceFailureMessage shouldBe "{0} was not equal to {1}"
@@ -1402,9 +1411,9 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
         it("should have correct MatcherResult") {
           mr.matches shouldBe true
           mr.failureMessage shouldBe "The reference was null"
-          mr.negatedFailureMessage shouldBe s"$myFileRight was not null"
+          mr.negatedFailureMessage shouldBe s"$myFileRightPrettified was not null"
           mr.midSentenceFailureMessage shouldBe "the reference was null"
-          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileRight was not null"
+          mr.midSentenceNegatedFailureMessage shouldBe s"$myFileRightPrettified was not null"
           mr.rawFailureMessage shouldBe "The reference was null"
           mr.rawNegatedFailureMessage shouldBe "{0} was not null"
           mr.rawMidSentenceFailureMessage shouldBe "the reference was null"
@@ -1420,9 +1429,9 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
         it("should have correct negated MatcherResult") {
           nmr.matches shouldBe false
-          nmr.failureMessage shouldBe s"$myFileRight was not null"
+          nmr.failureMessage shouldBe s"$myFileRightPrettified was not null"
           nmr.negatedFailureMessage shouldBe "The reference was null"
-          nmr.midSentenceFailureMessage shouldBe s"$myFileRight was not null"
+          nmr.midSentenceFailureMessage shouldBe s"$myFileRightPrettified was not null"
           nmr.midSentenceNegatedFailureMessage shouldBe "the reference was null"
           nmr.rawFailureMessage shouldBe "{0} was not null"
           nmr.rawNegatedFailureMessage shouldBe "The reference was null"
@@ -1713,15 +1722,16 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = new MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mr = mt(myFile)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.failureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         mr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1737,10 +1747,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.failureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
         nmr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -1771,15 +1781,16 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val myFile = new MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mr = mt(myFile)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.negatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        mr.midSentenceFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        mr.midSentenceNegatedFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.failureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.negatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        mr.midSentenceFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        mr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
         mr.rawFailureMessage shouldBe "{0} was an instance of {1}"
         mr.rawNegatedFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} was an instance of {1}"
@@ -1795,10 +1806,10 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.negatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
-        nmr.midSentenceFailureMessage shouldBe s"$myFile was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFile was an instance of " + clazz.getName
+        nmr.failureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.negatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
+        nmr.midSentenceFailureMessage shouldBe s"$myFilePrettified was not an instance of " + clazz.getName + ", but an instance of " + myFile.getClass.getName
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$myFilePrettified was an instance of " + clazz.getName
         nmr.rawFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
         nmr.rawNegatedFailureMessage shouldBe "{0} was an instance of {1}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} was not an instance of {1}, but an instance of {2}"
@@ -2805,6 +2816,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = not contain a (file)
       
@@ -2813,21 +2825,22 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val leftList = List(myFile)
+      val leftListPrettified = "List(MyFile(\"test\", true, false))"
       val mr = mt(leftList)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        mr.negatedFailureMessage shouldBe s"$leftList did not contain a file"
-        mr.midSentenceFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain a file"
+        mr.failureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        mr.negatedFailureMessage shouldBe s"$leftListPrettified did not contain a file"
+        mr.midSentenceFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified did not contain a file"
         mr.rawFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain a {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained a {1}: {2}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain a {1}"
-        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -2836,18 +2849,18 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$leftList did not contain a file"
-        nmr.negatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
-        nmr.midSentenceFailureMessage shouldBe s"$leftList did not contain a file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained a file: $myFile was a file"
+        nmr.failureMessage shouldBe s"$leftListPrettified did not contain a file"
+        nmr.negatedFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftListPrettified did not contain a file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified contained a file: $myFilePrettified was a file"
         nmr.rawFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain a {1}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained a {1}: {2}"
         nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
         nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was a file"))
+        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was a file"))
 
       }
     }
@@ -2861,6 +2874,7 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       val file = AnMatcher[MyFile]("file") { _.file  }
       val myFile = MyFile("test", true, false)
+      val myFilePrettified = "MyFile(\"test\", true, false)"
       
       val mt = not contain an (file)
       
@@ -2869,21 +2883,22 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       }
       
       val leftList = List(myFile)
+      val leftListPrettified = "List(MyFile(\"test\", true, false))"
       val mr = mt(leftList)
       
       it("should have correct MatcherResult") {
         mr.matches shouldBe false
-        mr.failureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        mr.negatedFailureMessage shouldBe s"$leftList did not contain an file"
-        mr.midSentenceFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        mr.midSentenceNegatedFailureMessage shouldBe s"$leftList did not contain an file"
+        mr.failureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        mr.negatedFailureMessage shouldBe s"$leftListPrettified did not contain an file"
+        mr.midSentenceFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        mr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified did not contain an file"
         mr.rawFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawNegatedFailureMessage shouldBe "{0} did not contain an {1}"
         mr.rawMidSentenceFailureMessage shouldBe "{0} contained an {1}: {2}"
         mr.rawMidSentenceNegatedFailureMessage shouldBe "{0} did not contain an {1}"
-        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        mr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         mr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        mr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         mr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
 
       }
@@ -2892,18 +2907,18 @@ class NotWordSpec extends AnyFunSpec with FileMocks {
       
       it("should have correct negated MatcherResult") {
         nmr.matches shouldBe true
-        nmr.failureMessage shouldBe s"$leftList did not contain an file"
-        nmr.negatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
-        nmr.midSentenceFailureMessage shouldBe s"$leftList did not contain an file"
-        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftList contained an file: $myFile was an file"
+        nmr.failureMessage shouldBe s"$leftListPrettified did not contain an file"
+        nmr.negatedFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
+        nmr.midSentenceFailureMessage shouldBe s"$leftListPrettified did not contain an file"
+        nmr.midSentenceNegatedFailureMessage shouldBe s"$leftListPrettified contained an file: $myFilePrettified was an file"
         nmr.rawFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.rawMidSentenceFailureMessage shouldBe "{0} did not contain an {1}"
         nmr.rawMidSentenceNegatedFailureMessage shouldBe "{0} contained an {1}: {2}"
         nmr.failureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        nmr.negatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
         nmr.midSentenceFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"))
-        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFile was an file"))
+        nmr.midSentenceNegatedFailureMessageArgs shouldBe Vector(leftList, UnquotedString("file"), UnquotedString(s"$myFilePrettified was an file"))
 
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
@@ -445,7 +445,7 @@ import StringReporter.withPossibleLineNumber
     val failingLineNumber = thisLineNumber - 6
     assert(rep.content ==
       s"""- test *** FAILED ***
-        |  Person(Student 1,22) did not equal Person(Student 2,23) (StringReporterSuite.scala:$failingLineNumber)
+        |  Person("Student 1", 22) did not equal Person("Student 2", 23) (StringReporterSuite.scala:$failingLineNumber)
         |  Analysis:
         |  StringReporterSuite$$Person(age: 22 -> 23, name: "Student [1]" -> "Student [2]")
         |""".stripMargin


### PR DESCRIPTION
In the PR https://github.com/scalatest/scalatest/pull/2131, `Prettifier.truncateAt` was added which allows the truncating of massive collections when they are pretty printed by ScalaTest. Unfortunately the current `Prettifier.truncateAt` doesn't work if collection/s are wrapped inside a `case class` (in my case the data I generate is located within `case class`es).

Due to Scala having `Product` along with methods for iterating over fields in a `case class`, the implementation is quite straight forward (just apply `prettify` on every element in the `productIterator`).

Note that we DO NOT truncate the number of fields within the case class, only the values behind those fields.