### PR TITLE
More Open Classes for Scala 3

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/FutureOutcome.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FutureOutcome.scala
@@ -99,7 +99,10 @@ And this confusion of Success(Failed) is what the Or is intended to alleviate.
  * with <code>FutureOutcome</code>.
  * </p>
  */
+// SKIP-DOTTY-START 
 class FutureOutcome(private[scalatest] val underlying: Future[Outcome]) {
+// SKIP-DOTTY-END
+//DOTTY-ONLY open class FutureOutcome(private[scalatest] val underlying: Future[Outcome]) {
   // TODO: add tests for pretty toString
 
   /**

--- a/jvm/core/src/main/scala/org/scalatest/Sequential.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Sequential.scala
@@ -63,7 +63,10 @@ import org.scalactic.exceptions.NullArgumentException
  *
  * @author Bill Venners
  */
+// SKIP-DOTTY-START 
 class Sequential(suitesToNest: Suite*) extends Suite with SequentialNestedSuiteExecution { thisSuite => 
+// SKIP-DOTTY-END
+//DOTTY-ONLY open class Sequential(suitesToNest: Suite*) extends Suite with SequentialNestedSuiteExecution { thisSuite =>
 
   requireNonNull(suitesToNest)
 

--- a/jvm/core/src/main/scala/org/scalatest/Stepwise.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Stepwise.scala
@@ -61,7 +61,10 @@ import org.scalactic.exceptions.NullArgumentException
  *
  * @author Bill Venners
  */
+// SKIP-DOTTY-START 
 class Stepwise(suitesToNest: Suite*) extends Suite with StepwiseNestedSuiteExecution { thisSuite => 
+// SKIP-DOTTY-END
+//DOTTY-ONLY open class Stepwise(suitesToNest: Suite*) extends Suite with StepwiseNestedSuiteExecution { thisSuite =>
 
   requireNonNull(suitesToNest)
 

--- a/jvm/core/src/main/scala/org/scalatest/Suites.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suites.scala
@@ -54,7 +54,10 @@ import org.scalactic.exceptions.NullArgumentException
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 //SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
+// SKIP-DOTTY-START
 class Suites(suitesToNest: Suite*) extends Suite { thisSuite =>
+// SKIP-DOTTY-END
+//DOTTY-ONLY open class Suites(suitesToNest: Suite*) extends Suite { thisSuite =>
 
   requireNonNull(suitesToNest)
 

--- a/jvm/core/src/main/scala/org/scalatest/Tag.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Tag.scala
@@ -146,7 +146,10 @@ package org.scalatest
  * @author Bill Venners
  * @author George Berger
  */
+// SKIP-DOTTY-START 
 class Tag(val name: String)
+// SKIP-DOTTY-END
+//DOTTY-ONLY open class Tag(val name: String)
 
 /**
  * Companion object for <code>Tag</code>, which offers a factory method.


### PR DESCRIPTION
Marked FutureOutcome, Sequential, Stepwise, Suites and Tag as open class in scala 3.