### PR TITLE
FuturePropCheckerAsserting via map2

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -1585,79 +1585,43 @@ trait FuturePropCheckerAsserting {
           } flatMap { result =>
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB, (a: A, b: B) => (a, b))
+                val roseTreeOfABC =
+                  RoseTree.map2[(A, B), C, (A, B, C)](
+                    roseTreeOfAB, 
+                    roseTreeOfC, { case ((a, b), c) => 
+                      (a, b, c)
+                    }
+                  )
+                val roseTreeOfABCD =
+                  RoseTree.map2[(A, B, C), D, (A, B, C, D)](
+                    roseTreeOfABC, 
+                    roseTreeOfD, { case ((a, b, c), d) => 
+                      (a, b, c, d)
+                    }
+                  )
+                val roseTreeOfABCDE =
+                  RoseTree.map2[(A, B, C, D), E, (A, B, C, D, E)](
+                    roseTreeOfABCD, 
+                    roseTreeOfE, { case ((a, b, c, d), e) => 
+                      (a, b, c, d, e)
+                    }
+                  )  
+
                 for {
-                  (shrunkRtOfAB, shrunkErrOpt) <- roseTreeOfA.combineFirstDepthShrinksForFuture[Throwable, B](
-                                                          { case (a, b) => {
-                                                              val result: Future[T] = fun(a, b, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
+                  (shrunkRtOfABCDE, shrunkErrOpt) <- roseTreeOfABCDE.depthFirstShrinksForFuture { case (a, b, c, d, e) => {
+                                                              val result: Future[T] = fun(a, b, c, d, e)
                                                               result.map { _ => 
                                                                 (true, None)
                                                               } recover {
                                                                 case shrunkEx: Throwable => (false, Some(shrunkEx))
                                                               }
                                                             }
-                                                          }, 
-                                                        roseTreeOfB)
-                  (shrunkRtOfABC, shrunkErrOpt2) <- shrunkRtOfAB.headOption.map { headRt =>
-                                                            headRt.combineFirstDepthShrinksForFuture[Throwable, C](
-                                                              { case ((a, b), c) => {
-                                                                  val result: Future[T] = fun(a, b, c, roseTreeOfD.value, roseTreeOfE.value)
-                                                                  result.map { _ => 
-                                                                    (true, None)
-                                                                  } recover {
-                                                                    case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                                  }
-                                                                }
-                                                              }, 
-                                                              roseTreeOfC
-                                                            )
-                                                          }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))
-                  (shrunkRtOfABCD, shrunkErrOpt3) <- shrunkRtOfABC.headOption.map { headRt =>
-                                                            headRt.combineFirstDepthShrinksForFuture[Throwable, D](
-                                                              { case (((a, b), c), d) => {
-                                                                  val result: Future[T] = fun(a, b, c, d, roseTreeOfE.value)
-                                                                  result.map { _ => 
-                                                                    (true, None)
-                                                                  } recover {
-                                                                    case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                                  }
-                                                                }
-                                                              }, 
-                                                              roseTreeOfD
-                                                            )
-                                                          }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))    
-                  (shrunkRtOfABCDE, shrunkErrOpt4) <- shrunkRtOfABCD.headOption.map { headRt =>
-                                                            headRt.combineFirstDepthShrinksForFuture[Throwable, E](
-                                                              { case ((((a, b), c), d), e) => {
-                                                                  val result: Future[T] = fun(a, b, c, d, e)
-                                                                  result.map { _ => 
-                                                                    (true, None)
-                                                                  } recover {
-                                                                    case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                                  }
-                                                                }
-                                                              }, 
-                                                              roseTreeOfE
-                                                            )
-                                                          }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))                                                                                                                      
+                                                          }
                 } yield {
-                  val bestABCDE = 
-                    shrunkRtOfABCDE.headOption.map(_.value) match {
-                      case Some(((((a, b), c), d), e)) => (a, b, c, d, e)
-                      case None =>
-                        shrunkRtOfABCD.headOption.map(_.value) match {
-                          case Some((((a, b), c), d)) => (a, b, c, d, roseTreeOfE.value)
-                          case None => 
-                            shrunkRtOfABC.headOption.map(_.value) match {
-                              case Some(((a, b), c)) => (a, b, c, roseTreeOfD.value, roseTreeOfE.value)
-                              case None => 
-                                shrunkRtOfAB.headOption.map(_.value) match {
-                                  case Some((a, b)) => (a, b, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
-                                  case None => (roseTreeOfA.value, roseTreeOfB.value, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
-                                }
-                            }
-                        }
-                    }
-                  val errOpt = List(f.ex, shrunkErrOpt, shrunkErrOpt2, shrunkErrOpt3, shrunkErrOpt4).flatten.lastOption
+                  val bestABCDE = shrunkRtOfABCDE.headOption.map(_.value).getOrElse((roseTreeOfA.value, roseTreeOfB.value, roseTreeOfC.value, 
+                                                                                     roseTreeOfD.value, roseTreeOfE.value))
+                  val errOpt: Option[Throwable] = List(f.ex, shrunkErrOpt).flatten.lastOption
 
                   val shrunkArgsPassed = List(if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), bestABCDE) else PropertyArgument(None, bestABCDE))
                   val theRes = new PropertyCheckResult.Failure(succeededCount, errOpt, names, shrunkArgsPassed, initSeed)
@@ -1684,79 +1648,43 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB, (a: A, b: B) => (a, b))
+            val roseTreeOfABC =
+              RoseTree.map2[(A, B), C, (A, B, C)](
+                roseTreeOfAB, 
+                roseTreeOfC, { case ((a, b), c) => 
+                  (a, b, c)
+                }
+              )
+            val roseTreeOfABCD =
+              RoseTree.map2[(A, B, C), D, (A, B, C, D)](
+                roseTreeOfABC, 
+                roseTreeOfD, { case ((a, b, c), d) => 
+                  (a, b, c, d)
+                }
+              )
+            val roseTreeOfABCDE =
+              RoseTree.map2[(A, B, C, D), E, (A, B, C, D, E)](
+                roseTreeOfABCD, 
+                roseTreeOfE, { case ((a, b, c, d), e) => 
+                  (a, b, c, d, e)
+                }
+              )  
+
             for {
-              (shrunkRtOfAB, shrunkErrOpt) <- roseTreeOfA.combineFirstDepthShrinksForFuture[Throwable, B](
-                                                      { case (a, b) => {
-                                                          val result: Future[T] = fun(a, b, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
+              (shrunkRtOfABCDE, shrunkErrOpt) <- roseTreeOfABCDE.depthFirstShrinksForFuture { case (a, b, c, d, e) => {
+                                                          val result: Future[T] = fun(a, b, c, d, e)
                                                           result.map { _ => 
                                                             (true, None)
                                                           } recover {
                                                             case shrunkEx: Throwable => (false, Some(shrunkEx))
                                                           }
                                                         }
-                                                      }, 
-                                                    roseTreeOfB)
-              (shrunkRtOfABC, shrunkErrOpt2) <- shrunkRtOfAB.headOption.map { headRt =>
-                                                        headRt.combineFirstDepthShrinksForFuture[Throwable, C](
-                                                          { case ((a, b), c) => {
-                                                              val result: Future[T] = fun(a, b, c, roseTreeOfD.value, roseTreeOfE.value)
-                                                              result.map { _ => 
-                                                                (true, None)
-                                                              } recover {
-                                                                case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                              }
-                                                            }
-                                                          }, 
-                                                          roseTreeOfC
-                                                        )
-                                                      }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))
-              (shrunkRtOfABCD, shrunkErrOpt3) <- shrunkRtOfABC.headOption.map { headRt =>
-                                                        headRt.combineFirstDepthShrinksForFuture[Throwable, D](
-                                                          { case (((a, b), c), d) => {
-                                                              val result: Future[T] = fun(a, b, c, d, roseTreeOfE.value)
-                                                              result.map { _ => 
-                                                                (true, None)
-                                                              } recover {
-                                                                case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                              }
-                                                            }
-                                                          }, 
-                                                          roseTreeOfD
-                                                        )
-                                                      }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))    
-              (shrunkRtOfABCDE, shrunkErrOpt4) <- shrunkRtOfABCD.headOption.map { headRt =>
-                                                        headRt.combineFirstDepthShrinksForFuture[Throwable, E](
-                                                          { case ((((a, b), c), d), e) => {
-                                                              val result: Future[T] = fun(a, b, c, d, e)
-                                                              result.map { _ => 
-                                                                (true, None)
-                                                              } recover {
-                                                                case shrunkEx: Throwable => (false, Some(shrunkEx))
-                                                              }
-                                                            }
-                                                          }, 
-                                                          roseTreeOfE
-                                                        )
-                                                      }.getOrElse(Future.successful((LazyListOrStream.empty, shrunkErrOpt)))                                                                                                                      
+                                                      }
             } yield {
-              val bestABCDE = 
-                shrunkRtOfABCDE.headOption.map(_.value) match {
-                  case Some(((((a, b), c), d), e)) => (a, b, c, d, e)
-                  case None =>
-                    shrunkRtOfABCD.headOption.map(_.value) match {
-                      case Some((((a, b), c), d)) => (a, b, c, d, roseTreeOfE.value)
-                      case None => 
-                        shrunkRtOfABC.headOption.map(_.value) match {
-                          case Some(((a, b), c)) => (a, b, c, roseTreeOfD.value, roseTreeOfE.value)
-                          case None => 
-                            shrunkRtOfAB.headOption.map(_.value) match {
-                              case Some((a, b)) => (a, b, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
-                              case None => (roseTreeOfA.value, roseTreeOfB.value, roseTreeOfC.value, roseTreeOfD.value, roseTreeOfE.value)
-                            }
-                        }
-                    }
-                }
-              val errOpt = List(Some(ex), shrunkErrOpt, shrunkErrOpt2, shrunkErrOpt3, shrunkErrOpt4).flatten.lastOption
+              val bestABCDE = shrunkRtOfABCDE.headOption.map(_.value).getOrElse((roseTreeOfA.value, roseTreeOfB.value, roseTreeOfC.value, 
+                                                                                  roseTreeOfD.value, roseTreeOfE.value))
+              val errOpt: Option[Throwable] = List(Some(ex), shrunkErrOpt).flatten.lastOption
 
               val shrunkArgsPassed = List(if (names.isDefinedAt(0)) PropertyArgument(Some(names(0)), bestABCDE) else PropertyArgument(None, bestABCDE))
               val theRes = new PropertyCheckResult.Failure(succeededCount, errOpt, names, shrunkArgsPassed, initSeed)

--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -1108,8 +1108,8 @@ trait FuturePropCheckerAsserting {
 
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
+                val roseTreeOfAB = RoseTree.map2[A, B, (A, B)](roseTreeOfA, roseTreeOfB, (a: A, b: B) => (a, b)) 
                 for {
-                  roseTreeOfAB <- RoseTree.map2ForFuture[A, B, (A, B)](roseTreeOfA, roseTreeOfB, (a: A, b: B) => (a, b))
                   (shrunkRtOfAB, shrunkErrOpt) <- roseTreeOfAB.depthFirstShrinksForFuture { case (a, b) => {
                                                               val result: Future[T] = fun(a, b)
                                                               result.map { _ => 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -1116,7 +1116,8 @@ trait FuturePropCheckerAsserting {
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
                 for {
-                  (shrunkRtOfAB, shrunkErrOpt, rnd4) <- roseTreeOfA.combineFirstDepthShrinksForFuture[Throwable, B](
+                  (roseTreeOfAB, rnd4) <- RoseTree.map2ForFuture[A, B, (A, B)](roseTreeOfA, roseTreeOfB, (a: A, b: B) => (a, b), result.rnd)
+                  (shrunkRtOfAB, shrunkErrOpt, rnd5) <- roseTreeOfAB.depthFirstShrinksForFuture(
                                                           { case (a, b) => {
                                                               val result: Future[T] = fun(a, b)
                                                               result.map { _ => 
@@ -1126,9 +1127,9 @@ trait FuturePropCheckerAsserting {
                                                               }
                                                             }
                                                           }, 
-                                                        result.rnd, 
-                                                        roseTreeOfB)
-                } yield {
+                                                          rnd4
+                                                        )
+                } yield {  
                   val bestAB = shrunkRtOfAB.headOption.map(_.value).getOrElse((roseTreeOfA.value, roseTreeOfB.value))
                   val errOpt: Option[Throwable] = List(f.ex, shrunkErrOpt).flatten.lastOption
 

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -77,17 +77,6 @@ trait RoseTree[+T] { thisRoseTreeOfT =>
     shrinkLoop(this, None, shrinks, Set(value))
   }
 
-  def combineFirstDepthShrinksForFuture[E, U](fun: (T, U) => Future[(Boolean, Option[E])], roseTreeOfU: RoseTree[U])(implicit execContext: ExecutionContext): Future[(LazyListOrStream[RoseTree[(T, U)]], Option[E])] = 
-    for {
-      (shrunkRtOfT, errOpt1) <- depthFirstShrinksForFuture(value => fun(value, roseTreeOfU.value))
-      bestT = shrunkRtOfT.headOption.getOrElse(this)
-      bestTValue = bestT.value
-      (shrunkRtOfU, errOpt2) <- roseTreeOfU.depthFirstShrinksForFuture(value => fun(bestTValue, value))
-      bestU = shrunkRtOfU.headOption.getOrElse(roseTreeOfU)
-      bestUValue = bestU.value
-      errOpt = LazyListOrStream(errOpt1, errOpt2).flatten.lastOption
-    } yield (LazyListOrStream(bestT.map(t => (t, bestUValue))), errOpt)
-
   // This makes sense to me say Char is on the inside, then T is Char, and U is (Char, Int). So
   // for each shrunken Char, we'll get the one (Char, Int).
   def map[U](f: T => U): RoseTree[U] = {

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -146,29 +146,6 @@ object RoseTree {
       }
     roseTreeOfV
   }
-
-  def map2ForFuture[T, U, V](tree1: RoseTree[T], tree2: RoseTree[U], f: (T, U) => V)(implicit execContext: ExecutionContext): Future[RoseTree[V]] = {
-    val tupValue = f(tree1.value, tree2.value)
-    val shrinks1 = tree1.shrinks
-    val candidateFutures1: LazyListOrStream[Future[RoseTree[V]]] = 
-      for (candidate <- shrinks1) yield map2ForFuture(candidate, tree2, f)
-    val shrinks2 = tree2.shrinks
-    val candidatesFutures2: LazyListOrStream[Future[RoseTree[V]]] = 
-      for (candidate <- shrinks2) yield map2ForFuture(tree1, candidate, f)      
-    for {
-      candidates1: LazyListOrStream[RoseTree[V]] <- Future.sequence(candidateFutures1)
-      candidates2 <- Future.sequence(candidatesFutures2)
-    } yield {
-      val roseTreeOfV =
-        new RoseTree[V] {
-          val value = tupValue
-          def shrinks: LazyListOrStream[RoseTree[V]] = {
-            candidates1 #::: candidates2
-          }
-        }
-      roseTreeOfV
-    }
-  }
 }
 
 // Terminal node of a RoseTree is a Rose.

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -172,17 +172,17 @@ object RoseTree {
     val tupValue = f(tree1.value, tree2.value)
     val (shrinks1, rnd2) = tree1.shrinks(rnd)
     val (candidateFutures1, rnd3Future) = {
-      val pairs: List[Future[(RoseTree[V], Randomizer)]] =
+      val pairs: LazyListOrStream[Future[(RoseTree[V], Randomizer)]] =
         for (candidate <- shrinks1) yield
           map2ForFuture(candidate, tree2, f, rnd2)
       (pairs.map(fut => fut.map(_._1)), pairs.map(fut => fut.map(_._2)).lastOption.getOrElse(Future.successful(rnd2)))
     }
     for {
-      candidates1 <- Future.sequence(candidateFutures1)
+      candidates1: LazyListOrStream[RoseTree[V]] <- Future.sequence(candidateFutures1)
       rnd3 <- rnd3Future
       (shrinks2, rnd4) = tree2.shrinks(rnd3)
       (candidatesFutures2, rnd5Future) = {
-        val pairs: List[Future[(RoseTree[V], Randomizer)]] =
+        val pairs: LazyListOrStream[Future[(RoseTree[V], Randomizer)]] =
           for (candidate <- shrinks2) yield
             map2ForFuture(tree1, candidate, f, rnd4)
         (pairs.map(fut => fut.map(_._1)), pairs.map(fut => fut.map(_._2)).lastOption.getOrElse(Future.successful(rnd4)))
@@ -193,8 +193,8 @@ object RoseTree {
       val roseTreeOfV =
         new RoseTree[V] {
           val value = tupValue
-          def shrinks(rnd: Randomizer): (List[RoseTree[V]], Randomizer) = {
-            (candidates1 ++ candidates2, rnd)
+          def shrinks(rnd: Randomizer): (LazyListOrStream[RoseTree[V]], Randomizer) = {
+            (candidates1 #::: candidates2, rnd)
           }
         }
       (roseTreeOfV, rnd5)   


### PR DESCRIPTION
- Changed FuturePropCheckerAsserting to use map2.
- Dropped combineFirstDepthShrinksForFuture from RoseTree.