### PR TITLE
RoseTree's map2 Unit Test + Test Hang Fix for Scala 2.11 and 2.12

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -130,7 +130,7 @@ object RoseTree {
       new RoseTree[V] {
         val value = tupValue
         def shrinks: LazyListOrStream[RoseTree[V]] = {
-          candidates1 ++ candidates2
+          candidates1 #::: candidates2
         }
       }
     roseTreeOfV

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -122,15 +122,11 @@ object RoseTree {
     val candidates1: LazyListOrStream[RoseTree[V]] =
       for (candidate <- shrinks1) yield
         map2(candidate, tree2, f)
-    val shrinks2 = tree2.shrinks
-    val candidates2: LazyListOrStream[RoseTree[V]] =
-      for (candidate <- shrinks2) yield
-        map2(tree1, candidate, f)
     val roseTreeOfV =
       new RoseTree[V] {
         val value = tupValue
         def shrinks: LazyListOrStream[RoseTree[V]] = {
-          candidates1 #::: candidates2
+          candidates1 #::: tree2.shrinks.map(candidate => map2(tree1, candidate, f))
         }
       }
     roseTreeOfV

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
@@ -229,6 +229,20 @@ class RoseTreeSpec extends AnyFunSpec with Matchers {
       Rose(42).toString shouldBe "Rose(42)"
     }
   }
+  describe("RoseTree companion object") {
+    it("should offer a map2 function that combines 2 RoseTree") {
+      import RoseTreeSpec._
+
+      val rtOfInt = intRoseTree(2)
+      val rtOfBoolean = booleanRoseTree(true)
+      val rtOfIntBoolean = RoseTree.map2(rtOfInt, rtOfBoolean, (i: Int, b: Boolean) => (i, b))
+      val shrinks = rtOfIntBoolean.shrinks
+      shrinks.length shouldBe 3
+      shrinks(0).value shouldBe (1, true)
+      shrinks(1).value shouldBe (0, true)
+      shrinks(2).value shouldBe (2, false)
+    }
+  }
 }
 
 object RoseTreeSpec {
@@ -251,6 +265,14 @@ object RoseTreeSpec {
         else toLazyListOrStream(userFriendlyChars).map(c => Rose(c))
       }
     }
+
+  def booleanRoseTree(i: Boolean): RoseTree[Boolean] =
+    new RoseTree[Boolean] {
+      val value: Boolean = i
+
+      def shrinks: LazyListOrStream[RoseTree[Boolean]] = 
+        if (i) LazyListOrStream(booleanRoseTree(false)) else LazyListOrStream.empty
+    }  
 
   def unfold[a](rt: RoseTree[a], indent: String = ""): Unit = {
     println(s"$indent ${rt.value}")


### PR DESCRIPTION
- Added unit test for RoseTree's map2 function.
- Fixed test hang problem when built under Scala 2.11 and 2.12.