### PR TITLE
StepwiseNestedSuiteExecution Async Support

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -69,9 +69,18 @@ trait StepwiseNestedSuiteExecution extends SuiteMixin { thisSuite: Suite =>
           val rawString = Resources.suiteCompletedNormally
           val formatter = formatterForSuiteCompleted(nestedSuite)
 
-          val duration = System.currentTimeMillis - suiteStartTime
-          report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
-          SucceededStatus
+          distributor match {
+            case Some(_) => 
+              status.withAfterEffect {
+                val duration = System.currentTimeMillis - suiteStartTime
+                report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+              }
+
+            case None => 
+              val duration = System.currentTimeMillis - suiteStartTime
+              report(SuiteCompleted(tracker.nextOrdinal(), nestedSuite.suiteName, nestedSuite.suiteId, Some(suiteClassName), Some(duration), formatter, Some(TopOfClass(nestedSuite.getClass.getName)), nestedSuite.rerunner))
+          }
+          status
         }
         catch {       
           case e: RuntimeException => {

--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -28,7 +28,7 @@ import collection.mutable.ListBuffer
  * Trait that causes the nested suites of any suite it is mixed into to be run sequentially even if
  * a <a href="Distributor.html"><code>Distributor</code></a> is passed to <code>runNestedSuites</code>. This trait overrides the 
  * <code>runNestedSuites</code> method and fowards every parameter passed to it to a superclass invocation
- * of <code>runNestedSuites</code>, except it always passes <code>None</code> for the <code>Distributor</code>.
+ * of <code>runNestedSuites</code>, and make the nested suites are run and completed one after one in order.
  * Mix in this trait into any suite whose nested suites need to be run sequentially even with the rest of the
  * run is being executed concurrently.
  */

--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -28,7 +28,7 @@ import collection.mutable.ListBuffer
  * Trait that causes the nested suites of any suite it is mixed into to be run sequentially even if
  * a <a href="Distributor.html"><code>Distributor</code></a> is passed to <code>runNestedSuites</code>. This trait overrides the 
  * <code>runNestedSuites</code> method and fowards every parameter passed to it to a superclass invocation
- * of <code>runNestedSuites</code>, and make the nested suites are run and completed one after one in order.
+ * of <code>runNestedSuites</code>, and make sure the nested suites are run and completed one after one in order.
  * Mix in this trait into any suite whose nested suites need to be run sequentially even with the rest of the
  * run is being executed concurrently.
  */


### PR DESCRIPTION
- Adjusted code in StepwiseNestedSuiteExecution to work with async test.
- Updated scaladoc in StepwiseNestedSuiteExecution.scala about passing down None for distributor field, it no longer true.