### PR TITLE
RoseTree Shrinking Filter and Having Size/Length Support

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -233,7 +233,6 @@ abstract class UnitPropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1) // TODO: See if PosZInt can be moved farther out
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val a = roseTreeOfA.value
@@ -274,12 +273,7 @@ abstract class UnitPropCheckerAsserting {
               new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
           case Failure(ex) =>
             // Let's shrink the failing value
-            val genAB = 
-              for {
-                a <- genA
-                b <- genB
-              } yield (a, b)
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
             val (shrunkRtOfAB, shrunkErrOpt) =
               roseTreeOfAB.depthFirstShrinks {
                 case (a, b) => 
@@ -325,7 +319,6 @@ abstract class UnitPropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -368,14 +361,8 @@ abstract class UnitPropCheckerAsserting {
             else
               new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
           case Failure(ex) =>
-            val genABC = 
-              for {
-                a <- genA
-                b <- genB
-                c <- genC
-              } yield (a, b, c)
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
             val (shrunkRtOfABC, shrunkErrOpt) =
               roseTreeOfABC.depthFirstShrinks {
                 case (a, b, c) => 
@@ -423,7 +410,6 @@ abstract class UnitPropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -469,16 +455,9 @@ abstract class UnitPropCheckerAsserting {
             else
               new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
           case Failure(ex) => 
-            val genABCD = 
-              for {
-                a <- genA
-                b <- genB
-                c <- genC
-                d <- genD
-              } yield (a, b, c, d)
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-            val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
             val (shrunkRtOfABCD, shrunkErrOpt) =
               roseTreeOfABCD.depthFirstShrinks { 
                 case (a, b, c, d) => 
@@ -529,7 +508,6 @@ abstract class UnitPropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -578,18 +556,10 @@ abstract class UnitPropCheckerAsserting {
             else
               new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
           case Failure(ex) =>
-            val genABCDE = 
-              for {
-                a <- genA
-                b <- genB
-                c <- genC
-                d <- genD
-                e <- genE
-              } yield (a, b, c, d, e)
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-            val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-            val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
             val (shrunkRtOfABCDE, shrunkErrOpt) =
               roseTreeOfABCDE.depthFirstShrinks { case (a, b, c, d, e) => 
                 Try { fun(a, b, c, d, e) } match {
@@ -640,7 +610,6 @@ abstract class UnitPropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, rnd1)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -693,20 +662,11 @@ abstract class UnitPropCheckerAsserting {
             else
               new PropertyCheckResult.Exhausted(succeededCount, nextDiscardedCount, names, argsPassed, initSeed)
           case Failure(ex) =>
-            val genABCDEF = 
-              for {
-                a <- genA
-                b <- genB
-                c <- genC
-                d <- genD
-                e <- genE
-                f <- genF
-              } yield (a, b, c, d, e, f)
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-            val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-            val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
-            val roseTreeOfABCDEF = RoseTree.map2WithFilter(roseTreeOfABCDE, roseTreeOfF)(genABCDEIsValid(sizeParam, genA, genB, genC, genD, genE), genIsValid(sizeParam, genF)) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+            val roseTreeOfABCDEF = RoseTree.map2(roseTreeOfABCDE, roseTreeOfF) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
             val (shrunkRtOfABCDEF, shrunkErrOpt) =
               roseTreeOfABCDEF.depthFirstShrinks { case (a, b, c, d, e, f) => 
                 Try { fun(a, b, c, d, e, f) } match {
@@ -886,7 +846,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextEdges, nextNextRnd) = genA.next(SizeParam(PosZInt(0), maxSize, size), edges, nextRnd) // TODO: Move PosZInt farther out
         val a = roseTreeOfA.value
 
@@ -1024,7 +983,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
         val (roseTreeOfB, nextBEdges, nextNextRnd) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val a = roseTreeOfA.value
@@ -1074,7 +1032,7 @@ trait FuturePropCheckerAsserting {
 
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
-                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a, b) => (a, b) }
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
                 for {
                   (shrunkRtOfAB, shrunkErrOpt) <- roseTreeOfAB.depthFirstShrinksForFuture { case (a, b) => {
                                                               val result: Future[T] = fun(a, b)
@@ -1114,7 +1072,7 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
-            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a, b) => (a, b) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
             for {
               (shrunkRtOfAB, shrunkErrOpt) <- roseTreeOfAB.depthFirstShrinksForFuture { case (a, b) => {
                                                           val result: Future[T] = fun(a, b)
@@ -1163,7 +1121,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, nextNextRnd) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -1214,8 +1171,8 @@ trait FuturePropCheckerAsserting {
           } flatMap { result =>
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
-                val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-                val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+                val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
                 for {
                   (shrunkRtOfABC, shrunkErrOpt) <- roseTreeOfABC.depthFirstShrinksForFuture { case (a, b, c) => {
                                                               val result: Future[T] = fun(a, b, c)
@@ -1255,8 +1212,8 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
             for {
               (shrunkRtOfABC, shrunkErrOpt) <- roseTreeOfABC.depthFirstShrinksForFuture { case (a, b, c) => {
                                                           val result: Future[T] = fun(a, b, c)
@@ -1306,7 +1263,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -1360,9 +1316,9 @@ trait FuturePropCheckerAsserting {
           } flatMap { result =>
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
-                val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-                val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-                val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+                val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+                val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
                 for {
                   (shrunkRtOfABCD, shrunkErrOpt) <- roseTreeOfABCD.depthFirstShrinksForFuture { case (a, b, c, d) => {
                                                               val result: Future[T] = fun(a, b, c, d)
@@ -1403,9 +1359,9 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-            val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
             for {
               (shrunkRtOfABCD, shrunkErrOpt) <- roseTreeOfABCD.depthFirstShrinksForFuture { case (a, b, c, d) => {
                                                           val result: Future[T] = fun(a, b, c, d)
@@ -1457,7 +1413,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -1514,10 +1469,10 @@ trait FuturePropCheckerAsserting {
           } flatMap { result =>
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
-                val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-                val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-                val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-                val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+                val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+                val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+                val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
                 for {
                   (shrunkRtOfABCDE, shrunkErrOpt) <- roseTreeOfABCDE.depthFirstShrinksForFuture { case (a, b, c, d, e) => {
                                                               val result: Future[T] = fun(a, b, c, d, e)
@@ -1558,10 +1513,10 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-            val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-            val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-            val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
             for {
               (shrunkRtOfABCDE, shrunkErrOpt) <- roseTreeOfABCDE.depthFirstShrinksForFuture { case (a, b, c, d, e) => {
                                                           val result: Future[T] = fun(a, b, c, d, e)
@@ -1615,7 +1570,6 @@ trait FuturePropCheckerAsserting {
               val (sz, nextRnd) = rnd.choosePosZInt(minSize, maxSize)
               (sz, Nil, nextRnd)
           }
-        val sizeParam =  SizeParam(config.minSize, config.sizeRange, PosZInt.ensuringValid(size))  
         val (roseTreeOfA, nextAEdges, rnd2) = genA.next(SizeParam(PosZInt(0), maxSize, size), aEdges, nextRnd)
         val (roseTreeOfB, nextBEdges, rnd3) = genB.next(SizeParam(PosZInt(0), maxSize, size), bEdges, rnd2)
         val (roseTreeOfC, nextCEdges, rnd4) = genC.next(SizeParam(PosZInt(0), maxSize, size), cEdges, rnd3)
@@ -1675,11 +1629,11 @@ trait FuturePropCheckerAsserting {
           } flatMap { result =>
             result.result match {
               case Some(f: PropertyCheckResult.Failure) => 
-                val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-                val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-                val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-                val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
-                val roseTreeOfABCDEF = RoseTree.map2WithFilter(roseTreeOfABCDE, roseTreeOfF)(genABCDEIsValid(sizeParam, genA, genB, genC, genD, genE), genIsValid(sizeParam, genF)) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
+                val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+                val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+                val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+                val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+                val roseTreeOfABCDEF = RoseTree.map2(roseTreeOfABCDE, roseTreeOfF) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
                 for {
                   (shrunkRtOfABCDEF, shrunkErrOpt) <- roseTreeOfABCDEF.depthFirstShrinksForFuture { case (a, b, c, d, e, f) => {
                                                               val result: Future[T] = fun(a, b, c, d, e, f)
@@ -1720,11 +1674,11 @@ trait FuturePropCheckerAsserting {
               loop(result.succeededCount, result.discardedCount, result.aEdges, result.bEdges, result.cEdges, result.dEdges, result.eEdges, result.fEdges, result.rnd, result.initialSizes, initSeed)
 
           case ex: Throwable =>
-            val roseTreeOfAB = RoseTree.map2WithFilter(roseTreeOfA, roseTreeOfB)(genIsValid(sizeParam, genA), genIsValid(sizeParam, genB)) { case (a, b) => (a, b) }
-                val roseTreeOfABC = RoseTree.map2WithFilter(roseTreeOfAB, roseTreeOfC)(genABIsValid(sizeParam, genA, genB), genIsValid(sizeParam, genC)) { case ((a, b), c) => (a, b, c) }
-                val roseTreeOfABCD = RoseTree.map2WithFilter(roseTreeOfABC, roseTreeOfD)(genABCIsValid(sizeParam, genA, genB, genC), genIsValid(sizeParam, genD)) { case ((a, b, c), d) => (a, b, c, d) }
-                val roseTreeOfABCDE = RoseTree.map2WithFilter(roseTreeOfABCD, roseTreeOfE)(genABCDIsValid(sizeParam, genA, genB, genC, genD), genIsValid(sizeParam, genE)) { case ((a, b, c, d), e) => (a, b, c, d, e)}
-                val roseTreeOfABCDEF = RoseTree.map2WithFilter(roseTreeOfABCDE, roseTreeOfF)(genABCDEIsValid(sizeParam, genA, genB, genC, genD, genE), genIsValid(sizeParam, genF)) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
+            val roseTreeOfAB = RoseTree.map2(roseTreeOfA, roseTreeOfB) { case (a: A, b: B) => (a, b) }
+            val roseTreeOfABC = RoseTree.map2(roseTreeOfAB, roseTreeOfC) { case ((a, b), c) => (a, b, c) }
+            val roseTreeOfABCD = RoseTree.map2(roseTreeOfABC, roseTreeOfD) { case ((a, b, c), d) => (a, b, c, d) }
+            val roseTreeOfABCDE = RoseTree.map2(roseTreeOfABCD, roseTreeOfE) { case ((a, b, c, d), e) => (a, b, c, d, e)}
+            val roseTreeOfABCDEF = RoseTree.map2(roseTreeOfABCDE, roseTreeOfF) { case ((a, b, c, d, e), f) => (a, b, c, d, e, f)}
             for {
               (shrunkRtOfABCDEF, shrunkErrOpt) <- roseTreeOfABCDEF.depthFirstShrinksForFuture { case (a, b, c, d, e, f) => {
                                                           val result: Future[T] = fun(a, b, c, d, e, f)
@@ -2064,23 +2018,4 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting with FutureP
     }
     sizesLoop(Nil, 0, initRndm)
   }
-
-  private[enablers] def genIsValid[A](sizeParam: SizeParam, genA: org.scalatest.prop.Generator[A])(a: A): Boolean = 
-      genA.isValid(a, sizeParam)
-
-  private[enablers] def genABIsValid[A, B](sizeParam: SizeParam, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B])(tup: (A, B)): Boolean = 
-      genA.isValid(tup._1, sizeParam) && genB.isValid(tup._2, sizeParam)
-
-  private[enablers] def genABCIsValid[A, B, C](sizeParam: SizeParam, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B], 
-                                       genC: org.scalatest.prop.Generator[C])(tup: (A, B, C)): Boolean = 
-      genA.isValid(tup._1, sizeParam) && genB.isValid(tup._2, sizeParam) && genC.isValid(tup._3, sizeParam)
-
-  private[enablers] def genABCDIsValid[A, B, C, D](sizeParam: SizeParam, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B], 
-                                       genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D])(tup: (A, B, C, D)): Boolean = 
-      genA.isValid(tup._1, sizeParam) && genB.isValid(tup._2, sizeParam) && genC.isValid(tup._3, sizeParam) && genD.isValid(tup._4, sizeParam)
-
-  private[enablers] def genABCDEIsValid[A, B, C, D, E](sizeParam: SizeParam, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B], 
-                                       genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D], 
-                                       genE: org.scalatest.prop.Generator[E])(tup: (A, B, C, D, E)): Boolean = 
-      genA.isValid(tup._1, sizeParam) && genB.isValid(tup._2, sizeParam) && genC.isValid(tup._3, sizeParam) && genD.isValid(tup._4, sizeParam) && genE.isValid(tup._5, sizeParam)
 }

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1701,7 +1701,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZFiniteFloat, sizeParam: SizeParam, isValidFun: (PosZFiniteFloat, SizeParam) => Boolean): RoseTree[PosZFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFiniteFloat], Randomizer) = {
         val (posZFiniteFloat, rnd2) = rnd.nextPosZFiniteFloat
-        (NextRoseTree(posZFiniteFloat, szp, isValid), rnd2)
+        (NextRoseTree(posZFiniteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZFiniteFloat]] = {
         case class CanonicalRoseTree(value: PosZFiniteFloat) extends RoseTree[PosZFiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2686,7 +2686,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegFiniteFloat, sizeParam: SizeParam, isValidFun: (NegFiniteFloat, SizeParam) => Boolean): RoseTree[NegFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFiniteFloat], Randomizer) = {
         val (negFiniteFloat, rnd2) = rnd.nextNegFiniteFloat
-        (NextRoseTree(negFiniteFloat, szp, isValid), rnd2)
+        (NextRoseTree(negFiniteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegFiniteFloat]] = {
         case class CanonicalRoseTree(value: NegFiniteFloat) extends RoseTree[NegFiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3025,7 +3025,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZFloat, sizeParam: SizeParam, isValidFun: (NegZFloat, SizeParam) => Boolean): RoseTree[NegZFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFloat], Randomizer) = {
         val (negZFloat, rnd2) = rnd.nextNegZFloat
-        (NextRoseTree(negZFloat, szp, isValid), rnd2)
+        (NextRoseTree(negZFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZFloat]] = {
         case class CanonicalRoseTree(value: NegZFloat) extends RoseTree[NegZFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2946,7 +2946,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZFiniteDouble, sizeParam: SizeParam, isValidFun: (NegZFiniteDouble, SizeParam) => Boolean): RoseTree[NegZFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFiniteDouble], Randomizer) = {
         val (negZFiniteDouble, rnd2) = rnd.nextNegZFiniteDouble
-        (NextRoseTree(negZFiniteDouble, szp, isValid), rnd2)
+        (NextRoseTree(negZFiniteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZFiniteDouble]] = {
         case class CanonicalRoseTree(value: NegZFiniteDouble) extends RoseTree[NegZFiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3325,8 +3325,9 @@ object Generator {
       }
       override def roseTreeOfEdge(edge: String, sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean): RoseTree[String] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (String, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[String], Randomizer) = {
-        val (s, rnd2) = rnd.nextString(szp.size)
-        (NextRoseTree(s)(szp, isValid), rnd2)
+        val (size, rnd2) = if (szp.minSize > 0 && szp.sizeRange > 0) rnd.chooseInt(szp.minSize.value, szp.minSize.value + szp.sizeRange.value) else (szp.size.value, rnd)
+        val (s, rnd3) = rnd2.nextString(PosZInt.ensuringValid(size))
+        (NextRoseTree(s)(szp, isValidFun), rnd3)
       }
       override def canonicals: LazyListOrStream[RoseTree[String]] = {
         val canonicalsOfChar = charGenerator.canonicals

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2308,7 +2308,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroFiniteFloat, sizeParam: SizeParam, isValidFun: (NonZeroFiniteFloat, SizeParam) => Boolean): RoseTree[NonZeroFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFiniteFloat], Randomizer) = {
         val (nonZeroFiniteFloat, rnd2) = rnd.nextNonZeroFiniteFloat
-        (NextRoseTree(nonZeroFiniteFloat, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroFiniteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroFiniteFloat]] = {
         case class CanonicalRoseTree(value: NonZeroFiniteFloat) extends RoseTree[NonZeroFiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4442,7 +4442,7 @@ object Generator {
         else {
           val (nextRoseTreeOfT, _, nextNextRnd) = genOfT.next(szp, Nil, nextRnd)
           val nextT = nextRoseTreeOfT.value
-          (NextRoseTree(Some(nextT), szp, isValid), nextNextRnd)
+          (NextRoseTree(Some(nextT), szp, isValidFun), nextNextRnd)
         }
       }
       override def toString = "Generator[Option[T]]"

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2152,7 +2152,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroFiniteDouble, sizeParam: SizeParam, isValidFun: (NonZeroFiniteDouble, SizeParam) => Boolean): RoseTree[NonZeroFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFiniteDouble], Randomizer) = {
         val (nonZeroFiniteDouble, rnd2) = rnd.nextNonZeroFiniteDouble
-        (NextRoseTree(nonZeroFiniteDouble, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroFiniteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroFiniteDouble]] = {
         case class CanonicalRoseTree(value: NonZeroFiniteDouble) extends RoseTree[NonZeroFiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3100,7 +3100,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZFiniteFloat, sizeParam: SizeParam, isValidFun: (NegZFiniteFloat, SizeParam) => Boolean): RoseTree[NegZFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFiniteFloat], Randomizer) = {
         val (negZFiniteFloat, rnd2) = rnd.nextNegZFiniteFloat
-        (NextRoseTree(negZFiniteFloat, szp, isValid), rnd2)
+        (NextRoseTree(negZFiniteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZFiniteFloat]] = {
         case class CanonicalRoseTree(value: NegZFiniteFloat) extends RoseTree[NegZFiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4530,11 +4530,11 @@ object Generator {
       def nextImpl(szp: SizeParam, isValidFun: (G Or B, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[G Or B], Randomizer) = {
         val (nextInt, nextRnd) = rnd.nextInt
         if (nextInt % 4 == 0) {
-          val (nextRoseTreeOfB, _, nextRnd) = genOfB.next(szp, Nil, rnd)
+          val (nextRoseTreeOfB, _, nextRnd) = genOfB.filter(b => isValidFun(Bad(b), szp)).next(szp, Nil, rnd)
           (nextRoseTreeOfB.map(b => Bad(b)), nextRnd)
         }
         else {
-          val (nextRoseTreeOfG, _, nextRnd) = genOfG.next(szp, Nil, rnd)
+          val (nextRoseTreeOfG, _, nextRnd) = genOfG.filter(g => isValidFun(Good(g), szp)).next(szp, Nil, rnd)
           (nextRoseTreeOfG.map(g => Good(g)), nextRnd)
         }
       }

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2076,7 +2076,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroDouble, sizeParam: SizeParam, isValidFun: (NonZeroDouble, SizeParam) => Boolean): RoseTree[NonZeroDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroDouble], Randomizer) = {
         val (nonZeroDouble, rnd2) = rnd.nextNonZeroDouble
-        (NextRoseTree(nonZeroDouble, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroDouble]] = {
         case class CanonicalRoseTree(value: NonZeroDouble) extends RoseTree[NonZeroDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1552,7 +1552,7 @@ object Generator {
       override def roseTreeOfEdge(edge: FiniteDouble, sizeParam: SizeParam, isValidFun: (FiniteDouble, SizeParam) => Boolean): RoseTree[FiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (FiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[FiniteDouble], Randomizer) = {
         val (finiteDouble, rnd2) = rnd.nextFiniteDouble
-        (NextRoseTree(finiteDouble, szp, isValid), rnd2)
+        (NextRoseTree(finiteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[FiniteDouble]] = {
         case class CanonicalRoseTree(value: FiniteDouble) extends RoseTree[FiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -867,7 +867,7 @@ object Generator {
       override def roseTreeOfEdge(edge: Long, sizeParam: SizeParam, isValidFun: (Long, SizeParam) => Boolean): RoseTree[Long] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Long, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Long], Randomizer) = {
         val (n, rnd2) = rnd.nextLong
-        (NextRoseTree(n, szp, isValid), rnd2)
+        (NextRoseTree(n, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Long]] = {
         case class CanonicalRoseTree(value: Long) extends RoseTree[Long] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1839,7 +1839,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosFiniteDouble, sizeParam: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean): RoseTree[PosFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFiniteDouble], Randomizer) = {
         val (posFiniteDouble, rnd2) = rnd.nextPosFiniteDouble
-        (NextRoseTree(posFiniteDouble, szp, isValid), rnd2)
+        (NextRoseTree(posFiniteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosFiniteDouble]] = {
         case class CanonicalRoseTree(value: PosFiniteDouble) extends RoseTree[PosFiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1054,7 +1054,7 @@ object Generator {
       override def roseTreeOfEdge(edge: Double, sizeParam: SizeParam, isValidFun: (Double, SizeParam) => Boolean): RoseTree[Double] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Double, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Double], Randomizer) = {
         val (d, rnd2) = rnd.nextDouble
-        (NextRoseTree(d, szp, isValid), rnd2)
+        (NextRoseTree(d, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Double]] = {
         case class CanonicalRoseTree(value: Double) extends RoseTree[Double] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2792,7 +2792,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegLong, sizeParam: SizeParam, isValidFun: (NegLong, SizeParam) => Boolean): RoseTree[NegLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegLong], Randomizer) = {
         val (negLong, rnd2) = rnd.nextNegLong
-        (NextRoseTree(negLong, szp, isValid), rnd2)
+        (NextRoseTree(negLong, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegLong]] = {
         case class CanonicalRoseTree(value: NegLong) extends RoseTree[NegLong] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -750,7 +750,7 @@ object Generator {
       override def roseTreeOfEdge(edge: Char, sizeParam: SizeParam, isValidFun: (Char, SizeParam) => Boolean): RoseTree[Char] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Char, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Char], Randomizer) = {
         val (c, rnd2) = rnd.nextChar
-        (NextRoseTree(c)(szp, isValid), rnd2)
+        (NextRoseTree(c)(szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Char]] = {
         val lowerAlphaChars = "zyxwvutsrqponmljkihgfedcba"

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1772,7 +1772,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosDouble, sizeParam: SizeParam, isValidFun: (PosDouble, SizeParam) => Boolean): RoseTree[PosDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosDouble], Randomizer) = {
         val (posDouble, rnd2) = rnd.nextPosDouble
-        (NextRoseTree(posDouble, szp, isValid), rnd2)
+        (NextRoseTree(posDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosDouble]] = {
         case class CanonicalRoseTree(value: PosDouble) extends RoseTree[PosDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -634,7 +634,7 @@ object Generator {
       }
       def nextImpl(szp: SizeParam, isValidFun: (Byte, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Byte], Randomizer) = {
         val (b, rnd2) = rnd.nextByte
-        (NextRoseTree(b)(szp, isValid), rnd2)
+        (NextRoseTree(b)(szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Byte]] = {
         case class CanonicalRoseTree(value: Byte) extends RoseTree[Byte] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -693,7 +693,7 @@ object Generator {
       override def roseTreeOfEdge(edge: Short, sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean): RoseTree[Short] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Short, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Short], Randomizer) = {
         val (s, rnd2) = rnd.nextShort
-        (NextRoseTree(s)(szp, isValid), rnd2)
+        (NextRoseTree(s)(szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Short]] = {
         case class CanonicalRoseTree(value: Short) extends RoseTree[Short] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -5206,7 +5206,7 @@ object Generator {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: SortedMap[K, V], rnd: org.scalatest.prop.Randomizer): (RoseTree[SortedMap[K, V]], org.scalatest.prop.Randomizer) =
               if (result.size == targetSize)
-                (NextRoseTree(result, ignoredSzp, isValid), rnd)
+                (NextRoseTree(result, ignoredSzp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfTuple2KV.next (szp, List.empty, rnd)
                 loop(targetSize, result + nextRoseTreeOfT.value, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2548,7 +2548,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegFiniteDouble, sizeParam: SizeParam, isValidFun: (NegFiniteDouble, SizeParam) => Boolean): RoseTree[NegFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFiniteDouble], Randomizer) = {
         val (negFiniteDouble, rnd2) = rnd.nextNegFiniteDouble
-        (NextRoseTree(negFiniteDouble, szp, isValid), rnd2)
+        (NextRoseTree(negFiniteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegFiniteDouble]] = {
         case class CanonicalRoseTree(value: NegFiniteDouble) extends RoseTree[NegFiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4919,7 +4919,7 @@ object Generator {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: Set[T], rnd: org.scalatest.prop.Randomizer): (RoseTree[Set[T]], org.scalatest.prop.Randomizer) =
               if (result.size == targetSize)
-                (NextRoseTree(result, ignoredSzp, isValid), rnd)
+                (NextRoseTree(result, ignoredSzp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfT.next(szp, List.empty, rnd)
                 loop(targetSize, result + nextRoseTreeOfT.value, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3206,7 +3206,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZLong, sizeParam: SizeParam, isValidFun: (NegZLong, SizeParam) => Boolean): RoseTree[NegZLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZLong], Randomizer) = {
         val (negZLong, rnd2) = rnd.nextNegZLong
-        (NextRoseTree(negZLong, szp, isValid), rnd2)
+        (NextRoseTree(negZLong, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZLong]] = {
         case class CanonicalRoseTree(value: NegZLong) extends RoseTree[NegZLong] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1106,7 +1106,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosInt, sizeParam: SizeParam, isValidFun: (PosInt, SizeParam) => Boolean): RoseTree[PosInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosInt], Randomizer) = {
         val (posInt, rnd2) = rnd.nextPosInt
-        (NextRoseTree(posInt, szp, isValid), rnd2)
+        (NextRoseTree(posInt, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosInt]] = {
         case class CanonicalRoseTree(value: PosInt) extends RoseTree[PosInt] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -960,7 +960,7 @@ object Generator {
       override def roseTreeOfEdge(edge: Float, sizeParam: SizeParam, isValidFun: (Float, SizeParam) => Boolean): RoseTree[Float] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Float, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Float], Randomizer) = {
         val (f, rnd2) = rnd.nextFloat
-        (NextRoseTree(f, szp, isValid), rnd2)
+        (NextRoseTree(f, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Float]] = {
         case class CanonicalRoseTree(value: Float) extends RoseTree[Float] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2410,7 +2410,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroLong, sizeParam: SizeParam, isValidFun: (NonZeroLong, SizeParam) => Boolean): RoseTree[NonZeroLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroLong], Randomizer) = {
         val (nonZeroLong, rnd2) = rnd.nextNonZeroLong
-        (NextRoseTree(nonZeroLong, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroLong, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroLong]] = {
         case class CanonicalRoseTree(value: NonZeroLong) extends RoseTree[NonZeroLong] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1402,7 +1402,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosFiniteFloat, sizeParam: SizeParam, isValidFun: (PosFiniteFloat, SizeParam) => Boolean): RoseTree[PosFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFiniteFloat], Randomizer) = {
         val (posFiniteFloat, rnd2) = rnd.nextPosFiniteFloat
-        (NextRoseTree(posFiniteFloat, szp, isValid), rnd2)
+        (NextRoseTree(posFiniteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosFiniteFloat]] = {
         case class CanonicalRoseTree(value: PosFiniteFloat) extends RoseTree[PosFiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1158,7 +1158,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZInt, sizeParam: SizeParam, isValidFun: (PosZInt, SizeParam) => Boolean): RoseTree[PosZInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZInt], Randomizer) = {
         val (posZInt, rnd2) = rnd.nextPosZInt
-        (NextRoseTree(posZInt, szp, isValid), rnd2)
+        (NextRoseTree(posZInt, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZInt]] = {
         case class CanonicalRoseTree(value: PosZInt) extends RoseTree[PosZInt] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2871,7 +2871,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZDouble, sizeParam: SizeParam, isValidFun: (NegZDouble, SizeParam) => Boolean): RoseTree[NegZDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZDouble], Randomizer) = {
         val (negZDouble, rnd2) = rnd.nextNegZDouble
-        (NextRoseTree(negZDouble, szp, isValid), rnd2)
+        (NextRoseTree(negZDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZDouble]] = {
         case class CanonicalRoseTree(value: NegZDouble) extends RoseTree[NegZDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -5013,7 +5013,7 @@ object Generator {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: SortedSet[T], rnd: org.scalatest.prop.Randomizer): (RoseTree[SortedSet[T]], org.scalatest.prop.Randomizer) =
               if (result.size == targetSize)
-                (NextRoseTree(result, ignoredSzp, isValid), rnd)
+                (NextRoseTree(result, ignoredSzp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfT.next(szp, List.empty, rnd)
                 loop(targetSize, result + nextRoseTreeOfT.value, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1631,7 +1631,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZFloat, sizeParam: SizeParam, isValidFun: (PosZFloat, SizeParam) => Boolean): RoseTree[PosZFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFloat], Randomizer) = {
         val (posZFloat, rnd2) = rnd.nextPosZFloat
-        (NextRoseTree(posZFloat, szp, isValid), rnd2)
+        (NextRoseTree(posZFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZFloat]] = {
         case class CanonicalRoseTree(value: PosZFloat) extends RoseTree[PosZFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1918,7 +1918,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZDouble, sizeParam: SizeParam, isValidFun: (PosZDouble, SizeParam) => Boolean): RoseTree[PosZDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZDouble], Randomizer) = {
         val (posZDouble, rnd2) = rnd.nextPosZDouble
-        (NextRoseTree(posZDouble, szp, isValid), rnd2)
+        (NextRoseTree(posZDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZDouble]] = {
         case class CanonicalRoseTree(value: PosZDouble) extends RoseTree[PosZDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4825,7 +4825,7 @@ object Generator {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: Vector[T], rnd: org.scalatest.prop.Randomizer): (RoseTree[Vector[T]], org.scalatest.prop.Randomizer) =
               if (result.length == targetSize)
-                (NextRoseTree(result, ignoredSzp, isValid), rnd)
+                (NextRoseTree(result, ignoredSzp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfT.next(szp, List.empty, rnd)
                 loop(targetSize, result :+ nextRoseTreeOfT.value, nextRnd)
@@ -4860,7 +4860,7 @@ object Generator {
           def nextImpl(szp: org.scalatest.prop.SizeParam, isValidFun: (Vector[T], SizeParam) => Boolean, rnd: org.scalatest.prop.Randomizer): (RoseTree[Vector[T]], org.scalatest.prop.Randomizer) = {
             val s = f(szp)
             val gen = generatorWithSize(s)
-            gen.nextImpl(s, isValid, rnd)
+            gen.nextImpl(s, isValidFun, rnd)
           }
           override def isValid(value: Vector[T], sizeParam: SizeParam): Boolean = {
             val fSizeParam = f(sizeParam)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1263,7 +1263,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZLong, sizeParam: SizeParam, isValidFun: (PosZLong, SizeParam) => Boolean): RoseTree[PosZLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZLong], Randomizer) = {
         val (posZLong, rnd2) = rnd.nextPosZLong
-        (NextRoseTree(posZLong, szp, isValid), rnd2)
+        (NextRoseTree(posZLong, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZLong]] = {
         case class CanonicalRoseTree(value: PosZLong) extends RoseTree[PosZLong] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3153,7 +3153,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegZInt, sizeParam: SizeParam, isValidFun: (NegZInt, SizeParam) => Boolean): RoseTree[NegZInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZInt], Randomizer) = {
         val (negZInt, rnd2) = rnd.nextNegZInt
-        (NextRoseTree(negZInt, szp, isValid), rnd2)
+        (NextRoseTree(negZInt, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegZInt]] = {
         case class CanonicalRoseTree(value: NegZInt) extends RoseTree[NegZInt] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2359,7 +2359,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroInt, sizeParam: SizeParam, isValidFun: (NonZeroInt, SizeParam) => Boolean): RoseTree[NonZeroInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroInt], Randomizer) = {
         val (nonZeroInt, rnd2) = rnd.nextNonZeroInt
-        (NextRoseTree(nonZeroInt, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroInt, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroInt]] = {
         case class CanonicalRoseTree(value: NonZeroInt) extends RoseTree[NonZeroInt] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2233,7 +2233,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NonZeroFloat, sizeParam: SizeParam, isValidFun: (NonZeroFloat, SizeParam) => Boolean): RoseTree[NonZeroFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFloat], Randomizer) = {
         val (nonZeroFloat, rnd2) = rnd.nextNonZeroFloat
-        (NextRoseTree(nonZeroFloat, szp, isValid), rnd2)
+        (NextRoseTree(nonZeroFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NonZeroFloat]] = {
         case class CanonicalRoseTree(value: NonZeroFloat) extends RoseTree[NonZeroFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -5110,7 +5110,7 @@ object Generator {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: Map[K, V], rnd: org.scalatest.prop.Randomizer): (RoseTree[Map[K, V]], org.scalatest.prop.Randomizer) =
               if (result.size == targetSize)
-                (NextRoseTree(result, ignoredSzp, isValid), rnd)
+                (NextRoseTree(result, ignoredSzp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfTuple2KV.next (szp, List.empty, rnd)
                 loop(targetSize, result + nextRoseTreeOfT.value, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3259,7 +3259,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NumericChar, sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean): RoseTree[NumericChar] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NumericChar], Randomizer) = {
         val (posZInt, rnd2) = rnd.choosePosZInt(PosZInt.ensuringValid(0), PosZInt.ensuringValid(9))
-        (NextRoseTree(NumericChar.ensuringValid((posZInt.value + 48).toChar))(szp, isValid), rnd2)
+        (NextRoseTree(NumericChar.ensuringValid((posZInt.value + 48).toChar))(szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NumericChar]] = {
         case class CanonicalRoseTree(value: NumericChar) extends RoseTree[NumericChar] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -603,7 +603,7 @@ object Generator {
     */
   implicit val byteGenerator: Generator[Byte] = 
     new Generator[Byte] {
-      case class NextRoseTree(value: Byte, sizeParam: SizeParam, isValidFun: (Byte, SizeParam) => Boolean) extends RoseTree[Byte] {
+      case class NextRoseTree(value: Byte)(sizeParam: SizeParam, isValidFun: (Byte, SizeParam) => Boolean) extends RoseTree[Byte] {
         def shrinks: LazyListOrStream[RoseTree[Byte]] = {
           def resLazyListOrStream(theValue: Byte): LazyListOrStream[RoseTree[Byte]] = {
             if (theValue == 0) LazyListOrStream.empty
@@ -617,7 +617,7 @@ object Generator {
               }
               else
                 LazyListOrStream((-half).toByte, half.toByte).filter(v => isValidFun(v, sizeParam))
-                                                      .map(v => NextRoseTree(v, sizeParam, isValidFun)) #::: resLazyListOrStream(half)
+                                                      .map(v => NextRoseTree(v)(sizeParam, isValidFun)) #::: resLazyListOrStream(half)
             }
           }
           resLazyListOrStream(value)
@@ -630,11 +630,11 @@ object Generator {
       }
       
       override def roseTreeOfEdge(edge: Byte, sizeParam: SizeParam, isValidFun: (Byte, SizeParam) => Boolean): RoseTree[Byte] = {
-        NextRoseTree(edge, sizeParam, isValidFun)
+        NextRoseTree(edge)(sizeParam, isValidFun)
       }
       def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[Byte], Randomizer) = {
         val (b, rnd2) = rnd.nextByte
-        (NextRoseTree(b, szp, isValid), rnd2)
+        (NextRoseTree(b)(szp, isValid), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Byte]] = {
         case class CanonicalRoseTree(value: Byte) extends RoseTree[Byte] {
@@ -656,7 +656,7 @@ object Generator {
 
       // For now I will not take a Randomizer. I'm hoping we can just get rid of it in shrinks. Shrinks can just
       // be based on the values being shrunk.
-      override def shrinksForValue(valueToShrink: Byte): Option[LazyListOrStream[RoseTree[Byte]]] = Some(NextRoseTree(valueToShrink, SizeParam(1, 0, 1), this.isValid).shrinks)
+      override def shrinksForValue(valueToShrink: Byte): Option[LazyListOrStream[RoseTree[Byte]]] = Some(NextRoseTree(valueToShrink)(SizeParam(1, 0, 1), this.isValid).shrinks)
     }
 
   /**
@@ -665,7 +665,7 @@ object Generator {
   implicit val shortGenerator: Generator[Short] =
     new Generator[Short] {
 
-      case class NextRoseTree(value: Short, sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean) extends RoseTree[Short] {
+      case class NextRoseTree(value: Short)(sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean) extends RoseTree[Short] {
         def shrinks: LazyListOrStream[RoseTree[Short]] = {
           def resLazyListOrStream(theValue: Short): LazyListOrStream[RoseTree[Short]] = {
             if (theValue == 0) LazyListOrStream.empty
@@ -679,7 +679,7 @@ object Generator {
               }
               else 
                 LazyListOrStream((-half).toShort, half.toShort).filter(v => isValidFun(v, sizeParam))
-                                                      .map(v => NextRoseTree(v, sizeParam, isValidFun)) #::: resLazyListOrStream(half)
+                                                      .map(v => NextRoseTree(v)(sizeParam, isValidFun)) #::: resLazyListOrStream(half)
             }
           }
           resLazyListOrStream(value)
@@ -690,10 +690,10 @@ object Generator {
         val (allEdges, nextRnd) = Randomizer.shuffle(shortEdges, rnd)
         (allEdges.take(maxLength), nextRnd)
       }
-      override def roseTreeOfEdge(edge: Short, sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean): RoseTree[Short] = NextRoseTree(edge, sizeParam, isValidFun)
+      override def roseTreeOfEdge(edge: Short, sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean): RoseTree[Short] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[Short], Randomizer) = {
         val (s, rnd2) = rnd.nextShort
-        (NextRoseTree(s, szp, isValid), rnd2)
+        (NextRoseTree(s)(szp, isValid), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[Short]] = {
         case class CanonicalRoseTree(value: Short) extends RoseTree[Short] {
@@ -712,7 +712,7 @@ object Generator {
         CanonicalRoseTree(4).shrinks
       }
       override def toString = "Generator[Short]"
-      override def shrinksForValue(valueToShrink: Short): Option[LazyListOrStream[RoseTree[Short]]] = Some(NextRoseTree(valueToShrink, SizeParam(1, 0, 1), isValid).shrinks)
+      override def shrinksForValue(valueToShrink: Short): Option[LazyListOrStream[RoseTree[Short]]] = Some(NextRoseTree(valueToShrink)(SizeParam(1, 0, 1), isValid).shrinks)
     }
 
   /**
@@ -3288,7 +3288,7 @@ object Generator {
       // For strings, we won't shrink the characters.  We could, but the trees could get really big. Just cut the length of
       // the list in half and try both halves each round, using the same characters.
       // TODO: Write a test for this shrinks implementation.
-      case class NextRoseTree(value: String, sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean) extends RoseTree[String] {
+      case class NextRoseTree(value: String)(sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean) extends RoseTree[String] {
         def shrinks: LazyListOrStream[RoseTree[String]] = {
           def resLazyListOrStream(theValue: String): LazyListOrStream[RoseTree[String]] = {
             if (theValue.isEmpty)
@@ -3306,7 +3306,7 @@ object Generator {
               // If value has an odd number of chars, the second half will be one character longer than the first half.
               LazyListOrStream(secondHalf, firstHalf)
                 .filter(isValidFun(_, sizeParam))
-                .map(NextRoseTree(_, sizeParam, isValidFun)) #::: resLazyListOrStream(firstHalf)
+                .map(NextRoseTree(_)(sizeParam, isValidFun)) #::: resLazyListOrStream(firstHalf)
             }
           }
           resLazyListOrStream(value)
@@ -3316,17 +3316,17 @@ object Generator {
       override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[String], Randomizer) = {
         (stringEdges.take(maxLength), rnd)
       }
-      override def roseTreeOfEdge(edge: String, sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean): RoseTree[String] = NextRoseTree(edge, sizeParam, isValidFun)
+      override def roseTreeOfEdge(edge: String, sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean): RoseTree[String] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], Randomizer) = {
         val (s, rnd2) = rnd.nextString(szp.size)
-        (NextRoseTree(s, szp, isValid), rnd2)
+        (NextRoseTree(s)(szp, isValid), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[String]] = {
         val canonicalsOfChar = charGenerator.canonicals
         canonicalsOfChar.map(t => Rose(s"${ t.value }")) #::: LazyListOrStream(Rose(""))
       }
       override def toString = "Generator[String]"
-      override def shrinksForValue(valueToShrink: String): Option[LazyListOrStream[RoseTree[String]]] = Some(NextRoseTree(valueToShrink, SizeParam(1, 0, 1), isValid).shrinks)
+      override def shrinksForValue(valueToShrink: String): Option[LazyListOrStream[RoseTree[String]]] = Some(NextRoseTree(valueToShrink)(SizeParam(1, 0, 1), isValid).shrinks)
     }
 
   // Should throw IAE on negative size in all generators, even the ones that ignore size.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2481,7 +2481,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegDouble, sizeParam: SizeParam, isValidFun: (NegDouble, SizeParam) => Boolean): RoseTree[NegDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegDouble], Randomizer) = {
         val (negDouble, rnd2) = rnd.nextNegDouble
-        (NextRoseTree(negDouble, szp, isValid), rnd2)
+        (NextRoseTree(negDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegDouble]] = {
         case class CanonicalRoseTree(value: NegDouble) extends RoseTree[NegDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3227,7 +3227,7 @@ object Generator {
   implicit val numericCharGenerator: Generator[NumericChar] =
     new Generator[NumericChar] {
 
-      case class NextRoseTree(value: NumericChar, sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean) extends RoseTree[NumericChar] {
+      case class NextRoseTree(value: NumericChar)(sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean) extends RoseTree[NumericChar] {
         def shrinks: LazyListOrStream[RoseTree[NumericChar]] = {
           def resLazyListOrStream(theValue: NumericChar): LazyListOrStream[RoseTree[NumericChar]] = {
             if (theValue.value == '0')
@@ -3236,30 +3236,23 @@ object Generator {
               val minusOne: Char = (theValue.value - 1).toChar // Go ahead and try all the values between i and '0'
               val numericCharMinusOne = NumericChar.ensuringValid(minusOne)
               if (isValidFun(numericCharMinusOne, sizeParam))
-                NextRoseTree(numericCharMinusOne, sizeParam, isValidFun) #:: resLazyListOrStream(numericCharMinusOne)
+                NextRoseTree(numericCharMinusOne)(sizeParam, isValidFun) #:: resLazyListOrStream(numericCharMinusOne)
               else
                 resLazyListOrStream(numericCharMinusOne)  
             }
           }
           resLazyListOrStream(value)
         }
-
-        override def equals(other: Any): Boolean = 
-          other match {
-            case NextRoseTree(v, _, _) => value == v
-            case _ => false
-          }
-        override def hashCode(): Int = value.hashCode()
       }
 
       override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NumericChar], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(numericCharEdges, rnd)
         (allEdges.take(maxLength), nextRnd)
       }
-      override def roseTreeOfEdge(edge: NumericChar, sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean): RoseTree[NumericChar] = NextRoseTree(edge, sizeParam, isValidFun)
+      override def roseTreeOfEdge(edge: NumericChar, sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean): RoseTree[NumericChar] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[NumericChar], Randomizer) = {
         val (posZInt, rnd2) = rnd.choosePosZInt(PosZInt.ensuringValid(0), PosZInt.ensuringValid(9))
-        (NextRoseTree(NumericChar.ensuringValid((posZInt.value + 48).toChar), szp, isValid), rnd2)
+        (NextRoseTree(NumericChar.ensuringValid((posZInt.value + 48).toChar))(szp, isValid), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NumericChar]] = {
         case class CanonicalRoseTree(value: NumericChar) extends RoseTree[NumericChar] {
@@ -3278,7 +3271,7 @@ object Generator {
         CanonicalRoseTree('4').shrinks
       }
       override def toString = "Generator[NumericChar]"
-      override def shrinksForValue(valueToShrink: NumericChar): Option[LazyListOrStream[RoseTree[NumericChar]]] = Some(NextRoseTree(valueToShrink, SizeParam(1, 0, 1), isValid).shrinks)
+      override def shrinksForValue(valueToShrink: NumericChar): Option[LazyListOrStream[RoseTree[NumericChar]]] = Some(NextRoseTree(valueToShrink)(SizeParam(1, 0, 1), isValid).shrinks)
     }
 
   // Should throw IAE on negative size in all generators, even the ones that ignore size.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2619,7 +2619,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegFloat, sizeParam: SizeParam, isValidFun: (NegFloat, SizeParam) => Boolean): RoseTree[NegFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFloat], Randomizer) = {
         val (negFloat, rnd2) = rnd.nextNegFloat
-        (NextRoseTree(negFloat, szp, isValid), rnd2)
+        (NextRoseTree(negFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegFloat]] = {
         case class CanonicalRoseTree(value: NegFloat) extends RoseTree[NegFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1211,7 +1211,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosLong, sizeParam: SizeParam, isValidFun: (PosLong, SizeParam) => Boolean): RoseTree[PosLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosLong], Randomizer) = {
         val (posLong, rnd2) = rnd.nextPosLong
-        (NextRoseTree(posLong, szp, isValid), rnd2)
+        (NextRoseTree(posLong, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosLong]] = {
         case class CanonicalRoseTree(value: PosLong) extends RoseTree[PosLong] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4626,11 +4626,11 @@ object Generator {
           // TODO: Here I was not sure if I should just map the RoseTree or takes
           // its value and wrap that in a shrink call. Might be the same thing ultimately.
           // Will check that later. Actually I'll try mapping first.
-          val (nextRoseTreeOfL, _, nextRnd) = genOfL.next(szp, Nil, rnd)
+          val (nextRoseTreeOfL, _, nextRnd) = genOfL.filter(l => isValidFun(Left(l), szp)).next(szp, Nil, rnd)
           (nextRoseTreeOfL.map(l => Left(l)), nextRnd)
         }
         else {
-          val (nextRoseTreeOfR, _, nextRnd) = genOfR.next(szp, Nil, rnd)
+          val (nextRoseTreeOfR, _, nextRnd) = genOfR.filter(r => isValidFun(Right(r), szp)).next(szp, Nil, rnd)
           (nextRoseTreeOfR.map(r => Right(r)), nextRnd)
         }
       }

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1993,7 +1993,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosZFiniteDouble, sizeParam: SizeParam, isValidFun: (PosZFiniteDouble, SizeParam) => Boolean): RoseTree[PosZFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFiniteDouble], Randomizer) = {
         val (posZFiniteDouble, rnd2) = rnd.nextPosZFiniteDouble
-        (NextRoseTree(posZFiniteDouble, szp, isValid), rnd2)
+        (NextRoseTree(posZFiniteDouble, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosZFiniteDouble]] = {
         case class CanonicalRoseTree(value: PosZFiniteDouble) extends RoseTree[PosZFiniteDouble] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1477,7 +1477,7 @@ object Generator {
       override def roseTreeOfEdge(edge: FiniteFloat, sizeParam: SizeParam, isValidFun: (FiniteFloat, SizeParam) => Boolean): RoseTree[FiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (FiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[FiniteFloat], Randomizer) = {
         val (finiteFloat, rnd2) = rnd.nextFiniteFloat
-        (NextRoseTree(finiteFloat, szp, isValid), rnd2)
+        (NextRoseTree(finiteFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[FiniteFloat]] = {
         case class CanonicalRoseTree(value: FiniteFloat) extends RoseTree[FiniteFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -4850,8 +4850,8 @@ object Generator {
       // Members declared in org.scalatest.prop.HavingSize
       def havingSize(len: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Vector[T]] = generatorWithSize(SizeParam(len, 0, len))
       def havingSizesBetween(from: org.scalactic.anyvals.PosZInt,to: org.scalactic.anyvals.PosZInt): org.scalatest.prop.Generator[Vector[T]] = {
-        require(from != to, Resources.fromEqualToToHavingLengthsBetween(from))
-        require(from < to, Resources.fromGreaterThanToHavingLengthsBetween(from, to))
+        require(from != to, Resources.fromEqualToToHavingSizesBetween(from))
+        require(from < to, Resources.fromGreaterThanToHavingSizesBetween(from, to))
         generatorWithSize(SizeParam(from, PosZInt.ensuringValid(to - from), from))
       }
       def havingSizesDeterminedBy(f: org.scalatest.prop.SizeParam => org.scalatest.prop.SizeParam): org.scalatest.prop.Generator[Vector[T]] =

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -3381,16 +3381,16 @@ object Generator {
         (listEdges.take(maxLength), rnd)
       }
 
-      override def roseTreeOfEdge(edge: List[T], sizeParam: SizeParam, isValidFun: (List[T], SizeParam) => Boolean): RoseTree[List[T]] = NextRoseTree(edge, sizeParam, isValid)
+      override def roseTreeOfEdge(edge: List[T], sizeParam: SizeParam, isValidFun: (List[T], SizeParam) => Boolean): RoseTree[List[T]] = NextRoseTree(edge, sizeParam, isValidFun)
 
       def generatorWithSize(szp: SizeParam): Generator[List[T]] =
         new Generator[List[T]] {
-          override def roseTreeOfEdge(edge: List[T], sizeParam: SizeParam, isValidFun: (List[T], SizeParam) => Boolean): RoseTree[List[T]] = NextRoseTree(edge, szp, isValid)
+          override def roseTreeOfEdge(edge: List[T], sizeParam: SizeParam, isValidFun: (List[T], SizeParam) => Boolean): RoseTree[List[T]] = NextRoseTree(edge, szp, isValidFun)
           def nextImpl(nextSzp: org.scalatest.prop.SizeParam, isValidFun: (List[T], SizeParam) => Boolean, rnd: org.scalatest.prop.Randomizer): (RoseTree[List[T]], org.scalatest.prop.Randomizer) = {
             @scala.annotation.tailrec
             def loop(targetSize: Int, result: List[T], rnd: org.scalatest.prop.Randomizer): (RoseTree[List[T]], org.scalatest.prop.Randomizer) =
               if (result.length == targetSize)
-                (NextRoseTree(result, szp, isValid), rnd)
+                (NextRoseTree(result, szp, isValidFun), rnd)
               else {
                 val (nextRoseTreeOfT, nextEdges, nextRnd) = genOfT.next(szp, List.empty, rnd)
                 loop(targetSize, result :+ nextRoseTreeOfT.value, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2739,7 +2739,7 @@ object Generator {
       override def roseTreeOfEdge(edge: NegInt, sizeParam: SizeParam, isValidFun: (NegInt, SizeParam) => Boolean): RoseTree[NegInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegInt], Randomizer) = {
         val (negInt, rnd2) = rnd.nextNegInt
-        (NextRoseTree(negInt, szp, isValid), rnd2)
+        (NextRoseTree(negInt, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[NegInt]] = {
         case class CanonicalRoseTree(value: NegInt) extends RoseTree[NegInt] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1335,7 +1335,7 @@ object Generator {
       override def roseTreeOfEdge(edge: PosFloat, sizeParam: SizeParam, isValidFun: (PosFloat, SizeParam) => Boolean): RoseTree[PosFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFloat], Randomizer) = {
         val (posFloat, rnd2) = rnd.nextPosFloat
-        (NextRoseTree(posFloat, szp, isValid), rnd2)
+        (NextRoseTree(posFloat, szp, isValidFun), rnd2)
       }
       override def canonicals: LazyListOrStream[RoseTree[PosFloat]] = {
         case class CanonicalRoseTree(value: PosFloat) extends RoseTree[PosFloat] {

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -139,24 +139,6 @@ object RoseTree {
       }
     roseTreeOfV
   }
-
-  def map2WithFilter[T, U, V](tree1: RoseTree[T], tree2: RoseTree[U])(filterT: T => Boolean, filterU: U => Boolean)(f: (T, U) => V): RoseTree[V] = {
-    val tupValue = f(tree1.value, tree2.value)
-    val shrinks1 = tree1.shrinks
-    val candidatesOfTU1: LazyListOrStream[RoseTree[(T, U)]] = 
-      shrinks1.map(rtOfT => rtOfT.map(t => (t, tree2.value))).filter(rt => filterT(rt.value._1) && filterU(rt.value._2))
-    val candidates1: LazyListOrStream[RoseTree[V]] = candidatesOfTU1.map(rt => rt.map(t => f(t._1, t._2)))
-    val roseTreeOfV =
-      new RoseTree[V] {
-        val value = tupValue
-        def shrinks: LazyListOrStream[RoseTree[V]] = {
-          candidates1 #::: tree2.shrinks.map(rtOfU => rtOfU.map(u => (tree1.value, u)))
-                                        .filter(rt => filterT(rt.value._1) && filterU(rt.value._2))
-                                        .map(rt => rt.map(t => f(t._1, t._2)))
-        }
-      }
-    roseTreeOfV
-  }
 }
 
 // Terminal node of a RoseTree is a Rose.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1728,6 +1728,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZFiniteFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZFiniteFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink PosZFiniteFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosZFiniteFloat]) =>
@@ -1751,6 +1760,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFiniteFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZFiniteFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for PosDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2854,6 +2854,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negDoubleGenerator.filter(_ < -5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegDouble(-5.0)
+          newRd
+        }
+      }
+
       it("should shrink NegDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegDouble]) =>
@@ -2877,6 +2886,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegDouble(-6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegDouble(-5.0)
+          newRd
+        }
       }
     }
     describe("for NegFiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1127,6 +1127,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val rnd = Randomizer.default
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
+
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posIntGenerator.filter(_ > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosInt(5)
+          newRd
+        }
+      }
       
       it("should shrink PosInts by algo towards 1") {
         import GeneratorDrivenPropertyChecks._
@@ -1151,6 +1160,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosInt(15), PosInt(7))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosInt(5)
+          newRd
+        }
       }
     }
     describe("for PosZInts") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3491,6 +3491,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
         assert(optShrink.shrinks.isEmpty)
       }
+
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.optionGenerator[String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Some("test")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (None)
+      }
     }
 
     describe("for Ors") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4228,6 +4228,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           s.size shouldBe 5
         }
       }
+      it("should not exhibit this bug in Set shrinking") {
+        val setGen = implicitly[Generator[Set[Set[Int]]]]
+        val xss = Set(Set(100, 200, 300, 400, 300))
+        setGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+      }
       it("should shrink Set with an algo towards empty Set") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Set[Int]]) =>

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4104,6 +4104,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         optCanon.map(rt => rt.value).filter(_.isDefined).map(_.get) should contain theSameElementsAs intCanon.map(rt => rt.value).toList
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.optionGenerator[Int].filter(_.nonEmpty)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should not be empty
+          newRd
+        }
+      }
+
       it("should use the base type for shrinking and also produce None") {
         import org.scalatest.OptionValues._
         import GeneratorDrivenPropertyChecks._
@@ -4157,6 +4166,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Some("test")), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (None)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
       }
     }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1212,6 +1212,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZIntGenerator.filter(_ > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZInt(5)
+          newRd
+        }
+      }
+
       it("should shrink PosZInts by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosZInt]) =>
@@ -1235,6 +1244,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZInt(15), PosZInt(7))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZInt(5)
+          newRd
+        }
       }
     }
     describe("for PosLongs") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1548,6 +1548,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posFiniteFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosFiniteFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink PosFiniteFloat by algo towards 1.0 and positive min value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosFiniteFloat]) =>
@@ -1571,6 +1580,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFiniteFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosFiniteFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for PosZFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3584,6 +3584,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink NonZeroDoubles with an algo towards min positive or negative value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroDouble]) =>
@@ -3610,6 +3619,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for NonZeroFiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -5341,6 +5341,27 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listOfIntCanonicals = listOfIntCanonicalsIt.map(_.value).toList
         listOfIntCanonicals shouldEqual intCanonicals.map(i => SortedSet(i))
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.sortedSetGenerator[Int].filter(_.size > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 99, 100), List.empty, rd)
+          rs.value.size should be > 5
+          newRd
+        }
+      }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.sortedSetGenerator[String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedSet("1", "2", "3", "4")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (Set.empty[String])
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
+      }
     }
 
     describe("for Map[K, V]s") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3395,6 +3395,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import org.scalatest.Inspectors
         Inspectors.forAll (canonicals.init) { (s: String) => s should (be >= "a" and be <= "z") }
       }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.stringGenerator.filter(_.length > 5)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List("one two three four five"), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not be empty
+        shrinkees.toList shouldBe List("ee four five", "one two thr", "wo thr")
+      }
     }
 
     describe("for Options") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4207,6 +4207,25 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         orCanon.map(_.value).toList should contain theSameElementsAs((gCanon.map(_.value).map(Good(_)) ++ bCanon.map(_.value).map(Bad(_))).toList)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        import org.scalactic._
+        val aGen = 
+          Generator.orGenerator[Int, Long].filter { 
+            case Good(g) => g > 200
+            case Bad(b) => b > 200
+          }
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val value = 
+            rs.value match {
+              case Good(g) => g > 200
+              case Bad(b) => b > 200
+            }
+          value shouldBe true
+          newRd
+        }
+      }
+
       it("should produce an appropriate mix of Good and Bad", Flicker) {
         import Generator._
         import org.scalactic._
@@ -4258,6 +4277,18 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val orBadShrinkees = orBadShrink.shrinks.map(_.value)
         orBadShrinkees should not be empty
         orBadShrinkees.toList shouldBe List(Bad(1000L), Bad(500L), Bad(250L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = gen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map { sh =>
+            sh.value match {
+              case Good(g) => g > 200
+              case Bad(b) => b > 200
+            }
+          }
+          all(shrinkees.toList) shouldBe true
+          newRd
+        }
       }
     }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1639,6 +1639,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.shouldGrowWithForShrink(_.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink PosZFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosFloat]) =>
@@ -1662,6 +1671,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for PosZFiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3392,6 +3392,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NonZeroFloats with an algo towards min positive or negative value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroFloat]) =>
@@ -3418,6 +3427,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for NonZeroFiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -648,16 +648,27 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           val shrinks: LazyListOrStream[Char] = shrinkRoseTree.shrinks.map(_.value)
           shrinks.distinct.length shouldEqual shrinks.length
           if (c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z')
-            shrinks shouldBe empty
+            shrinks shouldEqual expectedChars.drop(expectedChars.indexOf(c) + 1)
           else
-            shrinks shouldEqual expectedChars
+            shrinks shouldBe empty
+            
         }
         import org.scalatest.Inspectors
         Inspectors.forAll (expectedChars) { (c: Char) =>
           val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(c), Randomizer.default)
           val shrinks: LazyListOrStream[Char] = shrinkRoseTree.shrinks.map(_.value)
-          shrinks shouldBe empty
+          shrinks shouldEqual expectedChars.drop(expectedChars.indexOf(c) + 1)
         }
+      }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.charGenerator.filter(c => c.toLower == c)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List('9'), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not be empty
+        shrinkees.toList shouldBe List('8', '7', '6', '5', '4', '3', '2', '1', '0', 
+                                       'z', 'y', 'x', 'w', 'v', 'u', 't', 's', 'r', 
+                                       'q', 'p', 'o', 'n', 'm', 'l', 'j', 'k', 'i', 
+                                       'h', 'g', 'f', 'e', 'd', 'c', 'b', 'a')
       }
     }
     describe("for Floats") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3119,6 +3119,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZFiniteDoubleGenerator.filter(_ < -5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZFiniteDouble(-5.0)
+          newRd
+        }
+      }
+
       it("should shrink NegZFiniteDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZFiniteDouble]) =>
@@ -3142,6 +3151,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFiniteDouble(-6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZFiniteDouble(-5.0)
+          newRd
+        }
       }
     }
     describe("for NonZeroInts") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3744,6 +3744,86 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (l5, _, _) = gen.next(szp = SizeParam(PosZInt(100), 0, 100), edges = Nil, rnd = r4)
         l5.value.length shouldBe 100
       }
+      it("should produce List[T] following size determined by havingSize method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingSize(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.size shouldBe 3
+        }
+      }
+      it("should produce List[T] following length determined by havingLength method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingLength(PosZInt(3))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.length shouldBe 3
+        }
+      }
+      it("should produce List[T] following sizes determined by havingSizeBetween method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.size should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingSizesBetween is called with invalid from and to pair") {
+        val aGen= Generator.listGenerator[Int]
+        aGen.havingSizesBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingSizesBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce List[T] following lengths determined by havingLengthBetween method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.length should (be >= 3 and be <= 5)
+        }
+      }
+      it("should produce IllegalArgumentException when havingLengthBetween is called with invalid from and to pair") {
+        val aGen= Generator.listGenerator[Int]
+        aGen.havingLengthsBetween(PosZInt(3), PosZInt(5))
+        assertThrows[IllegalArgumentException] {
+          aGen.havingLengthsBetween(PosZInt(3), PosZInt(3))
+        }
+        assertThrows[IllegalArgumentException] {
+          aGen.havingLengthsBetween(PosZInt(3), PosZInt(2))
+        }
+      }
+      it("should produce List[T] following sizes determined by havingSizesDeterminedBy method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingSizesDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.size shouldBe 5
+        }
+      }
+      it("should produce List[T] following sizes determined by havingLengthsDeterminedBy method") {
+        val aGen= Generator.listGenerator[Int]
+        implicit val sGen: Generator[List[Int]] = aGen.havingLengthsDeterminedBy(s => SizeParam(5, 0, 5))
+
+        import GeneratorDrivenPropertyChecks._
+
+        forAll { (l: List[Int]) =>
+          l.length shouldBe 5
+        }
+      }
       it("should not exhibit this bug in List shrinking") {
         val lstGen = implicitly[Generator[List[List[Int]]]]
         val xss = List(List(100, 200, 300, 400, 300))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3944,6 +3944,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         List(a1, a2).map(_.value) should contain theSameElementsAs List(NumericChar('0'), NumericChar('9'))
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.numericCharGenerator.filter(_.value.toString.toInt > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value.value.toString.toInt should be > 5
+          newRd
+        }
+      }
+
       it("should have legitimate canonicals") {
         import Generator._
         val gen = numericCharGenerator
@@ -3974,6 +3983,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NumericChar('8'), NumericChar('7'), NumericChar('6'))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.map(_.value.toString.toInt).toList) should be > 5
+          newRd
+        }
       }
     }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1377,6 +1377,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZLongGenerator.filter(_ > 5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZLong(5L)
+          newRd
+        }
+      }
+
       it("should shrink PosZLongs by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosZLong]) =>
@@ -1400,6 +1409,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZLong(15L), PosZLong(7L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZLong(5L)
+          newRd
+        }
       }
     }
     describe("for PosFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4685,6 +4685,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           s.size shouldBe 5
         }
       }
+      it("should not exhibit this bug in SortedMap shrinking") {
+        implicit val ordering = Ordering.by[SortedMap[Int, String], Int](_.size)
+        val mapGen = implicitly[Generator[SortedMap[SortedMap[Int, String], String]]]
+        val xss = SortedMap(SortedMap(100 -> "100", 200 -> "200", 300 -> "300", 400 -> "400", 500 -> "500") -> "test")
+        mapGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+      }
       it("should shrink SortedMap with an algo towards empty SortedMap") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[SortedMap[Int, String]]) =>

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2329,6 +2329,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negLongGenerator.filter(_ < -5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegLong(-5L)
+          newRd
+        }
+      }
+
       it("should shrink NegLongs by algo towards -1") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegLong]) =>
@@ -2352,6 +2361,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegLong(-15L), NegLong(-7L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegLong(-5)
+          newRd
+        }
       }
     }
     describe("for NegZLongs") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4657,6 +4657,29 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listOfIntCanonicals = listOfIntCanonicalsIt.map(_.value).toList
         listOfIntCanonicals shouldEqual intCanonicals.map(i => List(i))
       }
+
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.listGenerator[Int].filter(_.length > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 99, 100), List.empty, rd)
+          rs.value.length should be > 5
+          newRd
+        }
+      }
+
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.listGenerator[String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(List("1", "2", "3", "4")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (List.empty[String])
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
+      }
     }
     describe("for Function0s") {
       it("should offer an implicit provider for constant function0's with a pretty toString") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1293,6 +1293,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val rnd = Randomizer.default
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posLongGenerator.filter(_ > 5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosLong(5L)
+          newRd
+        }
+      }
+
       it("should shrink PosLongs by algo towards 1") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosLong]) =>
@@ -1316,6 +1325,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosLong(15L), PosLong(7L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosLong(5L)
+          newRd
+        }
       }
     }
     describe("for PosZLongs") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4994,6 +4994,27 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listOfIntCanonicals = listOfIntCanonicalsIt.map(_.value).toList
         listOfIntCanonicals shouldEqual intCanonicals.map(i => List(i))
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.vectorGenerator[Int].filter(_.length > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 99, 100), List.empty, rd)
+          rs.value.length should be > 5
+          newRd
+        }
+      }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.vectorGenerator[String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector("1", "2", "3", "4")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (Vector.empty[String])
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
+      }
     }
 
     describe("for Set[T]s") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -5167,6 +5167,27 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listOfIntCanonicals = listOfIntCanonicalsIt.map(_.value).toList
         listOfIntCanonicals shouldEqual intCanonicals.map(i => Set(i))
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.setGenerator[Int].filter(_.size > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 99, 100), List.empty, rd)
+          rs.value.size should be > 5
+          newRd
+        }
+      }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.setGenerator[String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Set("1", "2", "3", "4")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (Set.empty[String])
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
+      }
     }
 
     describe("for SortedSet[T]s") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2939,6 +2939,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negFiniteDoubleGenerator.filter(_ < -5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegFiniteDouble(-5.0)
+          newRd
+        }
+      }
+
       it("should shrink NegFiniteDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegFiniteDouble]) =>
@@ -2962,6 +2971,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFiniteDouble(-6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegFiniteDouble(-5.0)
+          newRd
+        }
       }
     }
     describe("for NegZDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4533,6 +4533,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           s.size shouldBe 5
         }
       }
+      it("should not exhibit this bug in Map shrinking") {
+        val mapGen = implicitly[Generator[Map[Map[Int, String], String]]]
+        val xss = Map(Map(100 -> "100", 200 -> "200", 300 -> "300", 400 -> "400", 500 -> "500") -> "test")
+        mapGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+      }
       it("should shrink Map with an algo towards empty Map") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Map[Int, String]]) =>

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2678,6 +2678,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZFloatGenerator.filter(_ < -5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZFloat(-5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NegZFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZFloat]) =>
@@ -2701,6 +2710,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFloat(-6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZFloat(-5.0f)
+          newRd
+        }
       }
     }
     describe("for NegZFiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3486,6 +3486,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroFiniteFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroFiniteFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NonZeroFiniteFloats with an algo towards min positive or negative value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroFiniteFloat]) =>
@@ -3512,6 +3521,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFiniteFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroFiniteFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for NonZeroDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4053,6 +4053,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           v.length shouldBe 5
         }
       }
+      it("should not exhibit this bug in Vector shrinking") {
+        val vectorGen = implicitly[Generator[Vector[Vector[Int]]]]
+        val xss = Vector(Vector(100, 200, 300, 400, 300))
+        vectorGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+      }
       it("should shrink Vector with an algo towards empty Vector") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Vector[Int]]) =>

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1992,6 +1992,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink PosZDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosZDouble]) =>
@@ -2015,6 +2024,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for PosZFiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3294,6 +3294,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroLongGenerator.filter(_ > 5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroLong(5L)
+          newRd
+        }
+      }
+
       it("should shrink NonZeroLongs by algo towards min positive and negative values") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroLong]) =>
@@ -3320,6 +3329,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroLong(15L), NonZeroLong(7L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroLong(5L)
+          newRd
+        }
       }
     }
     describe("for NonZeroFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3775,7 +3775,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
 
       it("should produce values following constraint determined by filter method") {
-        val aGen = Generator.finiteFloatGenerator.filter(_ > 5.0)
+        val aGen = Generator.finiteFloatGenerator.filter(_ > 5.0f)
         (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
           val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
           rs.value should be > FiniteFloat(5.0f)
@@ -3869,6 +3869,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.finiteDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > FiniteDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink FiniteDoubles with an algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[FiniteDouble]) =>
@@ -3894,6 +3903,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(FiniteDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > FiniteDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for NumericChar") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2081,6 +2081,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posZFiniteDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosZFiniteDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink PosZFiniteDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosFiniteDouble]) =>
@@ -2104,6 +2113,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFiniteDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosZFiniteDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for NegInts") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3678,6 +3678,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroFiniteDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroFiniteDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink NonZeroFiniteDoubles with an algo towards min positive or negative value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroFiniteDouble]) =>
@@ -3704,6 +3713,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFiniteDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroFiniteDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for FiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4381,7 +4381,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should not exhibit this bug in SortedSet shrinking") {
-        implicit val ordering = Ordering.by[SortedSet[Int], Int](_.size)
+        implicit val ordering: Ordering[SortedSet[Int]] = Ordering.by[SortedSet[Int], Int](_.size)
         val setGen = implicitly[Generator[SortedSet[SortedSet[Int]]]]
         val xss = SortedSet(SortedSet(100, 200, 300, 400, 300))
         setGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
@@ -4686,7 +4686,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should not exhibit this bug in SortedMap shrinking") {
-        implicit val ordering = Ordering.by[SortedMap[Int, String], Int](_.size)
+        implicit val ordering: Ordering[SortedMap[Int, String]] = Ordering.by[SortedMap[Int, String], Int](_.size)
         val mapGen = implicitly[Generator[SortedMap[SortedMap[Int, String], String]]]
         val xss = SortedMap(SortedMap(100 -> "100", 200 -> "200", 300 -> "300", 400 -> "400", 500 -> "500") -> "test")
         mapGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1901,6 +1901,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posFiniteDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosFiniteDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink PosFiniteDouble by algo towards positive min value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosFiniteDouble]) =>
@@ -1924,6 +1933,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFiniteDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosFiniteDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for PosZDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -416,6 +416,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(-3, 3, -2, 2, -1, 1, 0).map(_.toShort)
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen= Generator.shortGenerator.filter(_ > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > 5.toShort
+          newRd
+        }
+      }
       it("should shrink Shorts by repeatedly halving and negating") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Short]) =>
@@ -444,6 +452,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15.toShort, 7.toShort)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > 5.toShort
+          newRd
+        }
       }
     }
     describe("for Ints") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3774,6 +3774,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.shouldGrowWithForShrink(_.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.finiteFloatGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > FiniteFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink FiniteFloats with an algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[FiniteFloat]) =>
@@ -3799,6 +3808,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(FiniteFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > FiniteFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for FiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2585,6 +2585,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negFiniteFloatGenerator.filter(_ < -5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegFiniteFloat(-5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NegFiniteFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegFiniteFloat]) =>
@@ -2610,6 +2619,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFiniteFloat(-6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegFiniteFloat(-5.0f)
+          newRd
+        }
       }
     }
     describe("for NegZFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1815,6 +1815,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posDoubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosDouble(5.0)
+          newRd
+        }
+      }
+
       it("should shrink PosDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosDouble]) =>
@@ -1838,6 +1847,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosDouble(6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosDouble(5.0)
+          newRd
+        }
       }
     }
     describe("for PosFiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -5514,6 +5514,27 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val mapCanonicals = mapCanonicalsIt.map(_.value).toList
         mapCanonicals shouldEqual tupleCanonicals.map(i => Map(i))
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.mapGenerator[Int, String].filter(_.size > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 99, 100), List.empty, rd)
+          rs.value.size should be > 5
+          newRd
+        }
+      }
+      it("should produce shrinkees following constraint determined by filter method") {
+        val aGen= Generator.mapGenerator[Int, String].filter(_.nonEmpty)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Map(1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4")), Randomizer.default)
+        val shrinkees = rs.shrinks.map(_.value)
+        shrinkees should not contain (Set.empty[String])
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should not be empty
+          newRd
+        }
+      }
     }
 
     describe("for SortedMaps") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1464,6 +1464,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.shouldGrowWithForShrink(_.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.posFloatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > PosFloat(5.0f)
+          newRd
+        }
+      }
+
       it("should shrink PosFloat by algo towards 1.0 and positive min value") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[PosFloat]) =>
@@ -1487,6 +1496,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFloat(6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > PosFloat(5.0f)
+          newRd
+        }
       }
     }
     describe("for PosFiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -341,6 +341,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(-3, 3, -2, 2, -1, 1, 0).map(_.toByte)
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen= Generator.byteGenerator.filter(_ > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > 5.toByte
+          newRd
+        }
+      }
       it("should shrink Bytes by repeatedly halving and negating") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Byte]) =>
@@ -369,6 +377,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15.toByte, 7.toByte)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > 5.toByte
+          newRd
+        }
       }
     }
     describe("for Shorts") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -608,6 +608,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(-3L, 3L, -2L, 2L, -1L, 1L, 0L)
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen= Generator.longGenerator.filter(_ > 5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > 5L
+          newRd
+        }
+      }
       it("should shrink Longs by repeatedly halving and negating") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Long]) =>
@@ -636,11 +644,18 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should produce shrinkees following constraint determined by filter method") {
-        val aGen= Generator.longGenerator.filter(_ > 5)
+        val aGen= Generator.longGenerator.filter(_ > 5L)
         val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(30L), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15L, 7L)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > 5L
+          newRd
+        }
       }
     }
     describe("for Chars") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3030,6 +3030,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZDoubleGenerator.filter(_ < -5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZDouble(-5.0)
+          newRd
+        }
+      }
+
       it("should shrink NegZDouble by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZDouble]) =>
@@ -3053,6 +3062,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZDouble(-6.0))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZDouble(-5.0)
+          newRd
+        }
       }
     }
     describe("for NegZFiniteDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2767,6 +2767,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZFiniteFloatGenerator.filter(_ < -5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZFiniteFloat(-5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NegZFiniteFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZFiniteFloat]) =>
@@ -2790,6 +2799,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFiniteFloat(-6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZFiniteFloat(-5.0f)
+          newRd
+        }
       }
     }
     describe("for NegDouble") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -699,6 +699,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import org.scalatest.Inspectors
         Inspectors.forAll (canonicals) { c => c should (be >= 'a' and be <= 'z') }
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.charGenerator.filter(_ > '5')
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > '5'
+          newRd
+        }
+      }
       it("should shrink Chars by trying selected printable characters") {
         import GeneratorDrivenPropertyChecks._
         val expectedChars = "9876543210ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmljkihgfedcba".toList
@@ -729,6 +737,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
                                        'z', 'y', 'x', 'w', 'v', 'u', 't', 's', 'r', 
                                        'q', 'p', 'o', 'n', 'm', 'l', 'j', 'k', 'i', 
                                        'h', 'g', 'f', 'e', 'd', 'c', 'b', 'a')
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          shrinkees.toList.foreach { s =>
+            s should equal (s.toLower)
+          } 
+          newRd
+        }                               
       }
     }
     describe("for Floats") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -795,6 +795,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(-3.0f, 3.0f, -2.0f, 2.0f, -1.0f, 1.0f, 0.0f)
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.floatGenerator.filter(_ > 5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > 5.0f
+          newRd
+        }
+      }
       it("should shrink Floats with an algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Float]) =>
@@ -846,11 +854,18 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should produce shrinkees following constraint determined by filter method") {
-        val aGen= Generator.floatGenerator.filter(_ > 5.0)
+        val aGen= Generator.floatGenerator.filter(_ > 5.0f)
         val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(40.0f), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(6.0f)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > 5.0f
+          newRd
+        }
       }
     }
     describe("for Doubles") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -4380,6 +4380,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
           s.size shouldBe 5
         }
       }
+      it("should not exhibit this bug in SortedSet shrinking") {
+        implicit val ordering = Ordering.by[SortedSet[Int], Int](_.size)
+        val setGen = implicitly[Generator[SortedSet[SortedSet[Int]]]]
+        val xss = SortedSet(SortedSet(100, 200, 300, 400, 300))
+        setGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+      }
       it("should shrink Set with an algo towards empty Set") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[SortedSet[Int]]) =>

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3643,6 +3643,28 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         eitherRightShrink.shrinks.map(_.value) should contain theSameElementsAs(rShrink.shrinks.map(_.value).map(Right(_)).toList)
         eitherLeftShrink.shrinks.map(_.value) should contain theSameElementsAs(lShrink.shrinks.map(_.value).map(Left(_)).toList)
       }
+
+      it("should produce shrinkees following constraint determined by filter method") {
+        import Generator._
+        import org.scalactic._
+        
+        val gen = eitherGenerator[Int, Long].filter { 
+          case Left(l) => l > 200
+          case Right(r) => r > 200
+        }
+
+        val rnd = Randomizer.default
+        
+        val (orLeftShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Left(1000)), rnd)
+        val orLeftShrinkees = orLeftShrink.shrinks.map(_.value)
+        orLeftShrinkees should not be empty
+        orLeftShrinkees.toList shouldBe List(Left(500), Left(250))
+
+        val (orRightShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Right(2000L)), rnd)
+        val orRightShrinkees = orRightShrink.shrinks.map(_.value)
+        orRightShrinkees should not be empty
+        orRightShrinkees.toList shouldBe List(Right(1000L), Right(500L), Right(250L))
+      }
     }
 
     import scala.collection.GenTraversable

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2164,7 +2164,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
 
       it("should produce values following constraint determined by filter method") {
-        val aGen = Generator.negIntGenerator.filter(_ < 5)
+        val aGen = Generator.negIntGenerator.filter(_ < -5)
         (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
           val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
           rs.value should be < NegInt(-5)
@@ -2247,6 +2247,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZIntGenerator.filter(_ < -5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZInt(-5)
+          newRd
+        }
+      }
+
       it("should shrink NegZInts by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZInt]) =>
@@ -2270,6 +2279,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZInt(-15), NegZInt(-7))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZInt(-5)
+          newRd
+        }
       }
     }
     describe("for NegLongs") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2413,6 +2413,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negZLongGenerator.filter(_ < -5L)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegZLong(-5L)
+          newRd
+        }
+      }
+
       it("should shrink NegZLongs by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegZLong]) =>
@@ -2436,6 +2445,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZLong(-15L), NegZLong(-7L))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegZLong(-5)
+          newRd
+        }
       }
     }
     describe("for NegFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2163,6 +2163,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negIntGenerator.filter(_ < 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegInt(-5)
+          newRd
+        }
+      }
+
       it("should shrink NegInts by algo towards -1") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegInt]) =>
@@ -2186,6 +2195,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegInt(-15), NegInt(-7))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegInt(-5)
+          newRd
+        }
       }
     }
     describe("for NegZInts") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -915,6 +915,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(-3.0, 3.0, -2.0, 2.0, -1.0, 1.0, 0.0)
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.doubleGenerator.filter(_ > 5.0)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > 5.0
+          newRd
+        }
+      }
       it("should shrink Doubles with an algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[Double]) =>
@@ -940,6 +948,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(6.0)
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > 5.0
+          newRd
+        }
       }
     }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -2500,6 +2500,15 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         gen.canonicals.shouldGrowWithForGeneratorLazyListOrStreamPair(_.value.value)
       }
 
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.negFloatGenerator.filter(_ < -5.0f)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be < NegFloat(-5.0f)
+          newRd
+        }
+      }
+
       it("should shrink NegFloat by algo towards 0") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NegFloat]) =>
@@ -2523,6 +2532,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFloat(-6.0f))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be < NegFloat(-5.0f)
+          newRd
+        }
       }
     }
     describe("for NegFiniteFloat") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3561,6 +3561,28 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         orGoodShrink.shrinks.map(_.value) should contain theSameElementsAs(gShrink.shrinks.map(_.value).map(Good(_)).toList)
         orBadShrink.shrinks.map(_.value) should contain theSameElementsAs(bShrink.shrinks.map(_.value).map(Bad(_)).toList)
       }
+
+      it("should produce shrinkees following constraint determined by filter method") {
+        import Generator._
+        import org.scalactic._
+        
+        val gen = orGenerator[Int, Long].filter { 
+          case Good(g) => g > 200
+          case Bad(b) => b > 200
+        }
+
+        val rnd = Randomizer.default
+        
+        val (orGoodShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Good(1000)), rnd)
+        val orGoodShrinkees = orGoodShrink.shrinks.map(_.value)
+        orGoodShrinkees should not be empty
+        orGoodShrinkees.toList shouldBe List(Good(500), Good(250))
+
+        val (orBadShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Bad(2000L)), rnd)
+        val orBadShrinkees = orBadShrink.shrinks.map(_.value)
+        orBadShrinkees should not be empty
+        orBadShrinkees.toList shouldBe List(Bad(1000L), Bad(500L), Bad(250L))
+      }
     }
 
     describe("for Eithers") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -3203,6 +3203,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val canonicals = gen.canonicals
         canonicals.map(_.value).toList shouldBe List(NonZeroInt(-3), NonZeroInt(3), NonZeroInt(-2), NonZeroInt(2), NonZeroInt(-1), NonZeroInt(1))
       }
+      it("should produce values following constraint determined by filter method") {
+        val aGen = Generator.nonZeroIntGenerator.filter(_ > 5)
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          rs.value should be > NonZeroInt(5)
+          newRd
+        }
+      }
       it("should shrink NonZeroInts by repeatedly halving and negating") {
         import GeneratorDrivenPropertyChecks._
         forAll { (shrinkRoseTree: RoseTree[NonZeroInt]) =>
@@ -3232,6 +3240,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroInt(15), NonZeroInt(7))
+
+        (0 to 100).foldLeft(Randomizer.default) { case (rd, _) =>
+          val (rs, _, newRd) = aGen.next(SizeParam(1, 0, 1), List.empty, rd)
+          val shrinkees = rs.shrinks.map(_.value)
+          all(shrinkees.toList) should be > NonZeroInt(5)
+          newRd
+        }
       }
     }
     describe("for NonZeroLongs") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
@@ -242,18 +242,6 @@ class RoseTreeSpec extends AnyFunSpec with Matchers {
       shrinks(1).value shouldBe (0, true)
       shrinks(2).value shouldBe (2, false)
     }
-
-    it("should offer a map2WithFilter function that combines 2 RoseTree") {
-      import RoseTreeSpec._
-
-      val rtOfInt = intRoseTree(2)
-      val rtOfBoolean = booleanRoseTree(true)
-      val rtOfIntBoolean = RoseTree.map2WithFilter(rtOfInt, rtOfBoolean)(_ > 0, _ => true) { case (i, b) => (i, b) }
-      val shrinks = rtOfIntBoolean.shrinks
-      shrinks.length shouldBe 2
-      shrinks(0).value shouldBe (1, true)
-      shrinks(1).value shouldBe (2, false)
-    }
   }
 }
 

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -832,7 +832,7 @@ import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 
   val sevenEleven: Generator[String] =
     new Generator[String] {
-      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], Randomizer) = {
+      def nextImpl(szp: SizeParam, isValidFun: (String, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[String], Randomizer) = {
         if (szp.size.value >= 7 && szp.size.value <= 11)
           (Rose("OKAY"), rnd)
         else
@@ -843,7 +843,7 @@ import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 
   val fiveFive: Generator[String] =
     new Generator[String] {
-      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], Randomizer) = {
+      def nextImpl(szp: SizeParam, isValidFun: (String, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[String], Randomizer) = {
         if (szp.size.value == 5)
           (Rose("OKAY"), rnd)
         else
@@ -3596,7 +3596,7 @@ $okayAssertions$
       |    } yield $initToLastName$($initLower$)
       |  }
       |
-      |  def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[$lastType$], Randomizer) = underlying.nextImpl(szp, rnd)
+      |  def nextImpl(szp: SizeParam, isValidFun: ($lastType$, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[$lastType$], Randomizer) = underlying.nextImpl(szp, isValidFun, rnd)
       |  override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[$lastType$], Randomizer) = underlying.initEdges(maxLength, rnd)
       |  override def map[Z](f: ($lastType$) => Z): Generator[Z] = underlying.map(f)
       |  override def flatMap[Z](f: ($lastType$) => Generator[Z]): Generator[Z] = underlying.flatMap(f)

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -832,7 +832,7 @@ import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 
   val sevenEleven: Generator[String] =
     new Generator[String] {
-      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], List[String], Randomizer) = {
+      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], Randomizer) = {
         if (szp.size.value >= 7 && szp.size.value <= 11)
           (Rose("OKAY"), rnd)
         else
@@ -843,7 +843,7 @@ import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 
   val fiveFive: Generator[String] =
     new Generator[String] {
-      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], List[String], Randomizer) = {
+      def nextImpl(szp: SizeParam, rnd: Randomizer): (RoseTree[String], Randomizer) = {
         if (szp.size.value == 5)
           (Rose("OKAY"), rnd)
         else


### PR DESCRIPTION
- Added isValid and roseTreeOfEdge to Generator.
- Refactored the code to make the behavior of returning edges first consistent with all prebuilt generators.
- Use isValid to support filter and having size/between implementations.