### PR TITLE
Recognize -S as a valid argument

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
@@ -65,6 +65,7 @@ private[tools] object ArgsParser {
           /* s.startsWith("-x") || */
           s.startsWith("-l") ||
           s.startsWith("-s") ||
+          s.startsWith("-S") ||
           s.startsWith("-i") ||
           s.startsWith("-j") ||
           s.startsWith("-m") ||

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
@@ -1739,6 +1739,15 @@ class ArgsParserSpec extends AnyFunSpec {
     }
   }
 
+  it("checkArgsForValidity should recognize -S") {
+    assertResult(None) {
+      ArgsParser.checkArgsForValidity(Array("-S", "1234"))
+    }
+    assertResult(None) {
+      ArgsParser.checkArgsForValidity(Array("-S", "1234", "-h", "htmldir"))
+    }
+  }
+
   // SKIP-SCALATESTJS,NATIVE-START
   it("parseChosenStylesIntoChosenStyleSet should work correctly") {
     intercept[IllegalArgumentException] {


### PR DESCRIPTION
Ran into this problem while trying to reproduce a test failure from a property-based test.