### PR TITLE
maybe this is the correct file?

### DIFF
--- a/examples/src/test/scala/org/scalatest/examples/refspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/SetSpec.scala
@@ -21,11 +21,11 @@ class SetSpec extends RefSpec {
 
   object `A Set` {
     object `when empty` {
-      def `should have size 0` {
+      def `should have size 0` = {
         assert(Set.empty.size === 0)
       }
     
-      def `should produce NoSuchElementException when head is invoked` {
+      def `should produce NoSuchElementException when head is invoked` = {
         assertThrows[NoSuchElementException] {
           Set.empty.head
         }


### PR DESCRIPTION
When I ran the RefSpec example from https://www.scalatest.org/user_guide/selecting_a_style, using scala 2.13.8, sbt 1.7.1, and scalatest 3.2.15... I got this error "procedure syntax is deprecated: instead, add : Unit = to explicitly declare..." I was able to fix it by adding the equals sign to the method definition. I am not sure if this is the file that needs to be updated. I just took a guess and went with it.