### PR TITLE
NoArg Deprecation

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
@@ -135,8 +135,8 @@ package org.scalatest.fixture
  * <p>
  * Note: As of Scala 2.11, <code>DelayedInit</code> (which is used by <code>NoArg</code>) has been deprecated, to indicate it is buggy and should be avoided
  * if possible. Those in charge of the Scala compiler and standard library have promised that <code>DelayedInit</code> will not be removed from Scala
- * unless an alternate way to achieve the same goal is provided. Thus it <em>should</em> be safe to use <code>NoArg</code>, but if you'd rather
- * not you can achieve the same effect with a bit more boilerplate by extending (<code>() =&gt; Unit</code>) instead of <code>NoArg</code> and placing
+ * unless an alternate way to achieve the same goal is provided. Unfortunately, <code>DelayedInit</code> was officially dropped in Scala 3 (https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html). 
+ * ScalaTest removed <code>NoArg</code> trait from its Scala 3 build starting 3.2.16. You can achieve the same effect with a bit more boilerplate by extending (<code>() =&gt; Unit</code>) instead of <code>NoArg</code> and placing
  * your code in an explicit <code>body</code> method. Here's an example:
  * </p>
  *
@@ -210,6 +210,7 @@ package org.scalatest.fixture
  * </pre>
  *
  */
+@deprecated("NoArg has been deprecated because DelayedInit is officially dropped in Scala 3 (https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html) NoArg will no longer be available in Scala 3 build for ScalaTest starting 3.2.16 and shall be removed totally in a future version of ScalaTest. Please use (() => Unit) as suggested in NoArg scaladoc instead.", "3.2.16") 
 trait NoArg extends DelayedInit with (() => Unit) {
 
   private var theBody: () => Unit = _

--- a/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
@@ -136,7 +136,7 @@ package org.scalatest.fixture
  * Note: As of Scala 2.11, <code>DelayedInit</code> (which is used by <code>NoArg</code>) has been deprecated, to indicate it is buggy and should be avoided
  * if possible. Those in charge of the Scala compiler and standard library have promised that <code>DelayedInit</code> will not be removed from Scala
  * unless an alternate way to achieve the same goal is provided. Unfortunately, <code>DelayedInit</code> was officially dropped in Scala 3 (https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html). 
- * ScalaTest removed <code>NoArg</code> trait from its Scala 3 build starting 3.2.16. You can achieve the same effect with a bit more boilerplate by extending (<code>() =&gt; Unit</code>) instead of <code>NoArg</code> and placing
+ * You can achieve the same effect with a bit more boilerplate by extending (<code>() =&gt; Unit</code>) instead of <code>NoArg</code> and placing
  * your code in an explicit <code>body</code> method. Here's an example:
  * </p>
  *
@@ -210,7 +210,7 @@ package org.scalatest.fixture
  * </pre>
  *
  */
-@deprecated("NoArg has been deprecated because DelayedInit is officially dropped in Scala 3 (https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html) NoArg will no longer be available in Scala 3 build for ScalaTest starting 3.2.16 and shall be removed totally in a future version of ScalaTest. Please use (() => Unit) as suggested in NoArg scaladoc instead.", "3.2.16") 
+@deprecated("NoArg has been deprecated because DelayedInit is officially dropped in Scala 3 (https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html). Please use (() => Unit) as suggested in NoArg scaladoc instead.", "3.2.16") 
 trait NoArg extends DelayedInit with (() => Unit) {
 
   private var theBody: () => Unit = _

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -268,9 +268,7 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List(
-        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
-      ), 
+      "org/scalatest/fixture" -> List.empty, 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 
@@ -334,9 +332,7 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List(
-        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
-      ), 
+      "org/scalatest/fixture" -> List.empty, 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 
@@ -400,9 +396,7 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List(
-        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
-      ), 
+      "org/scalatest/fixture" -> List.empty, 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 

--- a/project/GenScalaTestDotty.scala
+++ b/project/GenScalaTestDotty.scala
@@ -268,7 +268,9 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List.empty, 
+      "org/scalatest/fixture" -> List(
+        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
+      ), 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 
@@ -332,7 +334,9 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List.empty, 
+      "org/scalatest/fixture" -> List(
+        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
+      ), 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 
@@ -396,7 +400,9 @@ object GenScalaTestDotty {
         "InspectorAsserting.scala"     // Re-implemented without path-dependent type
       ), 
       "org/scalatest/events" -> List.empty, 
-      "org/scalatest/fixture" -> List.empty, 
+      "org/scalatest/fixture" -> List(
+        "NoArg.scala"  // skipped because scala 3 dropped DelayedInit.
+      ), 
       "org/scalatest/featurespec" -> List.empty, 
       "org/scalatest/funspec" -> List.empty, 
       "org/scalatest/funsuite" -> List.empty, 
@@ -599,7 +605,7 @@ object GenScalaTestDotty {
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/exceptions", "org/scalatest/exceptions", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/fixture", "org/scalatest/fixture", targetDir,
       List(
-        "NoArgSpec.scala",  // skipped because tests failed.
+        "NoArgSpec.scala",  // skipped because scala 3 dropped DelayedInit.
       )) ++ 
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
     copyDir("jvm/scalatest-test/src/test/scala/org/scalatest/prop", "org/scalatest/prop", targetDir, List.empty) ++
@@ -694,7 +700,7 @@ object GenScalaTestDotty {
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/exceptions", "org/scalatest/exceptions", targetDir, List.empty) ++
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/fixture", "org/scalatest/fixture", targetDir,
       List(
-        "NoArgSpec.scala",  // skipped because tests failed.
+        "NoArgSpec.scala",  // skipped because scala 3 dropped DelayedInit.
         "SuiteSpec.scala"    // skipped because depends on java reflections
       )) ++ 
     copyDirJS("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++
@@ -1098,7 +1104,7 @@ object GenScalaTestDotty {
     copyDirNative("jvm/scalatest-test/src/test/scala/org/scalatest/exceptions", "org/scalatest/exceptions", targetDir, List.empty) ++
     copyDirNative("jvm/scalatest-test/src/test/scala/org/scalatest/fixture", "org/scalatest/fixture", targetDir,
       List(
-        "NoArgSpec.scala",  // skipped because tests failed.
+        "NoArgSpec.scala",  // skipped because scala 3 dropped DelayedInit.
         "SuiteSpec.scala"    // skipped because depends on java reflections
       )) ++ 
     copyDirNative("jvm/scalatest-test/src/test/scala/org/scalatest/path", "org/scalatest/path", targetDir, List.empty) ++


### PR DESCRIPTION
- Deprecated NoArg as scala.DelayedInit is dropped from Scala 3 already, 
- Updated scaladoc about the scala.DelayedInit being dropped in Scala 3.