### PR TITLE
Fix: Correction of the path of exceptions thrown in certain comments to correct the DRI problem for scaladoc.

### DIFF
--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -467,7 +467,7 @@ trait Assertions extends TripleEquals  {
    * </p>
    *
    * @param condition the boolean condition to assert
-   * @throws TestFailedException if the condition is <code>false</code>.
+   * @throws org.scalatest.exceptions.TestFailedException if the condition is <code>false</code>.
    */
   inline def assert(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{""}) }
@@ -525,8 +525,8 @@ trait Assertions extends TripleEquals  {
    *
    * @param condition the boolean condition to assert
    * @param clue An objects whose <code>toString</code> method returns a message to include in a failure report.
-   * @throws TestFailedException if the condition is <code>false</code>.
-   * @throws NullArgumentException if <code>message</code> is <code>null</code>.
+   * @throws org.scalatest.exceptions.TestFailedException if the condition is <code>false</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> is <code>null</code>.
    */
   inline def assert(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assert('{condition}, '{prettifier}, '{pos}, '{clue}) }
@@ -574,7 +574,7 @@ trait Assertions extends TripleEquals  {
    * </p>
    *
    * @param condition the boolean condition to assume
-   * @throws TestCanceledException if the condition is <code>false</code>.
+   * @throws org.scalatest.exceptions.TestCanceledException if the condition is <code>false</code>.
    */
   inline def assume(inline condition: Boolean)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{""}) }
@@ -626,8 +626,8 @@ trait Assertions extends TripleEquals  {
    *
    * @param condition the boolean condition to assume
    * @param clue An objects whose <code>toString</code> method returns a message to include in a failure report.
-   * @throws TestCanceledException if the condition is <code>false</code>.
-   * @throws NullArgumentException if <code>message</code> is <code>null</code>.
+   * @throws org.scalatest.exceptions.TestCanceledException if the condition is <code>false</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> is <code>null</code>.
    */
   inline def assume(inline condition: Boolean, clue: Any)(implicit prettifier: Prettifier, pos: source.Position, use: UseDefaultAssertions.type): Assertion =
     ${ AssertionsMacro.assume('{condition}, '{prettifier}, '{pos}, '{clue}) }
@@ -751,7 +751,7 @@ trait Assertions extends TripleEquals  {
    * @param classTag an implicit <code>ClassTag</code> representing the type of the specified
    * type parameter.
    * @return the intercepted exception, if it is of the expected type
-   * @throws TestFailedException if the passed function does not complete abruptly with an exception
+   * @throws org.scalatest.exceptions.TestFailedException if the passed function does not complete abruptly with an exception
    *    that's an instance of the specified type.
    */
   inline def intercept[T <: AnyRef](f: => Any)(implicit classTag: ClassTag[T]): T = 
@@ -812,7 +812,7 @@ trait Assertions extends TripleEquals  {
    * @param classTag an implicit <code>ClassTag</code> representing the type of the specified
    * type parameter.
    * @return the <code>Succeeded</code> singleton, if an exception of the expected type is thrown
-   * @throws TestFailedException if the passed function does not complete abruptly with an exception
+   * @throws org.scalatest.exceptions.TestFailedException if the passed function does not complete abruptly with an exception
    *    that's an instance of the specified type.
    */
   inline def assertThrows[T <: AnyRef](f: => Any)(implicit classTag: ClassTag[T]): Assertion = 
@@ -954,7 +954,7 @@ trait Assertions extends TripleEquals  {
    * @param expected the expected value
    * @param clue An object whose <code>toString</code> method returns a message to include in a failure report.
    * @param actual the actual value, which should equal the passed <code>expected</code> value
-   * @throws TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
+   * @throws org.scalatest.exceptions.TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
    */
   inline def assertResult[L, R](expected: L, clue: Any)(actual: R)(implicit prettifier: Prettifier, caneq: scala.CanEqual[L, R]): Assertion = 
     ${ source.Position.withPosition[Assertion]('{(pos: source.Position) => assertResultImpl[L, R](expected, clue, actual, prettifier, pos, caneq) }) }
@@ -978,7 +978,7 @@ trait Assertions extends TripleEquals  {
    *
    * @param expected the expected value
    * @param actual the actual value, which should equal the passed <code>expected</code> value
-   * @throws TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
+   * @throws org.scalatest.exceptions.TestFailedException if the passed <code>actual</code> value does not equal the passed <code>expected</code> value.
    */
   inline def assertResult[L, R](expected: L)(actual: R)(implicit prettifier: Prettifier, caneq: scala.CanEqual[L, R]): Assertion = 
     ${ source.Position.withPosition[Assertion]('{(pos: source.Position) => assertResultImpl[L, R](expected, actual, prettifier, pos, caneq) }) }
@@ -1048,7 +1048,7 @@ trait Assertions extends TripleEquals  {
    * message, to indicate a test failed.
    *
    * @param message A message describing the failure.
-   * @throws NullArgumentException if <code>message</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> is <code>null</code>
    */
   inline def fail(message: String): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => failImpl(message, pos) }) }
@@ -1067,7 +1067,7 @@ trait Assertions extends TripleEquals  {
    *
    * @param message A message describing the failure.
    * @param cause A <code>Throwable</code> that indicates the cause of the failure.
-   * @throws NullArgumentException if <code>message</code> or <code>cause</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> or <code>cause</code> is <code>null</code>
    */
   inline def fail(message: String, cause: Throwable): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => failImpl(message, cause, pos) }) }
@@ -1086,7 +1086,7 @@ trait Assertions extends TripleEquals  {
    * will return <code>cause.toString</code>.
    *
    * @param cause a <code>Throwable</code> that indicates the cause of the failure.
-   * @throws NullArgumentException if <code>cause</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>cause</code> is <code>null</code>
    */
   inline def fail(cause: Throwable): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => failImpl(cause: Throwable, pos: source.Position) }) }
@@ -1110,7 +1110,7 @@ trait Assertions extends TripleEquals  {
    * message, to indicate a test was canceled.
    *
    * @param message A message describing the cancellation.
-   * @throws NullArgumentException if <code>message</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> is <code>null</code>
    */
   inline def cancel(message: String): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => cancelImpl(message, pos) }) }
@@ -1129,7 +1129,7 @@ trait Assertions extends TripleEquals  {
    *
    * @param message A message describing the failure.
    * @param cause A <code>Throwable</code> that indicates the cause of the failure.
-   * @throws NullArgumentException if <code>message</code> or <code>cause</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>message</code> or <code>cause</code> is <code>null</code>
    */
   inline def cancel(message: String, cause: Throwable): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => cancelImpl(message, cause, pos) }) }
@@ -1148,7 +1148,7 @@ trait Assertions extends TripleEquals  {
    * will return <code>cause.toString</code>.
    *
    * @param cause a <code>Throwable</code> that indicates the cause of the cancellation.
-   * @throws NullArgumentException if <code>cause</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if <code>cause</code> is <code>null</code>
    */
   inline def cancel(cause: Throwable): Nothing = 
     ${ source.Position.withPosition[Nothing]('{(pos: source.Position) => cancelImpl(cause, pos) }) }
@@ -1190,7 +1190,7 @@ trait Assertions extends TripleEquals  {
    * (Employee's name was Bob Jones) Expected IllegalArgumentException to be thrown, but no exception was thrown
    * </pre>
    *
-   * @throws NullArgumentException if the passed <code>clue</code> is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException if the passed <code>clue</code> is <code>null</code>
   */
   def withClue[T](clue: Any)(fun: => T): T = {
     requireNonNull(clue)
@@ -1296,7 +1296,7 @@ trait Assertions extends TripleEquals  {
    * </p>
    *
    * @param f a block of code, which if it completes abruptly, should trigger a <code>TestPendingException</code>
-   * @throws TestPendingException if the passed block of code completes abruptly with an <code>Exception</code> or <code>AssertionError</code>
+   * @throws org.scalatest.exceptions.TestPendingException if the passed block of code completes abruptly with an <code>Exception</code> or <code>AssertionError</code>
    */
   inline def pendingUntilFixed(f: => Unit): Assertion with PendingStatement = 
     ${ source.Position.withPosition[Assertion with PendingStatement]('{(pos: source.Position) => pendingUntilFixedImpl(f, pos) }) }

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -751,7 +751,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    * @param fullstacks a boolean that configures whether full stack traces should be printed for test failures
    * @param stats a boolean that configures whether test and suite statistics are printed to the standard output
    *
-   * @throws NullArgumentException if the passed <code>configMap</code> parameter is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if the passed <code>configMap</code> parameter is <code>null</code>.
    * @throws IllegalArgumentException if <code>testName</code> is defined, but no test with the specified test name
    *     exists in this <code>Suite</code>
    */
@@ -927,7 +927,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when the test started by this method has completed, and whether or not it failed .
    *
-   * @throws NullArgumentException if any of <code>testName</code> or <code>args</code> is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if any of <code>testName</code> or <code>args</code> is <code>null</code>.
    * @throws IllegalArgumentException if <code>testName</code> is defined, but no test with the specified test name
    *     exists in this <code>Suite</code>
    */
@@ -996,7 +996,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when all tests started by this method have completed, and whether or not a failure occurred.
    *
-   * @throws NullArgumentException if any of the passed parameters is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if any of the passed parameters is <code>null</code>.
    * @throws IllegalArgumentException if <code>testName</code> is defined, but no test with the specified test name
    *     exists in this <code>Suite</code>
    */
@@ -1089,7 +1089,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when all tests and nested suites started by this method have completed, and whether or not a failure occurred.
    *         
-   * @throws NullArgumentException if any passed parameter is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if any passed parameter is <code>null</code>.
    * @throws IllegalArgumentException if <code>testName</code> is defined, but no test with the specified test name
    *     exists in this <code>Suite</code>
    */
@@ -1151,7 +1151,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when all nested suites started by this method have completed, and whether or not a failure occurred.
    *
-   * @throws NullArgumentException if any passed parameter is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if any passed parameter is <code>null</code>.
    */
   protected def runNestedSuites(args: Args): Status = {
 

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -139,7 +139,7 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
    * @param testFun the test function
    * @throws DuplicateTestNameException if a test with the same name has been registered previously
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
-   * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException  if <code>specText</code> or any passed test tag is <code>null</code>
    */
   private def registerTestToRun(specText: String, testTags: List[Tag], methodName: String, testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
     // SKIP-SCALATESTJS,NATIVE-START
@@ -168,7 +168,7 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
    * @param testFun the test function
    * @throws DuplicateTestNameException if a test with the same name has been registered previously
    * @throws TestRegistrationClosedException if invoked after <code>run</code> has been invoked on this suite
-   * @throws NullArgumentException if <code>specText</code> or any passed test tag is <code>null</code>
+   * @throws org.scalactic.exceptions.NullArgumentException  if <code>specText</code> or any passed test tag is <code>null</code>
    */
   private def registerTestToIgnore(specText: String, testTags: List[Tag], methodName: String, testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
     // SKIP-SCALATESTJS,NATIVE-START
@@ -1226,7 +1226,7 @@ one error found
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when the test started by this method has completed, and whether or not it failed .
    *
-   * @throws NullArgumentException if any of <code>testName</code>, <code>reporter</code>, <code>stopper</code>, or <code>configMap</code>
+   * @throws org.scalactic.exceptions.NullArgumentException  if any of <code>testName</code>, <code>reporter</code>, <code>stopper</code>, or <code>configMap</code>
    *     is <code>null</code>.
    */
   protected override def runTest(testName: String, args: Args): Status = {
@@ -1301,7 +1301,7 @@ one error found
    * @param args the <code>Args</code> for this run
    * @return a <code>Status</code> object that indicates when all tests started by this method have completed, and whether or not a failure occurred.
    *
-   * @throws NullArgumentException if any of the passed parameters is <code>null</code>.
+   * @throws org.scalactic.exceptions.NullArgumentException  if any of the passed parameters is <code>null</code>.
    * @throws IllegalArgumentException if <code>testName</code> is defined, but no test with the specified test name
    *     exists in this <code>Suite</code>
    */


### PR DESCRIPTION
The aim of this PR is to correct link problems in certain comments in order to avoid a Scaladoc DRI problems. 
Indeed, the Scaladoc can't find out the paths of classes called in `throws` comments, so it needs the full path.
The examples below are taken from the Scaladoc generation of an external project using Scalatest.

## Before
<img width="864" alt="Screenshot 2023-05-30 at 11 37 35" src="https://github.com/scalatest/scalatest/assets/44496264/7f3c06f9-8395-49ab-ad97-a541aa820d04">

## After
<img width="864" alt="Screenshot 2023-05-30 at 11 27 08" src="https://github.com/scalatest/scalatest/assets/44496264/dbc55a69-ac3b-4505-b56c-f4c414f66f06">
