### PR TITLE
Latest Scala version

### DIFF
--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -9,7 +9,7 @@ import ScalaNativePlugin.autoImport.{nativeLinkStubs, nativeDump}
 
 trait BuildCommons {
 
-  lazy val scalaVersionsSettings: Seq[Setting[_]] = Seq(
+  def scalaVersionsSettings: Seq[Setting[_]] = Seq(
     crossScalaVersions := Seq("2.13.11", "2.12.18", "2.11.12"), 
     scalaVersion := crossScalaVersions.value.head,
   )

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -10,7 +10,7 @@ import ScalaNativePlugin.autoImport.{nativeLinkStubs, nativeDump}
 trait BuildCommons {
 
   lazy val scalaVersionsSettings: Seq[Setting[_]] = Seq(
-    crossScalaVersions := Seq("2.13.10", "2.12.17", "2.11.12"), 
+    crossScalaVersions := Seq("2.13.11", "2.12.18", "2.11.12"), 
     scalaVersion := crossScalaVersions.value.head,
   )
 

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -14,12 +14,17 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 trait JsBuild { this: BuildCommons =>
 
+  private lazy val jsSharedSettings = Seq(
+    crossScalaVersions := Seq("2.13.11", "2.12.18")
+  )
+
   val sjsPrefix = "_sjs1_"
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")
 
   lazy val scalacticMacroJS = project.in(file("js/scalactic-macro"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "Scalactic Macro.js",
       organization := "org.scalactic",
@@ -51,6 +56,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalacticJS = project.in(file("js/scalactic"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(scalacticDocSettings: _*)
     .settings(
       projectTitle := "Scalactic.js",
@@ -105,6 +111,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestAppJS = project.in(file("js/scalatest-app"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest App",
       name := "scalatest-app",
@@ -198,6 +205,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val commonTestJS = project.in(file("js/common-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "Common test classes used by scalactic.js and scalatest.js",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
@@ -215,6 +223,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalacticTestJS = project.in(file("js/scalactic-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "Scalactic Test.js",
       organization := "org.scalactic",
@@ -265,6 +274,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestTestJS = project.in(file("js/scalatest-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest Test",
@@ -296,6 +306,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestDiagramsTestJS = project.in(file("js/diagrams-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest Diagrams Test",
@@ -308,6 +319,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestFeatureSpecTestJS = project.in(file("js/featurespec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest FeatureSpec Test",
@@ -321,6 +333,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestFlatSpecTestJS = project.in(file("js/flatspec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest FlatSpec Test",
@@ -334,6 +347,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestFreeSpecTestJS = project.in(file("js/freespec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest FreeSpec Test",
@@ -347,6 +361,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestFunSpecTestJS = project.in(file("js/funspec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest FunSpec Test",
@@ -360,6 +375,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestFunSuiteTestJS = project.in(file("js/funsuite-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest FunSuite Test",
@@ -373,6 +389,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestPropSpecTestJS = project.in(file("js/propspec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec Test",
@@ -386,6 +403,7 @@ trait JsBuild { this: BuildCommons =>
 
   lazy val scalatestWordSpecTestJS = project.in(file("js/wordspec-test"))
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(sharedTestSettingsJS: _*)
     .settings(
       projectTitle := "ScalaTest WordSpec Test",
@@ -415,6 +433,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestCoreJS = project.in(file("js/core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Core JS",
@@ -499,6 +518,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestFeatureSpecJS = project.in(file("js/featurespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest FeatureSpec JS",
       organization := "org.scalatest",
@@ -532,6 +552,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestFlatSpecJS = project.in(file("js/flatspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest FlatSpec JS",
       organization := "org.scalatest",
@@ -565,6 +586,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestFreeSpecJS = project.in(file("js/freespec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest FreeSpec JS",
       organization := "org.scalatest",
@@ -598,6 +620,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestFunSuiteJS = project.in(file("js/funsuite"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSuite JS",
       organization := "org.scalatest",
@@ -631,6 +654,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestFunSpecJS = project.in(file("js/funspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSpec JS",
       organization := "org.scalatest",
@@ -664,6 +688,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestPropSpecJS = project.in(file("js/propspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec JS",
       organization := "org.scalatest",
@@ -697,6 +722,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestWordSpecJS = project.in(file("js/wordspec"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest WordSpec JS",
       organization := "org.scalatest",
@@ -730,6 +756,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestDiagramsJS = project.in(file("js/diagrams"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest Diagrams JS",
       organization := "org.scalatest",
@@ -762,6 +789,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestMatchersCoreJS = project.in(file("js/matchers-core"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest Matchers Core JS",
       organization := "org.scalatest",
@@ -796,6 +824,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestShouldMatchersJS = project.in(file("js/shouldmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest Should Matchers JS",
       organization := "org.scalatest",
@@ -828,6 +857,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestMustMatchersJS = project.in(file("js/mustmatchers"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest Must Matchers JS",
       organization := "org.scalatest",
@@ -860,6 +890,7 @@ trait JsBuild { this: BuildCommons =>
   lazy val scalatestJS = project.in(file("js/scalatest"))
     .enablePlugins(SbtOsgi)
     .settings(sharedSettings: _*)
+    .settings(jsSharedSettings: _*)
     .settings(
       projectTitle := "ScalaTest JS",
       organization := "org.scalatest",

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -14,7 +14,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 trait NativeBuild { this: BuildCommons =>
 
-  private lazy val sharedNativeSettings = Seq(
+  private lazy val nativeSharedSettings = Seq(
     // This hack calls class directory as "resource" that forces to add all NIRs that was generated
     // by scala-native for classes that has `EnableReflectiveInstantiation` annotation
     // it requires because otherway all this NIRs is ignored by OSGI
@@ -26,11 +26,12 @@ trait NativeBuild { this: BuildCommons =>
     // [error] * T89org.scalatest.tools.FrameworkL29org.scalatest.tools.Framework$SN$ReflectivelyInstantiate$
     //
     // Details: https://github.com/scala-native/scala-native/issues/1930
-    Compile / resourceDirectories += (Compile / classDirectory).value
+    Compile / resourceDirectories += (Compile / classDirectory).value, 
+    crossScalaVersions := Seq("2.13.11", "2.12.18")
   )
 
   lazy val scalacticMacroNative = project.in(file("native/scalactic-macro"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(
       projectTitle := "Scalactic Macro.native",
       organization := "org.scalactic",
@@ -53,7 +54,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalacticNative = project.in(file("native/scalactic"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalacticDocSettings: _*)
     .settings(
       projectTitle := "Scalactic.native",
@@ -96,7 +97,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestNative = project.in(file("native/scalatest"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Native",
@@ -146,7 +147,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestAppNative = project.in(file("scalatest-app.native"))
       .enablePlugins(SbtOsgi)
-      .settings(sharedSettings ++ sharedNativeSettings)
+      .settings(sharedSettings ++ nativeSharedSettings)
       .settings(
         projectTitle := "ScalaTest App",
         name := "scalatest-app",
@@ -239,7 +240,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestCoreNative = project.in(file("native/core"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Core Native",
@@ -313,7 +314,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestFeatureSpecNative = project.in(file("native/featurespec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FeatureSpec Native",
@@ -343,7 +344,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestFlatSpecNative = project.in(file("native/flatspec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FlatSpec Native",
@@ -373,7 +374,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestFreeSpecNative = project.in(file("native/freespec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FreeSpec Native",
@@ -403,7 +404,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestFunSuiteNative = project.in(file("native/funsuite"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSuite Native",
@@ -433,7 +434,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestFunSpecNative = project.in(file("native/funspec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest FunSpec Native",
@@ -463,7 +464,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestPropSpecNative = project.in(file("native/propspec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec Native",
@@ -493,7 +494,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestWordSpecNative = project.in(file("native/wordspec"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest WordSpec Native",
@@ -523,7 +524,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestDiagramsNative = project.in(file("native/diagrams"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Diagrams Native",
@@ -552,7 +553,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestMatchersCoreNative = project.in(file("native/matchers-core"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Matchers Core Native",
@@ -583,7 +584,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestShouldMatchersNative = project.in(file("native/shouldmatchers"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Should Matchers Native",
@@ -612,7 +613,7 @@ trait NativeBuild { this: BuildCommons =>
 
   lazy val scalatestMustMatchersNative = project.in(file("native/mustmatchers"))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(scalatestDocSettings: _*)
     .settings(
       projectTitle := "ScalaTest Must Matchers Native",
@@ -640,7 +641,7 @@ trait NativeBuild { this: BuildCommons =>
   ).dependsOn(scalacticMacroNative % "compile-internal, test-internal", scalatestMatchersCoreNative).enablePlugins(ScalaNativePlugin)
 
   lazy val commonTestNative = project.in(file("native/common-test"))
-      .settings(sharedSettings ++ sharedNativeSettings)
+      .settings(sharedSettings ++ nativeSharedSettings)
       .settings(
         projectTitle := "Common test classes used by scalactic.native and scalatest.native",
         Compile / sourceGenerators += {
@@ -656,7 +657,7 @@ trait NativeBuild { this: BuildCommons =>
       ).dependsOn(scalacticMacroNative, LocalProject("scalatestNative")).enablePlugins(ScalaNativePlugin)
 
   lazy val scalacticTestNative = project.in(file("native/scalactic-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(
       projectTitle := "Scalactic Test.native",
       organization := "org.scalactic",
@@ -674,7 +675,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(scalacticNative, scalatestNative % "test", commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestTestNative = project.in(file("native/scalatest-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest Test",
@@ -705,7 +706,7 @@ trait NativeBuild { this: BuildCommons =>
     )
 
   lazy val scalatestDiagramsTestNative = project.in(file("native/diagrams-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest Diagrams Test",
@@ -718,7 +719,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestFeatureSpecTestNative = project.in(file("native/featurespec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest FeatureSpec Test",
@@ -732,7 +733,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestFlatSpecTestNative = project.in(file("native/flatspec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest FlatSpec Test",
@@ -745,7 +746,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestFreeSpecTestNative = project.in(file("native/freespec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest FreeSpec Test",
@@ -758,7 +759,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestFunSpecTestNative = project.in(file("native/funspec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest FunSpec Test",
@@ -771,7 +772,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestFunSuiteTestNative = project.in(file("native/funsuite-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest FunSuite Test",
@@ -784,7 +785,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestPropSpecTestNative = project.in(file("native/propspec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest PropSpec Test",
@@ -797,7 +798,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)
 
   lazy val scalatestWordSpecTestNative = project.in(file("native/wordspec-test"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(sharedTestSettingsNative: _*)
     .settings(
       projectTitle := "ScalaTest WordSpec Test",
@@ -810,7 +811,7 @@ trait NativeBuild { this: BuildCommons =>
     ).dependsOn(commonTestNative % "test").enablePlugins(ScalaNativePlugin)  
 
   lazy val scalatestModulesNative = project.in(file("modules/native/modules-aggregation"))
-    .settings(sharedSettings ++ sharedNativeSettings)
+    .settings(sharedSettings ++ nativeSharedSettings)
     .settings(
       publishArtifact := false,
       publish := {},


### PR DESCRIPTION
- Updated to use Scala 2.13.11 and 2.12.18.
- Disabled Scala 2.11 build for Scala-js and Scala-native.