### PR TITLE
Short-Circuit Fix for & and | in Macro

### DIFF
--- a/jvm/expectations-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
+++ b/jvm/expectations-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
@@ -758,13 +758,13 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
     it("should return No with correct message when is used to check a == 2 & b == 5") {
       val fact = expect(a == 2 & b == 5, ", dude")
       assert(fact.isNo)
-      assert(fact.factMessage == "3 did not equal 2, dude")
+      assert(fact.factMessage == "3 did not equal 2, but 5 equaled 5, dude")
     }
 
     it("should return No with correct message when is used to check a == 2 & b == 6") {
       val fact = expect(a == 2 & b == 6, ", dude")
       assert(fact.isNo)
-      assert(fact.factMessage == "3 did not equal 2, dude")
+      assert(fact.factMessage == "3 did not equal 2, and 5 did not equal 6, dude")
     }
 
     it("should return Yes with correct message when is used to check a == 3 || b == 5") {
@@ -794,13 +794,13 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
     it("should return Yes with correct message when is used to check a == 3 | b == 5") {
       val fact = expect(a == 3 | b == 5, ", dude")
       assert(fact.isYes)
-      assert(fact.factMessage == "3 equaled 3, dude")
+      assert(fact.factMessage == "3 equaled 3, and 5 equaled 5, dude")
     }
 
     it("should return Yes with correct message when is used to check a == 3 | b == 6") {
       val fact = expect(a == 3 | b == 6, ", dude")
       assert(fact.isYes)
-      assert(fact.factMessage == "3 equaled 3, dude")
+      assert(fact.factMessage == "3 equaled 3, but 5 did not equal 6, dude")
     }
 
     it("should return Yes with correct message when is used to check a == 2 | b == 5") {
@@ -862,6 +862,34 @@ class ExpectationsSpec extends AnyFunSpec with Expectations {
       val fact = expect(a == 5 && s.changeState, ", dude")
       assert(fact.isNo)
       assert(s.state == false)
+    }
+
+    it("should not short-circuit & when first condition was false") {
+      val s = new Stateful
+      val fact = expect(a == 5 & s.changeState, ", dude")
+      assert(fact.isNo)
+      assert(s.state == true)
+    }
+
+    it("should short-circuit || when first condition was true") {
+      val s = new Stateful
+      val fact = expect(a == 3 || s.changeState, ", dude")
+      assert(fact.isYes)
+      assert(s.state == false)
+    }
+
+    it("should not short-circuit | when first condition was true") {
+      val s = new Stateful
+      val fact = expect(a == 3 | s.changeState, ", dude")
+      assert(fact.isYes)
+      assert(s.state == true)
+    }
+
+    it("should return Yes with correct message when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
+      val fact = expect(a == 3 && { println("hi"); b == 5}, ", dude")
+      assert(fact.isYes)
+      assert(fact.factMessage.startsWith("3 equaled 3, and "))
+      assert(fact.factMessage.endsWith(" was true, dude"))
     }
   }
 

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -459,7 +459,7 @@ private[org] class BooleanMacro[C <: Context](val context: C) {
             case argTypeApply: TypeApply => transformAst(argTypeApply.duplicate, prettifierTree)
             case _ => simpleMacroBool(rightExpr.duplicate, getText(rightExpr), prettifierTree)
           }
-        if (operator == "&&" || operator == "&")  {// generate if (left.value) {...} else false
+        if (operator == "&&")  {// generate if (left.value) {...} else false
           If(
             Select(
               Ident(newTermName("$org_scalatest_assert_macro_left")),
@@ -469,7 +469,7 @@ private[org] class BooleanMacro[C <: Context](val context: C) {
             simpleMacroBool(context.literal(false).tree, "", prettifierTree)
           )
         }
-        else if (operator == "||" || operator == "|") // || and |, generate if (left.value) true else {...}
+        else if (operator == "||") // || and |, generate if (left.value) true else {...}
           If(
             Select(
               Ident(newTermName("$org_scalatest_assert_macro_left")),

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
@@ -401,14 +401,14 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       val e = intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 2 & b == 5)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)))
     }
 
     it("should throw IllegalArgumentException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 2 & b == 6)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)))
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -497,12 +497,12 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -511,10 +511,10 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalactic.Requirements.require(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -1564,14 +1564,14 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       val e = intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 2 & b == 5, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude")
     }
 
     it("should throw IllegalArgumentException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 2 & b == 6, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude")
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -1660,12 +1660,12 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalArgumentException] {
         org.scalactic.Requirements.require(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -1674,10 +1674,10 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalactic.Requirements.require(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -2687,14 +2687,14 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       val e = intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 2 & b == 5)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)))
     }
 
     it("should throw IllegalStateException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 2 & b == 6)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)))
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -2783,12 +2783,12 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -2797,10 +2797,10 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalactic.Requirements.requireState(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -3850,14 +3850,14 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       val e = intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 2 & b == 5, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude")
     }
 
     it("should throw IllegalStateException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 2 & b == 6, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude")
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -3946,12 +3946,12 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalStateException] {
         org.scalactic.Requirements.requireState(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -3960,10 +3960,10 @@ class DirectRequirementsSpec extends funspec.AnyFunSpec with OptionValues {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalactic.Requirements.requireState(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -401,14 +401,14 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       val e = intercept[IllegalArgumentException] {
         require(a == 2 & b == 5)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)))
     }
 
     it("should throw IllegalArgumentException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalArgumentException] {
         require(a == 2 & b == 6)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)))
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -497,12 +497,12 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalArgumentException] {
         require(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -511,10 +511,10 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       require(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -1564,14 +1564,14 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       val e = intercept[IllegalArgumentException] {
         require(a == 2 & b == 5, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude")
     }
 
     it("should throw IllegalArgumentException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalArgumentException] {
         require(a == 2 & b == 6, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude")
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -1660,12 +1660,12 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalArgumentException] {
         require(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -1674,10 +1674,10 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       require(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -2687,14 +2687,14 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       val e = intercept[IllegalStateException] {
         requireState(a == 2 & b == 5)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)))
     }
 
     it("should throw IllegalStateException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalStateException] {
         requireState(a == 2 & b == 6)
       }
-      assert(e.getMessage == didNotEqual(3, 2))
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)))
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -2783,12 +2783,12 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalStateException] {
         requireState(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -2797,10 +2797,10 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       requireState(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -3850,14 +3850,14 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       val e = intercept[IllegalStateException] {
         requireState(a == 2 & b == 5, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude")
     }
 
     it("should throw IllegalStateException with correct message and stack depth when is used to check a == 2 & b == 6") {
       val e = intercept[IllegalStateException] {
         requireState(a == 2 & b == 6, ", dude")
       }
-      assert(e.getMessage == didNotEqual(3, 2) + ", dude")
+      assert(e.getMessage == commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude")
     }
 
     it("should do nothing when is used to check a == 3 || b == 5") {
@@ -3946,12 +3946,12 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[IllegalStateException] {
         requireState(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -3960,10 +3960,10 @@ class RequirementsSpec extends funspec.AnyFunSpec with Requirements with OptionV
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       requireState(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {

--- a/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
@@ -117,7 +117,7 @@ trait Bool {
    */
   def &&(bool: => Bool): Bool =
     if (value)
-      new AndBool(this, bool, prettifier)
+      new AndBool(this, bool, true, prettifier)
     else
       this
 
@@ -127,7 +127,7 @@ trait Bool {
    * @param bool another <code>Bool</code>
    * @return a <code>Bool</code> that represents the result of logical <code>and</code>
    */
-  def &(bool: => Bool): Bool = &&(bool)
+  def &(bool: => Bool): Bool = new AndBool(this, bool, false, prettifier)
 
   /**
    * Logical <code>or</code> this <code>Bool</code> with another <code>Bool</code>
@@ -135,7 +135,11 @@ trait Bool {
    * @param bool another <code>Bool</code>
    * @return a <code>Bool</code> that represents the result of logical <code>or</code>
    */
-  def ||(bool: => Bool): Bool = new OrBool(this, bool, prettifier)
+  def ||(bool: => Bool): Bool = 
+    if (value)
+      this
+    else  
+      new OrBool(this, bool, true, prettifier)
 
   /**
    * Logical <code>or</code> this <code>Bool</code> with another <code>Bool</code>
@@ -143,7 +147,7 @@ trait Bool {
    * @param bool another <code>Bool</code>
    * @return a <code>Bool</code> that represents the result of logical <code>or</code>
    */
-  def |(bool: => Bool): Bool = ||(bool)
+  def |(bool: => Bool): Bool = new OrBool(this, bool, false, prettifier)
 
   /**
    * Negate this <code>Bool</code>
@@ -369,7 +373,7 @@ private[scalactic] class SimpleBool(expression: Boolean, val prettifier: Prettif
  * @param bool1 the first <code>Bool</code>
  * @param bool2 the second <code>Bool</code>
  */
-private[scalactic] class AndBool(bool1: Bool, bool2: => Bool, val prettifier: Prettifier) extends Bool {
+private[scalactic] class AndBool(bool1: Bool, bool2: => Bool, shortCircuit: Boolean, val prettifier: Prettifier) extends Bool {
 
   /**
    * the result of <code>bool1.value</code> logical <code>AND</code> <code>bool2.value</code>
@@ -381,14 +385,23 @@ private[scalactic] class AndBool(bool1: Bool, bool2: => Bool, val prettifier: Pr
    *
    * @return Localized raw string for "{0}, but {1}"
    */
-  def rawFailureMessage: String = Resources.rawCommaBut
+  def rawFailureMessage: String = 
+    if (shortCircuit && !bool1.value) 
+      bool1.rawFailureMessage
+    else {
+      if (bool1.value == bool2.value)
+        Resources.rawCommaAnd
+      else
+        Resources.rawCommaBut
+    }
 
   /**
    * raw message with a meaning opposite to that of the failure message
    *
    * @return Localized raw string for "{0}, and {1}"
    */
-  def rawNegatedFailureMessage: String = Resources.rawCommaAnd
+  def rawNegatedFailureMessage: String = 
+      Resources.rawCommaAnd
 
   /**
    * raw mid sentence message to report a failure
@@ -409,7 +422,14 @@ private[scalactic] class AndBool(bool1: Bool, bool2: => Bool, val prettifier: Pr
    *
    * @return <code>Vector</code> that contains <code>bool1.negatedFailureMessage</code> and <code>bool2.midSentenceFailureMessage</code>
    */
-  def failureMessageArgs = Vector(UnquotedString(bool1.negatedFailureMessage), UnquotedString(bool2.midSentenceFailureMessage))
+  def failureMessageArgs = 
+    if (shortCircuit && !bool1.value) 
+      bool1.failureMessageArgs
+    else  
+      Vector(
+        if (bool1.value) UnquotedString(bool1.negatedFailureMessage) else UnquotedString(bool1.failureMessage), 
+        if (bool2.value) UnquotedString(bool2.midSentenceNegatedFailureMessage) else UnquotedString(bool2.midSentenceFailureMessage)
+      )
 
   /**
    * Arguments to construct final negated failure message with raw message returned from <code>rawNegatedFailureMessage</code>.
@@ -439,26 +459,46 @@ private[scalactic] class AndBool(bool1: Bool, bool2: => Bool, val prettifier: Pr
  * @param bool1 the first <code>Bool</code>
  * @param bool2 the second <code>Bool</code>
  */
-private[scalactic] class OrBool(bool1: Bool, bool2: => Bool, val prettifier: Prettifier) extends Bool {
+private[scalactic] class OrBool(bool1: Bool, bool2: => Bool, shortCircuit: Boolean, val prettifier: Prettifier) extends Bool {
 
   /**
    * the result of <code>bool1.value</code> logical <code>OR</code> <code>bool2.value</code>
    */
-  lazy val value: Boolean = bool1.value || bool2.value
+  lazy val value: Boolean = 
+    if (shortCircuit)
+      bool1.value || bool2.value
+    else
+      bool1.value | bool2.value  
 
   /**
    * raw message to report a failure
    *
    * @return Localized raw string for "{0}, and {1}"
    */
-  def rawFailureMessage: String = Resources.rawCommaAnd
+  def rawFailureMessage: String = 
+    if (shortCircuit && bool1.value) 
+      bool1.rawFailureMessage
+    else {
+      if (bool1.value == bool2.value)
+        Resources.rawCommaAnd
+      else
+        Resources.rawCommaBut
+    }
 
   /**
    * raw message with a meaning opposite to that of the failure message
    *
    * @return Localized raw string for "{0}, and {1}"
    */
-  def rawNegatedFailureMessage: String = if (bool1.value) bool1.rawNegatedFailureMessage else Resources.rawCommaBut
+  def rawNegatedFailureMessage: String = 
+    if (shortCircuit && bool1.value) 
+      bool1.rawNegatedFailureMessage 
+    else { 
+      if (bool1.value == bool2.value)
+        Resources.rawCommaAnd
+      else
+        Resources.rawCommaBut
+    }
 
   /**
    * raw mid sentence message to report a failure
@@ -479,14 +519,25 @@ private[scalactic] class OrBool(bool1: Bool, bool2: => Bool, val prettifier: Pre
    *
    * @return <code>Vector</code> that contains <code>bool1.failureMessage</code> and <code>bool2.midSentenceFailureMessage</code>
    */
-  def failureMessageArgs = Vector(UnquotedString(bool1.failureMessage), UnquotedString(bool2.midSentenceFailureMessage))
+  def failureMessageArgs = 
+    Vector(
+      if (bool1.value) UnquotedString(bool1.negatedFailureMessage) else UnquotedString(bool1.failureMessage), 
+      if (bool2.value) UnquotedString(bool2.midSentenceNegatedFailureMessage) else UnquotedString(bool2.midSentenceFailureMessage)
+    )
 
   /**
    * Arguments to construct final negated failure message with raw message returned from <code>rawNegatedFailureMessage</code>.
    *
    * @return <code>Vector</code> that contains <code>bool1.failureMessage</code> and <code>bool2.midSentenceNegatedFailureMessage</code>
    */
-  def negatedFailureMessageArgs = if (bool1.value) bool1.negatedFailureMessageArgs else Vector(UnquotedString(bool1.failureMessage), UnquotedString(bool2.midSentenceNegatedFailureMessage))
+  def negatedFailureMessageArgs = 
+    if (shortCircuit && bool1.value) 
+      bool1.negatedFailureMessageArgs 
+    else 
+      Vector(
+        if (bool1.value) UnquotedString(bool1.negatedFailureMessage) else UnquotedString(bool1.failureMessage), 
+        if (bool2.value) UnquotedString(bool2.midSentenceNegatedFailureMessage) else UnquotedString(bool2.midSentenceFailureMessage)
+      )
 
   /**
    * Arguments to construct final mid sentence failure message with raw message returned from <code>rawMidSentenceFailureMessage</code>.
@@ -715,7 +766,7 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
         }
       case "eq" => Resources.rawWasNotTheSameInstanceAs
       case "ne" => Resources.rawWasTheSameInstanceAs
-      case "&&" | "&" =>
+      case "&&" =>
         (left, right) match {
           case (leftBool: Bool, rightBool: Bool) =>
             if (leftBool.value)
@@ -727,6 +778,18 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
               Resources.rawCommaBut
             else
               leftBool.rawFailureMessage
+          case _ =>
+            Resources.rawCommaBut
+        }
+      case "&" => 
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) =>
+            if (leftBool.value == rightBool.value)
+              Resources.rawCommaAnd
+            else
+              Resources.rawCommaBut
+          case (leftBool: Bool, rightAny: Any) =>
+            Resources.rawCommaBut
           case _ =>
             Resources.rawCommaBut
         }
@@ -761,7 +824,7 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
       case "eq" => Resources.rawWasTheSameInstanceAs
       case "ne" => Resources.rawWasNotTheSameInstanceAs
       case "&&" | "&" => Resources.rawCommaAnd
-      case "||" | "|" => 
+      case "||" => 
         left match {
           case leftBool: Bool => 
             if (leftBool.value)
@@ -769,6 +832,14 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
             else
               Resources.rawCommaBut
         }
+      case "|" =>
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) => 
+            if (leftBool.value == rightBool.value)
+              Resources.rawCommaAnd
+            else
+              Resources.rawCommaBut
+        }  
       case _ => Resources.rawExpressionWasTrue
     }
 
@@ -800,7 +871,7 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
         Vector(leftee, rightee)
       case "startsWith" | "endsWith" | "contains" | "eq" | "ne" =>
         Vector(left, right)
-      case "&&" | "&" =>
+      case "&&" =>
         (left, right) match {
           case (leftBool: Bool, rightBool: Bool) =>
             if (leftBool.value)
@@ -817,6 +888,28 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
           case _ =>
             Vector(left, right)
         }
+
+      case "&" => 
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) =>
+            Vector(
+              if (leftBool.value) UnquotedString(leftBool.negatedFailureMessage) else UnquotedString(leftBool.failureMessage), 
+              if (rightBool.value) UnquotedString(rightBool.negatedFailureMessage) else UnquotedString(rightBool.failureMessage)
+            )
+          case (leftBool: Bool, rightAny: Any) =>
+            Vector(
+              if (leftBool.value) UnquotedString(leftBool.negatedFailureMessage) else UnquotedString(leftBool.failureMessage), 
+              rightAny
+            )
+          case (leftAny: Any, rightBool: Bool) =>
+            Vector(
+              leftAny, 
+              if (rightBool.value) UnquotedString(rightBool.negatedFailureMessage) else UnquotedString(rightBool.failureMessage)
+            )
+          case _ =>
+            Vector(left, right)
+        }
+
       case "||" | "|" =>
         (left, right) match {
           case (leftBool: Bool, rightBool: Bool) =>
@@ -859,7 +952,8 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
           case _ =>
             Vector(left, right)
         }
-      case "||" | "|" =>
+        
+      case "||" =>
         (left, right) match {
           case (leftBool: Bool, rightBool: Bool) =>
             if (leftBool.value)
@@ -879,6 +973,22 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
           case _ =>
             Vector(left, right)
         }
+
+      case "|" =>
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) =>
+            Vector(
+              UnquotedString(if (leftBool.value) leftBool.negatedFailureMessage else leftBool.failureMessage),
+              UnquotedString(if (rightBool.value) rightBool.midSentenceNegatedFailureMessage else rightBool.midSentenceFailureMessage)
+            )
+          case (leftBool: Bool, rightAny: Any) =>
+            Vector(UnquotedString(if (leftBool.value) leftBool.negatedFailureMessage else leftBool.failureMessage), rightAny)
+          case (leftAny: Any, rightBool: Bool) =>
+            Vector(leftAny, UnquotedString(if (rightBool.value) rightBool.midSentenceNegatedFailureMessage else rightBool.midSentenceFailureMessage))
+          case _ =>
+            Vector(left, right)
+        }
+
       case _ => Vector.empty
     }
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
@@ -793,7 +793,28 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
           case _ =>
             Resources.rawCommaBut
         }
-      case "||" | "|" => Resources.rawCommaAnd
+      case "||"=> 
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) =>
+            if (leftBool.value)
+              leftBool.rawNegatedFailureMessage
+            else
+              if (leftBool.value == rightBool.value) Resources.rawCommaAnd else Resources.rawCommaBut
+          case (leftBool: Bool, rightAny: Any) =>
+            if (leftBool.value)
+              leftBool.rawNegatedFailureMessage
+            else
+              Resources.rawCommaBut
+          case _ =>
+            Resources.rawCommaBut
+        }
+      case "|" => 
+        (left, right) match {
+          case (leftBool: Bool, rightBool: Bool) =>
+            if (leftBool.value == rightBool.value) Resources.rawCommaAnd else Resources.rawCommaBut
+          case _ =>
+            Resources.rawCommaBut
+        }
       case _ => Resources.rawExpressionWasFalse
     }
   }
@@ -942,13 +963,13 @@ private[scalactic] class BinaryMacroBool(left: Any, operator: String, right: Any
         (left, right) match {
           case (leftBool: Bool, rightBool: Bool) =>
             Vector(
-              UnquotedString(if (leftBool.value) leftBool.negatedFailureMessage else leftBool.failureMessage),
-              UnquotedString(if (rightBool.value) rightBool.midSentenceNegatedFailureMessage else rightBool.midSentenceFailureMessage)
+              UnquotedString(leftBool.negatedFailureMessage),
+              UnquotedString(rightBool.midSentenceNegatedFailureMessage)
             )
           case (leftBool: Bool, rightAny: Any) =>
-            Vector(UnquotedString(if (leftBool.value) leftBool.negatedFailureMessage else leftBool.failureMessage), rightAny)
+            Vector(UnquotedString(leftBool.negatedFailureMessage), rightAny)
           case (leftAny: Any, rightBool: Bool) =>
-            Vector(leftAny, UnquotedString(if (rightBool.value) rightBool.midSentenceNegatedFailureMessage else rightBool.negatedFailureMessage))
+            Vector(leftAny, UnquotedString(rightBool.midSentenceNegatedFailureMessage))
           case _ =>
             Vector(left, right)
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -761,7 +761,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 2 & b == 5)
       }
-      assert(e.message === Some(didNotEqual(3, 2)))
+      assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5))))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -770,7 +770,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 2 & b == 6)
       }
-      assert(e.message === Some(didNotEqual(3, 2)))
+      assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6))))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -873,12 +873,12 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestFailedException] {
         assert(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -887,10 +887,10 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       assert(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -2247,7 +2247,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 2 & b == 5, ", dude")
       }
-      assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -2256,7 +2256,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         assert(a == 2 & b == 6, ", dude")
       }
-      assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -2359,12 +2359,12 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestFailedException] {
         assert(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -2373,10 +2373,10 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       assert(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -3724,7 +3724,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 2 & b == 5)
       }
-      assert(e.message === Some(didNotEqual(3, 2)))
+      assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5))))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -3733,7 +3733,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 2 & b == 6)
       }
-      assert(e.message === Some(didNotEqual(3, 2)))
+      assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6))))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -3836,12 +3836,12 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestCanceledException] {
         assume(a == 5 & s.changeState)
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -3850,10 +3850,10 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       assume(a == 3 | s.changeState)
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -5207,7 +5207,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 2 & b == 5, ", dude")
       }
-      assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -5216,7 +5216,7 @@ class AssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         assume(a == 2 & b == 6, ", dude")
       }
-      assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude"))
       assert(e.failedCodeFileName === (Some(fileName)))
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -5319,12 +5319,12 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestCanceledException] {
         assume(a == 5 & s.changeState, ", dude")
       }
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -5333,10 +5333,10 @@ class AssertionsSpec extends AnyFunSpec {
       assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       assume(a == 3 | s.changeState, ", dude")
-      assert(s.state == false)
+      assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
@@ -730,7 +730,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 2 & b == 5)
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2)))
+      org.scalatest.Assertions.assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5))))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -739,7 +739,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 2 & b == 6)
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2)))
+      org.scalatest.Assertions.assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6))))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -842,12 +842,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 5 & s.changeState)
       }
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -856,10 +856,10 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalatest.Assertions.assert(a == 3 | s.changeState)
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -2179,7 +2179,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 2 & b == 5, ", dude")
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      org.scalatest.Assertions.assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude"))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -2188,7 +2188,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 2 & b == 6, ", dude")
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      org.scalatest.Assertions.assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude"))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -2291,12 +2291,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestFailedException] {
         org.scalatest.Assertions.assert(a == 5 & s.changeState, ", dude")
       }
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -2305,10 +2305,10 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalatest.Assertions.assert(a == 3 | s.changeState, ", dude")
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -3621,7 +3621,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 2 & b == 5)
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2)))
+      org.scalatest.Assertions.assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5))))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -3630,7 +3630,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 2 & b == 6)
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2)))
+      org.scalatest.Assertions.assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6))))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -3733,12 +3733,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 5 & s.changeState)
       }
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -3747,10 +3747,10 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalatest.Assertions.assume(a == 3 | s.changeState)
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {
@@ -5070,7 +5070,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 2 & b == 5, ", dude")
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      org.scalatest.Assertions.assert(e.message === Some(commaBut(didNotEqual(3, 2), equaled(5, 5)) + ", dude"))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -5079,7 +5079,7 @@ class DirectAssertionsSpec extends AnyFunSpec {
       val e = intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 2 & b == 6, ", dude")
       }
-      org.scalatest.Assertions.assert(e.message === Some(didNotEqual(3, 2) + ", dude"))
+      org.scalatest.Assertions.assert(e.message === Some(commaAnd(didNotEqual(3, 2), didNotEqual(5, 6)) + ", dude"))
       org.scalatest.Assertions.assert(e.failedCodeFileName === (Some(fileName)))
       org.scalatest.Assertions.assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
@@ -5182,12 +5182,12 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit & when first condition was false") {
+    it("should not short-circuit & when first condition was false") {
       val s = new Stateful
       intercept[TestCanceledException] {
         org.scalatest.Assertions.assume(a == 5 & s.changeState, ", dude")
       }
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should short-circuit || when first condition was true") {
@@ -5196,10 +5196,10 @@ class DirectAssertionsSpec extends AnyFunSpec {
       org.scalatest.Assertions.assert(s.state == false)
     }
 
-    it("should short-circuit | when first condition was true") {
+    it("should not short-circuit | when first condition was true") {
       val s = new Stateful
       org.scalatest.Assertions.assume(a == 3 | s.changeState, ", dude")
-      org.scalatest.Assertions.assert(s.state == false)
+      org.scalatest.Assertions.assert(s.state == true)
     }
 
     it("should do nothing when it is used to check a == 3 && { println(\"hi\"); b == 5}") {


### PR DESCRIPTION
Fixed inconsistency behavior for & and |, where both of them should not short-circuit, to be consistent with Scala's & and | behavior.