### PR TITLE
Macrotask Executor

### DIFF
--- a/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -33,7 +33,6 @@ import scala.concurrent.Promise
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.util.Success
-import scala.scalajs.concurrent.JSExecutionContext
 
 import scala.compat.Platform
 import scala.concurrent.duration.Duration
@@ -61,10 +60,9 @@ final class TaskRunner(task: TaskDef,
   def taskDef(): TaskDef = task
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: (Array[Task]) => Unit): Unit = {
-    implicit val execCtx = JSExecutionContext.queue
+    import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
     val future = executionFuture(eventHandler, loggers)
     future.recover { case t =>
-println("GOT TO THIS RECOVER CALL")
       loggers.foreach(_.trace(t))
     }.onComplete{ _ =>
       continuation(Array.empty)

--- a/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
@@ -213,12 +213,13 @@ import enablers.Futuristic
  */
 trait AsyncTestSuite extends Suite with RecoverMethods with CompleteLastly { thisAsyncTestSuite =>
 
+  private final val serialExecutionContext: ExecutionContext = new concurrent.SerialExecutionContext
+
   /**
    * An implicit execution context used by async styles to transform <code>Future[Assertion]</code> values
    * returned by tests into <code>FutureOutcome</code> values, and can be used within the async tests themselves,
    * for example, when mapping assertions onto futures.
    */
-  private final val serialExecutionContext: ExecutionContext = new concurrent.SerialExecutionContext
   implicit def executionContext: ExecutionContext = serialExecutionContext
 
   private def anAsyncExceptionThatShouldCauseAnAbort(ex: Throwable): Boolean =

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
@@ -1048,11 +1048,27 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
+
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -1081,6 +1097,7 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
@@ -1049,26 +1049,26 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
 
     it("should allow other execution context to be used") {
 
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
 
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -1097,7 +1097,7 @@ class AsyncFeatureSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.Succeeded
 
 class FixtureAsyncFeatureSpecLikeSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpecLike") {
 
     // ParallelTestExecution not working yet.
@@ -859,7 +861,7 @@ class FixtureAsyncFeatureSpecLikeSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
@@ -877,11 +877,25 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -910,6 +924,7 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
   }
 }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
@@ -877,25 +877,25 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -924,7 +924,7 @@ class FixtureAsyncFeatureSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
   }
 }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.Succeeded
 
 class FixtureAsyncFeatureSpecSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpec") {
 
     // ParallelTestExecution not working yet.
@@ -856,7 +858,7 @@ class FixtureAsyncFeatureSpecSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -958,25 +958,25 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1010,7 +1010,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -958,11 +958,25 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -996,6 +1010,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -26,6 +26,8 @@ import org.scalatest
 
 class DeprecatedAsyncFeatureSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -945,7 +947,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
@@ -958,25 +958,25 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1010,7 +1010,7 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
@@ -958,11 +958,25 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -996,6 +1010,7 @@ class DeprecatedAsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -952,7 +952,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        // SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
@@ -958,25 +958,25 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1010,7 +1010,7 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
@@ -958,11 +958,25 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -996,6 +1010,7 @@ class FixtureAsyncFeatureSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.featurespec
 
 class AsyncFeatureSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -946,7 +948,7 @@ class AsyncFeatureSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
@@ -958,11 +958,25 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -996,6 +1010,7 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
@@ -958,25 +958,25 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends featurespec.FixtureAsyncFeatureSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1010,7 +1010,7 @@ class AsyncFeatureSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.featurespec
 
 class AsyncFeatureSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -952,7 +954,7 @@ class AsyncFeatureSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
@@ -767,11 +767,25 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFlatSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should "test A" in {
           Future { assert(a == 1) }
@@ -794,6 +808,7 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
@@ -767,25 +767,25 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFlatSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should "test A" in {
           Future { assert(a == 1) }
@@ -808,7 +808,7 @@ class AsyncFlatSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.Succeeded
 
 class AsyncFlatSpecLikeSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFlatSpecLike") {
 
     // ParallelTestExecution not working yet.
@@ -739,7 +741,7 @@ class AsyncFlatSpecLikeSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         "feature 1" should "test A" in {
           Future { assert(a == 1) }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
@@ -780,25 +780,25 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFlatSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should "test A" in {
           Future { assert(a == 1) }
@@ -821,7 +821,7 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
@@ -780,11 +780,25 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFlatSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should "test A" in {
           Future { assert(a == 1) }
@@ -807,6 +821,7 @@ class AsyncFlatSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
@@ -814,11 +814,25 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
      }
 
      it("should allow other execution context to be used") {
+       //SCALATESTJS-ONLY var changeMe = false
+
+       //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+       //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+       //SCALATESTJS-ONLY     changeMe = true
+       //SCALATESTJS-ONLY     try {
+       //SCALATESTJS-ONLY       runnable.run()
+       //SCALATESTJS-ONLY     } catch {
+       //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+       //SCALATESTJS-ONLY     }
+       //SCALATESTJS-ONLY   }
+       //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+       //SCALATESTJS-ONLY     t.printStackTrace()
+       //SCALATESTJS-ONLY }
        class TestSpec extends flatspec.FixtureAsyncFlatSpecLike {
          // SKIP-SCALATESTJS,NATIVE-START
-         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
          // SKIP-SCALATESTJS,NATIVE-END
-         // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+         //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -846,6 +860,7 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        assert(reporter.scopeClosedEventsReceived.length == 3)
        assert(reporter.testStartingEventsReceived.length == 3)
        assert(reporter.testSucceededEventsReceived.length == 3)
+       //SCALATESTJS-ONLY assert(changeMe)
      }
 
    }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
@@ -814,25 +814,25 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
      }
 
      it("should allow other execution context to be used") {
-       //SCALATESTJS-ONLY var changeMe = false
+       //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-       //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-       //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-       //SCALATESTJS-ONLY     changeMe = true
-       //SCALATESTJS-ONLY     try {
-       //SCALATESTJS-ONLY       runnable.run()
-       //SCALATESTJS-ONLY     } catch {
-       //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-       //SCALATESTJS-ONLY     }
-       //SCALATESTJS-ONLY   }
-       //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-       //SCALATESTJS-ONLY     t.printStackTrace()
-       //SCALATESTJS-ONLY }
+       //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+       //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+       //SCALATESTJS,NATIVE-ONLY     changeMe = true
+       //SCALATESTJS,NATIVE-ONLY     try {
+       //SCALATESTJS,NATIVE-ONLY       runnable.run()
+       //SCALATESTJS,NATIVE-ONLY     } catch {
+       //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+       //SCALATESTJS,NATIVE-ONLY     }
+       //SCALATESTJS,NATIVE-ONLY   }
+       //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+       //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+       //SCALATESTJS,NATIVE-ONLY }
        class TestSpec extends flatspec.FixtureAsyncFlatSpecLike {
          // SKIP-SCALATESTJS,NATIVE-START
          override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
          // SKIP-SCALATESTJS,NATIVE-END
-         //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+         //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
          type FixtureParam = String
          def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -860,7 +860,7 @@ class FixtureAsyncFlatSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
        assert(reporter.scopeClosedEventsReceived.length == 3)
        assert(reporter.testStartingEventsReceived.length == 3)
        assert(reporter.testSucceededEventsReceived.length == 3)
-       //SCALATESTJS-ONLY assert(changeMe)
+       //SCALATESTJS,NATIVE-ONLY assert(changeMe)
      }
 
    }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.flatspec
 
 class FixtureAsyncFlatSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFlatSpecLike") {
 
     // ParallelTestExecution not working yet.
@@ -805,7 +807,7 @@ class FixtureAsyncFlatSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
@@ -833,25 +833,25 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends flatspec.FixtureAsyncFlatSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -879,7 +879,7 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
@@ -833,11 +833,25 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends flatspec.FixtureAsyncFlatSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -865,6 +879,7 @@ class FixtureAsyncFlatSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.flatspec
 
 class FixtureAsyncFlatSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFlatSpec") {
 
     // ParallelTestExecution not working yet.
@@ -805,7 +807,7 @@ class FixtureAsyncFlatSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
@@ -911,11 +911,25 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFreeSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" - {
           "scenario A" in {
@@ -944,6 +958,7 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
@@ -911,25 +911,25 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFreeSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" - {
           "scenario A" in {
@@ -958,7 +958,7 @@ class AsyncFreeSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.freespec.AsyncFreeSpecLike
 
 class AsyncFreeSpecLikeSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -854,7 +856,7 @@ class AsyncFreeSpecLikeSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         "feature 1" - {
           "scenario A" in {

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
@@ -910,25 +910,25 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFreeSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" - {
           "scenario A" in {
@@ -957,7 +957,7 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
@@ -910,11 +910,25 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFreeSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" - {
           "scenario A" in {
@@ -943,6 +957,7 @@ class AsyncFreeSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.freespec.AsyncFreeSpec
 
 class AsyncFreeSpecSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -852,7 +854,7 @@ class AsyncFreeSpecSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         "feature 1" - {
           "scenario A" in {

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
@@ -968,11 +968,25 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends freespec.FixtureAsyncFreeSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
@@ -1005,6 +1019,7 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
@@ -968,25 +968,25 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends freespec.FixtureAsyncFreeSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
@@ -1019,7 +1019,7 @@ class FixtureAsyncFreeSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.freespec
 
 class FixtureAsyncFreeSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFreeSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncFreeSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
@@ -971,11 +971,25 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends freespec.FixtureAsyncFreeSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
@@ -1008,6 +1022,7 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
@@ -971,25 +971,25 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends freespec.FixtureAsyncFreeSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")
@@ -1022,7 +1022,7 @@ class FixtureAsyncFreeSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.freespec
 
 class FixtureAsyncFreeSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFreeSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncFreeSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = test("testing")

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
@@ -850,11 +850,25 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFunSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         describe("feature 1") {
           it("test A") {
@@ -883,6 +897,7 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
@@ -850,25 +850,25 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFunSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         describe("feature 1") {
           it("test A") {
@@ -897,7 +897,7 @@ class AsyncFunSpecLikeSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec2.scala
@@ -29,6 +29,8 @@ import scala.util.Success
 import org.scalatest.funspec.AsyncFunSpecLike
 
 class AsyncFunSpecLikeSpec2 extends funspec.AsyncFunSpec {
+  
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
   describe("AsyncFunSpecLike") {
 
@@ -853,7 +855,7 @@ class AsyncFunSpecLikeSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         describe("feature 1") {
           it("test A") {

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
@@ -912,25 +912,25 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         describe("feature 1") {
           it("test A") {
@@ -959,7 +959,7 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
@@ -912,11 +912,25 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         describe("feature 1") {
           it("test A") {
@@ -945,6 +959,7 @@ class AsyncFunSpecSpec extends funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec2.scala
@@ -30,6 +30,8 @@ import org.scalatest.funspec.{ AsyncFunSpec, AsyncFunSpecLike }
 
 class AsyncFunSpecSpec2 extends funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return a Future under parallel async test execution") {
@@ -886,7 +888,7 @@ class AsyncFunSpecSpec2 extends funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         describe("feature 1") {
           it("test A") {

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
@@ -944,11 +944,25 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends funspec.FixtureAsyncFunSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -982,6 +996,7 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
@@ -944,25 +944,25 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends funspec.FixtureAsyncFunSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -996,7 +996,7 @@ class FixtureAsyncFunSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.funspec
 
 class FixtureAsyncFunSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncFunSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
@@ -971,11 +971,25 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS-ONLY var changeMe = false
+
+      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS-ONLY     changeMe = true
+      //SCALATESTJS-ONLY     try {
+      //SCALATESTJS-ONLY       runnable.run()
+      //SCALATESTJS-ONLY     } catch {
+      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS-ONLY     }
+      //SCALATESTJS-ONLY   }
+      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS-ONLY     t.printStackTrace()
+      //SCALATESTJS-ONLY }
       class TestSpec extends funspec.FixtureAsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1009,6 +1023,7 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
@@ -971,25 +971,25 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
-      //SCALATESTJS-ONLY var changeMe = false
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
 
-      //SCALATESTJS-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
-      //SCALATESTJS-ONLY   override def execute(runnable: Runnable): Unit = {
-      //SCALATESTJS-ONLY     changeMe = true
-      //SCALATESTJS-ONLY     try {
-      //SCALATESTJS-ONLY       runnable.run()
-      //SCALATESTJS-ONLY     } catch {
-      //SCALATESTJS-ONLY       case t: Throwable => reportFailure(t)
-      //SCALATESTJS-ONLY     }
-      //SCALATESTJS-ONLY   }
-      //SCALATESTJS-ONLY   def reportFailure(t: Throwable): Unit =
-      //SCALATESTJS-ONLY     t.printStackTrace()
-      //SCALATESTJS-ONLY }
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends funspec.FixtureAsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -1023,7 +1023,7 @@ class FixtureAsyncFunSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
-      //SCALATESTJS-ONLY assert(changeMe)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.funspec
 
 class FixtureAsyncFunSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncFunSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec.scala
@@ -728,11 +728,25 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFunSuiteLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         test("test A") {
           Future { assert(a == 1) }
@@ -753,6 +767,7 @@ class AsyncFunSuiteLikeSpec extends AnyFunSpec {
       // SKIP-SCALATESTJS,NATIVE-END
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.funsuite.AsyncFunSuiteLike
 
 class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -733,7 +735,7 @@ class AsyncFunSuiteLikeSpec2 extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         test("test A") {
           Future { assert(a == 1) }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec.scala
@@ -756,11 +756,25 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFunSuite {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         test("test A") {
           Future { assert(a == 1) }
@@ -781,6 +795,7 @@ class AsyncFunSuiteSpec extends AnyFunSpec {
       // SKIP-SCALATESTJS,NATIVE-END
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.funsuite.AsyncFunSuite
 
 class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   override def newInstance = new AsyncFunSuiteSpec2
 
   describe("AsyncFunSuite") {
@@ -735,7 +737,7 @@ class AsyncFunSuiteSpec2 extends AsyncFunSpec with ParallelTestExecution {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         test("test A") {
           Future { assert(a == 1) }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec.scala
@@ -812,11 +812,25 @@ class FixtureAsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends funsuite.FixtureAsyncFunSuiteLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -842,6 +856,7 @@ class FixtureAsyncFunSuiteLikeSpec extends scalatest.funspec.AnyFunSpec {
       // SKIP-SCALATESTJS,NATIVE-END
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.funsuite
 
 class FixtureAsyncFunSuiteLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSuiteLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -792,7 +794,7 @@ class FixtureAsyncFunSuiteLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec.scala
@@ -843,11 +843,25 @@ class FixtureAsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends funsuite.FixtureAsyncFunSuite {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -873,6 +887,7 @@ class FixtureAsyncFunSuiteSpec extends scalatest.funspec.AnyFunSpec {
       // SKIP-SCALATESTJS,NATIVE-END
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec2.scala
@@ -26,6 +26,8 @@ import org.scalatest
 
 class FixtureAsyncFunSuiteSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFunSuite") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -797,7 +799,7 @@ class FixtureAsyncFunSuiteSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome =

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -1041,11 +1041,25 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -1074,6 +1088,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec extends AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -26,6 +26,8 @@ import org.scalatest.funspec.AsyncFunSpec
 
 class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -854,7 +856,7 @@ class DeprecatedAsyncFeatureSpecLikeSpec2 extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
@@ -870,11 +870,25 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncFeatureSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {
@@ -903,6 +917,7 @@ class DeprecatedAsyncFeatureSpecSpec extends AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -26,6 +26,8 @@ import org.scalatest.funspec.AsyncFunSpec
 
 class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncFeatureSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -851,7 +853,7 @@ class DeprecatedAsyncFeatureSpecSpec2 extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         Feature("feature 1") {
           Scenario("scenario A") {

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec.scala
@@ -1107,11 +1107,25 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncWordSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should {
           "test A" in {
@@ -1140,15 +1154,16 @@ class AsyncWordSpecLikeSpec extends AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      
     }
 
     it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
       class TestSpec extends AsyncWordSpecLike {
 
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         import org.scalatest.prop.TableDrivenPropertyChecks._
         "trying something" should {

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.wordspec.AsyncWordSpecLike
 
 class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -850,7 +852,7 @@ class AsyncWordSpecLikeSpec2 extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         "feature 1" should {
           "test A" in {

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
@@ -1106,11 +1106,25 @@ class AsyncWordSpecSpec extends AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends AsyncWordSpec {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
         val a = 1
         "feature 1" should {
           "test A" in {
@@ -1139,15 +1153,16 @@ class AsyncWordSpecSpec extends AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
     it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
       class TestSpec extends AsyncWordSpec {
 
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         import org.scalatest.prop.TableDrivenPropertyChecks._
         "trying something" should {

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.wordspec.AsyncWordSpec
 
 class AsyncWordSpecSpec2 extends AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -850,7 +852,7 @@ class AsyncWordSpecSpec2 extends AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
         val a = 1
         "feature 1" should {
           "test A" in {

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
@@ -1190,11 +1190,25 @@ class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends wordspec.FixtureAsyncWordSpecLike {
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
@@ -1227,15 +1241,16 @@ class FixtureAsyncWordSpecLikeSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
     it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
       class TestSpec extends wordspec.FixtureAsyncWordSpecLike {
 
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        // SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.wordspec
 
 class FixtureAsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncWordSpecLike") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncWordSpecLikeSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
@@ -1190,11 +1190,25 @@ class FixtureAsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
     }
 
     it("should allow other execution context to be used") {
+      //SCALATESTJS,NATIVE-ONLY var changeMe = false
+
+      //SCALATESTJS,NATIVE-ONLY object CustomTestExecutionContext extends scala.concurrent.ExecutionContextExecutor {
+      //SCALATESTJS,NATIVE-ONLY   override def execute(runnable: Runnable): Unit = {
+      //SCALATESTJS,NATIVE-ONLY     changeMe = true
+      //SCALATESTJS,NATIVE-ONLY     try {
+      //SCALATESTJS,NATIVE-ONLY       runnable.run()
+      //SCALATESTJS,NATIVE-ONLY     } catch {
+      //SCALATESTJS,NATIVE-ONLY       case t: Throwable => reportFailure(t)
+      //SCALATESTJS,NATIVE-ONLY     }
+      //SCALATESTJS,NATIVE-ONLY   }
+      //SCALATESTJS,NATIVE-ONLY   def reportFailure(t: Throwable): Unit =
+      //SCALATESTJS,NATIVE-ONLY     t.printStackTrace()
+      //SCALATESTJS,NATIVE-ONLY }
       class TestSpec extends wordspec.FixtureAsyncWordSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS,NATIVE-ONLY override implicit val executionContext: ExecutionContext = CustomTestExecutionContext
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }
@@ -1227,15 +1241,16 @@ class FixtureAsyncWordSpecSpec extends scalatest.funspec.AnyFunSpec {
       assert(reporter.scopeClosedEventsReceived.length == 3)
       assert(reporter.testStartingEventsReceived.length == 3)
       assert(reporter.testSucceededEventsReceived.length == 3)
+      //SCALATESTJS,NATIVE-ONLY assert(changeMe)
     }
 
     it("should throw DuplicateTestNameException when duplicate test name is detected inside in a forAll") {
       class TestSpec extends wordspec.FixtureAsyncWordSpec {
 
         // SKIP-SCALATESTJS,NATIVE-START
-        override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        // SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
@@ -27,6 +27,8 @@ import org.scalatest.wordspec
 
 class FixtureAsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
 
+  //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   describe("AsyncWordSpec") {
 
     it("can be used for tests that return Future under parallel async test execution") {
@@ -916,7 +918,7 @@ class FixtureAsyncWordSpecSpec2 extends scalatest.funspec.AsyncFunSpec {
         // SKIP-SCALATESTJS,NATIVE-START
         override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
         // SKIP-SCALATESTJS,NATIVE-END
-        // SCALATESTJS-ONLY override implicit val executionContext = scala.scalajs.concurrent.JSExecutionContext.runNow
+        //SCALATESTJS-ONLY override implicit val executionContext: ExecutionContext = org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
         type FixtureParam = String
         def withFixture(test: OneArgAsyncTest): FutureOutcome = { test("hi") }

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -7,6 +7,8 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion
 import scalanative.sbtplugin.ScalaNativePlugin
 import ScalaNativePlugin.autoImport.{nativeLinkStubs, nativeDump}
 
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+
 trait BuildCommons {
 
   def scalaVersionsSettings: Seq[Setting[_]] = Seq(
@@ -16,10 +18,13 @@ trait BuildCommons {
 
   val runFlickerTests = Option(System.getenv("SCALATEST_RUN_FLICKER_TESTS")).getOrElse("FALSE").toUpperCase == "TRUE"
 
-  def scalatestJSLibraryDependencies =
+  def scalatestJSLibraryDependencies = Def.setting {
     Seq(
-      ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
+      ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13), 
+      "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1"
     )
+  }    
+    
 
   val releaseVersion = "3.3.0-SNAP3"
   val previousReleaseVersion = "3.2.14"

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -291,7 +291,7 @@ trait DottyBuild { this: BuildCommons =>
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
       libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.1.0", 
-      libraryDependencies ++= scalatestJSLibraryDependencies, 
+      libraryDependencies ++= scalatestJSLibraryDependencies.value, 
       packageManagedSources,
       Compile / sourceGenerators += Def.task {
         GenModulesDotty.genScalaTestCoreJS((Compile / sourceManaged).value, version.value, scalaVersion.value) ++
@@ -889,7 +889,6 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "Common test classes used by scalactic and scalatest",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
-      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1", 
       Compile / sourceGenerators += Def.task {
         GenCommonTestDotty.genMainJS((Compile / sourceManaged).value / "scala", version.value, scalaVersion.value) ++ 
         GenCompatibleClasses.genTest((Compile / sourceManaged).value, version.value, scalaVersion.value)

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -889,6 +889,7 @@ trait DottyBuild { this: BuildCommons =>
     .settings(
       projectTitle := "Common test classes used by scalactic and scalatest",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
+      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1", 
       Compile / sourceGenerators += Def.task {
         GenCommonTestDotty.genMainJS((Compile / sourceManaged).value / "scala", version.value, scalaVersion.value) ++ 
         GenCompatibleClasses.genTest((Compile / sourceManaged).value, version.value, scalaVersion.value)

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -117,7 +117,7 @@ trait JsBuild { this: BuildCommons =>
       name := "scalatest-app",
       organization := "org.scalatest",
       moduleName := "scalatest-app",
-      libraryDependencies ++= scalatestJSLibraryDependencies,
+      libraryDependencies ++= scalatestJSLibraryDependencies.value,
       // include the scalactic classes and resources in the jar
       Compile / packageBin / mappings ++= (scalacticJS / Compile / packageBin / mappings).value,
       // include the scalactic sources in the source jar
@@ -210,7 +210,6 @@ trait JsBuild { this: BuildCommons =>
     .settings(
       projectTitle := "Common test classes used by scalactic.js and scalatest.js",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
-      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1", 
       Compile / sourceGenerators += {
         Def.task{
           GenCommonTestJS.genMain((Compile / sourceManaged).value, version.value, scalaVersion.value) ++
@@ -459,7 +458,7 @@ trait JsBuild { this: BuildCommons =>
                                       |import org.scalactic._
                                       |import Matchers._""".stripMargin,
       scalacOptions ++= Seq("-P:scalajs:mapSourceURI:" + rootProject.base.toURI + "->https://raw.githubusercontent.com/scalatest/scalatest/v" + version.value + "/"),
-      libraryDependencies ++= scalatestJSLibraryDependencies,
+      libraryDependencies ++= scalatestJSLibraryDependencies.value,
       //jsDependencies += RuntimeDOM % "test",
       Compile / sourceGenerators += {
         Def.task {

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -210,6 +210,7 @@ trait JsBuild { this: BuildCommons =>
     .settings(
       projectTitle := "Common test classes used by scalactic.js and scalatest.js",
       libraryDependencies ++= crossBuildTestLibraryDependencies.value,
+      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1", 
       Compile / sourceGenerators += {
         Def.task{
           GenCommonTestJS.genMain((Compile / sourceManaged).value, version.value, scalaVersion.value) ++


### PR DESCRIPTION
Changed TaskRunner and scala-js tests to use macrotask executor (https://github.com/scala-js/scala-js-macrotask-executor).