### PR TITLE
SBT 1.9.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.6


### PR DESCRIPTION
Updated to the latest SBT 1.9.6, this allow us to build with JDK 21, though when running tests ConductorSuite seems to hang, while building with JDK8 still works, we'll look into the hang problem on JDK 21 separately.