### PR TITLE
Conductors Adjustment

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Conductors.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Conductors.scala
@@ -1048,10 +1048,17 @@ trait Conductors extends PatienceConfiguration {
         // TIMED_WAITING. (BLOCKED is waiting for a lock. WAITING is in the wait set.)
         while (threadGroup.areAnyThreadsAlive) {
           if (!firstExceptionThrown.isEmpty) {
-            // If any exception has been thrown, stop any live test thread.
+            // If any exception has been thrown, stop or interrupt any live test thread.
             threadGroup.getThreads.foreach { t =>
-              if (t.isAlive)
-                t.stop()
+              if (t.isAlive) { 
+                try{
+                  t.stop()
+                }
+                catch {
+                  case _: UnsupportedOperationException => t.interrupt()
+                }
+                
+              }
             }
           }
           // If any threads are in the RUNNABLE state, just check to see if there's been

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
@@ -267,6 +267,9 @@ class ConductorSuite extends AnyFunSuite with Matchers with Conductors with Seve
         case t: ThreadDeath =>
           threadWasKilled.set(true)
           throw t
+        case t: InterruptedException =>
+          threadWasKilled.set(true)
+          throw t  
       }
     }
     thread {


### PR DESCRIPTION
Try to catch UnsupportedOperationException when calling Thread's stop, and try to call method interrupt when that happens as next attempt to stop the running thread.  This unblocks the ConductorSuite when runs using JDK 21.