### PR TITLE
Provide information to `Suite` about other discovered Suites

### DIFF
--- a/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest.tools
 
-import org.scalatest.Tracker
+import org.scalatest.{RunningSuite, Tracker}
 import org.scalatest.events.Summary
 import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => SbtStatus, _}
 
@@ -164,11 +164,18 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
         paths.exists(path => td.fullyQualifiedName.startsWith(path) && td.fullyQualifiedName.substring(path.length).lastIndexOf('.') <= 0)
       }
 
-    def createTask(t: TaskDef): Task =
-      new TaskRunner(t, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+    def createTask(allRunningSuites: () => List[RunningSuite], t: TaskDef): TaskRunner =
+      new TaskRunner(t, allRunningSuites, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
         presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
 
-    (if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct).map(createTask)
+    val chosenTaskDefs = if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
+
+    lazy val taskRunners: Array[TaskRunner] = {
+      val allRunningSuites = () => taskRunners.map(_.runningSuite).toList
+      chosenTaskDefs.map(createTask(allRunningSuites, _))
+    }
+
+    taskRunners.toArray[Task]
   }
 
   private def send(msg: String): Unit = {
@@ -204,8 +211,9 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
 
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
     val taskDef = deserializer(task)
-    new TaskRunner(taskDef, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+    lazy val taskRunner: TaskRunner = new TaskRunner(taskDef, () => List(taskRunner.runningSuite), testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
       presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
+    taskRunner
   }
 
 }

--- a/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest.tools
 
-import org.scalatest.{Resources, Tracker}
+import org.scalatest.{Resources, RunningSuite, Tracker}
 import org.scalatest.events.Summary
 import sbt.testing.{Framework => BaseFramework, Event => SbtEvent, Status => SbtStatus, _}
 import ArgsParser._
@@ -132,11 +132,18 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
         paths.exists(path => td.fullyQualifiedName.startsWith(path) && td.fullyQualifiedName.substring(path.length).lastIndexOf('.') <= 0)
       }
 
-    def createTask(t: TaskDef): Task =
-      new TaskRunner(t, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+    def createTask(allRunningSuites: () => List[RunningSuite], t: TaskDef): TaskRunner =
+      new TaskRunner(t, allRunningSuites, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
         presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(notifyServer))
 
-    (if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct).map(createTask)
+    val chosenTaskDefs = if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
+
+    lazy val taskRunners: Array[TaskRunner] = {
+      val allRunningSuites = () => taskRunners.map(_.runningSuite).toList
+      chosenTaskDefs.map(createTask(allRunningSuites, _))
+    }
+
+    taskRunners.toArray[Task]
   }
 
   def receiveMessage(msg: String): Option[String] =
@@ -147,8 +154,9 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
 
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
     val taskDef = deserializer(task)
-    new TaskRunner(taskDef, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+    lazy val taskRunner: TaskRunner = new TaskRunner(taskDef, () => List(taskRunner.runningSuite), testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
       presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(notifyServer))
+    taskRunner
   }
 
 }

--- a/js/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
@@ -4,8 +4,8 @@ import org.scalatest.{RunningSuite, Suite}
 import scala.scalajs.reflect.Reflect
 
 private[tools] object SuiteInstantiationHelper {
-  def createRunningSuite(className: String): RunningSuite = {
+  def createRunningSuite(className: String, isMaster: Boolean): RunningSuite = {
     lazy val suite: Suite = Reflect.lookupInstantiatableClass(className).getOrElse(throw new RuntimeException("Cannot load suite class: " + className)).newInstance().asInstanceOf[Suite]
-    RunningSuite(className, () => suite)
+    RunningSuite(className, () => suite, isMaster)
   }
 }

--- a/js/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
@@ -1,0 +1,11 @@
+package org.scalatest.tools
+
+import org.scalatest.{RunningSuite, Suite}
+import scala.scalajs.reflect.Reflect
+
+private[tools] object SuiteInstantiationHelper {
+  def createRunningSuite(className: String): RunningSuite = {
+    lazy val suite: Suite = Reflect.lookupInstantiatableClass(className).getOrElse(throw new RuntimeException("Cannot load suite class: " + className)).newInstance().asInstanceOf[Suite]
+    RunningSuite(className, () => suite)
+  }
+}

--- a/jvm/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
@@ -263,7 +263,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
 
   def getIndexesForTestInformerEventOrderTests(suite: Suite, testName: String, infoMsg: String): (Int, Int) = {
     val myRep = new EventRecordingReporter
-    suite.run(None, Args(myRep))
+    suite.run(None, Args(myRep, runningSuites = List.empty))
 
     val indexedList = myRep.eventsReceived.zipWithIndex
 
@@ -293,7 +293,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
   def getIndexesForInformerEventOrderTests(suite: Suite, testName: String, infoMsg: String): (Int, Int, Int) = {
 
     val myRep = new EventRecordingReporter
-    suite.run(None, Args(myRep))
+    suite.run(None, Args(myRep, runningSuites = List.empty))
 
     val indexedList = myRep.eventsReceived.zipWithIndex
 
@@ -326,7 +326,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
   def getIndentedTextFromInfoProvided(suite: Suite): IndentedText = {
 
     val myRep = new EventRecordingReporter
-    suite.run(None, Args(myRep))
+    suite.run(None, Args(myRep, runningSuites = List.empty))
 
     val infoProvidedOption = myRep.eventsReceived.find(_.isInstanceOf[InfoProvided])
 
@@ -342,7 +342,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
 
   def getIndentedTextFromTestInfoProvided(suite: Suite): IndentedText = {
     val myRep = new EventRecordingReporter
-    suite.run(None, Args(myRep))
+    suite.run(None, Args(myRep, runningSuites = List.empty))
     val recordedEvents: Seq[Event] = myRep.eventsReceived.find { e =>
       e match {
         case testSucceeded: TestSucceeded =>
@@ -385,7 +385,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
 
   def ensureTestFailedEventReceived(suite: Suite, testName: String): Unit = {
     val reporter = new EventRecordingReporter
-    suite.run(None, Args(reporter))
+    suite.run(None, Args(reporter, runningSuites = List.empty))
     val testFailedEvent = reporter.eventsReceived.find(_.isInstanceOf[TestFailed])
     assert(testFailedEvent.isDefined)
     assert(testFailedEvent.get.asInstanceOf[TestFailed].testName === testName)
@@ -393,7 +393,7 @@ object SharedHelpers extends Assertions with LineNumberHelper {
 
   def ensureTestFailedEventReceivedWithCorrectMessage(suite: Suite, testName: String, expectedMessage: String): Unit = {
     val reporter = new EventRecordingReporter
-    suite.run(None, Args(reporter))
+    suite.run(None, Args(reporter, runningSuites = List.empty))
     val testFailedEvent = reporter.eventsReceived.find(_.isInstanceOf[TestFailed])
     assert(testFailedEvent.isDefined)
     assert(testFailedEvent.get.asInstanceOf[TestFailed].testName == testName)

--- a/jvm/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
@@ -3,7 +3,7 @@ package org.scalatest
 import org.scalatest.SharedHelpers.SilentReporter
 import java.util.concurrent.ExecutorService
 
-class TestConcurrentDistributor(execService: ExecutorService) extends tools.ConcurrentDistributor(Args(reporter = SilentReporter), execService) {
+class TestConcurrentDistributor(execService: ExecutorService) extends tools.ConcurrentDistributor(Args(reporter = SilentReporter, runningSuites = List.empty), execService) {
   override def apply(suite: Suite, tracker: Tracker): Unit = {
     throw new UnsupportedOperationException("Please use apply with args.")
   }

--- a/jvm/core/src/main/scala/org/scalatest/Args.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Args.scala
@@ -51,6 +51,7 @@ import org.scalatest.time.{Seconds, Span}
  *                              for the parallel-executed tests of one suite back into sequential order on the fly, with a timeout in case a test takes too long to complete
  * @param distributedSuiteSorter an optional <a href="DistributedSuiteSorter.html"><code>DistributedSuiteSorter</code></a> used by <code>ParallelTestExecution</code> to ensure the events
  *                              for the parallel-executed suites are sorted back into sequential order, with a timeout in case a suite takes to long to complete, even when tests are executed in parallel
+ * @param runningSuites information about all the suites running in the current test run. The <code>List</code> may be empty if the current suite is the only suite in this run.
  * @throws NullArgumentException if any passed parameter is <code>null</code>.
  *
  */
@@ -61,6 +62,7 @@ case class Args(
   configMap: ConfigMap = ConfigMap.empty,
   distributor: Option[Distributor] = None,
   tracker: Tracker = Tracker.default,
+  runningSuites: List[RunningSuite] = List.empty,
   runTestInNewInstance: Boolean = false,
   distributedTestSorter: Option[DistributedTestSorter] = None,
   distributedSuiteSorter: Option[DistributedSuiteSorter] = None

--- a/jvm/core/src/main/scala/org/scalatest/RunningSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RunningSuite.scala
@@ -1,0 +1,18 @@
+package org.scalatest
+
+import org.scalactic.Requirements.requireNonNull
+
+/**
+ * Contains information and a handle to a discovered <a href="Suite.html"><code>Suite</code></a> that will be ran or is already running in the current test run.
+ *
+ * @param className the name of the class of the suite
+ * @param lazyHandle the lazy handle to a singleton instance of the suite. If the suite hasn't been instantiated yet, calling this function will instantiate it.
+ *
+ * @throws NullArgumentException if any passed parameter is <code>null</code>.
+ */
+case class RunningSuite(
+  className: String,
+  lazyHandle: () => Suite
+) {
+    requireNonNull(className, lazyHandle)
+}

--- a/jvm/core/src/main/scala/org/scalatest/RunningSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RunningSuite.scala
@@ -6,13 +6,22 @@ import org.scalactic.Requirements.requireNonNull
  * Contains information and a handle to a discovered <a href="Suite.html"><code>Suite</code></a> that will be ran or is already running in the current test run.
  *
  * @param className the name of the class of the suite
- * @param lazyHandle the lazy handle to a singleton instance of the suite. If the suite hasn't been instantiated yet, calling this function will instantiate it.
+ * @param lazyHandle the lazy handle to a (usually singleton) instance of the suite.
+ *                   If the suite hasn't been instantiated yet, calling this function will instantiate it.
+ * @param isSingleton indicates whether calling <code>lazyHandle</code> will return a singleton instance of the Suite.
+ *                    Always <code>true</code> on the JVM.
+ *                    However on Scala.js and Scala Native, when tests run using a worker (<code>org.scalatest.tools.SlaveRunner</code>),
+ *                    singleton-ness cannot be guaranteed anymore.
+ *                    As of the time of writing, tests on Scala Native nearly always run in separate worker processes,
+ *                    making singleton guarantees impossible.
+ *                    If this is <code>false</code>, running <code>lazyHandle</code> will duplicate the Suite.
  *
  * @throws NullArgumentException if any passed parameter is <code>null</code>.
  */
 case class RunningSuite(
   className: String,
-  lazyHandle: () => Suite
+  lazyHandle: () => Suite,
+  isSingleton: Boolean
 ) {
-    requireNonNull(className, lazyHandle)
+    requireNonNull(className, lazyHandle, isSingleton)
 }

--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -64,7 +64,7 @@ trait StepwiseNestedSuiteExecution extends SuiteMixin { thisSuite: Suite =>
 
         try {
           // Same thread, so OK to send same tracker
-          val status = nestedSuite.run(None, Args(report, stopper, filter, configMap, distributor, tracker))
+          val status = nestedSuite.run(None, Args(report, stopper, filter, configMap, distributor, tracker, runningSuites))
 
           val rawString = Resources.suiteCompletedNormally
           val formatter = formatterForSuiteCompleted(nestedSuite)

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -821,7 +821,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
           configMap,
           None,
           tracker,
-          List.empty)
+          List(RunningSuite(suiteClassName, () => this, true)))
         )
       status.waitUntilCompleted()
       val suiteCompletedFormatter = formatterForSuiteCompleted(thisSuite)
@@ -2127,5 +2127,3 @@ used for test events like succeeded/failed, etc.
   }
   // SKIP-SCALATESTJS-END
 }
-
-

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -820,7 +820,8 @@ trait Suite extends Assertions with Serializable { thisSuite =>
           filter,
           configMap,
           None,
-          tracker)
+          tracker,
+          List.empty)
         )
       status.waitUntilCompleted()
       val suiteCompletedFormatter = formatterForSuiteCompleted(thisSuite)
@@ -1174,7 +1175,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
 
         try {
           // Same thread, so OK to send same tracker
-          val status = nestedSuite.run(None, Args(report, stopper, filter, configMap, distributor, tracker))
+          val status = nestedSuite.run(None, Args(report, stopper, filter, configMap, distributor, tracker, runningSuites))
 
           val rawString = Resources.suiteCompletedNormally
           val formatter = formatterForSuiteCompleted(nestedSuite)

--- a/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
@@ -65,7 +65,7 @@ private[scalatest] class SuiteRerunner(suiteClassName: String) extends Rerunner 
         val formatter = formatterForSuiteStarting(suite)
 
         report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suite.getClass.getName)), suite.rerunner))
-        suite.run(None, Args(report, stopper, filter, configMap, distributor, tracker))
+        suite.run(None, Args(report, stopper, filter, configMap, distributor, tracker, List.empty))
 
         val rawString2 = Resources.suiteCompletedNormally
         val formatter2 = formatterForSuiteCompleted(suite)

--- a/jvm/core/src/main/scala/org/scalatest/TestRerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestRerunner.scala
@@ -40,7 +40,7 @@ private[scalatest] class TestRerunner(suiteClassName: String, testName: String) 
 
       report(RunStarting(tracker.nextOrdinal(), 1, configMap))
 
-      suite.run(Some(testName), Args(report, stopper, filter, configMap, distributor, tracker))
+      suite.run(Some(testName), Args(report, stopper, filter, configMap, distributor, tracker, List.empty))
 
       val duration = System.currentTimeMillis - runStartTime
       report(RunCompleted(tracker.nextOrdinal(), Some(duration)))

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -439,7 +439,7 @@ class Framework extends SbtFramework {
         } catch {
           case t: Throwable => new DeferredAbortedSuite(suiteClass.getName, suiteClass.getName, t)
         }
-      RunningSuite(taskDefinition.fullyQualifiedName, () => suite)
+      RunningSuite(taskDefinition.fullyQualifiedName, () => suite, true)
     }
 
     def tags =

--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1225,7 +1225,7 @@ object Runner {
 
           val expectedTestCount = sumInts(testCountList)
 
-          val runningSuites = suiteInstances.map(suiteConfig => RunningSuite(getSuiteClassName(suiteConfig.suite), () => suiteConfig.suite))
+          val runningSuites = suiteInstances.map(suiteConfig => RunningSuite(getSuiteClassName(suiteConfig.suite), () => suiteConfig.suite, true))
 
           dispatch(RunStarting(tracker.nextOrdinal(), expectedTestCount, configMap))
           
@@ -1544,4 +1544,3 @@ object Runner {
     )
   }
 }
-

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -437,7 +437,7 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
 
             try {
               // Old SBT interface does not pass any information about the other discovered suites to us, so it's impossible to properly populate `runningSuites` here
-              val runningSuites = List.empty[RunningSuite]
+              val runningSuites = List(RunningSuite(suiteClassName, () => suite, true))
 
               val status = suite.run(None, Args(report, Stopper.default, filter, configMap, None, tracker, runningSuites, false, None, None))
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -436,7 +436,10 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
             report(SuiteStarting(tracker.nextOrdinal(), suite.suiteName, suite.suiteId, Some(suiteClassName), formatter, Some(TopOfClass(suiteClassName))))
 
             try {
-              val status = suite.run(None, Args(report, Stopper.default, filter, configMap, None, tracker, false, None, None))
+              // Old SBT interface does not pass any information about the other discovered suites to us, so it's impossible to properly populate `runningSuites` here
+              val runningSuites = List.empty[RunningSuite]
+
+              val status = suite.run(None, Args(report, Stopper.default, filter, configMap, None, tracker, runningSuites, false, None, None))
 
               val formatter = formatterForSuiteCompleted(suite)
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunningSuitesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunningSuitesSpec.scala
@@ -1,0 +1,37 @@
+package org.scalatest.tools
+
+import org.scalatest.{Args, RunningSuite, Status}
+import org.scalatest.funspec.AnyFunSpec
+
+class RunningSuitesSpec extends AnyFunSpec {
+
+  var runningSuites: List[RunningSuite] = _
+
+  override def run(testName: Option[String], args: Args): Status = {
+    this.runningSuites = args.runningSuites
+    super.run(testName, args)
+  }
+
+  it("Args.runningSuites contains the current running suite") {
+    runningSuites.find(_.className == this.getClass.getName) match {
+      case Some(thisSuite) =>
+        if (thisSuite.isSingleton) {
+          assert(thisSuite.lazyHandle() == this)
+        } else {
+          cancel("Running in a worker process")
+        }
+      case None =>
+        fail("Expected Args.runningSuites to contain the current suite")
+    }
+  }
+
+  it("Args.runningSuites contains other suites if not running under testOnly") {
+    if (runningSuites.size == 1) {
+      cancel(s"Running in testOnly. $runningSuites")
+    } else {
+      assert(runningSuites.size > 1)
+      assert(runningSuites == runningSuites.distinct)
+    }
+  }
+
+}

--- a/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -127,7 +127,10 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
   val tracker = new Tracker
   val summaryCounter = new SummaryCounter
 
+  var knownSuites: Map[(String, List[Selector]), TaskRunner] = Map.empty
+
   def done(): String = {
+    knownSuites = Map.empty
     val duration = Platform.currentTime - runStartTime
     val summary = new Summary(summaryCounter.testsSucceededCount, summaryCounter.testsFailedCount, summaryCounter.testsIgnoredCount, summaryCounter.testsPendingCount,
       summaryCounter.testsCanceledCount, summaryCounter.suitesCompletedCount, summaryCounter.suitesAbortedCount, summaryCounter.scopesPendingCount)
@@ -165,7 +168,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
       }
 
     def createTask(allRunningSuites: () => List[RunningSuite], t: TaskDef): TaskRunner =
-      new TaskRunner(t, allRunningSuites, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+      new TaskRunner(t, allRunningSuites, true, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
         presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
 
     val chosenTaskDefs = if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
@@ -174,6 +177,11 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
       val allRunningSuites = () => taskRunners.map(_.runningSuite).toList
       chosenTaskDefs.map(createTask(allRunningSuites, _))
     }
+
+    knownSuites ++= taskRunners.map { t =>
+      val taskDef = t.taskDef()
+      (taskDef.fullyQualifiedName() -> taskDef.selectors().toList) -> t
+    }.toMap
 
     taskRunners.toArray[Task]
   }
@@ -206,14 +214,29 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
     None
   }
 
-  def serializeTask(task: Task, serializer: (TaskDef) => String): String =
-    serializer(task.taskDef())
+  def serializeTask(task: Task, serializer: (TaskDef) => String): String = {
+    val knownSuitesInfoSerialized = task match {
+      case taskRunner: TaskRunner =>
+        TaskRunner.serializeKnownSuites(taskRunner)
+      case _ => ""
+    }
+    knownSuitesInfoSerialized + serializer(task.taskDef())
+  }
 
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
-    val taskDef = deserializer(task)
-    lazy val taskRunner: TaskRunner = new TaskRunner(taskDef, () => List(taskRunner.runningSuite), testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
-      presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
-    taskRunner
+    // ignore serialized suite info and use saved `knownSuites` instead if we're on the master thread
+    val taskIgnoreSuites = TaskRunner.stripKnownSuites(task)
+    val taskDef = deserializer(taskIgnoreSuites)
+    val knownSuites = this.knownSuites
+    val key = taskDef.fullyQualifiedName() -> taskDef.selectors().toList
+    knownSuites.get(key) match {
+      case Some(knownTask) =>
+        knownTask
+      case None =>
+        val knownRunningSuites = knownSuites.map(_._2.runningSuite).toList
+        new TaskRunner(taskDef, () => knownRunningSuites, true, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+          presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(send))
+    }
   }
 
 }

--- a/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -133,7 +133,7 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
       }
 
     def createTask(allRunningSuites: () => List[RunningSuite], t: TaskDef): TaskRunner =
-      new TaskRunner(t, allRunningSuites, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+      new TaskRunner(t, allRunningSuites, false, testClassLoader, tracker, tagsToInclude, tagsToExclude, t.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
         presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(notifyServer))
 
     val chosenTaskDefs = if (wildcard.isEmpty && membersOnly.isEmpty) taskDefs else (filterWildcard(wildcard, taskDefs) ++ filterMembersOnly(membersOnly, taskDefs)).distinct
@@ -149,14 +149,23 @@ class SlaveRunner(theArgs: Array[String], theRemoteArgs: Array[String], testClas
   def receiveMessage(msg: String): Option[String] =
     None
 
-  def serializeTask(task: Task, serializer: (TaskDef) => String): String =
-    serializer(task.taskDef())
+  def serializeTask(task: Task, serializer: (TaskDef) => String): String = {
+    val knownSuitesInfoSerialized = task match {
+      case taskRunner: TaskRunner =>
+        TaskRunner.serializeKnownSuites(taskRunner)
+      case _ => ""
+    }
+    knownSuitesInfoSerialized + serializer(task.taskDef())
+  }
 
   def deserializeTask(task: String, deserializer: (String) => TaskDef): Task = {
-    val taskDef = deserializer(task)
-    lazy val taskRunner: TaskRunner = new TaskRunner(taskDef, () => List(taskRunner.runningSuite), testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
+    // on Scala.js worker thread has no access to global mutable state, so the best
+    // we can do is deserialize classNames serialized on the MasterRunner
+    val (runningSuites, taskIgnoreSuites) = TaskRunner.deserializeKnownSuites(task, testClassLoader)
+    val taskDef = deserializer(taskIgnoreSuites)
+
+    new TaskRunner(taskDef, () => runningSuites, false, testClassLoader, tracker, tagsToInclude, tagsToExclude, taskDef.selectors() ++ autoSelectors, false, presentAllDurations, presentInColor, presentShortStackTraces, presentFullStackTraces, presentUnformatted, presentReminder,
       presentReminderWithShortStackTraces, presentReminderWithFullStackTraces, presentReminderWithoutCanceledTests, presentFilePathname, presentJson, Some(notifyServer))
-    taskRunner
   }
 
 }

--- a/native/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
@@ -4,8 +4,8 @@ import org.scalajs.testinterface.TestUtils
 import org.scalatest.{RunningSuite, Suite}
 
 object SuiteInstantiationHelper {
-  def createRunningSuite(className: String, cl: ClassLoader): RunningSuite = {
+  def createRunningSuite(className: String, cl: ClassLoader, isMaster: Boolean): RunningSuite = {
     lazy val suite = TestUtils.newInstance(className, cl)(Seq.empty).asInstanceOf[Suite]
-    RunningSuite(className, () => suite)
+    RunningSuite(className, () => suite, isMaster)
   }
 }

--- a/native/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SuiteInstantiationHelper.scala
@@ -1,0 +1,11 @@
+package org.scalatest.tools
+
+import org.scalajs.testinterface.TestUtils
+import org.scalatest.{RunningSuite, Suite}
+
+object SuiteInstantiationHelper {
+  def createRunningSuite(className: String, cl: ClassLoader): RunningSuite = {
+    lazy val suite = TestUtils.newInstance(className, cl)(Seq.empty).asInstanceOf[Suite]
+    RunningSuite(className, () => suite)
+  }
+}

--- a/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -38,7 +38,8 @@ import scala.compat.Platform
 import scala.concurrent.duration.Duration
 
 final class TaskRunner(task: TaskDef,
-                       allRunningSuites: () => List[RunningSuite],
+                       val allRunningSuites: () => List[RunningSuite],
+                       isMaster: Boolean,
                        cl: ClassLoader,
                        tracker: Tracker,
                        tagsToInclude: Set[String],
@@ -57,7 +58,7 @@ final class TaskRunner(task: TaskDef,
                        presentFilePathname: Boolean,
                        presentJson: Boolean,
                        notifyServer: Option[String => Unit]) extends Task {
-  val runningSuite: RunningSuite = SuiteInstantiationHelper.createRunningSuite(task.fullyQualifiedName(), cl)
+  val runningSuite: RunningSuite = SuiteInstantiationHelper.createRunningSuite(task.fullyQualifiedName(), cl, isMaster)
 
   def tags(): Array[String] = Array.empty
   def taskDef(): TaskDef = task
@@ -251,4 +252,34 @@ println("GOT TO THIS RECOVER CALL")
 
     def dispose() = ()
   }
+}
+
+object TaskRunner {
+  def serializeKnownSuites(taskRunner: TaskRunner): String = {
+    KnownSuitesPreamble +
+      taskRunner.allRunningSuites().map(_.className).mkString(KnownSuitesSeparator) +
+      KnownSuitesEnd
+  }
+
+  def deserializeKnownSuites(task: String, cl: ClassLoader): (List[RunningSuite], String) = {
+    val afterPreamble = task.stripPrefix(KnownSuitesPreamble)
+    if (afterPreamble != task) {
+      val endingPosition = afterPreamble.indexOf(KnownSuitesEnd)
+      val (suitesStr, restWithEnding) = afterPreamble.splitAt(endingPosition)
+      val classNames = suitesStr.split(KnownSuitesSeparator)
+      val runningSuites = classNames.map(SuiteInstantiationHelper.createRunningSuite(_, cl, false)).toList
+      val rest = restWithEnding.stripPrefix(KnownSuitesEnd)
+
+      (runningSuites, rest)
+    } else (List.empty, task)
+  }
+
+  def stripKnownSuites(task: String): String = {
+    val endingPosition = task.indexOf(KnownSuitesEnd)
+    task.drop(endingPosition).stripPrefix(KnownSuitesEnd)
+  }
+
+  private val KnownSuitesPreamble = "{org.scalatest.tools.TaskRunner.allRunningSuites}[[["
+  private val KnownSuitesSeparator = ";;;"
+  private val KnownSuitesEnd = "]]]{org.scalatest.tools.TaskRunner.allRunningSuites}"
 }


### PR DESCRIPTION
Hi, a few years ago we’ve made an open source test framework - [distage-testkit](https://izumi.7mind.io/distage/distage-testkit.html). We’ve decided to base it on ScalaTest, instead of writing a new test framework from scratch – which would have required us to write IDE integration from scratch too. It has grown popular now, but since the beginning, we’ve had issues[[1]](https://github.com/7mind/izumi/issues/1055) connected to ScalaTest’s SBT Framework runner instantiating suite classes lazily in parallel (unlike Scalatest’s native Runner, which instantiates them eagerly).

Why would such a small detail become a problem? Our test framework has unique features - specifically [resource sharing without global variables](https://izumi.7mind.io/distage/distage-testkit.html#resource-reuse-memoization) among test suites - which require orchestration of all tests from a single point, instead of them running independently. To do this, instead of each test running independently, on instantiation suites register themselves and their Reporters in a global collection and the first suite which’s `run` method is called by ScalaTest actually executes the entire ensemble of suites on its own and uses the stored Reporters to report the results of all other suites.[[2]](https://github.com/7mind/izumi/blob/53c3c1e6b106d8e88efdd09ee84c5bcae64202ec/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala#L166)

This works well with ScalaTest’s regular Runner - and in IntelliJ which uses it. Because regular Runner instantiates suites first, before running them in parallel, we know that by the time the first `run` method is called, all suites have registered themselves, so the list of registered tests contains all the tests we have to run.

But this scheme breaks down in SBT, because in ScalaTest’s Framework suite instantiation happens inside of the returned `TaskDef`, not before – instantiations and `run`’s happen in parallel with each other. So there’s reasonable no way to know when all the discovered suites have been instantiated or ran, any time `run` method is called, more suites could still be instantiated and registered later with no way to find which suite is the last one – we lose the ability to know which suites sbt / ScalaTest have discovered and which we should run.
So, when running under SBT we perform discovery on the classpath ourselves, instead of relying on sbt, because by the time a suite is ran there’s no way to recover the information sbt passed to ScalaTest about the discovered suites. Doing discovery again is error-prone - we don’t have all the information sbt has, and e.g. we have to figure out whether suites belong to the current module or not using a heuristic[[3]](https://github.com/7mind/izumi/pull/2052)[[4]](https://github.com/7mind/izumi/issues/2054)[[5]](https://github.com/7mind/izumi/pull/2055) – this is something sbt already knows and automatically avoids tests that come from dependencies.

At this point, I believe the only way to fix these issues for good is to fix them at ScalaTest’s level - either by adding information about the other discovered Suites to Args that ScalaTest passes to the Suite, or by making `Framework` behave the same way as `Runner` does and instantiate all the Suites first before running them in parallel – so that we can rely on side effects during Suite instantiation to find all the running suites.

In this PR I opt for the second option. I may be wrong, but I think it’s a smaller change and it would be easier to accept into ScalaTest codebase.