### PR TITLE
Fast InsertionOrderSet

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/InsertionOrderSet.scala
+++ b/jvm/core/src/main/scala/org/scalatest/InsertionOrderSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 Artima, Inc.
+ * Copyright 2001-2024 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  */
 package org.scalatest
 
+import org.scalactic.ColCompatHelper
+
 private[scalatest] object InsertionOrderSet {
-  def apply[A](elements: List[A]): Set[A] =
-    scala.collection.immutable.SortedSet(elements: _*)(new Ordering[A] {
-      def compare(x: A, y: A): Int = elements.indexOf(x) compare elements.indexOf(y)
-    })
+  def apply[A](elements: List[A]): Set[A] = new ColCompatHelper.InsertionOrderSet[A](elements)
 }

--- a/project/GenColCompatHelper.scala
+++ b/project/GenColCompatHelper.scala
@@ -75,9 +75,9 @@ object GenColCompatHelper {
           |    def excl(elem: A): scala.collection.immutable.Set[A] = new InsertionOrderSet(elements.filter(_ != elem))
           |    def incl(elem: A): scala.collection.immutable.Set[A] = 
           |      if (underlying.contains(elem)) 
-          |        new InsertionOrderSet(elements) 
+          |        this 
           |      else 
-          |        new InsertionOrderSet(if (underlying.contains(elem)) elements else elements :+ elem)
+          |        new InsertionOrderSet(elements :+ elem)
           |  }
           |}
           |
@@ -149,9 +149,9 @@ object GenColCompatHelper {
           |    def -(elem: A): scala.collection.immutable.Set[A] = new InsertionOrderSet(elements.filter(_ != elem))
           |    def +(elem: A): scala.collection.immutable.Set[A] = 
           |      if (underlying.contains(elem)) 
-          |        new InsertionOrderSet(elements) 
+          |        this
           |      else 
-          |        new InsertionOrderSet(if (underlying.contains(elem)) elements else elements :+ elem)
+          |        new InsertionOrderSet(elements :+ elem)
           |  }
           |}
           |

--- a/project/GenColCompatHelper.scala
+++ b/project/GenColCompatHelper.scala
@@ -67,6 +67,18 @@ object GenColCompatHelper {
           |  def newBuilder[A, C](f: Factory[A, C]): scala.collection.mutable.Builder[A, C] = f.newBuilder
           |
           |  type StringOps = scala.collection.StringOps
+          |
+          |  class InsertionOrderSet[A](elements: List[A]) extends scala.collection.immutable.Set[A] {
+          |    private val underlying = scala.collection.mutable.LinkedHashSet(elements: _*)
+          |    def contains(elem: A): Boolean = underlying.contains(elem)
+          |    def iterator: Iterator[A] = underlying.iterator
+          |    def excl(elem: A): scala.collection.immutable.Set[A] = new InsertionOrderSet(elements.filter(_ != elem))
+          |    def incl(elem: A): scala.collection.immutable.Set[A] = 
+          |      if (underlying.contains(elem)) 
+          |        new InsertionOrderSet(elements) 
+          |      else 
+          |        new InsertionOrderSet(if (underlying.contains(elem)) elements else elements :+ elem)
+          |  }
           |}
           |
         """.stripMargin
@@ -129,6 +141,18 @@ object GenColCompatHelper {
           |  def newBuilder[A, C](f: Factory[A, C]): scala.collection.mutable.Builder[A, C] = f.apply()
           |
           |  type StringOps = scala.collection.immutable.StringOps
+          |
+          |  class InsertionOrderSet[A](elements: List[A]) extends scala.collection.immutable.Set[A] {
+          |    private val underlying = scala.collection.mutable.LinkedHashSet(elements: _*)
+          |    def contains(elem: A): Boolean = underlying.contains(elem)
+          |    def iterator: Iterator[A] = underlying.iterator
+          |    def -(elem: A): scala.collection.immutable.Set[A] = new InsertionOrderSet(elements.filter(_ != elem))
+          |    def +(elem: A): scala.collection.immutable.Set[A] = 
+          |      if (underlying.contains(elem)) 
+          |        new InsertionOrderSet(elements) 
+          |      else 
+          |        new InsertionOrderSet(if (underlying.contains(elem)) elements else elements :+ elem)
+          |  }
           |}
           |
         """.stripMargin


### PR DESCRIPTION
Reimplemented InsertionOrderSet using scala.collection.mutable.LinkedHashSet.