### PR TITLE
Expose a method to run any queued-up tasks on the SerialExecutionContext

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
@@ -213,7 +213,9 @@ import enablers.Futuristic
  */
 trait AsyncTestSuite extends Suite with RecoverMethods with CompleteLastly { thisAsyncTestSuite =>
 
-  private final val serialExecutionContext: ExecutionContext = new concurrent.SerialExecutionContext
+  private final val serialExecutionContext = new concurrent.SerialExecutionContext
+
+  protected def executeSerialECTasks(): Unit = serialExecutionContext.runNow(Future.successful(Succeeded))
 
   /**
    * An implicit execution context used by async styles to transform <code>Future[Assertion]</code> values


### PR DESCRIPTION
For calling from outside of a test when there are pending things dispatched to there - e.g. in `afterAll()` during cleanup.

`SerialExecutionContext` is private - and so this run method is inaccessible from outside of ScalaTest.

To address https://github.com/scalatest/scalatest/issues/2314