### PR TITLE
Support scala-natve 0.5.0

### DIFF
--- a/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -26,7 +26,7 @@ import org.scalatest.events.{TestFailed,
                              SeeStackDepthException}
 import org.scalatest.tools.StringReporter._
 import sbt.testing._
-import org.scalajs.testinterface.TestUtils
+import scala.scalanative.reflect.Reflect
 import org.scalatest._
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Promise
@@ -77,7 +77,11 @@ println("GOT TO THIS RECOVER CALL")
 
   def executionFuture(eventHandler: EventHandler, loggers: Array[Logger]): Future[Unit] = {
     val suiteStartTime = Platform.currentTime
-    val suite = TestUtils.newInstance(task.fullyQualifiedName(), cl)(Seq.empty).asInstanceOf[Suite]
+    val suite = Reflect
+      .lookupInstantiatableClass(task.fullyQualifiedName())
+      .getOrElse(throw new RuntimeException("Cannot load suite class: " + task.fullyQualifiedName()))
+      .newInstance()
+      .asInstanceOf[Suite]
     val sbtLogInfoReporter = new SbtLogInfoReporter(
       loggers,
       presentAllDurations,

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -248,7 +248,7 @@ trait BuildCommons {
       case Some((2, 10)) => Seq.empty
       case Some((2, 11)) => Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
       case Some((scalaEpoch, scalaMajor)) if (scalaEpoch == 2 && scalaMajor >= 12) || scalaEpoch == 3 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.1.0"))
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.3.0"))
     }
   }    
 

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -14,7 +14,7 @@ trait BuildCommons {
 
   val runFlickerTests = Option(System.getenv("SCALATEST_RUN_FLICKER_TESTS")).getOrElse("FALSE").toUpperCase == "TRUE"
 
-  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.8.0")
+  val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
   def scalatestJSLibraryDependencies =
     Seq(
       "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -4,7 +4,6 @@ import java.io.PrintWriter
 import scala.io.Source
 
 import scalanative.sbtplugin.ScalaNativePlugin
-import ScalaNativePlugin.autoImport.{nativeLinkStubs, nativeDump}
 
 trait BuildCommons {
 
@@ -259,8 +258,6 @@ trait BuildCommons {
       libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
       // libraryDependencies += "io.circe" %%% "circe-parser" % "0.7.1" % "test",
       fork in test := false,
-      nativeLinkStubs in Test := true,
-      nativeDump in Test := false, 
       testOptions in Test := scalatestTestJSNativeOptions,
       publishArtifact := false,
       publish := {},

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -289,7 +289,7 @@ trait DottyBuild { this: BuildCommons =>
       initialCommands in console := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.1.0", 
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.3.0",
       libraryDependencies += ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).withDottyCompat(dottyVersion), 
       packageManagedSources,
       sourceGenerators in Compile += Def.task {
@@ -365,7 +365,7 @@ trait DottyBuild { this: BuildCommons =>
       initialCommands in console := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.1.0", 
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.3.0",
       libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
       packageManagedSources,
       sourceGenerators in Compile += Def.task {

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -366,7 +366,7 @@ trait DottyBuild { this: BuildCommons =>
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
       libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.1.0", 
-      libraryDependencies += ("org.scala-native" %% "test-interface_native0.4" % nativeVersion), 
+      libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
       packageManagedSources,
       sourceGenerators in Compile += Def.task {
         GenModulesDotty.genScalaTestCoreNative((sourceManaged in Compile).value, version.value, scalaVersion.value) ++
@@ -1119,7 +1119,7 @@ trait DottyBuild { this: BuildCommons =>
         organization := "org.scalatest",
         moduleName := "scalatest-app",
         //libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-        libraryDependencies += ("org.scala-native" %% "test-interface_native0.4" % nativeVersion), 
+        libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
         // include the scalacticDottyNative classes and resources in the jar
         mappings in (Compile, packageBin) ++= mappings.in(scalacticDottyNative, Compile, packageBin).value,
         // include the scalacticDottyNative sources in the source jar

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -19,7 +19,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.27/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.1.3")
+  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.3.3")
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     scalacOptions ++= List("-language:implicitConversions", "-noindent", "-Xprint-suspension")

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -655,7 +655,6 @@ trait NativeBuild { this: BuildCommons =>
       organization := "org.scalactic",
       testOptions in Test ++=
         Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oDIF")),
-      nativeLinkStubs in Test := true,
       sourceGenerators in Test += {
         Def.task {
           GenScalacticNative.genTest((sourceManaged in Test).value / "scala", version.value, scalaVersion.value)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.8.0")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
 
-val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.9")
+val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.5.0")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -158,7 +158,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
       case _ => // for scala 2.11, 2.12, 2.13 and 3.x
         Seq(
-          "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.1.1"
+          "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0"
         )
     }
   }

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -133,7 +133,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
       case Some((2, 10)) => Seq.empty
       case Some((2, 11)) => Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
       case Some((scalaEpoch, scalaMajor)) if (scalaEpoch == 2 && scalaMajor >= 12) || scalaEpoch == 3 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.1.0"))
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.3.0"))
     }
 
   def scalaLibraries(theScalaVersion: String) =

--- a/publish.sh
+++ b/publish.sh
@@ -6,7 +6,7 @@ sbt ++2.10.7 "project scalacticJS" clean publishSigned
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.13 "project scalacticJS" clean publishSigned
 sbt ++2.13.4 "project scalacticJS" clean publishSigned
-export SCALAJS_VERSION=1.8.0
+export SCALAJS_VERSION=1.16.0
 sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.17 "project scalacticJS" clean publishSigned
@@ -31,7 +31,7 @@ sbt ++2.10.7 "project scalatestJS" clean publishSigned
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.13 "project scalatestJS" clean publishSigned
 sbt ++2.13.4 "project scalatestJS" clean publishSigned
-export SCALAJS_VERSION=1.8.0
+export SCALAJS_VERSION=1.16.0
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
@@ -59,7 +59,7 @@ sbt ++2.10.7 "project scalatestAppJS" clean publishSigned
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.13 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.4 "project scalatestAppJS" clean publishSigned
-export SCALAJS_VERSION=1.8.0
+export SCALAJS_VERSION=1.16.0
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned

--- a/publish.sh
+++ b/publish.sh
@@ -11,7 +11,7 @@ sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
 sbt ++2.12.17 "project scalacticJS" clean publishSigned
 sbt ++2.13.10 "project scalacticJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.9
+export SCALANATIVE_VERSION=0.5.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalacticNative" clean publishSigned
 sbt ++2.12.17 "project scalacticNative" clean publishSigned
@@ -37,7 +37,7 @@ sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
 sbt ++2.12.17 "project scalatestJS" clean publishSigned
 sbt ++2.13.10 "project scalatestJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.9
+export SCALANATIVE_VERSION=0.5.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestNative" clean publishSigned
 sbt ++2.12.17 "project scalatestNative" clean publishSigned
@@ -65,7 +65,7 @@ sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
 sbt ++2.12.17 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.10 "project scalatestAppJS" clean publishSigned
-export SCALANATIVE_VERSION=0.4.9
+export SCALANATIVE_VERSION=0.5.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestAppNative" clean publishSigned
 sbt ++2.12.17 "project scalatestAppNative" clean publishSigned


### PR DESCRIPTION
It has a few changes in build plugin, which requires to cleanup a bit build script.

And one deprectated class was removed.

Tested as:
```
export SCALANATIVE_VERSION=0.5.0-RC2

sbt clean

sbt ++2.12.17 "project scalacticNative" clean publishLocal
sbt ++2.13.10 "project scalacticNative" clean publishLocal
sbt "project scalacticDottyNative" clean publishLocal

sbt ++2.12.17 "project scalatestNative" clean publishLocal
sbt ++2.13.10 "project scalatestNative" clean publishLocal
sbt "project scalatestDottyNative" clean publishLocal

sbt ++2.12.17 "project scalatestAppNative" clean publishLocal
sbt ++2.13.10 "project scalatestAppNative" clean publishLocal
sbt "project scalatestAppDottyNative" clean publishLocal
```