### PR TITLE
Prettifier escapes strings

### DIFF
--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
@@ -48,6 +48,8 @@ class PrettifierSpec extends funspec.AnyFunSpec with matchers.should.Matchers {
         }
       myLittlePretty(Yell("I like fruit loops")) should be ("I LIKE FRUIT LOOPS!!!")
       myLittlePretty("hi") should be ("\"hi\"")
+      myLittlePretty("h\u0000i") should be ("\"h\\" + "u0000i\"")
+      myLittlePretty("h\ti") should be (raw""""h\ti"""")
       myLittlePretty('h') should be ("'h'")
       myLittlePretty(Array(1, 2, 3)) should be ("Array(1, 2, 3)")
       myLittlePretty(WrappedArray.make(Array(1, 2, 3))) should be ("Array(1, 2, 3)")

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/FullyMatchWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/FullyMatchWordSpec.scala
@@ -33,7 +33,7 @@ class FullyMatchWordSpec extends AnyFreeSpec with Matchers {
       val mt = fullyMatch regex decimal
       
       "should have pretty toString" in {
-        mt.toString should be ("fullyMatch regex \"" + decimal + "\"")
+        mt.toString should be ("""fullyMatch regex "(-)?(\\d+)(\\.\\d*)?"""")
       }
       
       val mr = mt("2.7")


### PR DESCRIPTION
A user on discord reported confusion when a test failed because of an embedded "null" character but the string was displayed "normal".

That case was a "contains" test, so a string "diff" would not help, unless a user could request a diff against every element in the collection under test.

This commit prettifies strings as Scala strings with the usual escapes, including Unicode escape if `isControl`.