### PR TITLE
Latest Scala + Scala Native Fix

### DIFF
--- a/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -183,6 +183,8 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
     ()
   }
 
+  private lazy val getDiscoveredSuitesPattern = "getDiscoveredSuites-(.+)".r
+
   def receiveMessage(msg: String): Option[String] = {
     msg match {
       case "org.scalatest.events.TestPending" =>
@@ -201,7 +203,7 @@ class MasterRunner(theArgs: Array[String], theRemoteArgs: Array[String], testCla
         summaryCounter.incrementSuitesAbortedCount()
       case "org.scalatest.events.ScopePending" =>
         summaryCounter.incrementScopesPendingCount()
-      case s"getDiscoveredSuites-$filePath" =>
+      case getDiscoveredSuitesPattern(filePath)  =>
         val tempFile = new java.io.File(filePath)
         val writer = new PrintWriter(filePath)
         try {

--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -11,7 +11,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 trait BuildCommons {
 
   def scalaVersionsSettings: Seq[Setting[_]] = Seq(
-    crossScalaVersions := Seq("2.13.14", "2.12.20", "2.11.12"), 
+    crossScalaVersions := Seq("2.13.15", "2.12.20", "2.11.12"), 
     scalaVersion := crossScalaVersions.value.head,
   )
 

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -18,7 +18,7 @@ trait DottyBuild { this: BuildCommons =>
 
   // List of available night build at https://repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.27/
   // lazy val dottyVersion = dottyLatestNightlyBuild.get
-  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.3.3")
+  lazy val dottyVersion = System.getProperty("scalatest.dottyVersion", "3.3.4")
   lazy val dottySettings = List(
     scalaVersion := dottyVersion,
     scalacOptions ++= List("-language:implicitConversions", "-noindent", "-Xprint-suspension")

--- a/project/JsBuild.scala
+++ b/project/JsBuild.scala
@@ -15,7 +15,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 trait JsBuild { this: BuildCommons =>
 
   private lazy val jsSharedSettings = Seq(
-    crossScalaVersions := Seq("2.13.14", "2.12.20")
+    crossScalaVersions := Seq("2.13.15", "2.12.20")
   )
 
   lazy val deleteJsDependenciesTask = taskKey[Unit]("Delete JS_DEPENDENCIES")

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -27,7 +27,7 @@ trait NativeBuild { this: BuildCommons =>
     //
     // Details: https://github.com/scala-native/scala-native/issues/1930
     Compile / resourceDirectories += (Compile / classDirectory).value, 
-    crossScalaVersions := Seq("2.13.14", "2.12.20")
+    crossScalaVersions := Seq("2.13.15", "2.12.20")
   )
 
   lazy val scalacticMacroNative = project.in(file("native/scalactic-macro"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.17.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
- Bumped up to use scala 3.3.4.
- Updated to latest 2.13.15 and scala-js 1.17.0.
- Fixed compile error when building with scala-native using scala 2.12.20.