### PR TITLE
FunSuite Consistent Visibility Between Scala 2 and 3

### DIFF
--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
@@ -150,11 +150,11 @@ trait AnyFunSuiteLike extends TestSuite with Informing with Notifying with Alert
     * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
     */
   // SKIP-DOTTY-START
-  protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+  protected final def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     testImpl(testName, testTags: _*)(testFun, pos)
   }
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY protected inline def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */): Unit = {
   //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => testImpl(testName, testTags: _*)(testFun, pos) }) } 
   //DOTTY-ONLY }
 
@@ -184,11 +184,11 @@ trait AnyFunSuiteLike extends TestSuite with Informing with Notifying with Alert
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     */
   // SKIP-DOTTY-START
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+  protected final def ignore(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     ignoreImpl(testName, testTags: _*)(testFun, pos)
   }
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline def ignore(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY protected inline def ignore(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */): Unit = {
   //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testName, testTags: _*)(testFun, pos) }) } 
   //DOTTY-ONLY }
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
@@ -137,11 +137,11 @@ trait AsyncFunSuiteLike extends AsyncTestSuite with Informing with Notifying wit
     * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
     */
   // SKIP-DOTTY-START
-  protected def test(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected final def test(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
     testImpl(testName, testTags: _*)(testFun, pos)
   }
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline def test(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY protected inline def test(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]): Unit = {
   //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => testImpl(testName, testTags: _*)(testFun, pos) }) } 
   //DOTTY-ONLY }
 
@@ -165,11 +165,11 @@ trait AsyncFunSuiteLike extends AsyncTestSuite with Informing with Notifying wit
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     */
   // SKIP-DOTTY-START
-  protected def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+  protected final def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
     ignoreImpl(testName, testTags: _*)(testFun, pos)
   }
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY protected inline def ignore(testName: String, testTags: Tag*)(testFun: => Future[compatible.Assertion]): Unit = {
   //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testName, testTags: _*)(testFun, pos) }) } 
   //DOTTY-ONLY }
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
@@ -140,7 +140,7 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     }
     
     // SKIP-DOTTY-START
-    def apply(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    final def apply(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
       applyImpl(testFun: FixtureParam => Any /* Assertion */, pos: source.Position)
     }
     // SKIP-DOTTY-END
@@ -159,7 +159,7 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     }
 
     // SKIP-DOTTY-START
-    def apply(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    final def apply(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
       applyImpl(testFun: () => Any /* Assertion */, pos: source.Position)
     }
     // SKIP-DOTTY-END
@@ -183,17 +183,6 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
     */
   protected def test(testName: String, testTags: Tag*): ResultOfTestInvocation = new ResultOfTestInvocation(testName, testTags: _*)
-  /*
-    protected def test(testName: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */) {
-      // SKIP-SCALATESTJS,NATIVE-START
-      val stackDepth = 4
-      val stackDepthAdjustment = -2
-      // SKIP-SCALATESTJS,NATIVE-END
-      //SCALATESTJS,NATIVE-ONLY val stackDepth = 6
-      //SCALATESTJS,NATIVE-ONLY val stackDepthAdjustment = -6
-      engine.registerTest(testName, org.scalatest.fixture.Transformer(testFun), Resources.testCannotAppearInsideAnotherTest, sourceFileName, "test", stackDepth, stackDepthAdjustment, None, None, None, testTags: _*)
-    }
-  */
 
   class ResultOfIgnoreInvocation(testName: String, testTags: Tag*) {
     
@@ -208,7 +197,7 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     }
     
     // SKIP-DOTTY-START
-    def apply(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    final def apply(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -227,7 +216,7 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     }
 
     // SKIP-DOTTY-START
-    def apply(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    final def apply(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -252,17 +241,6 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     */
   protected def ignore(testName: String, testTags: Tag*): ResultOfIgnoreInvocation = new ResultOfIgnoreInvocation(testName, testTags: _*)
-  /*
-    protected def ignore(testName: String, testTags: Tag*)(testFun: FixtureParam => Any /* Assertion */) {
-      // SKIP-SCALATESTJS,NATIVE-START
-      val stackDepth = 4
-      val stackDepthAdjustment = -3
-      // SKIP-SCALATESTJS,NATIVE-END
-      //SCALATESTJS,NATIVE-ONLY val stackDepth = 6
-      //SCALATESTJS,NATIVE-ONLY val stackDepthAdjustment = -7
-      engine.registerIgnoredTest(testName, org.scalatest.fixture.Transformer(testFun), Resources.ignoreCannotAppearInsideATest, sourceFileName, "ignore", stackDepth, stackDepthAdjustment, None, testTags: _*)
-    }
-  */
 
   /**
     * An immutable <code>Set</code> of test names. If this <code>FixtureAnyFunSuite</code> contains no tests, this method returns an empty <code>Set</code>.
@@ -413,19 +391,6 @@ trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with Informi
   protected implicit def convertPendingToFixtureFunction(f: => PendingStatement): (FixtureParam => Any /* Assertion */) = {
     fixture => { f; Succeeded }
   }
-
-  /**
-    * Implicitly converts a function that takes no parameters and results in <code>Any</code> to
-    * a function from <code>FixtureParam</code> to <code>Any</code>, to enable no-arg tests to registered
-    * by methods that require a test function that takes a <code>FixtureParam</code>.
-    *
-    * @param fun a function
-    * @return a function of <code>FixtureParam => Any</code>
-    */
-  /*
-    protected implicit def convertNoArgToFixtureFunction(fun: () => Any /* Assertion */): (FixtureParam => Any /* Assertion */) =
-      new NoArgTestWrapper(fun)
-  */
 
   override def testDataFor(testName: String, theConfigMap: ConfigMap = ConfigMap.empty): TestData = createTestDataFor(testName, theConfigMap, this)
 }

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
@@ -126,7 +126,7 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     }
     
     // SKIP-DOTTY-START
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    final def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -139,7 +139,7 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     }
 
     // SKIP-DOTTY-START
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    final def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -163,17 +163,6 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     * @throws NullArgumentException if <code>testName</code> or any passed test tag is <code>null</code>
     */
   protected def test(testName: String, testTags: Tag*): ResultOfTestInvocation = new ResultOfTestInvocation(testName, testTags: _*)
-  /*
-    protected def test(testName: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion]) {
-      // SKIP-SCALATESTJS,NATIVE-START
-      val stackDepth = 4
-      val stackDepthAdjustment = -2
-      // SKIP-SCALATESTJS,NATIVE-END
-      //SCALATESTJS,NATIVE-ONLY val stackDepth = 6
-      //SCALATESTJS,NATIVE-ONLY val stackDepthAdjustment = -6
-      engine.registerAsyncTest(testName, transformToOutcome(testFun), Resources.testCannotAppearInsideAnotherTest, sourceFileName, "test", stackDepth, stackDepthAdjustment, None, None, testTags: _*)
-    }
-  */
 
   class ResultOfIgnoreInvocation(testName: String, testTags: Tag*) {
 
@@ -182,7 +171,7 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     }
     
     // SKIP-DOTTY-START
-    def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    final def apply(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -195,7 +184,7 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     }
 
     // SKIP-DOTTY-START
-    def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    final def apply(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
       applyImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
@@ -220,17 +209,6 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
     * @throws NotAllowedException if <code>testName</code> had been registered previously
     */
   protected def ignore(testName: String, testTags: Tag*): ResultOfIgnoreInvocation = new ResultOfIgnoreInvocation(testName, testTags: _*)
-  /*
-    protected def ignore(testName: String, testTags: Tag*)(testFun: FixtureParam => Future[compatible.Assertion]) {
-      // SKIP-SCALATESTJS,NATIVE-START
-      val stackDepth = 4
-      val stackDepthAdjustment = -3
-      // SKIP-SCALATESTJS,NATIVE-END
-      //SCALATESTJS,NATIVE-ONLY val stackDepth = 6
-      //SCALATESTJS,NATIVE-ONLY val stackDepthAdjustment = -7
-      engine.registerIgnoredAsyncTest(testName, transformToOutcome(testFun), Resources.ignoreCannotAppearInsideATest, sourceFileName, "ignore", stackDepth, stackDepthAdjustment, None, testTags: _*)
-    }
-  */
 
   /**
     * An immutable <code>Set</code> of test names. If this <code>FixtureAsyncFunSuite</code> contains no tests, this method returns an empty <code>Set</code>.
@@ -385,19 +363,6 @@ trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with 
   protected implicit def convertPendingToFixtureFunction(f: => PendingStatement): (FixtureParam => compatible.Assertion) = {
     fixture => { f; Succeeded }
   }
-
-  /**
-    * Implicitly converts a function that takes no parameters and results in <code>Any</code> to
-    * a function from <code>FixtureParam</code> to <code>Any</code>, to enable no-arg tests to registered
-    * by methods that require a test function that takes a <code>FixtureParam</code>.
-    *
-    * @param fun a function
-    * @return a function of <code>FixtureParam => Any</code>
-    */
-  /*
-    protected implicit def convertNoArgToFixtureFunction(fun: () => compatible.Assertion): (FixtureParam => compatible.Assertion) =
-      new NoArgTestWrapper(fun)
-  */
 
   override def testDataFor(testName: String, theConfigMap: ConfigMap = ConfigMap.empty): TestData = createTestDataFor(testName, theConfigMap, this)
 }


### PR DESCRIPTION
- Made visibility for functions in FunSuite consistent between Scala 2 and 3.
- Removed unused commented source in FunSuite module.
