### PR TITLE
add `ResourceManagerFixture` trait, for resource management with `scala.util.Using.Manager`

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/fixture/ResourceManagerFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/ResourceManagerFixture.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2001-2024 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalatest
+package fixture
+
+import scala.util.Using
+
+/**
+ * A Trait that facilitates the management of resources that need to be
+ * disposed of after using them.
+ * It provides two separate instances of the <code>Using.Manager</code>
+ * class from the Scala standard library (see the Scala standard library
+ * documentationon <code>scala.util.Using</code> for details on how it
+ * works).
+ * 
+ * The first instance can be obtained by calling the <code>suiteScoped</code>
+ * method. Its purpose is to clean up resources that are shared between
+ * different tests in a suite. This method can only be called after test
+ * execution has started. It is therefore recommended to use it to initialize
+ * a <code>lazy val</code> in the Suite class. This way, the 
+ * <code>lazy val</code> can be used to access the resource while deferring
+ * the <code>suiteScoped</code> call until test execution has started.
+ * 
+ * The second instance is passed as a fixture parameter to the test.
+ * It is cleaned up after the test has completed and can therefore be used
+ * to clean up resources that are only required inside a single test.
+ *
+*/
+trait ResourceManagerFixture extends FixtureTestSuite {
+  override type FixtureParam = Using.Manager
+
+  private var suiteManagerVar: Using.Manager = null
+
+  protected def suiteScoped = Option(suiteManagerVar).getOrElse {
+    throw new IllegalStateException("""
+      |`suiteScoped`` cannot be called from outside a test.
+      |Use a `lazy val` to store Suite-scoped resources in order to defer
+      |initialization of such resources until the start of a test.
+    """.stripMargin)
+  }
+
+  protected def withFixture(test: OneArgTest): Outcome =
+    Using.Manager { manager =>
+      withFixture(test.toNoArgTest(manager))
+    }.get
+
+  override protected def runTests(testName: Option[String], args: Args): Status =
+    Using.Manager { manager =>
+      suiteManagerVar = manager
+      super.runTests(testName, args)
+    }.get
+}


### PR DESCRIPTION
Hey there,

As a long-time ScalaTest user, there are some issues with its support for resource management using `BeforeAndAfterAll` and `BeforeAndAfterEach` that have been bothering me for a long time.
 ## Motivation
These are:
 - the need for `var` and `null`. When you want to use `BeforeAndAfterAll` to initialize a shared (between tests in a suite) resource, you basically have to use a `var` initialized to `null` that you assign to in `beforeAll` and destroy in `afterAll`. Both `null` and `var` are widely considered something to avoid if possible
 - Fixture traits just don't work as a unit of composition. For example, you might have a trait that provides a database container fixture, and another trait that provides a connection pool fixture. You can't use the two together because there is only one `FixtureParam` type. Some libraries like testcontainers-scala-scalatest work around this by defining their own mechanisms for composition, and of course none of these are interoperable
 - resource management with `BeforeAndAfter*` is awkward and brittle. When overriding `before*` or `after*` you have to remember calling `super.before*` and `super.after*`, and you need to do it in the right order, which it isn't even clear what that is. Order of evaluation depends on the order that you mix in the traits, which is subtle and easy to get wrong. And when one of multiple stacked traits fails in its `before*` method, how do you make sure that previously allocated resources are cleaned up?

For these reasons I think another approach is needed.

## Design

`ResourceManagerFixture` is a trait that can be mixed into any `FixtureTestSuite`.

It provides a [`Using.Manager`](https://www.scala-lang.org/api/2.13.16/scala/util/Using$.html) to every test as a fixture parameter, and the protected `suiteScoped` method will give you access to a `Using.Manager` that will be cleaned up after all tests in the suite have finished.

Usage would look something like this:

```scala
import org.scalatest.fixture.ResourceManagerFixture
import org.scalatest.funsuite.FixtureAnyFunSuite

class DatabaseTest extends FixtureAnyFunSuite with ResourceManagerFixture {
  lazy val dbContainer = suiteScope {
    // create database container here
  }

  test("some database test") { use =>
    val dataSource = use {
      // create datasource here, with parameters obtained from `dbContainer`
    }
  }
}
```
The use of `lazy val` neatly avoids use of `var` and `null`. It also makes things efficient: if you never touch that `lazy val`, it won't be initialized at all. So you can e. g. define a database container in your base test suite class, and only those tests that interact with the database will actually spin up a container. This doesn't work with an `afterAll` method: if you define `lazy val someResource = …` in the suite and then call `someResource.close()` in `afterAll`, even if the `lazy val` wasn't used before, it will be initialized when `afterAll` runs only to then call `.close()` on it.
For the `Using.Manager` instance that is cleaned up after each test, I considered two approaches: pass it as a fixture parameter, or store it in a `var`. I ultimately went with a fixture because this allows tests to run in parallel.
This approach also works a lot better than loan-fixture methods. If you need multiple resources, the calls need to be nested, negatively impacting readability. With a `Using.Manager`, you just assign multiple vals:
```
  val resource1 = use(createResource())
  val resource2 = use(createOtherResource())
```
Suite-scoped and test-scoped resources can trivially be combined. And if any resource initialization fails, resources allocated before will be cleaned up correctly. You can even allocate resources in a loop!

I have used this approach to great effect in various projects and it really makes resource management a lot less painful than what's currently possible. So I wanted to share it with the wider ScalaTest community. 