### PR TITLE
FixtureAsyncTestSuite.withFixture consistent with FixtureTestSuite.withFixture

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/FixtureAsyncTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FixtureAsyncTestSuite.scala
@@ -287,5 +287,5 @@ trait FixtureAsyncTestSuite extends org.scalatest.FixtureSuite with org.scalates
    * @param test the <code>OneArgAsyncTest</code> to invoke, passing in a fixture
    * @return an instance of <code>FutureOutcome</code>
    */
-  def withFixture(test: OneArgAsyncTest): FutureOutcome
+  protected def withFixture(test: OneArgAsyncTest): FutureOutcome
 }


### PR DESCRIPTION
Made withFixture method in FixtureAsyncTestSuite.scala protected, to be consistent with withFixture method in FixtureTestSuite.scala.

This is a breaking change, so let's do it only in the upcoming 3.3.0.