### PR TITLE
Scala 3 Macro TypeCheckedTripleEqual Fix 

### DIFF
--- a/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -98,6 +98,19 @@ object BooleanMacro {
           }
         }.asExprOf[Bool]
 
+      case Apply(Apply(TypeApply(sel @ Select(lhs, op @ ("===" | "!==")), targs), rhs :: Nil), implicitArgs) =>
+        let(Symbol.spliceOwner, lhs) { left =>
+          let(Symbol.spliceOwner, rhs) { right =>
+            let(Symbol.spliceOwner, lhs.select(sel.symbol).appliedToTypeTrees(targs).appliedTo(right).appliedToArgs(implicitArgs)) { result =>
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
+              val code = '{ Bool.binaryMacroBool($l, ${ Expr(op) }, $r, $b, $prettifier) }
+              code.asTerm
+            }
+          }
+        }.asExprOf[Bool]
+
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         def binaryDefault =
           if (isByNameMethodType(sel.tpe)) defaultCase

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -683,66 +683,6 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should do nothing when is used to check a === 3 with TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(a === 3)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 with TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a === 5)
-      }
-      assert(e.message === Some(didNotEqual(3, 5)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 3 === a with TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(3 === a)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a with TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(5 === a)
-      }
-      assert(e.message === Some(didNotEqual(5, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a === 3 with TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(a === 3)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 with TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a === 5)
-      }
-      assert(e.message === Some(didNotEqual(3, 5)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 3 === a with TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(3 === a)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a with TypeCheckedTripleEquals ") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(5 === a)
-      }
-      assert(e.message === Some(didNotEqual(5, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
     it("should do nothing when is used to check a !== 5") {
       assert(a !== 5)
     }
@@ -761,66 +701,6 @@ class AssertionsSpec extends AnyFunSpec {
     }
 
     it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a") {
-      val e = intercept[TestFailedException] {
-        assert(3 !== a)
-      }
-      assert(e.message === Some(equaled(3, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a !== 5 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(a !== 5)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a !== 3)
-      }
-      assert(e.message === Some(equaled(3, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 5 !== a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(5 !== a)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(3 !== a)
-      }
-      assert(e.message === Some(equaled(3, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(a !== 5)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a !== 3)
-      }
-      assert(e.message === Some(equaled(3, 3)))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(5 !== a)
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
       val e = intercept[TestFailedException] {
         assert(3 !== a)
       }
@@ -2285,66 +2165,6 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    it("should do nothing when is used to check a === 3 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(a === 3, "dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a === 5, "dude")
-      }
-      assert(e.message === Some(didNotEqual(3, 5) + " dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 3 === a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(3 === a, ", dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(5 === a, ", dude")
-      }
-      assert(e.message === Some(didNotEqual(5, 3) + ", dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a === 3 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(a === 3, "dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a === 5, "dude")
-      }
-      assert(e.message === Some(didNotEqual(3, 5) + " dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 3 === a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(3 === a, ", dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(5 === a, ", dude")
-      }
-      assert(e.message === Some(didNotEqual(5, 3) + ", dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
     it("should do nothing when is used to check a !== 5") {
       assert(a !== 5, ". dude")
     }
@@ -2363,66 +2183,6 @@ class AssertionsSpec extends AnyFunSpec {
     }
 
     it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a") {
-      val e = intercept[TestFailedException] {
-        assert(3 !== a, "; dude")
-      }
-      assert(e.message === Some(equaled(3, 3) + "; dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a !== 5 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(a !== 5, ". dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a !== 3, ". dude")
-      }
-      assert(e.message === Some(equaled(3, 3) + ". dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 5 !== a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      assert(5 !== a, "; dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TripleEquals") {
-      import org.scalactic.TripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(3 !== a, "; dude")
-      }
-      assert(e.message === Some(equaled(3, 3) + "; dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(a !== 5, ". dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      val e = intercept[TestFailedException] {
-        assert(a !== 3, ". dude")
-      }
-      assert(e.message === Some(equaled(3, 3) + ". dude"))
-      assert(e.failedCodeFileName === (Some(fileName)))
-      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
-    }
-
-    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
-      assert(5 !== a, "; dude")
-    }
-
-    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
-      import org.scalactic.TypeCheckedTripleEquals._
       val e = intercept[TestFailedException] {
         assert(3 !== a, "; dude")
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -657,10 +657,6 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    // TripleEquals tests
-    // currently these tests are not calling TripleEquals's === and !== yet, import org.scalactic.TripleEquals does not seems to work
-    // Should make Assertions to extend TripleEquals instead of LegacyTripleEquals instead.
-
     it("should do nothing when is used to check a === 3") {
       assert(a === 3)
     }
@@ -687,6 +683,66 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check a === 3 with TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(a === 3)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 with TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a === 5)
+      }
+      assert(e.message === Some(didNotEqual(3, 5)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a with TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(3 === a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a with TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(5 === a)
+      }
+      assert(e.message === Some(didNotEqual(5, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a === 3 with TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(a === 3)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 with TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a === 5)
+      }
+      assert(e.message === Some(didNotEqual(3, 5)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a with TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(3 === a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a with TypeCheckedTripleEquals ") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(5 === a)
+      }
+      assert(e.message === Some(didNotEqual(5, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check a !== 5") {
       assert(a !== 5)
     }
@@ -705,6 +761,66 @@ class AssertionsSpec extends AnyFunSpec {
     }
 
     it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a") {
+      val e = intercept[TestFailedException] {
+        assert(3 !== a)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(a !== 5)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a !== 3)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(5 !== a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(3 !== a)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(a !== 5)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a !== 3)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(5 !== a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
       val e = intercept[TestFailedException] {
         assert(3 !== a)
       }
@@ -2143,10 +2259,6 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
-    // TripleEquals tests
-    // currently these tests are not calling TripleEquals's === and !== yet, import org.scalactic.TripleEquals does not seems to work
-    // Should make Assertions to extend TripleEquals instead of LegacyTripleEquals instead.
-
     it("should do nothing when is used to check a === 3") {
       assert(a === 3, "dude")
     }
@@ -2173,6 +2285,66 @@ class AssertionsSpec extends AnyFunSpec {
       assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
     }
 
+    it("should do nothing when is used to check a === 3 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(a === 3, "dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a === 5, "dude")
+      }
+      assert(e.message === Some(didNotEqual(3, 5) + " dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(3 === a, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(5 === a, ", dude")
+      }
+      assert(e.message === Some(didNotEqual(5, 3) + ", dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a === 3 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(a === 3, "dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a === 5, "dude")
+      }
+      assert(e.message === Some(didNotEqual(3, 5) + " dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(3 === a, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(5 === a, ", dude")
+      }
+      assert(e.message === Some(didNotEqual(5, 3) + ", dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
     it("should do nothing when is used to check a !== 5") {
       assert(a !== 5, ". dude")
     }
@@ -2191,6 +2363,66 @@ class AssertionsSpec extends AnyFunSpec {
     }
 
     it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a") {
+      val e = intercept[TestFailedException] {
+        assert(3 !== a, "; dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + "; dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(a !== 5, ". dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a !== 3, ". dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + ". dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      assert(5 !== a, "; dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TripleEquals") {
+      import org.scalactic.TripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(3 !== a, "; dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + "; dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(a !== 5, ". dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      val e = intercept[TestFailedException] {
+        assert(a !== 3, ". dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + ". dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
+      assert(5 !== a, "; dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
+      import org.scalactic.TypeCheckedTripleEquals._
       val e = intercept[TestFailedException] {
         assert(3 !== a, "; dude")
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsWithTypeCheckedTripleEqualsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsWithTypeCheckedTripleEqualsSpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2001-2015 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatest
+
+import org.scalatest.exceptions.TestFailedException
+import SharedHelpers.thisLineNumber
+import org.scalactic.{Prettifier, TypeCheckedTripleEquals}
+import org.scalatest.funspec.AnyFunSpec
+
+class AssertionsWithTypeCheckedTripleEqualsSpec extends AnyFunSpec with TypeCheckedTripleEquals {
+
+  val fileName: String = "AssertionsWithTypeCheckedTripleEqualsSpec.scala"
+
+  private val prettifier = Prettifier.default
+
+  def didNotEqual(left: Any, right: Any): String = {
+    val (leftee, rightee) = Suite.getObjectsForFailureMessage(left, right)
+    FailureMessages.didNotEqual(prettifier, leftee, rightee)
+  }
+
+  def equaled(left: Any, right: Any): String =
+    FailureMessages.equaled(prettifier, left, right)
+
+  describe("The assert(boolean) method") {
+    val a = 3
+
+    it("should do nothing when is used to check a === 3 with TypeCheckedTripleEquals") {
+      assert(a === 3)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 with TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(a === 5)
+      }
+      assert(e.message === Some(didNotEqual(3, 5)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a with TypeCheckedTripleEquals") {
+      assert(3 === a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a with TypeCheckedTripleEquals ") {
+      val e = intercept[TestFailedException] {
+        assert(5 === a)
+      }
+      assert(e.message === Some(didNotEqual(5, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
+      assert(a !== 5)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(a !== 3)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
+      assert(5 !== a)
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(3 !== a)
+      }
+      assert(e.message === Some(equaled(3, 3)))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+  }
+
+  describe("The assert(boolean, clue) method") {
+
+    val a = 3
+
+    it("should do nothing when is used to check a === 3 using TypeCheckedTripleEquals") {
+      assert(a === 3, "dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a === 5 using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(a === 5, "dude")
+      }
+      assert(e.message === Some(didNotEqual(3, 5) + " dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 3 === a using TypeCheckedTripleEquals") {
+      assert(3 === a, ", dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 5 === a using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(5 === a, ", dude")
+      }
+      assert(e.message === Some(didNotEqual(5, 3) + ", dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check a !== 5 using TypeCheckedTripleEquals") {
+      assert(a !== 5, ". dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check a !== 3 using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(a !== 3, ". dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + ". dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+    it("should do nothing when is used to check 5 !== a using TypeCheckedTripleEquals") {
+      assert(5 !== a, "; dude")
+    }
+
+    it("should throw TestFailedException with correct message and stack depth when is used to check 3 !== a using TypeCheckedTripleEquals") {
+      val e = intercept[TestFailedException] {
+        assert(3 !== a, "; dude")
+      }
+      assert(e.message === Some(equaled(3, 3) + "; dude"))
+      assert(e.failedCodeFileName === (Some(fileName)))
+      assert(e.failedCodeLineNumber === (Some(thisLineNumber - 4)))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Fixed TypeCheckedTripleEqual macro problem in Scala 3.