### PR TITLE
Scaladoc Fix about Default Execution Context in JS

### DIFF
--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -243,10 +243,8 @@ import org.scalatest.Suite
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -201,10 +201,8 @@ import org.scalatest.Suite
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -210,10 +210,8 @@ import org.scalatest.Suite
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -207,10 +207,8 @@ import org.scalatest.Suite
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -185,10 +185,8 @@ import org.scalatest.{Suite, Finders}
   *
   * <p>
   * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
-  * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
-  * execution is the only possibility, the default execution context is
-  * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM,
-  * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+  * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+  * provided by ScalaTest itself.
   * </p>
   *
   * <p>

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -238,10 +238,8 @@ import org.scalatest.Suite
  * 
  * <p>
  * On both the JVM and Scala.js, the default execution context provided by ScalaTest's asynchronous
- * testing styles confines execution to a single thread per test. On JavaScript, where single-threaded
- * execution is the only possibility, the default execution context is
- * <code>scala.scalajs.concurrent.JSExecutionContext.Implicits.queue</code>. On the JVM, 
- * the default execution context is a <em>serial execution context</em> provided by ScalaTest itself.
+ * testing styles confines execution to a single thread per test, using a <em>serial execution context</em> 
+ * provided by ScalaTest itself.
  * </p>
  * 
  * <p>


### PR DESCRIPTION
Corrected scaladoc about default execution context in JS.