### PR TITLE
Backport StringReporter Match

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/tools/StringReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/StringReporter.scala
@@ -489,7 +489,7 @@ private[scalatest] object StringReporter {
           }
         }
         else simpleFileNameApproach(stackDepth.failedCodeFileNameAndLineNumberString)
-      case None => stringToPrint
+      case _ => stringToPrint
     }
   }
 


### PR DESCRIPTION
Backported a fix for a match warning in StringReporter.scala.