### PR TITLE
Dependencies Version Upgrades

### DIFF
--- a/project/BuildCommons.scala
+++ b/project/BuildCommons.scala
@@ -247,12 +247,7 @@ trait BuildCommons {
     )    
 
   def nativeCrossBuildLibraryDependencies = Def.setting {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) => Seq.empty
-      case Some((2, 11)) => Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
-      case Some((scalaEpoch, scalaMajor)) if (scalaEpoch == 2 && scalaMajor >= 12) || scalaEpoch == 3 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.3.0"))
-    }
+    Seq(("org.scala-lang.modules" %% "scala-xml" % "2.4.0"))
   }    
 
   def sharedTestSettingsNative: Seq[Setting[_]] =

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -293,7 +293,7 @@ trait DottyBuild { this: BuildCommons =>
       console / initialCommands := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.1.0", 
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0", 
       libraryDependencies ++= scalatestJSLibraryDependencies.value, 
       packageManagedSources,
       Compile / sourceGenerators += Def.task {
@@ -369,7 +369,7 @@ trait DottyBuild { this: BuildCommons =>
       console / initialCommands := """|import org.scalatest._
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.3.0",
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0",
       libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
       packageManagedSources,
       Compile / sourceGenerators += Def.task {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.18.2")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.19.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -131,9 +131,9 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   def scalaXmlDependency(theScalaVersion: String): Seq[ModuleID] =
     CrossVersion.partialVersion(theScalaVersion) match {
-      case Some((2, 11)) => Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.0"))
+      case Some((2, 11)) => Seq(("org.scala-lang.modules" %% "scala-xml" % "1.3.1"))
       case Some((scalaEpoch, scalaMajor)) if (scalaEpoch == 2 && scalaMajor >= 12) || scalaEpoch == 3 =>
-        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.1.0"))
+        Seq(("org.scala-lang.modules" %% "scala-xml" % "2.4.0"))
     }
 
   def scalaLibraries(theScalaVersion: String) =

--- a/project/scalatest.scala
+++ b/project/scalatest.scala
@@ -151,7 +151,7 @@ object ScalatestBuild extends BuildCommons with DottyBuild with NativeBuild with
 
   def crossBuildTestLibraryDependencies: sbt.Def.Initialize[Seq[ModuleID]] = Def.setting {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 11)) => Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.1.1")
+      case Some((2, 11)) => Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.2.0")
       case _ => Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0")
     }
   }


### PR DESCRIPTION
- Scala-js to 1.19.0
- Scala-xml 2.4.0, 1.3.1 for Scala 2.11 Build
- Scala-parser-combinators 2.2.0 for Scala 2.11 Build