### PR TITLE
Scaladoc Improvements

### DIFF
--- a/dotty/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Assertions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/core/src/main/scala/org/scalatest/AssertionsMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/AssertionsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/dotty/core/src/main/scala/org/scalatest/CompileMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/core/src/main/scala/org/scalatest/Inspectors.scala
+++ b/dotty/core/src/main/scala/org/scalatest/Inspectors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
+++ b/dotty/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedAssertionsMacro.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedAssertionsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExpr.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
+++ b/dotty/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/dotty/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/expectations/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
+++ b/dotty/expectations/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/CompileMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternHelper.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
+++ b/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/CompileMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/TypeMatcherMacro.scala
+++ b/dotty/mustmatchers/src/main/scala/org/scalatest/matchers/must/TypeMatcherMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/Requirements.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/Requirements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/Snapshots.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/Snapshots.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/CompileTimeAssertions.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/CompileTimeAssertions.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/NumericString.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/NumericString.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/NumericStringMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/NumericStringMacro.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/PercentageInt.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/PercentageInt.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/PercentageIntMacros.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/PercentageIntMacros.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/RegexString.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/RegexString.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/anyvals/RegexStringMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/anyvals/RegexStringMacro.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/source/Position.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/source/Position.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalactic/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/AssertionsCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/AssertionsCanEqualSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must/MustBeCanEqualSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
+++ b/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should/ShouldBeCanEqualSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
+++ b/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/CompileMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/TypeMatcherMacro.scala
+++ b/dotty/shouldmatchers/src/main/scala/org/scalatest/matchers/should/TypeMatcherMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/java/org/scalatest/examples/refspec/tagging/DbTest.java
+++ b/examples/src/test/java/org/scalatest/examples/refspec/tagging/DbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/java/org/scalatest/examples/refspec/tagging/SlowTest.java
+++ b/examples/src/test/java/org/scalatest/examples/refspec/tagging/SlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/TVSetActorSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/TVSetActorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/composingwithasyncfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/composingwithasyncfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/ignore/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/ignore/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/ignoreall/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/ignoreall/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/noargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/noargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/oneargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/oneargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/pending/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/pending/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/sharedtests/StackSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/sharedtests/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/tagging/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfeaturespec/tagging/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/composingwithasyncfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/composingwithasyncfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/ignore/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/ignore/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/ignoreall/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/ignoreall/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/noargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/noargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/oneargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/oneargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/pending/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/pending/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/sharedtests/StackSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/sharedtests/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncflatspec/tagging/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncflatspec/tagging/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/composingwithasyncfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/composingwithasyncfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/ignore/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/ignore/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/ignoreall/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/ignoreall/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/noargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/noargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/oneargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/oneargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/pending/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/pending/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/sharedtests/StackSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/sharedtests/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfreespec/tagging/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfreespec/tagging/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/composingwithasyncfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/composingwithasyncfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/ignore/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/ignore/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/ignoreall/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/ignoreall/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/noargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/noargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/oneargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/oneargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/pending/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/pending/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/sharedtests/StackSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/sharedtests/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunspec/tagging/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunspec/tagging/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/AddSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/AddSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/beforeandafter/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/beforeandafter/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/composingbeforeandaftereach/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/composingbeforeandaftereach/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/composingwithasyncfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/composingwithasyncfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/getfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/getfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/ignore/AddSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/ignore/AddSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/ignoreall/AddSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/ignoreall/AddSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/loanfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/loanfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/noargasynctest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/noargasynctest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/oneargasynctest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/oneargasynctest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/pending/AddSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/pending/AddSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/sharedtests/StackSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/sharedtests/StackSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/tagging/AddSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncfunsuite/tagging/AddSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncpropspec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncpropspec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asynctimelimitedtests/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asynctimelimitedtests/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/composingwithasyncfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/composingwithasyncfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/ignore/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/ignore/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/ignoreall/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/ignoreall/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/noargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/noargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/oneargasynctest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/oneargasynctest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/pending/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/pending/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/sharedtests/StackSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/sharedtests/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/asyncwordspec/tagging/AddSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/asyncwordspec/tagging/AddSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/beforeandafterallconfigmap/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/beforeandafterallconfigmap/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/TVSetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/TVSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/ignore/TVSetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/ignore/TVSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/infopending/TVSetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/infopending/TVSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/pending/TVSetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/pending/TVSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/featurespec/tagging/TVSetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/featurespec/tagging/TVSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/asyncfunsuite/sharing/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/asyncfunsuite/sharing/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/configmapfixture/ExampleAsyncSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/configmapfixture/ExampleAsyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/configmapfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/configmapfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/featurespec/sharing/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/featurespec/sharing/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/flatspec/sharing/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/flatspec/sharing/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/freespec/sharing/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/freespec/sharing/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/funspec/sharing/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/funspec/sharing/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/funsuite/sharing/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/funsuite/sharing/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/testdatafixture/ExampleAsyncSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/testdatafixture/ExampleAsyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/testdatafixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/testdatafixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/fixture/wordspec/sharing/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/fixture/wordspec/sharing/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/composingbeforeandaftereachtestdata/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/composingbeforeandaftereachtestdata/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/cpuall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/cpuall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/diskall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/diskall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/ignoreall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/ignoreall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/networkall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/networkall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/slowall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/slowall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/flatspec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/flatspec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/ignoreall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/ignoreall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/freespec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/freespec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/ignoreall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/ignoreall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/note/SetSpec.scala
@@ -1,4 +1,4 @@
-/* * Copyright 2001-2024 Artima, Inc.
+/* * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funspec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funspec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/beforeandafter/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/beforeandafter/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/composingbeforeandaftereach/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/composingbeforeandaftereach/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/composingwithfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/composingwithfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/fixturecontext/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/fixturecontext/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/getfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/getfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/ignore/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/ignore/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/ignoreall/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/ignoreall/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/info/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/info/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/loanfixture/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/loanfixture/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/markup/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/markup/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/noargtest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/noargtest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/note/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/note/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/oneargtest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/oneargtest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/oneinstancepertest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/oneinstancepertest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/pending/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/pending/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/sharedtests/StackFunSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/sharedtests/StackFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/funsuite/tagging/SetSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/funsuite/tagging/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/multi/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/multi/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/propspec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/propspec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/cpu/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/cpu/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/disk/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/disk/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/ignoreall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/ignoreall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/network/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/network/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/slow/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/slow/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/refspec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/refspec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/selenium/GoogleSearchSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/selenium/GoogleSearchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/suite/noargtest/ExampleSuite.scala
+++ b/examples/src/test/scala/org/scalatest/examples/suite/noargtest/ExampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/timelimitedtests/ExampleSignalerSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/timelimitedtests/ExampleSignalerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/timelimitedtests/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/timelimitedtests/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/beforeandafter/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/beforeandafter/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/composingbeforeandaftereach/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/composingbeforeandaftereach/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/composingwithfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/composingwithfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/fixturecontext/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/fixturecontext/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/getfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/getfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/ignore/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/ignore/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/ignoreall/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/ignoreall/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/info/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/info/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/loanfixture/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/loanfixture/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/markup/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/markup/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/noargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/noargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/note/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/note/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/oneargtest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/oneargtest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/oneinstancepertest/ExampleSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/oneinstancepertest/ExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/pending/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/pending/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/org/scalatest/examples/wordspec/tagging/SetSpec.scala
+++ b/examples/src/test/scala/org/scalatest/examples/wordspec/tagging/SetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/js/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/compatible/Assertion.scala
+++ b/js/core/src/main/scala/org/scalatest/compatible/Assertion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/compatible/package.scala
+++ b/js/core/src/main/scala/org/scalatest/compatible/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/concurrent/SleepHelper.scala
+++ b/js/core/src/main/scala/org/scalatest/concurrent/SleepHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/concurrent/TestExecutionContext.scala
+++ b/js/core/src/main/scala/org/scalatest/concurrent/TestExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/js/core/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/SbtReporter.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SbtReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/ScalaTestSbtEvent.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/ScalaTestSbtEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/SummaryCounter.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/SummaryCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/js/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
+++ b/js/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
@@ -1,5 +1,5 @@
   /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/BookPropertyMatchers.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/BookPropertyMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/EmptyMocks.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/EmptyMocks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/FileMocks.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/FileMocks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/FruitMocks.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/FruitMocks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/JSON.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/JSON.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/LineNumberMacro.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/LineNumberMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/OperatorNames.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/OperatorNames.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/ReturnsNormallyThrowsAssertion.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/ReturnsNormallyThrowsAssertion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/SharedHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/StringFixture.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/StringFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/StubReporter.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/StubReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/mytags.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/mytags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/common-test/src/main/scala/org/scalatest/path/ExampleLikeSpecs.scala
+++ b/jvm/common-test/src/main/scala/org/scalatest/path/ExampleLikeSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/compatible/src/main/java/org/scalatest/compatible/Assertion.java
+++ b/jvm/compatible/src/main/java/org/scalatest/compatible/Assertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/DoNotDiscover.java
+++ b/jvm/core/src/main/java/org/scalatest/DoNotDiscover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/Finders.java
+++ b/jvm/core/src/main/java/org/scalatest/Finders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/Ignore.java
+++ b/jvm/core/src/main/java/org/scalatest/Ignore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/TagAnnotation.java
+++ b/jvm/core/src/main/java/org/scalatest/TagAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/WrapWith.java
+++ b/jvm/core/src/main/java/org/scalatest/WrapWith.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/CPU.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/CPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/ChromeBrowser.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/ChromeBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/Disk.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/Disk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/FirefoxBrowser.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/FirefoxBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/HtmlUnitBrowser.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/HtmlUnitBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/InternetExplorerBrowser.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/InternetExplorerBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/Network.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/Retryable.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/Retryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/SafariBrowser.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/SafariBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/java/org/scalatest/tags/Slow.java
+++ b/jvm/core/src/main/java/org/scalatest/tags/Slow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Alerter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Alerter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Alerting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Alerting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/AppendedClues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AppendedClues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Args.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Args.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Assertions.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Assertions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/AssertionsMacro.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AssertionsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/AsyncTestSuiteMixin.scala
+++ b/jvm/core/src/main/scala/org/scalatest/AsyncTestSuiteMixin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/BeforeAndAfter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/BeforeAndAfter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterAll.scala
+++ b/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterAll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterAllConfigMap.scala
+++ b/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterAllConfigMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterEach.scala
+++ b/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterEach.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterEachTestData.scala
+++ b/jvm/core/src/main/scala/org/scalatest/BeforeAndAfterEachTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/CancelAfterFailure.scala
+++ b/jvm/core/src/main/scala/org/scalatest/CancelAfterFailure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/CatchReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/CatchReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Checkpoints.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Checkpoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/jvm/core/src/main/scala/org/scalatest/CompileMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/CompleteLastly.scala
+++ b/jvm/core/src/main/scala/org/scalatest/CompleteLastly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/ConcurrentInformer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ConcurrentInformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ConfigMapWrapperSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DeferredAbortedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DiagrammedExpr.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DiagrammedExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DiagrammedExprMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DispatchReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DispatchReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DistributedSuiteSorter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DistributedSuiteSorter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DistributedTestSorter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DistributedTestSorter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Distributor.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Distributor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Doc.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Doc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DocSpec.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DocSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DocSpecLike.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DocSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Documenter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Documenter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Documenting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Documenting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/DynaTags.scala
+++ b/jvm/core/src/main/scala/org/scalatest/DynaTags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EitherValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/EncodedOrdering.scala
+++ b/jvm/core/src/main/scala/org/scalatest/EncodedOrdering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Engine.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Engine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Entry.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Entry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Fact.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Fact.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Filter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Filter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/FixtureAsyncTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FixtureAsyncTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/FixtureContext.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FixtureContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/FixtureSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FixtureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/FixtureTestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FixtureTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/FutureOutcome.scala
+++ b/jvm/core/src/main/scala/org/scalatest/FutureOutcome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/GivenWhenThen.scala
+++ b/jvm/core/src/main/scala/org/scalatest/GivenWhenThen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Informer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Informer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Informing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Informing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/InsertionOrderSet.scala
+++ b/jvm/core/src/main/scala/org/scalatest/InsertionOrderSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Inside.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Inside.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Inspectors.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Inspectors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/JSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/JSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/jvm/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/LoneElement.scala
+++ b/jvm/core/src/main/scala/org/scalatest/LoneElement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/NonImplicitAssertions.scala
+++ b/jvm/core/src/main/scala/org/scalatest/NonImplicitAssertions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Notifier.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Notifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Notifying.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Notifying.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/OneInstancePerTest.scala
+++ b/jvm/core/src/main/scala/org/scalatest/OneInstancePerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/OptionValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/OptionValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Outcome.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Outcome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/OutcomeOf.scala
+++ b/jvm/core/src/main/scala/org/scalatest/OutcomeOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/ParallelTestExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ParallelTestExecution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/PartialFunctionValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/PartialFunctionValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Payloads.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Payloads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/PendingStatement.scala
+++ b/jvm/core/src/main/scala/org/scalatest/PendingStatement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/PrivateMethodTester.scala
+++ b/jvm/core/src/main/scala/org/scalatest/PrivateMethodTester.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/RandomTestOrder.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RandomTestOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/RecoverMethods.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RecoverMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Reporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Reporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Rerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Rerunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/ResourcefulReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/ResourcefulReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Retries.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Retries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/RunningTest.scala
+++ b/jvm/core/src/main/scala/org/scalatest/RunningTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Sequential.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Sequential.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SequentialNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SequentialNestedSuiteExecution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SeveredStackTraces.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SeveredStackTraces.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Shell.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Shell.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Slowpoke.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Slowpoke.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SlowpokeDetector.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SlowpokeDetector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Status.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Status.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Stepwise.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Stepwise.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StepwiseNestedSuiteExecution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StopOnFailure.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StopOnFailure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StopOnFailureReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StopOnFailureReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Stopper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Stopper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StreamlinedXml.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StreamlinedXml.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StreamlinedXmlEquality.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StreamlinedXmlEquality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/StreamlinedXmlNormMethods.scala
+++ b/jvm/core/src/main/scala/org/scalatest/StreamlinedXmlNormMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Suite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SuiteHelpers.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SuiteHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SuiteMixin.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SuiteMixin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/SuiteRerunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Suites.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Tag.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Tag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TestData.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TestRerunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestRerunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TestSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TestSuiteMixin.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestSuiteMixin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TestsBeforeNestedSuites.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TestsBeforeNestedSuites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Tracker.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Tracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/Transformer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Transformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/TryValues.scala
+++ b/jvm/core/src/main/scala/org/scalatest/TryValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/UnquotedString.scala
+++ b/jvm/core/src/main/scala/org/scalatest/UnquotedString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/AbstractPatienceConfiguration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/AbstractPatienceConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncCancelAfterFailure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncTimeLimitedTests.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/AsyncTimeLimitedTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/ConductorFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/ConductorFixture.scala
@@ -1,5 +1,5 @@
 /*
-  * Copyright 2001-2024 Artima, Inc.
+  * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/ConductorMethods.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/ConductorMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Conductors.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Conductors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/DoNotSignal.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/DoNotSignal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Eventually.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Eventually.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Futures.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Futures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/IntegrationPatience.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/IntegrationPatience.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/JavaFutures.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/JavaFutures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/PatienceConfiguration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/PatienceConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/PimpedReadWriteLock.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/PimpedReadWriteLock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/PimpedThreadGroup.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/PimpedThreadGroup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/ScalaFutures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/ScaledTimeSpans.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/ScaledTimeSpans.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/SelectorSignaler.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/SelectorSignaler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/SerialExecutionContext.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/SerialExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Signaler.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Signaler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/SignalerTimeoutTask.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/SignalerTimeoutTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/SleepHelper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/SleepHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/SocketSignaler.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/SocketSignaler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/TestThreadsStartingCounter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/TestThreadsStartingCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/ThreadSignaler.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/ThreadSignaler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/TimeLimitedTests.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/TimeLimitedTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/TimeLimits.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/TimeLimits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/Waiters.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/Waiters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/concurrent/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/concurrent/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Collecting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Collecting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Definition.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Definition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Emptiness.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Emptiness.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Existence.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Existence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Futuristic.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Futuristic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/KeyMapping.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/KeyMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Length.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Length.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Messaging.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Messaging.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Readability.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Readability.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Size.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Size.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Slicing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Slicing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sortable.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sortable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Timed.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Timed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/ValueMapping.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/ValueMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/WheneverAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/WheneverAsserting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Writability.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Writability.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/enablers/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/Event.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Event.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/EventXmlHelper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/EventXmlHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/Formatter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Formatter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/Location.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Location.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/NameInfo.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/NameInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/Ordinal.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Ordinal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/Summary.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/Summary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/events/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/events/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/DiscardedEvaluationException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/DiscardedEvaluationException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/DuplicateTestNameException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/DuplicateTestNameException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/ModifiableMessage.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/ModifiableMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/ModifiablePayload.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/ModifiablePayload.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/NotAllowedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/NotAllowedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/NotSerializableWrapperException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/NotSerializableWrapperException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/PayloadField.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/PayloadField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/PropertyCheckFailedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/StackDepth.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/StackDepth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TestCanceledException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TestFailedDueToTimeoutException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TestFailedDueToTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TestFailedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TestPendingException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TestPendingException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TestRegistrationClosedException.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TestRegistrationClosedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/TimeoutField.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/TimeoutField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/exceptions/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/exceptions/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/AsyncConfigMapFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/AsyncConfigMapFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/AsyncPendingTransformer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/AsyncPendingTransformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/AsyncTestDataFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/AsyncTestDataFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/ConfigMapFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/ConfigMapFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/FixtureNodeFamily.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/FixtureNodeFamily.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/NoArg.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/NoArgTestWrapper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/NoArgTestWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/TestDataFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/TestDataFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/Transformer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/Transformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/UnitFixture.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/UnitFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/fixture/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/fixture/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Classification.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Classification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Classification.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Classification.scala
@@ -18,34 +18,30 @@ package org.scalatest.prop
 import org.scalactic.anyvals.{PosInt,PosZInt}
 
 /**
-  * The results of a call to [[CommonGenerators.classify]].
+  * Represents the result of [[CommonGenerators.classify]], showing how generated values are distributed into buckets.
   *
-  * The `classify` function takes a [[PartialFunction]] and a [[Generator]], and organizes the values created
-  * by the Generator based on the PartialFunction. It returns this data structure, which describes
-  * how many of the values fall into each bucket.
+  * The `classify` function organizes values from a [[Generator]] using a [[PartialFunction]], counting how many fall into each bucket.
+  * If some values are not covered by the PartialFunction, [[totals]] will not include them, and the sum of [[totals]] may be less than [[totalGenerated]].
   *
-  * If the PartialFunction did not cover all the possible generated values, then the [[totals]] field will
-  * not include the others, and the numbers in [[totals]] will add up to less than [[totalGenerated]].
-  *
-  * @param totalGenerated How many values were actually created by the Generator overall.
-  * @param totals For each of the buckets defined in the PartialFunction, how many values belonged in each one.
+  * @param totalGenerated Total number of values generated.
+  * @param totals Map of bucket name to count of values in that bucket.
   */
 case class Classification(val totalGenerated: PosInt, val totals: Map[String, PosZInt]) {
 
   /**
-    * For each bucket, what fraction of the generated values fell into it?
+    * Returns the fraction of generated values in each bucket.
     *
-    * @return The exact proportion of the values fell into each bucket.
+    * @return Map of bucket name to proportion (0.0 to 1.0).
     */
   def portions: Map[String, Double] =
     totals.mapValues(count => count.toDouble / totalGenerated.toDouble).toMap
 
   /**
-    * For each bucket, what percentage of the generated values fell into it?
+    * Returns the percentage of generated values in each bucket (rounded to integer).
     *
-    * This is essentially a lower-precision but easier-to-understand variant of [[portions]].
+    * Easier to interpret than [[portions]].
     *
-    * @return The approximate proportion of the values fell into each bucket.
+    * @return Map of bucket name to percentage (0 to 100).
     */
   def percentages: Map[String, PosZInt] =
     (totals mapValues { count =>

--- a/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Configuration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Configuration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/HavingLength.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/HavingLength.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/HavingSize.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/HavingSize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/PrettyFunction0.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/PropertyArgument.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/PropertyArgument.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/PropertyCheckResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/PropertyChecks.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/PropertyChecks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Seed.scala
@@ -1,7 +1,7 @@
 package org.scalatest.prop
 
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/SizeParam.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/SizeParam.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/Whenever.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Whenever.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/prop/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/run.scala
+++ b/jvm/core/src/main/scala/org/scalatest/run.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/CPU.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/CPU.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/ChromeBrowser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/ChromeBrowser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/Disk.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/Disk.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/FirefoxBrowser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/FirefoxBrowser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/HtmlUnitBrowser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/HtmlUnitBrowser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/InternetExplorerBrowser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/InternetExplorerBrowser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/Network.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/Network.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/Retryable.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/Retryable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/SafariBrowser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/SafariBrowser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/Slow.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/Slow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tagobjects/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tagobjects/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/time/Now.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/Now.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/time/Span.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/Span.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/time/SpanSugar.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/SpanSugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/time/Units.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/Units.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/time/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/AboutJDialog.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/AboutJDialog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/AnsiColor.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/AnsiColor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/AnsiReset.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/AnsiReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ArgsParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ColorBar.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ColorBar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ConcurrentDistributor.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ConcurrentDistributor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/DashboardReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/DashboardReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/DistributedTestRunnerSuite.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/DistributedTestRunnerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Durations.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Durations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/EventHolder.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/EventHolder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/EventToPresent.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/EventToPresent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/FileReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/FileReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/FilterReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/FilterReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Fragment.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Fragment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/IconEmbellishedListCellRenderer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/IconEmbellishedListCellRenderer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/JUnitXmlReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Memento.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Memento.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/MemoryReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/MemoryReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/NarrowJOptionPane.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/NarrowJOptionPane.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/NestedSuiteParam.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/NestedSuiteParam.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ParsedArgs.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ParsedArgs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/PrintReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/PrintReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ProgressBarPanel.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ProgressBarPanel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ReporterConfigParam.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ReporterConfigParam.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ReporterConfiguration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ReporterConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ReporterFactory.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ReporterFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/RunDoneListener.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/RunDoneListener.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/RunnerGUI.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/RunnerGUI.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/RunnerGUIState.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/RunnerGUIState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SbtCommandParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SbtDispatchReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SbtDispatchReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SocketReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/StandardErrReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/StandardErrReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/StandardOutReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/StandardOutReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/StatusJPanel.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/StatusJPanel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/StringReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/StringReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteParam.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteParam.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteResult.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteResultHolder.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteResultHolder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteRunner.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteSortingReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/SuiteSummary.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/SuiteSummary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/TestSortingReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/TestSortingReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/TestSpec.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/TestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/TestSpecificReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/TestSpecificReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Utils.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/XmlReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/XmlReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/XmlSocketReporter.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/XmlSocketReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/tools/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/ArrayWrapper.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/ArrayWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/BehaveWord.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/BehaveWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/CanVerb.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/CanVerb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/CompileWord.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/CompileWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/MustVerb.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/MustVerb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfAfterWordApplication.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfAfterWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfStringPassedToVerb.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfStringPassedToVerb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfTaggedAsInvocation.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/ResultOfTaggedAsInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/ShouldVerb.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/ShouldVerb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbBehaveLikeInvocation.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbBehaveLikeInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbBlockRegistration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbBlockRegistration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbStringInvocation.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/StringVerbStringInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/SubjectWithAfterWordRegistration.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/SubjectWithAfterWordRegistration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/TypeCheckWord.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/TypeCheckWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/WillVerb.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/WillVerb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/core/src/main/scala/org/scalatest/verbs/package.scala
+++ b/jvm/core/src/main/scala/org/scalatest/verbs/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DiagramsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DiagramsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
+++ b/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams/DirectDiagrammedAssertionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExpr.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExprMacro.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagrammedExprMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/Diagrams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/DiagramsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/diagrams/src/main/scala/org/scalatest/diagrams/package.scala
+++ b/jvm/diagrams/src/main/scala/org/scalatest/diagrams/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/expectations-test/src/test/scala/org/scalatest/expectations/DirectExpectationsSpec.scala
+++ b/jvm/expectations-test/src/test/scala/org/scalatest/expectations/DirectExpectationsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/expectations-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
+++ b/jvm/expectations-test/src/test/scala/org/scalatest/expectations/ExpectationsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/jvm/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/expectations/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
+++ b/jvm/expectations/src/main/scala/org/scalatest/expectations/ExpectationsMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AnyFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/AsyncFeatureSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedFixtureFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/DeprecatedFixtureFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec2.scala
+++ b/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpec.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/package.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AnyFlatSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/AsyncFlatSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAnyFlatSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec2.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecImportedMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecImportedMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecMixedInMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FixtureFlatSpecMixedInMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FlatSpecImportedMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FlatSpecImportedMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FlatSpecMixedInMatchersSpec.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/FlatSpecMixedInMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/SlowTest.scala
+++ b/jvm/flatspec-test/src/test/scala/org/scalatest/flatspec/SlowTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpec.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/package.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AnyFreeSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/AsyncFreeSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAnyFreeSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec2.scala
+++ b/jvm/freespec-test/src/test/scala/org/scalatest/freespec/FixtureAsyncFreeSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpec.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/package.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AnyFunSpecSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/AsyncFunSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAnyFunSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec2.scala
+++ b/jvm/funspec-test/src/test/scala/org/scalatest/funspec/FixtureAsyncFunSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpec.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/package.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AnyFunSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/AsyncFunSuiteSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAnyFunSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec2.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FunSuiteSuite.scala
+++ b/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite/FunSuiteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/package.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/AMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/AMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/AnMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/AnMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BeMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BeMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BePropertyMatchResult.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BePropertyMatchResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BePropertyMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/BePropertyMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/EqualMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/EqualMatcher.scala
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/HavePropertyMatchResult.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/HavePropertyMatchResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/HavePropertyMatcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/HavePropertyMatcher.scala
@@ -1,4 +1,4 @@
-/* * Copyright 2001-2024 Artima, Inc.
+/* * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/LazyArg.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/LazyArg.scala
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/LazyMessage.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/LazyMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchFailed.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchFailed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternHelper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchPatternMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchResult.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchSucceeded.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchSucceeded.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchersHelper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatchersHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/TypeMatcherMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/WillMatchersHelper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/WillMatchersHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ContainWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ContainWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/DefinedWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/DefinedWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EmptyWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EmptyWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EndWithWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EndWithWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ExistWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ExistWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/FullyMatchWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/FullyMatchWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/HaveWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/HaveWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/IncludeWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/IncludeWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaCollectionWrapper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaCollectionWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaMapWrapper.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/JavaMapWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/LengthWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/LengthWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatcherWords.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatcherWords.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NoExceptionWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NoExceptionWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/PleaseUseNoExceptionShouldSyntaxInstead.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/PleaseUseNoExceptionShouldSyntaxInstead.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ReadableWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ReadableWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/RegexWithGroups.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/RegexWithGroups.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToAMatcherApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToAMatcherApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToBePropertyMatcherApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToBePropertyMatcherApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAllElementsOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAllElementsOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAllOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAllOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToAnMatcherApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToAnMatcherApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToBePropertyMatcherApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToBePropertyMatcherApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneElementOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneElementOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneElementOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneElementOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeThrownBy.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeThrownBy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAType.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnType.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoException.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfContainWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfContainWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfDefinedAt.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfDefinedAt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparison.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparison.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderElementsOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderElementsOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderOnlyApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfInOrderOnlyApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfKeyWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfKeyWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparison.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparison.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNoElementsOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNoElementsOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNoneOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNoneOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotExist.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotExist.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOfTypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOfTypeInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOneElementOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOneElementOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOneOfApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOneOfApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOnlyApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfOnlyApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfRegexWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfRegexWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsAsApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsAsApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsInOrderAsApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsInOrderAsApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameInstanceAsApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheSameInstanceAsApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfThrownByApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfThrownByApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfValueWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfValueWordApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SizeWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SizeWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SortedWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SortedWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/StartWithWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/StartWithWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/WritableWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/WritableWord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/package.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/package.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AnyPropSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/AsyncPropSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAnyPropSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec2.scala
+++ b/jvm/propspec-test/src/test/scala/org/scalatest/propspec/FixtureAsyncPropSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpec.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/package.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/refspec/src/main/scala/org/scalatest/refspec/RefSpec.scala
+++ b/jvm/refspec/src/main/scala/org/scalatest/refspec/RefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/refspec/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/jvm/refspec/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/refspec/src/main/scala/org/scalatest/refspec/package.scala
+++ b/jvm/refspec/src/main/scala/org/scalatest/refspec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/BooleanMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/MacroOwnerRepair.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/MacroOwnerRepair.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/NameUtil.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/NameUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/Or.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/Or.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/Validation.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/Validation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/CompileTimeAssertions.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/CompileTimeAssertions.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericString.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericString.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericStringMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/NumericStringMacro.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/PercentageInt.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/PercentageInt.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/PercentageIntMacros.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/PercentageIntMacros.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/RegexString.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/RegexString.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/RegexStringMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/anyvals/RegexStringMacro.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/source/Position.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/source/Position.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/source/PositionMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/source/PositionMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-macro/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
+++ b/jvm/scalactic-macro/src/main/scala/org/scalactic/source/TypeInfoMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/AccumulationSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/AccumulationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/ChainSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DecidersSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DecidersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DefaultEqualitySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DefaultEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DifferSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DifferSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/EitherSugarSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/EitherSugarSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/EqualitySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/EqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/EverySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/ExplicitlySpecHelpers.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/ExplicitlySpecHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/FutureSugarSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/NormMethodsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/NormMethodsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/NormalizationSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/NormalizationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/NormalizingEqualitySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/NormalizingEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/NumericEqualityConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/NumericEqualityConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/OptionSugarSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/OptionSugarSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/OrSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/OrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettifierSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/PrettyMethodsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/PrettyMethodsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/SnapshotsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/SnapshotsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/SpreadSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/SpreadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/StringNormalizationsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/StringNormalizationsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TimesOnIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TimesOnIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/ToleranceSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/ToleranceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TolerantEqualitySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TolerantEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TolerantEquivalenceSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TolerantEquivalenceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TraversableConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TraversableConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TripleEqualsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TripleEqualsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TrySugarSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TrySugarSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedMapEqualityConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedMapEqualityConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSeqEqualityConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSeqEqualityConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSetEqualityConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSetEqualityConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTraversableEqualityConstraintsSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTraversableEqualityConstraintsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTripleEqualsExplicitlySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTripleEqualsExplicitlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/UnitSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/ValidationSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/ValidationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/FiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegLongSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NegZLongSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyArraySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyListSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyListSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyMapSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyMapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptySetSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptySetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyVectorSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyVectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonZeroLongSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericCharSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericCharSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddInt.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddInt.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddIntMacro.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddIntMacro.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/OddIntSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PercentageIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PercentageIntSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosLongSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteDoubleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFiniteFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZFloatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZIntSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/PosZLongSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/RegexStringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/exceptions/ValidationFailedExceptionSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/exceptions/ValidationFailedExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/source/ObjectMetaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/source/PositionSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/source/PositionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/AbstractStringUniformity.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/AbstractStringUniformity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Accumulation.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Accumulation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Bool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/CanEqual.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/CanEqual.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Catcher.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Catcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/ComposedNormalizingEquality.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/ComposedNormalizingEquality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/ComposedNormalizingEquivalence.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/ComposedNormalizingEquivalence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/DefaultEquality.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/DefaultEquality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Differ.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Differ.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/EitherSugar.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/EitherSugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Equality.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Equality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Equivalence.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Equivalence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Explicitly.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Explicitly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/FutureSugar.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/FutureSugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/LowPriorityTypeCheckedConstraint.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/LowPriorityTypeCheckedConstraint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/MapEqualityConstraints.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/MapEqualityConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/NormMethods.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/NormMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Normalization.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Normalization.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/NormalizingEquality.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/NormalizingEquality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/NormalizingEquivalence.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/NormalizingEquivalence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/NumericEqualityConstraints.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/NumericEqualityConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/OptionSugar.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/OptionSugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/PrettyMethods.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/PrettyMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/PrettyPair.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/PrettyPair.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Requirements.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Requirements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/SeqEqualityConstraints.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/SeqEqualityConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/SetEqualityConstraints.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/SetEqualityConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/SizeLimit.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/SizeLimit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Snapshots.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Snapshots.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/StringNormalizations.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/StringNormalizations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TolerantNumerics.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TolerantNumerics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TraversableEqualityConstraints.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TraversableEqualityConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TripleEqualsSupport.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TripleEqualsSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TrySugar.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TrySugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/TypeCheckedTripleEquals.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TypeCheckedTripleEquals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/Uniformity.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Uniformity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/UnquotedString.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/UnquotedString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/End.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/End.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/exceptions/NullArgumentException.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/exceptions/NullArgumentException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/exceptions/ValidationFailedException.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/exceptions/ValidationFailedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/package.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/source/TypeInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test-osgi/scala/org/scalatest/osgi/OsgiSuite.scala
+++ b/jvm/scalatest-test/src/test-osgi/scala/org/scalatest/osgi/OsgiSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/FastAsLight.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/FastAsLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/HasField.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/HasField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldAndGetMethod.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldAndGetMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldAndMethod.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldAndMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldMethodAndGetMethod.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/HasFieldMethodAndGetMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/PackageAccessConstructorSuite.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/PackageAccessConstructorSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/SlowAsMolasses.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/SlowAsMolasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/WeakAsAKitten.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/WeakAsAKitten.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/junit/JBitterSuite.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/junit/JBitterSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/junit/JHappySuite.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/junit/JHappySuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/junit/JUnit3TestCase.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/junit/JUnit3TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/junit/JUnit3TestSuite.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/junit/JUnit3TestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/java/org/scalatest/tools/PackageAccessSuite.java
+++ b/jvm/scalatest-test/src/test/java/org/scalatest/tools/PackageAccessSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AlerterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AlerterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AnMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AnMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AnyValMatchersSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AnyValMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AppendedCluesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AppendedCluesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ArgsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ArgsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsWithTypeCheckedTripleEqualsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AssertionsWithTypeCheckedTripleEqualsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2015 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncEngineSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncEngineSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFixturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncFixturesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncInspectorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AsyncInspectorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllConfigMapSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllConfigMapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAsyncSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterConfigSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterConfigSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAsyncSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BigSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BigSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BigSuiteSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BigSuiteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CancelAfterFailureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CancelAfterFailureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CatchReporterProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CatchReporterProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CatchReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CatchReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CheckpointsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CheckpointsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ClassTaggingProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ClassTaggingProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ClueSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ClueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CompleteLastlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ConfigMapWrapperSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/CustomMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/CustomMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedAsyncFeatureSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedBeforeAndAfterAllProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedBeforeAndAfterAllProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedCatchReporterProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedCatchReporterProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedClassTaggingProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedClassTaggingProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionInfoExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionInfoExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionOrderExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionOrderExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionSuiteTimeoutExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionSuiteTimeoutExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionTestTimeoutExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedParallelTestExecutionTestTimeoutExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedRandomTestOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedRandomTestOrderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedStatusProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedStatusProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedStopOnFailureProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedStopOnFailureProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedTestDataProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedTestDataProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedTestNameProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DeprecatedTestNameProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DirectAssertionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DispatchReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DispatchReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/DocSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/DocSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EasySuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EasySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EitherValuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EncodedOrderingSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EncodedOrderingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EntrySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EntrySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EventHelpers.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EventHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryLoneElementSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryLoneElementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleBeforeAfterParallelSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleBeforeAfterParallelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleParallelSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleParallelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleStackSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleStackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleSuiteTimeoutSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleSuiteTimeoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleTimeoutParallelSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExampleTimeoutParallelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExamplesSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ExpectationHavePropertyMatchers.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ExpectationHavePropertyMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FactSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FactSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FailureMessagesSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FailureMessagesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FilterProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FilterProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FilterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FixtureContextSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FixtureContextSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FunctionSuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FunctionSuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FunctionSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FunctionSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/FutureOutcomeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/FutureOutcomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/GivenWhenThenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/GivenWhenThenSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InformerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InformerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InheritedTagProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InheritedTagProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InsertionOrderSetSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InsertionOrderSetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InsideMixinSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InsideMixinSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InsideSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InsideSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsRegexWithGroupsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsRegexWithGroupsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorShorthandsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsForMapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InspectorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/JavaMapLoneElementSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/JavaMapLoneElementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListLoneElementSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListLoneElementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptyLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptyLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldBeEmptySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2001-2024 Artima, Inc.
+* Copyright 2001-2025 Artima, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MapShouldBeDefinedAtSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MapShouldBeDefinedAtSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherGenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherGenSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatchersSerializableSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatchersSerializableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatchersSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MethodSuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MethodSuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MethodSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MethodSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NonImplicitAssertionsSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NonImplicitAssertionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NotifierSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NotifierSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OldDocSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OldDocSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneInstancePerTestSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneInstancePerTestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionValuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OutcomeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OutcomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionInfoExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionInfoExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionOrderExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionOrderExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionParallelSuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionParallelSuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSuiteTimeoutExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionSuiteTimeoutExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionTestTimeoutExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ParallelTestExecutionTestTimeoutExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/PartialFunctionValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/PartialFunctionValuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/PrettyAstSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/PrettyAstSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/PrivateMethodTesterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/PrivateMethodTesterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/PropertyFunSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/PropertyFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RandomAsyncTestExecutionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RandomTestOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RandomTestOrderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RecoverMethodsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RecoverMethodsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RefSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RefSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RetriesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RetriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RunInSpurtsSpec1.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RunInSpurtsSpec1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RunInSpurtsSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RunInSpurtsSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/RunningTestSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/RunningTestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SavesConfigMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SequentialNestedSuiteExecutionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesFailureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesFailureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SeveredStackTracesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShellSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShellSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShorthandShouldBeThrownBySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShorthandShouldBeThrownBySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShorthandShouldNotBeThrownBySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShorthandShouldNotBeThrownBySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAMatcherAndOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAMatcherAndOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeASymbolSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeASymbolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeATypeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeATypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnMatcherAndOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnMatcherAndOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnSymbolSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnSymbolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnTypeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeAnySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedAtForAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedAtForAllSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedAtSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedAtSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this thing except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedStructuralSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyStructuralSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeNullSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeNullSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBePropertyMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableStructuralSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandForAllSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeShorthandSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSymbolSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSymbolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeThrownBySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeThrownBySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this opt except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableStructuralSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBehaveLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBehaveLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsToleranceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCollectedTripleEqualsToleranceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldCompileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainKeySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainKeySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainValueSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainValueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithRegexSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithRegexSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithSubstringSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEndWithSubstringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualExplicitlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualExplicitlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualNullSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualNullSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualTokenToleranceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualTokenToleranceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualToleranceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualToleranceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrImplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrImplicitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldFileBePropertyMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldFileBePropertyMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldFullyMatchSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldFullyMatchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldHavePropertiesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldHavePropertiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeRegexSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeRegexSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeSubstringSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldIncludeSubstringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSizeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSizeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLengthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLogicalMatcherExprSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldLogicalMatcherExprSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMatchPatternSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMatchPatternSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMessageSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotBeThrownBySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotBeThrownBySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotCompileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandForAllSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotShorthandSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldNotTypeCheckSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldOrderedSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldOrderedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldPlusOrMinusSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldPlusOrMinusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldSameInstanceAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldSameInstanceAsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldSizeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithRegexSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithRegexSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithSubstringSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStartWithSubstringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralLengthSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralLengthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralSizeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldStructuralSizeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldThrowSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldThrowSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsToleranceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTripleEqualsToleranceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTypeCheckedTripleEqualsEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldTypeCheckedTripleEqualsEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SlowpokeDetectorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SlowpokeDetectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StatefulStatusSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StatefulStatusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StatusProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StatusProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StatusSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StatusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StepwiseNestedSuiteExecutionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StopOnFailureProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StopOnFailureProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StopOnFailureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StopOnFailureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlNormMethodsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StringLoneElementSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StringLoneElementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteCompletedStatusReporter.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteCompletedStatusReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuiteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/SuitesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/SuitesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TagGroupsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TagGroupsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TaggingScopesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TaggingScopesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TestColonEscapeProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TestColonEscapeProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TestDataProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TestDataProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TestNameProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TestNameProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TestsBeforeNestedSuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TestsBeforeNestedSuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ThreadNameSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ThreadNameSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TryValuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TypeCheckedAssertionsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TypeCheckedAssertionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/UnitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/VariousWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/VariousWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncCancelAfterFailureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncCancelAfterFailureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec2.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/AsyncTimeLimitedTestsSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorFixtureSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorFixtureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorMethodsSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorMethodsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ConductorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DeprecatedIntegrationPatienceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DeprecatedIntegrationPatienceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DoOver.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DoOver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DoOverSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/DoOverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/EventuallySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/IntegrationPatienceSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/IntegrationPatienceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/JavaFuturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/JavaFuturesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/PatienceConfigurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/PatienceConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScalaFuturesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScaledTimeSpansSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/ScaledTimeSpansSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/SignalerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/SignalerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TestThreadsStartingCounterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TestThreadsStartingCounterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitedTestsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitedTestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/TimeLimitsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/WaitersSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/concurrent/WaitersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/CollectingSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/CollectingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/NoParamSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/NoParamSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingAsyncSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingAsyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/enablers/PropCheckerAssertingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedLocationFunctionSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedLocationFunctionSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedLocationSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedLocationSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedScopePendingProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/DeprecatedScopePendingProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/EventSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/EventSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationFunctionSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationFunctionSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationMethodSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationMethodSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationSuiteProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/LocationSuiteProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/OrdinalSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/OrdinalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/ScopePendingProp.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/ScopePendingProp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationFunctionServices.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationFunctionServices.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationJUnit3Suite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationJUnit3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationJUnitSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationJUnitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodJUnit3Suite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodJUnit3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodJUnitSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodJUnitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodServices.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodServices.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodTestNGSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationMethodTestNGSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationServices.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationServices.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationTestNGSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/TestLocationTestNGSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/examples/ExampleCancelInNestedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/examples/ExampleCancelInNestedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/events/examples/ExampleCancelSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/events/examples/ExampleCancelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedExceptionSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/GeneratorDrivenPropertyCheckFailedExceptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/PayloadSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/PayloadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/StackDepthExceptionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/StackDepthExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedExceptionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TableDrivenPropertyCheckFailedExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestCanceledExceptionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestCanceledExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionWithImportSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/exceptions/TestFailedExceptionWithImportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncConfigMapFixtureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncConfigMapFixtureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFixturesSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncFixturesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncTestDataFixtureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/AsyncTestDataFixtureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/ConfigMapFixtureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/ConfigMapFixtureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/NoArgAlternativeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/NoArgAlternativeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/NoArgSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/NoArgSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/SuiteSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/SuiteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/TestDataFixtureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/TestDataFixtureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/UnitFixtureSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/fixture/UnitFixtureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/AMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/AMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/AnMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/AnMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BeMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BeMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BePropertyMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BePropertyMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BookPropertyMatchers.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/BookPropertyMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/HavePropertyMatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/HavePropertyMatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/LazyArgSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/LazyArgSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatchResultSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatchResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherFactorySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherFactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherProducersSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherProducersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherToStringSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/MatcherToStringSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/ShouldAndMustSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/ShouldAndMustSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/ShouldBehaveLikeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/ShouldBehaveLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/BeWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ContainWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/DefinedWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/DefinedWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/EmptyWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/EmptyWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/EndWithWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/EndWithWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ExistWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ExistWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/FullyMatchWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/FullyMatchWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/HaveWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/IncludeWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/IncludeWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/LengthWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/LengthWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/MatcherWordsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/MatcherWordsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NoExceptionWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NoExceptionWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/NotWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ReadableWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ReadableWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/RegexWithGroupsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/RegexWithGroupsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToAMatcherApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToAMatcherApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToBePropertyMatcherApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToBePropertyMatcherApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAWordToSymbolApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAllElementsOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAllElementsOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAllOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAllOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToAnMatcherApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToAnMatcherApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToBePropertyMatcherApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToBePropertyMatcherApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAnWordToSymbolApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneElementOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneElementOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtLeastOneOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneElementOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneElementOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfAtMostOneOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForATypeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForATypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnTypeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoExceptionSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoExceptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfContainWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfContainWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfDefinedAtSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfDefinedAtSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparisonSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparisonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparisonSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparisonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderElementsOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderElementsOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderOnlyApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfInOrderOnlyApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfKeyWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfKeyWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparisonSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparisonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparisonSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparisonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNoElementsOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNoElementsOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNoneOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNoneOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNotExistSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNotExistSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAnySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAnySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOfTypeInvocationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOfTypeInvocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOneElementOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOneElementOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOneOfApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOneOfApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOnlyApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfOnlyApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfRegexWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfRegexWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsAsApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsAsApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsInOrderAsApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameElementsInOrderAsApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameInstanceAsApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheSameInstanceAsApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfThrownByApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfThrownByApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfValueWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/ResultOfValueWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/SizeWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/SizeWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/SortedWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/SortedWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/StartWithWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/StartWithWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/WritableWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/matchers/dsl/WritableWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/path/FreeSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/path/FunSpecSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/path/FunSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/path/StackSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/path/StackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/AsyncGeneratorDrivenPropertyChecksSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ClassificationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ClassificationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/FactWheneverSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/FactWheneverSpec.scala
@@ -1,5 +1,5 @@
 /*
-3* Copyright 2001-2024 Artima, Inc.
+3* Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/OrgScalaTestPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PrettyFunction0Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigParamSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigParamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigurationSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigurationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RandomizerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/RoseTreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/SizeParamSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/TableStyleSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/TableStyleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/WheneverSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/WheneverSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedFirstTestIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedFirstTestIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedInfoInsideTestFiredAfterTestExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedInfoInsideTestFiredAfterTestExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedSecondTestIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedSecondTestIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoSlowAndOneWeakTestExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoSlowAndOneWeakTestExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoSlowTestsExample.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoSlowTestsExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoTestsIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/DeprecatedTwoTestsIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/FirstTestIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/FirstTestIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/InfoInsideTestFiredAfterTestExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/InfoInsideTestFiredAfterTestExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/OnlyFirstTestExecutedOnCreationExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/OnlyFirstTestExecutedOnCreationExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathBeforeAndAfterExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathBeforeAndAfterExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathListBufferExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathListBufferExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathSuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathSuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathSuiteMatrix.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/PathSuiteMatrix.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SecondTestIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SecondTestIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SuiteExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SuiteExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SuiteMatrix.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/SuiteMatrix.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoSlowAndOneWeakTestExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoSlowAndOneWeakTestExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoSlowTestsExample.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoSlowTestsExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoTestsIgnoredExamples.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/suiteprop/TwoTestsIgnoredExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tagobjects/Flicker.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tagobjects/Flicker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/time/DurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/time/DurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanMatchers.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanSugarSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/time/SpanSugarSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ArgsParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/DashboardReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/DashboardReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/DiscoverySuiteSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/DiscoverySuiteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FilterReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FilterReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/HtmlReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/HtmlReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/JUnitXmlReporterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/MemoryReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/MemoryReporterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunnerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/RunnerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SbtCommandParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestAntTaskSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestAntTaskSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestFrameworkSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestFrameworkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestRunnerSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/ScalaTestRunnerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiClass.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiClass.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiClassRunner.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiClassRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiSubClass.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SomeApiSubClass.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterAlertSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterAlertSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSummarySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/StringReporterSummarySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteDiscoveryHelperSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteDiscoveryHelperSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteRunnerSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteRunnerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteSortingReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/SuiteSortingReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/TestSortingReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/TestSortingReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/XmlSocketReporterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/AbortedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/AbortedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/BadBeforeAsyncSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/BadBeforeAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/CPUTaggedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/CPUTaggedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/CustomTaggedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/CustomTaggedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/DiskTaggedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/DiskTaggedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/DoNotDiscoverSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/DoNotDiscoverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterAllConfigMapSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterAllConfigMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterAllSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterAllSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterEachSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterEachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterEachTestDataSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterEachTestDataSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/FaulthyBeforeAndAfterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NestedConfigMapSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NestedConfigMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NetworkTaggedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NetworkTaggedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NotASuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/NotASuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SampleInheritedSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SampleInheritedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SampleSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SlowSampleSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SlowSampleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithFailedCanceledTests.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithFailedCanceledTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithFailedSkippedTests.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithFailedSkippedTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithNestedSuites.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/scalasbt/SuiteWithNestedSuites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/BehaveWordSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/BehaveWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/CanVerbSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/CanVerbSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/ResultOfAfterWordApplicationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/verbs/ResultOfAfterWordApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/us/US.scala
+++ b/jvm/scalatest-test/src/us/US.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/scalatest-test/src/us/runem.scala
+++ b/jvm/scalatest-test/src/us/runem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/package.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AnyWordSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/AsyncWordSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAnyWordSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLikeSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureAsyncWordSpecSpec2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecImportedMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecImportedMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecMixedInMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/FixtureWordSpecMixedInMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecImportedMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecImportedMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecMixedInMatchersSpec.scala
+++ b/jvm/wordspec-test/src/test/scala/org/scalatest/wordspec/WordSpecMixedInMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpec.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/package.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
+++ b/native/core/src/main/scala/org/scalatest/JavaClassesWrappers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/compatible/Assertion.scala
+++ b/native/core/src/main/scala/org/scalatest/compatible/Assertion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/compatible/package.scala
+++ b/native/core/src/main/scala/org/scalatest/compatible/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/native/core/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/MasterRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/SbtReporter.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SbtReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/ScalaTestSbtEvent.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/ScalaTestSbtEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SlaveRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/SummaryCounter.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/SummaryCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
+++ b/native/core/src/main/scala/org/scalatest/tools/TaskRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2024 Artima, Inc.
+ * Copyright 2001-2025 Artima, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Improved scaladoc in [‎jvm/core/src/main/scala/org/scalatest/prop/Classification.scala](https://github.com/scalatest/scalatest/commit/af5a9bcb08deb032e05dc1daecc919836ba650ec#diff-6788391274081c12f95a19d037be7e440624e80419a2e232dc7d960ef7443911), assisted by our friend.
- Ran script to update copyright years.